### PR TITLE
fix: outcoming active call dissapear when click on active call notification

### DIFF
--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -304,6 +304,7 @@ class AppRouter extends _$AppRouter {
     final handlers = <DeepLinkHandler>[
       HandleAndroidBackgroundIncomingCall(deepLink, _appBloc.pendingCallHandler),
       HandleAutoprovision(deepLink),
+      HandleReturnToMain(deepLink),
     ];
 
     for (final handler in handlers) {

--- a/lib/app/router/deeplinks.dart
+++ b/lib/app/router/deeplinks.dart
@@ -42,3 +42,15 @@ class HandleAutoprovision implements DeepLinkHandler {
 
   bool get _isAutoprovision => deepLink.path.startsWith(kAutoprovisionRout);
 }
+
+class HandleReturnToMain implements DeepLinkHandler {
+  HandleReturnToMain(this.deepLink);
+
+  final PlatformDeepLink deepLink;
+
+  @override
+  DeepLink? handle() => _isMain && !_isInitial ? DeepLink.none : null;
+
+  bool get _isMain => deepLink.path == '/';
+  bool get _isInitial => deepLink.initial;
+}


### PR DESCRIPTION
Pass user to app 'as is' when he returns to '/' instead of push another DeepLink.defaultPath above subroutes