### PR TITLE
refactor: move signaling parsing to utils

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -14,6 +14,7 @@ import 'package:logging/logging.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:ssl_certificates/ssl_certificates.dart';
 
@@ -501,7 +502,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
       if (emit.isDone) return;
 
-      final signalingUrl = _parseCoreUrlToSignalingUrl(coreUrl);
+      final signalingUrl = WebtritSignalingUtils.parseCoreUrlToSignalingUrl(coreUrl);
       final signalingClient = await WebtritSignalingClient.connect(
         signalingUrl,
         tenantId,
@@ -2378,15 +2379,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       await _appSound.stopOutgoingCall();
     } catch (e) {
       _logger.info('_ringtoneStop: $e');
-    }
-  }
-
-  Uri _parseCoreUrlToSignalingUrl(String coreUrl) {
-    final uri = Uri.parse(coreUrl);
-    if (uri.scheme.endsWith('s')) {
-      return uri.replace(scheme: 'wss');
-    } else {
-      return uri.replace(scheme: 'ws');
     }
   }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -7,3 +7,4 @@ export 'orientations.dart';
 export 'path_provider/path_provider.dart';
 export 'regexes.dart';
 export 'webtrit_api_client.dart';
+export 'webtrit_signaling_utils.dart';

--- a/lib/utils/webtrit_signaling_utils.dart
+++ b/lib/utils/webtrit_signaling_utils.dart
@@ -1,0 +1,8 @@
+class WebtritSignalingUtils {
+  WebtritSignalingUtils._();
+
+  static Uri parseCoreUrlToSignalingUrl(String coreUrl) {
+    final uri = Uri.parse(coreUrl);
+    return uri.replace(scheme: uri.scheme.endsWith('s') ? 'wss' : 'ws');
+  }
+}


### PR DESCRIPTION
The signaling parsing logic is currently used in two places, so it has been centralized to a single location for better maintainability. In the future, it might be beneficial to move this logic to the signaling package for even greater modularity.