### PR TITLE
refactor: change return type in data

### DIFF
--- a/lib/data/app_certificates.dart
+++ b/lib/data/app_certificates.dart
@@ -21,7 +21,7 @@ class AppCertificates {
   TrustedCertificates get trustedCertificates => _trustedCertificates;
 
   /// Initialize the AppCerts instance with the certificates
-  static Future<void> init() async {
+  static Future<AppCertificates> init() async {
     final certificatePaths = Assets.certificates.values.where((it) => it != Assets.certificates.credentials);
     final credentialsPath = Assets.certificates.credentials;
 
@@ -33,6 +33,7 @@ class AppCertificates {
         certificates: certificates,
       ),
     );
+    return _instance;
   }
 
   /// Loads certificate bytes from assets using the provided path and credentials.

--- a/lib/data/app_info.dart
+++ b/lib/data/app_info.dart
@@ -10,12 +10,13 @@ final Logger _logger = Logger('AppInfo');
 class AppInfo {
   static late AppInfo _instance;
 
-  static Future<void> init() async {
+  static Future<AppInfo> init() async {
     final id = await FirebaseInstallations.instance.getId();
 
     String? appVersion = await _getAppVersion();
 
     _instance = AppInfo._(id, appVersion);
+    return _instance;
   }
 
   static Future<String?> _getAppVersion() async {

--- a/lib/data/app_permissions.dart
+++ b/lib/data/app_permissions.dart
@@ -15,7 +15,7 @@ class AppPermissions {
 
   static late AppPermissions _instance;
 
-  static Future<void> init() async {
+  static Future<AppPermissions> init() async {
     final featureAccess = FeatureAccess();
 
     final specialStatuses = await Future.wait(_specialPermissions.map((permission) => permission.status()));
@@ -30,6 +30,7 @@ class AppPermissions {
     final statuses = await Future.wait(permissions.map((permission) => permission.status));
     final isDenied = statuses.every((status) => status.isDenied) || specialStatuses.every((status) => status.isDenied);
     _instance = AppPermissions._(isDenied, permissions);
+    return _instance;
   }
 
   factory AppPermissions() {

--- a/lib/data/app_preferences.dart
+++ b/lib/data/app_preferences.dart
@@ -32,8 +32,9 @@ class AppPreferences {
 
   static late AppPreferences _instance;
 
-  static Future<void> init() async {
+  static Future<AppPreferences> init() async {
     _instance = AppPreferences._(await SharedPreferences.getInstance());
+    return _instance;
   }
 
   factory AppPreferences() {

--- a/lib/data/app_sound.dart
+++ b/lib/data/app_sound.dart
@@ -5,7 +5,7 @@ import 'package:webtrit_phone/extensions/extensions.dart';
 class AppSound {
   static late AppSound _instance;
 
-  static Future<void> init({
+  static Future<AppSound> init({
     required String outgoingCallRingAsset,
     int outgoingCallRingRepeat = 50,
   }) async {
@@ -14,6 +14,7 @@ class AppSound {
     final ringSoundId = await sound.loadAsset(outgoingCallRingAsset);
 
     _instance = AppSound._(sound, outgoingCallRingRepeat, ringSoundId);
+    return _instance;
   }
 
   factory AppSound() {

--- a/lib/data/app_themes.dart
+++ b/lib/data/app_themes.dart
@@ -14,7 +14,7 @@ final Logger _logger = Logger('AppThemes');
 class AppThemes {
   static late AppThemes _instance;
 
-  static Future<void> init() async {
+  static Future<AppThemes> init() async {
     final themeJson = await _getJson(Assets.themes.original);
 
     final themeWidgetLightConfigJson = await _getJson(Assets.themes.originalWidgetLightConfig);
@@ -53,6 +53,7 @@ class AppThemes {
     }
 
     _instance = AppThemes._(themes, appConfig);
+    return _instance;
   }
 
   static Future<dynamic> _getJson(String path) async {

--- a/lib/data/app_time.dart
+++ b/lib/data/app_time.dart
@@ -8,7 +8,7 @@ final Logger _logger = Logger('AppTime');
 class AppTime {
   static late final AppTime _instance;
 
-  static Future<void> init() async {
+  static Future<AppTime> init() async {
     final is24HourFormat = await _determine24HourFormat();
 
     final shortDateFormat = is24HourFormat ? DateFormat.Hm() : DateFormat.jms();
@@ -17,6 +17,7 @@ class AppTime {
     _logger.info('Initialized with format: $is24HourFormat');
 
     _instance = AppTime._(is24HourFormat, shortDateFormat, detailDateFormat);
+    return _instance;
   }
 
   static Future<bool> _determine24HourFormat() async {

--- a/lib/data/device_info.dart
+++ b/lib/data/device_info.dart
@@ -11,7 +11,7 @@ final Logger _logger = Logger('DeviceInfo');
 class DeviceInfo {
   static late DeviceInfo _instance;
 
-  static Future<void> init() async {
+  static Future<DeviceInfo> init() async {
     final deviceInfoPlugin = DeviceInfoPlugin();
 
     late final Map<String, dynamic> deviceData;
@@ -41,6 +41,7 @@ class DeviceInfo {
       };
     }
     _instance = DeviceInfo._(deviceData);
+    return _instance;
   }
 
   factory DeviceInfo() {

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -27,7 +27,7 @@ class FeatureAccess {
   final SettingsFeature settingsFeature;
   final CallFeature callFeature;
 
-  static Future<void> init() async {
+  static Future<FeatureAccess> init() async {
     final theme = AppThemes();
     final preferences = AppPreferences();
 
@@ -44,6 +44,7 @@ class FeatureAccess {
       _logger.severe('Failed to initialize FeatureAccess', e, stackTrace);
       rethrow;
     }
+    return _instance;
   }
 
   factory FeatureAccess() => _instance;

--- a/lib/data/package_info.dart
+++ b/lib/data/package_info.dart
@@ -3,8 +3,9 @@ import 'package:package_info_plus/package_info_plus.dart' as plugin;
 class PackageInfo {
   static late PackageInfo _instance;
 
-  static Future<void> init() async {
+  static Future<PackageInfo> init() async {
     _instance = PackageInfo._(await plugin.PackageInfo.fromPlatform());
+    return _instance;
   }
 
   factory PackageInfo() {

--- a/lib/data/secure_storage.dart
+++ b/lib/data/secure_storage.dart
@@ -1,5 +1,19 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+/// The `SecureStorage` class uses a local cache (`_cache`) to store values
+/// read from `FlutterSecureStorage`, reducing the number of expensive read/write
+/// operations and improving performance.
+///
+/// Issue:
+/// In multi-isolate scenarios, each isolate creates its own instance of `SecureStorage`
+/// with an independent local cache. If one isolate updates the data, other isolates
+/// will not be aware of the changes because the cache is local and not synchronized
+/// across isolates.
+///
+/// Recommendation:
+/// If it is necessary to access up-to-date data in a secondary isolate,
+/// consider creating a new instance of `SecureStorage` each time or reading
+/// directly from `FlutterSecureStorage`, avoiding reliance on the local cache.
 class SecureStorage {
   static const _kCoreUrlKey = 'core-url';
   static const _kTenantIdKey = 'tenant-id';

--- a/lib/data/secure_storage.dart
+++ b/lib/data/secure_storage.dart
@@ -11,7 +11,7 @@ class SecureStorage {
 
   static late SecureStorage _instance;
 
-  static Future<void> init() async {
+  static Future<SecureStorage> init() async {
     const storage = FlutterSecureStorage(
       iOptions: IOSOptions(
         accessibility: KeychainAccessibility.first_unlock,
@@ -26,6 +26,7 @@ class SecureStorage {
     }
 
     _instance = SecureStorage._(storage, cache);
+    return _instance;
   }
 
   factory SecureStorage() {

--- a/lib/data/session_cleanup_worker.dart
+++ b/lib/data/session_cleanup_worker.dart
@@ -11,9 +11,10 @@ final logger = Logger('SessionCleanupWorker');
 class SessionCleanupWorker {
   static late SessionCleanupWorker _instance;
 
-  static Future<void> init() async {
+  static Future<SessionCleanupWorker> init() async {
     final requestStorage = RequestStorage();
     _instance = SessionCleanupWorker._(requestStorage);
+    return _instance;
   }
 
   factory SessionCleanupWorker() {


### PR DESCRIPTION
This change simplifies singleton initialization by condensing the setup logic into a single line per instance.

 For example:

_appPreferences ??= await AppPreferences.init();
_appCertificates ??= await AppCertificates.init();

This ensures that the instances are initialized only once (if not already initialized) in a concise and readable manner.