### PR TITLE
feat: replace sqlite "like" command with "regexp" for utf-8 support

### DIFF
--- a/packages/data/app_database/lib/src/app_database.dart
+++ b/packages/data/app_database/lib/src/app_database.dart
@@ -304,7 +304,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
           contactsTable.firstName,
           contactsTable.aliasName,
           contactPhonesTable.number,
-        ].map((c) => c.like('%$searchBit%')).reduce((v, e) => v | e),
+        ].map((c) => c.regexp('.*$searchBit.*', caseSensitive: false)).reduce((v, e) => v | e),
       );
     }
     q.groupBy([contactPhonesTable.contactId]);

--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -1,0 +1,100 @@
+import 'package:drift/native.dart';
+import 'package:test/test.dart';
+
+import 'package:app_database/app_database.dart';
+
+void main() {
+  late AppDatabase database;
+
+  setUp(() async {
+    database = AppDatabase(NativeDatabase.memory());
+
+    final contactsDao = database.contactsDao;
+
+    await contactsDao.insertOnUniqueConflictUpdateContact(ContactDataCompanion(
+      sourceType: Value(ContactSourceTypeEnum.local),
+      sourceId: Value('source1'),
+      firstName: Value(''),
+      lastName: Value('Тарас Шевченко'),
+      aliasName: Value('ТШ'),
+    ));
+
+    await contactsDao.insertOnUniqueConflictUpdateContact(ContactDataCompanion(
+      sourceType: Value(ContactSourceTypeEnum.local),
+      sourceId: Value('source2'),
+      firstName: Value('Jane'),
+      lastName: Value('Smith'),
+      aliasName: Value('JS'),
+    ));
+
+    await contactsDao.insertOnUniqueConflictUpdateContact(ContactDataCompanion(
+      sourceType: Value(ContactSourceTypeEnum.local),
+      sourceId: Value('source3'),
+      firstName: Value('Bob'),
+      lastName: Value('Marly'),
+      aliasName: Value('BM'),
+    ));
+
+    await database.contactPhonesDao.insertOnUniqueConflictUpdateContactPhone(ContactPhoneDataCompanion(
+      contactId: Value(1),
+      number: Value('1234567890'),
+      label: Value('Home'),
+    ));
+
+    await database.contactPhonesDao.insertOnUniqueConflictUpdateContactPhone(ContactPhoneDataCompanion(
+      contactId: Value(2),
+      number: Value('0987654321'),
+      label: Value('Work'),
+    ));
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('watchAllLikeContacts matching "Тарас"', () async {
+    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['Тарас']);
+    final likeContacts = await likeContactsStream.first;
+
+    expect(likeContacts.length, 1);
+    expect(likeContacts.first.firstName, '');
+    expect(likeContacts.first.lastName, 'Тарас Шевченко');
+  });
+
+  test('watchAllLikeContacts matching "шев"', () async {
+    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['шев']);
+    final likeContacts = await likeContactsStream.first;
+
+    expect(likeContacts.length, 1);
+    expect(likeContacts.first.firstName, '');
+    expect(likeContacts.first.lastName, 'Тарас Шевченко');
+  });
+
+  test('watchAllLikeContacts matching "Smit"', () async {
+    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['Smit']);
+    final likeContacts = await likeContactsStream.first;
+
+    expect(likeContacts.length, 1);
+    expect(likeContacts.first.firstName, 'Jane');
+    expect(likeContacts.first.lastName, 'Smith');
+  });
+
+  test('watchAllLikeContacts matching "mar"', () async {
+    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['mar']);
+    final likeContacts = await likeContactsStream.first;
+
+    expect(likeContacts.length, 1);
+    expect(likeContacts.first.firstName, 'Bob');
+    expect(likeContacts.first.lastName, 'Marly');
+  });
+
+  test('watchAllContacts', () async {
+    final allContactsStream = database.contactsDao.watchAllContacts();
+    final allContacts = await allContactsStream.first;
+
+    expect(allContacts.length, 3);
+    expect(allContacts.any((contact) => contact.lastName == 'Тарас Шевченко'), isTrue);
+    expect(allContacts.any((contact) => contact.lastName == 'Smith'), isTrue);
+    expect(allContacts.any((contact) => contact.lastName == 'Marly'), isTrue);
+  });
+}

--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -52,49 +52,51 @@ void main() {
     await database.close();
   });
 
