### PR TITLE
Refactor/app greeting

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -139,7 +139,10 @@ class _AppState extends State<App> {
             path: '/login/:${LoginStep.pathParameterName}(${LoginStep.values.map((e) => e.name).join('|')})',
             builder: (context, state) {
               final step = LoginStep.values.byName(state.pathParameters[LoginStep.pathParameterName]!);
-              final widget = LoginScreen(step);
+              final widget = LoginScreen(
+                step,
+                appGreeting: EnvironmentConfig.APP_GREETING.isEmpty ? null : EnvironmentConfig.APP_GREETING,
+              );
               final provider = BlocProvider(
                 create: (context) => LoginCubit(
                   step,

--- a/lib/environment_config.dart
+++ b/lib/environment_config.dart
@@ -32,6 +32,11 @@ class EnvironmentConfig {
     defaultValue: 'WebTrit',
   );
 
+  static const APP_GREETING = String.fromEnvironment(
+    'WEBTRIT_APP_GREETING',
+    defaultValue: 'WebTrit',
+  );
+
   static const APP_DESCRIPTION = String.fromEnvironment(
     'WEBTRIT_APP_DESCRIPTION',
   );

--- a/lib/features/login/view/login_mode_select_tab.dart
+++ b/lib/features/login/view/login_mode_select_tab.dart
@@ -13,7 +13,10 @@ import '../login.dart';
 class LoginModeSelectTab extends StatelessWidget {
   const LoginModeSelectTab({
     Key? key,
+    this.appGreeting,
   }) : super(key: key);
+
+  final String? appGreeting;
 
   @override
   Widget build(BuildContext context) {
@@ -66,6 +69,7 @@ class LoginModeSelectTab extends StatelessWidget {
                 const Spacer(),
                 OnboardingPictureLogo(
                   color: themeData.colorScheme.onPrimary,
+                  text: appGreeting,
                 ),
                 const Spacer(),
                 if (isDemoModeEnabled)

--- a/lib/features/login/view/login_screen.dart
+++ b/lib/features/login/view/login_screen.dart
@@ -15,9 +15,12 @@ class LoginScreen extends StatefulWidget {
   const LoginScreen(
     this.step, {
     super.key,
+    this.appGreeting,
   });
 
   final LoginStep step;
+
+  final String? appGreeting;
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -60,11 +63,13 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
       child: TabBarView(
         controller: _tabController,
         physics: const NeverScrollableScrollPhysics(),
-        children: const [
-          LoginModeSelectTab(),
-          LoginCoreUrlAssignTab(),
-          LoginOtpRequestTab(),
-          LoginOtpVerifyTab(),
+        children: [
+          LoginModeSelectTab(
+            appGreeting: widget.appGreeting,
+          ),
+          const LoginCoreUrlAssignTab(),
+          const LoginOtpRequestTab(),
+          const LoginOtpVerifyTab(),
         ],
       ),
     );

--- a/lib/features/login/widgets/onboarding_picture_logo.dart
+++ b/lib/features/login/widgets/onboarding_picture_logo.dart
@@ -7,9 +7,11 @@ class OnboardingPictureLogo extends StatelessWidget {
   const OnboardingPictureLogo({
     super.key,
     this.color,
+    this.text,
   });
 
   final Color? color;
+  final String? text;
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +24,7 @@ class OnboardingPictureLogo extends StatelessWidget {
     final logo = themeData.extension<LogoAssets>()!.primaryOnboarding;
     return WebTritPhonePictureLogo(
       asset: logo,
+      text: text,
       logoWidth: mediaQueryData.size.width * 0.42,
       dividerHeight: titleStyle.fontSize,
       titleStyle: titleStyle,

--- a/lib/widgets/logos.dart
+++ b/lib/widgets/logos.dart
@@ -7,6 +7,7 @@ class WebTritPhonePictureLogo extends StatelessWidget {
   const WebTritPhonePictureLogo({
     super.key,
     required this.asset,
+    this.text,
     this.logoWidth,
     this.logoHeight,
     this.logoFit = BoxFit.contain,
@@ -16,6 +17,7 @@ class WebTritPhonePictureLogo extends StatelessWidget {
   });
 
   final ThemeSvgAsset asset;
+  final String? text;
   final double? logoWidth;
   final double? logoHeight;
   final BoxFit logoFit;
@@ -37,13 +39,15 @@ class WebTritPhonePictureLogo extends StatelessWidget {
           fit: logoFit,
           alignment: logoAlignment,
         ),
-        SizedBox(
-          height: dividerHeight ?? fontSize / 3,
-        ),
-        Text(
-          EnvironmentConfig.APP_NAME,
-          style: titleStyle,
-        ),
+        if (text != null) ...[
+          SizedBox(
+            height: dividerHeight ?? fontSize / 3,
+          ),
+          Text(
+            text!,
+            style: titleStyle,
+          ),
+        ],
       ],
     );
   }

--- a/screenshots/lib/screenshots/login_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_screen_screenshot.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/features/features.dart';
 
 import 'package:screenshots/mocks/mocks.dart';
@@ -20,6 +21,7 @@ class LoginScreenScreenshot extends StatelessWidget {
       create: (context) => MockLoginCubit.loginScreen(step),
       child: LoginScreen(
         step,
+        appGreeting: EnvironmentConfig.APP_GREETING.isEmpty ? null : EnvironmentConfig.APP_GREETING,
       ),
     );
   }


### PR DESCRIPTION
1. In "Onboardings" widget i add named param as "text" because this widget can be used in another flow and meaning of text can be another

2. By default i use text not nullable , only set default value in constructor, by reason
    - String.fromEnvironment can't return null only empty
    - If it will be null we should add checking for null and for empty
    
 3. In scree "LoginScreen"  field appGreeting using only for passing in another widged, i thought create builder for movig it on top level or passing children as list but i think it's can triggered additional testing by reason  possibilition of lossing context or state