### PR TITLE
fix: handle trailing slash in tenantUrl to prevent duplicate path segments

### DIFF
--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -22,7 +22,7 @@ class WebtritApiClient {
     if (tenantId.isEmpty) {
       return baseUrl;
     } else {
-      final baseUrlPathSegments = List.of(baseUrl.pathSegments);
+      final baseUrlPathSegments = List.of(baseUrl.pathSegments.where((segment) => segment.isNotEmpty));
       if (baseUrlPathSegments.length >= 2 && baseUrlPathSegments[baseUrlPathSegments.length - 2] == 'tenant') {
         baseUrlPathSegments.removeRange(baseUrlPathSegments.length - 2, baseUrlPathSegments.length);
       }
@@ -77,7 +77,7 @@ class WebtritApiClient {
   }) async {
     final url = tenantUrl.replace(
       pathSegments: [
-        ...tenantUrl.pathSegments,
+        ...tenantUrl.pathSegments.where((segment) => segment.isNotEmpty),
         'api',
         'v1',
         ...pathSegments,

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -29,7 +29,7 @@ class WebtritSignalingClient {
     if (tenantId.isEmpty) {
       return baseUrl;
     } else {
-      final baseUrlPathSegments = List.of(baseUrl.pathSegments);
+      final baseUrlPathSegments = List.of(baseUrl.pathSegments.where((segment) => segment.isNotEmpty));
       if (baseUrlPathSegments.length >= 2 && baseUrlPathSegments[baseUrlPathSegments.length - 2] == 'tenant') {
         baseUrlPathSegments.removeRange(baseUrlPathSegments.length - 2, baseUrlPathSegments.length);
       }


### PR DESCRIPTION
This pull request addresses an issue where a trailing slash (/) in the tenantUrl caused duplicate path segments in the generated URLs. The problem arose due to the inclusion of an empty string in the pathSegments list, leading to incorrect URL reconstruction.

What’s Changed

	•	Updated the buildTenantUrl method to filter out empty segments from baseUrl.pathSegments using where((segment) => segment.isNotEmpty).
	•	Ensured that removeRange correctly removes the tenant and tenantId segments without duplication.
	•	Improved URL reconstruction to handle both scenarios (with and without a trailing slash).

What Happens Without This Fix

If the tenantUrl contains a trailing slash, the following issues occur:
	•	The pathSegments includes an empty string ('') at the end, which disrupts the logic for removing existing segments.
	•	This results in duplicate segments when reconstructing the URL.

For example:
	•	Input: https://core.demo.webtrit.com/tenant/002e100a4-879c-45ec-bd05-20eb54736322/
	•	Without Fix: https://core.demo.webtrit.com/tenant/002e100a4-879c-45ec-bd05-20eb54736322/tenant/002e100a4-879c-45ec-bd05-20eb54736322/api/v1/system-info
	•	With Fix: https://core.demo.webtrit.com/tenant/002e100a4-879c-45ec-bd05-20eb54736322/api/v1/system-info

How It Works

	1.	Filters out empty segments from pathSegments caused by trailing slashes.
	2.	Prevents duplicate tenant and tenantId segments by correctly removing them before appending new values.
	3.	Ensures consistency in generated URLs for both cases.

Impact

This fix ensures consistent and accurate URL generation across the application, resolving issues with redundant path segments in HTTP requests.