-  test('watchAllLikeContacts matching "Тарас"', () async {
-    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['Тарас']);
-    final likeContacts = await likeContactsStream.first;
+  group('watchAllLikeContacts', () {
+    test('matching "Тарас"', () async {
+      final likeContactsStream = database.contactsDao.watchAllLikeContacts(['Тарас']);
+      final likeContacts = await likeContactsStream.first;
 
-    expect(likeContacts.length, 1);
-    expect(likeContacts.first.firstName, '');
-    expect(likeContacts.first.lastName, 'Тарас Шевченко');
-  });
+      expect(likeContacts.length, 1);
+      expect(likeContacts.first.firstName, '');
+      expect(likeContacts.first.lastName, 'Тарас Шевченко');
+    });
 
-  test('watchAllLikeContacts matching "шев"', () async {
-    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['шев']);
-    final likeContacts = await likeContactsStream.first;
+    test('matching "шев"', () async {
+      final likeContactsStream = database.contactsDao.watchAllLikeContacts(['шев']);
+      final likeContacts = await likeContactsStream.first;
 
-    expect(likeContacts.length, 1);
-    expect(likeContacts.first.firstName, '');
-    expect(likeContacts.first.lastName, 'Тарас Шевченко');
-  });
+      expect(likeContacts.length, 1);
+      expect(likeContacts.first.firstName, '');
+      expect(likeContacts.first.lastName, 'Тарас Шевченко');
+    });
 
-  test('watchAllLikeContacts matching "Smit"', () async {
-    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['Smit']);
-    final likeContacts = await likeContactsStream.first;
+    test('matching "Smit"', () async {
+      final likeContactsStream = database.contactsDao.watchAllLikeContacts(['Smit']);
+      final likeContacts = await likeContactsStream.first;
 
-    expect(likeContacts.length, 1);
-    expect(likeContacts.first.firstName, 'Jane');
-    expect(likeContacts.first.lastName, 'Smith');
-  });
+      expect(likeContacts.length, 1);
+      expect(likeContacts.first.firstName, 'Jane');
+      expect(likeContacts.first.lastName, 'Smith');
+    });
 
-  test('watchAllLikeContacts matching "mar"', () async {
-    final likeContactsStream = database.contactsDao.watchAllLikeContacts(['mar']);
-    final likeContacts = await likeContactsStream.first;
+    test('matching "mar"', () async {
+      final likeContactsStream = database.contactsDao.watchAllLikeContacts(['mar']);
+      final likeContacts = await likeContactsStream.first;
 
-    expect(likeContacts.length, 1);
-    expect(likeContacts.first.firstName, 'Bob');
-    expect(likeContacts.first.lastName, 'Marly');
-  });
+      expect(likeContacts.length, 1);
+      expect(likeContacts.first.firstName, 'Bob');
+      expect(likeContacts.first.lastName, 'Marly');
+    });
 
-  test('watchAllContacts', () async {
-    final allContactsStream = database.contactsDao.watchAllContacts();
-    final allContacts = await allContactsStream.first;
+    test('all contacts', () async {
+      final allContactsStream = database.contactsDao.watchAllContacts();
+      final allContacts = await allContactsStream.first;
 
-    expect(allContacts.length, 3);
-    expect(allContacts.any((contact) => contact.lastName == 'Тарас Шевченко'), isTrue);
-    expect(allContacts.any((contact) => contact.lastName == 'Smith'), isTrue);
-    expect(allContacts.any((contact) => contact.lastName == 'Marly'), isTrue);
+      expect(allContacts.length, 3);
+      expect(allContacts.any((contact) => contact.lastName == 'Тарас Шевченко'), isTrue);
+      expect(allContacts.any((contact) => contact.lastName == 'Smith'), isTrue);
+      expect(allContacts.any((contact) => contact.lastName == 'Marly'), isTrue);
+    });
   });
 }


### PR DESCRIPTION
https://www.sqlite.org/faq.html#q18

The default configuration of SQLite only supports case-insensitive comparisons of ASCII characters. The reason for this is that doing full Unicode case-insensitive comparisons and case conversions requires tables and logic that would nearly double the size of the SQLite library. The SQLite developers reason that any application that needs full Unicode case support probably already has the necessary tables and functions and so SQLite should not take up space to duplicate this ability.
Instead of providing full Unicode case support by default, SQLite provides the ability to link against external Unicode comparison and conversion routines. The application can overload the built-in [NOCASE](https://www.sqlite.org/datatype3.html#collation) collating sequence (using [sqlite3_create_collation()](https://www.sqlite.org/c3ref/create_collation.html)) and the built-in [like()](https://www.sqlite.org/lang_corefunc.html#like), [upper()](https://www.sqlite.org/lang_corefunc.html#upper), and [lower()](https://www.sqlite.org/lang_corefunc.html#lower) functions (using [sqlite3_create_function()](https://www.sqlite.org/c3ref/create_function.html)). The SQLite source code includes an "ICU" extension that does these overloads. Or, developers can write their own overloads based on their own Unicode-aware comparison routines already contained within their project.