### PR TITLE
feat: improve signaling info on call screen

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -12,6 +12,7 @@ class CallActiveScaffold extends StatefulWidget {
   const CallActiveScaffold({
     super.key,
     required this.speaker,
+    required this.callStatus,
     required this.activeCalls,
     required this.transferConfig,
     required this.localePlaceholderBuilder,
@@ -19,6 +20,7 @@ class CallActiveScaffold extends StatefulWidget {
   });
 
   final bool? speaker;
+  final CallStatus callStatus;
   final List<ActiveCall> activeCalls;
   final TransferConfig transferConfig;
   final WidgetBuilder? localePlaceholderBuilder;
@@ -165,6 +167,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                         acceptedTime: activeCall.acceptedTime,
                                         color: onTabGradient,
                                         activeCallStatus: activeCall.status,
+                                        callStatus: widget.callStatus,
                                       ),
                                     if (activeTransfer is AttendedTransferConfirmationRequested)
                                       CallInfo(
@@ -175,8 +178,10 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                         held: false,
                                         username: activeTransfer.referTo,
                                         color: onTabGradient,
+                                        callStatus: widget.callStatus,
                                       ),
                                     CallActions(
+                                      enableInteractions: widget.callStatus == CallStatus.ready,
                                       isIncoming: activeCall.isIncoming,
                                       video: activeCall.video,
                                       wasAccepted: activeCall.wasAccepted,

--- a/lib/features/call/view/call_screen.dart
+++ b/lib/features/call/view/call_screen.dart
@@ -67,6 +67,7 @@ class _CallScreenState extends State<CallScreen> with AutoRouteAwareStateMixin {
         if (state.isActive) {
           return CallActiveScaffold(
             speaker: state.speaker,
+            callStatus: state.status,
             activeCalls: state.activeCalls,
             transferConfig: widget.transferConfig,
             localePlaceholderBuilder: widget.localePlaceholderBuilder,

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -159,7 +159,8 @@ class _CallActionsState extends State<CallActions> {
     final onHeldChanged = widget.enableInteractions ? widget.onHeldChanged : null;
     final onSwapPressed = widget.enableInteractions ? widget.onSwapPressed : null;
     final onAcceptPressed = widget.enableInteractions ? widget.onAcceptPressed : null;
-    final onHangupPressed = widget.enableInteractions ? widget.onHangupPressed : null;
+    // Always allow the user to hang up the call
+    final onHangupPressed = widget.onHangupPressed;
     final onHangupAndAcceptPressed = widget.enableInteractions ? widget.onHangupAndAcceptPressed : null;
     final onKeyPressed = widget.enableInteractions ? widget.onKeyPressed : null;
     final onApproveTransferPressed = widget.enableInteractions ? widget.onApproveTransferPressed : null;

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -14,6 +14,7 @@ export 'call_actions_styles.dart';
 class CallActions extends StatefulWidget {
   const CallActions({
     super.key,
+    required this.enableInteractions,
     required this.isIncoming,
     required this.video,
     required this.wasAccepted,
@@ -42,6 +43,7 @@ class CallActions extends StatefulWidget {
     this.style,
   });
 
+  final bool enableInteractions;
   final bool isIncoming;
   final bool video;
   final bool wasAccepted;
@@ -147,22 +149,22 @@ class _CallActionsState extends State<CallActions> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
 
-    final onCameraChanged = widget.onCameraChanged;
-    final onMutedChanged = widget.onMutedChanged;
-    final speakerValue = widget.speakerValue;
-    final onSpeakerChanged = widget.onSpeakerChanged;
-    final onBlindTransferInitiated = widget.onBlindTransferInitiated;
-    final onAttendedTransferInitiated = widget.onAttendedTransferInitiated;
-    final onAttendedTransferSubmitted = widget.onAttendedTransferSubmitted;
-    final onHeldChanged = widget.onHeldChanged;
-    final onSwapPressed = widget.onSwapPressed;
-    final onAcceptPressed = widget.onAcceptPressed;
-    final onHangupPressed = widget.onHangupPressed;
-    final onHangupAndAcceptPressed = widget.onHangupAndAcceptPressed;
-    final onKeyPressed = widget.onKeyPressed;
-    final onApproveTransferPressed = widget.onApproveTransferPressed;
-    final onHoldAndAcceptPressed = widget.onHoldAndAcceptPressed;
-    final onDeclineTransferPressed = widget.onDeclineTransferPressed;
+    final onCameraChanged = widget.enableInteractions ? widget.onCameraChanged : null;
+    final onMutedChanged = widget.enableInteractions ? widget.onMutedChanged : null;
+    final speakerValue = widget.enableInteractions ? widget.speakerValue : null;
+    final onSpeakerChanged = widget.enableInteractions ? widget.onSpeakerChanged : null;
+    final onBlindTransferInitiated = widget.enableInteractions ? widget.onBlindTransferInitiated : null;
+    final onAttendedTransferInitiated = widget.enableInteractions ? widget.onAttendedTransferInitiated : null;
+    final onAttendedTransferSubmitted = widget.enableInteractions ? widget.onAttendedTransferSubmitted : null;
+    final onHeldChanged = widget.enableInteractions ? widget.onHeldChanged : null;
+    final onSwapPressed = widget.enableInteractions ? widget.onSwapPressed : null;
+    final onAcceptPressed = widget.enableInteractions ? widget.onAcceptPressed : null;
+    final onHangupPressed = widget.enableInteractions ? widget.onHangupPressed : null;
+    final onHangupAndAcceptPressed = widget.enableInteractions ? widget.onHangupAndAcceptPressed : null;
+    final onKeyPressed = widget.enableInteractions ? widget.onKeyPressed : null;
+    final onApproveTransferPressed = widget.enableInteractions ? widget.onApproveTransferPressed : null;
+    final onHoldAndAcceptPressed = widget.enableInteractions ? widget.onHoldAndAcceptPressed : null;
+    final onDeclineTransferPressed = widget.enableInteractions ? widget.onDeclineTransferPressed : null;
 
     final style = CallActionsStyle.merge(widget.style, Theme.of(context).extension<CallActionsStyles>()?.primary);
 

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -156,6 +156,13 @@ class _CallActionsState extends State<CallActions> {
     final onAttendedTransferSubmitted = widget.onAttendedTransferSubmitted;
     final onHeldChanged = widget.onHeldChanged;
     final onSwapPressed = widget.onSwapPressed;
+    final onAcceptPressed = widget.onAcceptPressed;
+    final onHangupPressed = widget.onHangupPressed;
+    final onHangupAndAcceptPressed = widget.onHangupAndAcceptPressed;
+    final onKeyPressed = widget.onKeyPressed;
+    final onApproveTransferPressed = widget.onApproveTransferPressed;
+    final onHoldAndAcceptPressed = widget.onHoldAndAcceptPressed;
+    final onDeclineTransferPressed = widget.onDeclineTransferPressed;
 
     final style = CallActionsStyle.merge(widget.style, Theme.of(context).extension<CallActionsStyles>()?.primary);
 
@@ -170,7 +177,7 @@ class _CallActionsState extends State<CallActions> {
                   ? context.l10n.call_CallActionsTooltip_decline_inviteToAttendedTransfer
                   : context.l10n.call_CallActionsTooltip_hangup,
               child: TextButton(
-                onPressed: widget.onHangupPressed,
+                onPressed: onHangupPressed,
                 style: style.hangup,
                 child: const Icon(Icons.call_end),
               ),
@@ -181,7 +188,7 @@ class _CallActionsState extends State<CallActions> {
                   ? context.l10n.call_CallActionsTooltip_accept_inviteToAttendedTransfer
                   : context.l10n.call_CallActionsTooltip_accept,
               child: TextButton(
-                onPressed: widget.onAcceptPressed,
+                onPressed: onAcceptPressed,
                 style: style.callStart,
                 child: Icon(widget.video ? Icons.videocam : Icons.call),
               ),
@@ -195,7 +202,7 @@ class _CallActionsState extends State<CallActions> {
             Tooltip(
               message: context.l10n.call_CallActionsTooltip_hangupAndAccept,
               child: TextButton(
-                onPressed: widget.onHangupAndAcceptPressed,
+                onPressed: onHangupAndAcceptPressed,
                 style: style.callStart,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
@@ -209,7 +216,7 @@ class _CallActionsState extends State<CallActions> {
             Tooltip(
               message: context.l10n.call_CallActionsTooltip_hangup,
               child: TextButton(
-                onPressed: widget.onHangupPressed,
+                onPressed: onHangupPressed,
                 style: style.hangup,
                 child: const Icon(Icons.call_end),
               ),
@@ -217,7 +224,7 @@ class _CallActionsState extends State<CallActions> {
             Tooltip(
               message: context.l10n.call_CallActionsTooltip_holdAndAccept,
               child: TextButton(
-                onPressed: widget.onHoldAndAcceptPressed,
+                onPressed: onHoldAndAcceptPressed,
                 style: style.callStart,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
@@ -231,14 +238,14 @@ class _CallActionsState extends State<CallActions> {
           ],
         );
       }
-    } else if (widget.onApproveTransferPressed != null || widget.onDeclineTransferPressed != null) {
+    } else if (onApproveTransferPressed != null || onDeclineTransferPressed != null) {
       buttonsTable = TextButtonsTable(
         minimumSize: Size.square(_dimension),
         children: [
           Tooltip(
             message: context.l10n.call_CallActionsTooltip_hangup,
             child: TextButton(
-              onPressed: widget.onDeclineTransferPressed,
+              onPressed: onDeclineTransferPressed,
               style: style.hangup,
               child: const Icon(Icons.call_end),
             ),
@@ -247,7 +254,7 @@ class _CallActionsState extends State<CallActions> {
           Tooltip(
             message: context.l10n.call_CallActionsTooltip_accept,
             child: TextButton(
-              onPressed: widget.onApproveTransferPressed,
+              onPressed: onApproveTransferPressed,
               style: style.callStart,
               child: const Icon(Icons.phone_forwarded),
             ),
@@ -274,7 +281,7 @@ class _CallActionsState extends State<CallActions> {
                     _keypadTextFieldEditableTextState?.userUpdateTextEditingValue(
                         value, SelectionChangedCause.keyboard);
 
-                    widget.onKeyPressed!(key);
+                    onKeyPressed!(key);
                   },
                   style: style.key,
                 ),
@@ -429,7 +436,7 @@ class _CallActionsState extends State<CallActions> {
           Tooltip(
             message: context.l10n.call_CallActionsTooltip_showKeypad,
             child: TextButton(
-              onPressed: widget.onKeyPressed == null || !_isOrientationPortrait
+              onPressed: onKeyPressed == null || !_isOrientationPortrait
                   ? null
                   : () {
                       setState(() {
@@ -458,7 +465,7 @@ class _CallActionsState extends State<CallActions> {
           Tooltip(
             message: context.l10n.call_CallActionsTooltip_hangup,
             child: TextButton(
-              onPressed: widget.onHangupPressed,
+              onPressed: onHangupPressed,
               style: style.hangup,
               child: const Icon(Icons.call_end),
             ),

--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -22,6 +22,7 @@ class CallInfo extends StatefulWidget {
     this.acceptedTime,
     this.color,
     this.activeCallStatus,
+    required this.callStatus,
   });
 
   final bool transfering;
@@ -33,6 +34,9 @@ class CallInfo extends StatefulWidget {
   final DateTime? acceptedTime;
   final Color? color;
   final ActiveCallStatus? activeCallStatus;
+
+// TODO(Serdun): Rename class to better represent the actual data it holds
+  final CallStatus callStatus;
 
   @override
   State<CallInfo> createState() => _CallInfoState();
@@ -97,7 +101,9 @@ class _CallInfoState extends State<CallInfo> {
     final statusStyle = textTheme.labelLarge!.copyWith(color: themeData.colorScheme.surface);
 
     final String statusMessage;
-    if (duration == null) {
+    if (widget.callStatus != CallStatus.ready) {
+      statusMessage = widget.callStatus.l10n(context);
+    } else if (duration == null) {
       if (widget.inviteToAttendedTransfer) {
         statusMessage = context.l10n.call_description_inviteToAttendedTransfer;
       } else if (widget.requestToAttendedTransfer) {


### PR DESCRIPTION
When the signaling has not been initialized or encounters an issue, we should disable interaction with the action button and display an appropriate status.