### PR TITLE
feat: extend Logzio appender to enable ignoring specific logs

### DIFF
--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -1,5 +1,7 @@
 export 'anonymizing_formatter.dart';
 export 'callkeep_logs.dart';
+export 'filtered_logz_io_appender.dart';
 export 'isolate_database.dart';
 export 'remote_formatter.dart';
+export 'remote_log_filter.dart';
 export 'signaling_manager.dart';

--- a/lib/common/filtered_logz_io_appender.dart
+++ b/lib/common/filtered_logz_io_appender.dart
@@ -1,0 +1,21 @@
+import 'package:logging/logging.dart';
+import 'package:logging_appenders/logging_appenders.dart';
+
+import 'remote_log_filter.dart';
+
+class FilteredLogzIoAppender extends LogzIoApiAppender {
+  FilteredLogzIoAppender({
+    required LogRecordFormatter super.formatter,
+    required super.url,
+    required super.apiToken,
+    super.bufferSize,
+    super.labels = const {},
+  });
+
+  @override
+  void handle(LogRecord record) {
+    if (RemoteLogFilter.shouldLog(record)) {
+      super.handle(record);
+    }
+  }
+}

--- a/lib/common/remote_log_filter.dart
+++ b/lib/common/remote_log_filter.dart
@@ -1,0 +1,24 @@
+import 'package:logging/logging.dart';
+import 'package:dio/dio.dart' show DioException, DioExceptionType;
+
+class RemoteLogFilter {
+  static const List<String> ignoredHosts = [
+    'listener.logz.io',
+  ];
+
+  static bool shouldLog(LogRecord record) {
+    if (record.error == null) return true;
+
+    if (record.error is! DioException) return true;
+
+    final dioError = record.error as DioException;
+
+    // Skip adding spam logs to the buffer if there is no internet connection for the specified hosts
+    if ((dioError.type == DioExceptionType.connectionTimeout || dioError.type == DioExceptionType.connectionError) &&
+        ignoredHosts.any((host) => dioError.toString().contains(host))) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -31,7 +31,7 @@ class AppLogger {
         wrappedFormatter: const RemoteFormatter(),
       );
 
-      LogzIoApiAppender(
+      FilteredLogzIoAppender(
         formatter: remoteFormatter,
         url: remoteLogzIOLoggingUrl,
         apiToken: remoteLogzIOLoggingToken,


### PR DESCRIPTION
Added functionality to the Logzio client to ignore specific logs, such as exceptions emitted in common logs when there is no internet connection. This enhancement prevents unnecessary noise in logs and improves log management during connectivity issues.