### PR TITLE
refactor: remove web view controller parameter from WebViewScaffold

### DIFF
--- a/lib/features/login/features/login_embedded/view/login_embedded_screen.dart
+++ b/lib/features/login/features/login_embedded/view/login_embedded_screen.dart
@@ -41,7 +41,7 @@ class LoginEmbeddedScreen extends StatelessWidget {
               _loginJavascriptChannelName: (JavaScriptMessage message) =>
                   context.read<LoginEmbeddedCubit>().login(message.message),
             },
-            errorPlaceholder: (context, error, controller) => Column(
+            errorBuilder: (context, error, controller) => Column(
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [

--- a/lib/widgets/webview_scaffold.dart
+++ b/lib/widgets/webview_scaffold.dart
@@ -22,7 +22,7 @@ class WebViewScaffold extends StatefulWidget {
     required this.initialUri,
     this.addLocaleNameToQueryParameters = true,
     this.javaScriptChannels = const {},
-    this.errorPlaceholder,
+    this.errorBuilder,
     this.showToolbar = true,
     this.builder,
   });
@@ -31,8 +31,8 @@ class WebViewScaffold extends StatefulWidget {
   final Uri initialUri;
   final bool addLocaleNameToQueryParameters;
   final Map<String, void Function(JavaScriptMessage)> javaScriptChannels;
-  final Widget? Function(BuildContext context, WebResourceError error, WebViewController controller)? errorPlaceholder;
   final bool showToolbar;
+  final Widget? Function(BuildContext context, WebResourceError error, WebViewController controller)? errorBuilder;
   final TransitionBuilder? builder;
 
   @override
@@ -163,10 +163,10 @@ class _WebViewScaffoldState extends State<WebViewScaffold> {
           : null,
       body: Builder(
         builder: (context) {
-          final hasWebViewError = widget.errorPlaceholder != null && _latestError != null;
+          final hasWebViewError = widget.errorBuilder != null && _latestError != null;
 
           final errorPlaceholderBuilder = Builder(builder: (context) {
-            return widget.errorPlaceholder!(context, _latestError!, _webViewController) ?? const SizedBox.shrink();
+            return widget.errorBuilder!(context, _latestError!, _webViewController) ?? const SizedBox.shrink();
           });
 
           final successBuilder = Builder(builder: (context) {

--- a/lib/widgets/webview_scaffold.dart
+++ b/lib/widgets/webview_scaffold.dart
@@ -24,7 +24,6 @@ class WebViewScaffold extends StatefulWidget {
     this.javaScriptChannels = const {},
     this.errorPlaceholder,
     this.showToolbar = true,
-    this.controller,
     this.builder,
   });
 
@@ -34,7 +33,6 @@ class WebViewScaffold extends StatefulWidget {
   final Map<String, void Function(JavaScriptMessage)> javaScriptChannels;
   final Widget? Function(BuildContext context, WebResourceError error, WebViewController controller)? errorPlaceholder;
   final bool showToolbar;
-  final WebViewController? controller;
   final TransitionBuilder? builder;
 
   @override
@@ -68,7 +66,7 @@ class _WebViewScaffoldState extends State<WebViewScaffold> {
   void initState() {
     super.initState();
 
-    _webViewController = widget.controller ?? WebViewController();
+    _webViewController = WebViewController();
 
     final userAgent = '${PackageInfo().appName}/${PackageInfo().version} '
         '(${Platform.operatingSystem}; ${Platform.operatingSystemVersion})';


### PR DESCRIPTION
Removed WebViewController from optional parameters to prevent breaking widget logic and reduce responsibility spreading