### PR TITLE
fix: missed call parameters

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -270,7 +270,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         line: _kUndefinedLine,
         callId: event.call!.id,
         handle: CallkeepHandle.number(event.call!.handle),
-        video: false,
+        displayName: event.call?.displayName,
+        video: event.call?.hasVideo ?? false,
         createdTime: DateTime.now(),
       ),
     ));


### PR DESCRIPTION
Add the missing parameters for the correct visualization of the call