### PR TITLE
fix: screenshots_app android-sdk update

### DIFF
--- a/screenshots/android/app/build.gradle
+++ b/screenshots/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
 
     defaultConfig {
         applicationId "com.webtrit.phone.screenshots"
-        minSdkVersion 23 // flutter.minSdkVersion
+        minSdkVersion 26 // flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Update minSdkVersion to 26 coresponding to callkeep package that requires 26 api and cause build error.