### PR TITLE
feat: enable use of app session identifier in remote logging system

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -46,7 +46,7 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
       };
 
       // Initialization order is crucial for proper app setup
-      await AppInfo.init();
+      await AppInfo.init(FirebaseAppIdProvider());
       await DeviceInfo.init();
       await PackageInfo.init();
       await AppLogger.init();
@@ -135,6 +135,7 @@ Future<void> _initFirebaseMessaging() async {
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   // Initialize the logger for handling Firebase Cloud Messaging (FCM) in the background isolate.
+  await AppInfo.init(const SharedPreferencesAppIdProvider());
   await DeviceInfo.init();
   await PackageInfo.init();
   await AppLogger.init();

--- a/lib/common/app_id_provider.dart
+++ b/lib/common/app_id_provider.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:firebase_app_installations/firebase_app_installations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:logging/logging.dart';
+
+const _appIdKey = 'app_id_key';
+
+final Logger _logger = Logger('AppIdProvider');
+
+abstract class AppIdProvider {
+  Future<String> getId();
+
+  Stream<String> get onIdChange;
+}
+
+class FirebaseAppIdProvider implements AppIdProvider {
+  final _idChangeController = StreamController<String>.broadcast();
+
+  FirebaseAppIdProvider() {
+    _initializeIdListener();
+  }
+
+  @override
+  Future<String> getId() async {
+    try {
+      final id = await FirebaseInstallations.instance.getId();
+      await _saveIdToSharedPreferences(id);
+      return id;
+    } catch (e) {
+      _logger.severe('Firebase ID fetch failed: $e');
+      return _generateFallbackId();
+    }
+  }
+
+  @override
+  Stream<String> get onIdChange => _idChangeController.stream;
+
+  void _initializeIdListener() {
+    FirebaseInstallations.instance.onIdChange.listen((id) async {
+      await _saveIdToSharedPreferences(id);
+      _idChangeController.add(id);
+      _logger.info('Firebase ID changed: $id');
+    });
+  }
+
+  Future<void> _saveIdToSharedPreferences(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_appIdKey, id);
+  }
+
+  Future<String> _generateFallbackId() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    final newId = _generateRandomId();
+    await prefs.setString(_appIdKey, newId);
+    _logger.info('Generated fallback ID: $newId');
+    return newId;
+  }
+
+  String _generateRandomId([int length = 32]) {
+    final random = Random();
+    return String.fromCharCodes(List.generate(length, (index) => random.nextInt(26) + 97));
+  }
+
+  void dispose() {
+    _idChangeController.close();
+  }
+}
+
+class SharedPreferencesAppIdProvider implements AppIdProvider {
+  const SharedPreferencesAppIdProvider();
+
+  @override
+  Future<String> getId() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.getString(_appIdKey) ?? 'Undefine';
+    } catch (e) {
+      _logger.severe(e);
+      return 'Undefine';
+    }
+  }
+
+  @override
+  Stream<String> get onIdChange => const Stream.empty();
+}

--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -1,4 +1,5 @@
 export 'anonymizing_formatter.dart';
+export 'app_id_provider.dart';
 export 'callkeep_logs.dart';
 export 'filtered_logz_io_appender.dart';
 export 'isolate_database.dart';

--- a/lib/data/app_info.dart
+++ b/lib/data/app_info.dart
@@ -1,21 +1,21 @@
 import 'package:flutter/services.dart' as services;
 
-import 'package:firebase_app_installations/firebase_app_installations.dart';
 import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/app/assets.gen.dart';
+import 'package:webtrit_phone/common/common.dart';
 
 final Logger _logger = Logger('AppInfo');
 
 class AppInfo {
   static late AppInfo _instance;
 
-  static Future<AppInfo> init() async {
-    final id = await FirebaseInstallations.instance.getId();
+  static Future<AppInfo> init(AppIdProvider appIdProvider) async {
+    final id = await appIdProvider.getId();
 
     String? appVersion = await getAppVersion();
 
-    _instance = AppInfo._(id, appVersion);
+    _instance = AppInfo._(appIdProvider, id, appVersion);
     return _instance;
   }
 
@@ -34,11 +34,13 @@ class AppInfo {
     return _instance;
   }
 
-  AppInfo._(this._identifier, this._appVersion) {
-    FirebaseInstallations.instance.onIdChange.listen((String id) {
+  AppInfo._(this.appInfo, this._identifier, this._appVersion) {
+    appInfo.onIdChange.listen((String id) {
       _identifier = id;
     });
   }
+
+  AppIdProvider appInfo;
 
   String _identifier;
 

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -50,14 +50,11 @@ class AppLogger {
   static Future<Map<String, String>> _prepareRemoteLabels() async {
     final packageInfo = PackageInfo();
     final deviceInfo = DeviceInfo();
-
-    // TODO(Serdun): Use getAppVersion directly to avoid initializing Firebase inside isolates,
-    // as AppInfo depends on Firebase.
-    final appVersion = await AppInfo.getAppVersion() ?? 'Undefine';
+    final appInfo = AppInfo();
 
     return <String, String>{
       'app': packageInfo.appName,
-      'appVersion': appVersion,
+      'appVersion': appInfo.version,
       'storeVersion': packageInfo.version,
       'packageName': packageInfo.packageName,
       'buildNumber': packageInfo.buildNumber,

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -55,6 +55,7 @@ class AppLogger {
     return <String, String>{
       'app': packageInfo.appName,
       'appVersion': appInfo.version,
+      'appSessionIdentifier': appInfo.identifier,
       'storeVersion': packageInfo.version,
       'packageName': packageInfo.packageName,
       'buildNumber': packageInfo.buildNumber,

--- a/lib/features/call/services/background_call_isolate.dart
+++ b/lib/features/call/services/background_call_isolate.dart
@@ -2,6 +2,7 @@ import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
 import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
 import 'background_call_event_service.dart';
@@ -16,10 +17,12 @@ AppLogger? _appLogger;
 AppPreferences? _appPreferences;
 SecureStorage? _secureStorage;
 AppCertificates? _appCertificates;
+AppInfo? _appInfo;
 
 CallLogsRepository? _callLogsRepository;
 
 Future<void> _initializeDependencies() async {
+  _appInfo ??= await AppInfo.init(const SharedPreferencesAppIdProvider());
   _deviceInfo ??= await DeviceInfo.init();
   _packageInfo ??= await PackageInfo.init();
   _appLogger ??= await AppLogger.init();

--- a/lib/features/settings/features/about/bloc/about_bloc.dart
+++ b/lib/features/settings/features/about/bloc/about_bloc.dart
@@ -29,6 +29,7 @@ class AboutBloc extends Bloc<AboutEvent, AboutState> {
           storeBuildVersion: packageInfo.version,
           storeBuildNumber: packageInfo.buildNumber,
           appVersion: appInfo.version,
+          appIdentifier: appInfo.identifier,
           fcmPushToken: secureStorage.readFCMPushToken(),
           coreUrl: infoRepository.coreUrl,
         )) {

--- a/lib/features/settings/features/about/bloc/about_bloc.freezed.dart
+++ b/lib/features/settings/features/about/bloc/about_bloc.freezed.dart
@@ -49,6 +49,7 @@ mixin _$AboutState {
   String get storeBuildVersion => throw _privateConstructorUsedError;
   String get storeBuildNumber => throw _privateConstructorUsedError;
   String get appVersion => throw _privateConstructorUsedError;
+  String get appIdentifier => throw _privateConstructorUsedError;
   Uri get coreUrl => throw _privateConstructorUsedError;
   String? get fcmPushToken => throw _privateConstructorUsedError;
   Version? get coreVersion => throw _privateConstructorUsedError;
@@ -73,6 +74,7 @@ abstract class $AboutStateCopyWith<$Res> {
       String storeBuildVersion,
       String storeBuildNumber,
       String appVersion,
+      String appIdentifier,
       Uri coreUrl,
       String? fcmPushToken,
       Version? coreVersion});
@@ -99,6 +101,7 @@ class _$AboutStateCopyWithImpl<$Res, $Val extends AboutState>
     Object? storeBuildVersion = null,
     Object? storeBuildNumber = null,
     Object? appVersion = null,
+    Object? appIdentifier = null,
     Object? coreUrl = null,
     Object? fcmPushToken = freezed,
     Object? coreVersion = freezed,
@@ -127,6 +130,10 @@ class _$AboutStateCopyWithImpl<$Res, $Val extends AboutState>
       appVersion: null == appVersion
           ? _value.appVersion
           : appVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+      appIdentifier: null == appIdentifier
+          ? _value.appIdentifier
+          : appIdentifier // ignore: cast_nullable_to_non_nullable
               as String,
       coreUrl: null == coreUrl
           ? _value.coreUrl
@@ -159,6 +166,7 @@ abstract class _$$AboutStateImplCopyWith<$Res>
       String storeBuildVersion,
       String storeBuildNumber,
       String appVersion,
+      String appIdentifier,
       Uri coreUrl,
       String? fcmPushToken,
       Version? coreVersion});
@@ -183,6 +191,7 @@ class __$$AboutStateImplCopyWithImpl<$Res>
     Object? storeBuildVersion = null,
     Object? storeBuildNumber = null,
     Object? appVersion = null,
+    Object? appIdentifier = null,
     Object? coreUrl = null,
     Object? fcmPushToken = freezed,
     Object? coreVersion = freezed,
@@ -212,6 +221,10 @@ class __$$AboutStateImplCopyWithImpl<$Res>
           ? _value.appVersion
           : appVersion // ignore: cast_nullable_to_non_nullable
               as String,
+      appIdentifier: null == appIdentifier
+          ? _value.appIdentifier
+          : appIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
       coreUrl: null == coreUrl
           ? _value.coreUrl
           : coreUrl // ignore: cast_nullable_to_non_nullable
@@ -238,6 +251,7 @@ class _$AboutStateImpl extends _AboutState {
       required this.storeBuildVersion,
       required this.storeBuildNumber,
       required this.appVersion,
+      required this.appIdentifier,
       required this.coreUrl,
       this.fcmPushToken,
       this.coreVersion})
@@ -257,6 +271,8 @@ class _$AboutStateImpl extends _AboutState {
   @override
   final String appVersion;
   @override
+  final String appIdentifier;
+  @override
   final Uri coreUrl;
   @override
   final String? fcmPushToken;
@@ -265,7 +281,7 @@ class _$AboutStateImpl extends _AboutState {
 
   @override
   String toString() {
-    return 'AboutState(progress: $progress, appName: $appName, packageName: $packageName, storeBuildVersion: $storeBuildVersion, storeBuildNumber: $storeBuildNumber, appVersion: $appVersion, coreUrl: $coreUrl, fcmPushToken: $fcmPushToken, coreVersion: $coreVersion)';
+    return 'AboutState(progress: $progress, appName: $appName, packageName: $packageName, storeBuildVersion: $storeBuildVersion, storeBuildNumber: $storeBuildNumber, appVersion: $appVersion, appIdentifier: $appIdentifier, coreUrl: $coreUrl, fcmPushToken: $fcmPushToken, coreVersion: $coreVersion)';
   }
 
   @override
@@ -284,6 +300,8 @@ class _$AboutStateImpl extends _AboutState {
                 other.storeBuildNumber == storeBuildNumber) &&
             (identical(other.appVersion, appVersion) ||
                 other.appVersion == appVersion) &&
+            (identical(other.appIdentifier, appIdentifier) ||
+                other.appIdentifier == appIdentifier) &&
             (identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl) &&
             (identical(other.fcmPushToken, fcmPushToken) ||
                 other.fcmPushToken == fcmPushToken) &&
@@ -300,6 +318,7 @@ class _$AboutStateImpl extends _AboutState {
       storeBuildVersion,
       storeBuildNumber,
       appVersion,
+      appIdentifier,
       coreUrl,
       fcmPushToken,
       coreVersion);
@@ -321,6 +340,7 @@ abstract class _AboutState extends AboutState {
       required final String storeBuildVersion,
       required final String storeBuildNumber,
       required final String appVersion,
+      required final String appIdentifier,
       required final Uri coreUrl,
       final String? fcmPushToken,
       final Version? coreVersion}) = _$AboutStateImpl;
@@ -338,6 +358,8 @@ abstract class _AboutState extends AboutState {
   String get storeBuildNumber;
   @override
   String get appVersion;
+  @override
+  String get appIdentifier;
   @override
   Uri get coreUrl;
   @override

--- a/lib/features/settings/features/about/bloc/about_state.dart
+++ b/lib/features/settings/features/about/bloc/about_state.dart
@@ -11,6 +11,7 @@ class AboutState with _$AboutState {
     required String storeBuildVersion,
     required String storeBuildNumber,
     required String appVersion,
+    required String appIdentifier,
     required Uri coreUrl,
     String? fcmPushToken,
     Version? coreVersion,

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -76,6 +76,24 @@ class AboutScreen extends StatelessWidget {
                     height: delimiterHeight,
                   ),
                   CopyToClipboard(
+                    data: state.appIdentifier,
+                    child: Text(
+                      context.l10n.settings_AboutText_AppSessionIdentifier,
+                    ),
+                  ),
+                  CopyToClipboard(
+                    data: state.appIdentifier,
+                    child: Text(
+                      state.appIdentifier ?? '-',
+                      style: themeData.textTheme.labelSmall,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  SizedBox(
+                    height: delimiterHeight,
+                  ),
+                  CopyToClipboard(
                     data: state.fcmPushToken,
                     child: Text(
                       context.l10n.settings_AboutText_FCMPushNotificationToken,

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1861,6 +1861,12 @@ abstract class AppLocalizations {
   /// **'FCM Push Notification Token'**
   String get settings_AboutText_FCMPushNotificationToken;
 
+  /// No description provided for @settings_AboutText_AppSessionIdentifier.
+  ///
+  /// In en, this message translates to:
+  /// **'Application session identifier'**
+  String get settings_AboutText_AppSessionIdentifier;
+
   /// No description provided for @settings_AccountDeleteConfirmDialog_content.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -733,6 +733,74 @@ class AppLocalizationsMapper {
           localizations.diagnostic_battery_tile_title,
       'diagnostic_battery_navigate_section':
           localizations.diagnostic_battery_navigate_section,
+      'signalingResponseCodeType_unauthorized':
+          localizations.signalingResponseCodeType_unauthorized,
+      'signalingResponseCodeType_unknown':
+          localizations.signalingResponseCodeType_unknown,
+      'signalingResponseCodeType_transport':
+          localizations.signalingResponseCodeType_transport,
+      'signalingResponseCodeType_request':
+          localizations.signalingResponseCodeType_request,
+      'signalingResponseCodeType_session':
+          localizations.signalingResponseCodeType_session,
+      'signalingResponseCodeType_plugin':
+          localizations.signalingResponseCodeType_plugin,
+      'signalingResponseCodeType_webrtc':
+          localizations.signalingResponseCodeType_webrtc,
+      'signalingResponseCodeType_token':
+          localizations.signalingResponseCodeType_token,
+      'signalingResponseCode_unauthorizedRequest':
+          localizations.signalingResponseCode_unauthorizedRequest,
+      'signalingResponseCode_unauthorizedAccess':
+          localizations.signalingResponseCode_unauthorizedAccess,
+      'signalingResponseCode_unknownError':
+          localizations.signalingResponseCode_unknownError,
+      'signalingResponseCode_transportSpecificError':
+          localizations.signalingResponseCode_transportSpecificError,
+      'signalingResponseCode_missingRequest':
+          localizations.signalingResponseCode_missingRequest,
+      'signalingResponseCode_unknownRequest':
+          localizations.signalingResponseCode_unknownRequest,
+      'signalingResponseCode_invalidJson':
+          localizations.signalingResponseCode_invalidJson,
+      'signalingResponseCode_invalidJsonObject':
+          localizations.signalingResponseCode_invalidJsonObject,
+      'signalingResponseCode_missingMandatoryElement':
+          localizations.signalingResponseCode_missingMandatoryElement,
+      'signalingResponseCode_invalidPath':
+          localizations.signalingResponseCode_invalidPath,
+      'signalingResponseCode_sessionNotFound':
+          localizations.signalingResponseCode_sessionNotFound,
+      'signalingResponseCode_handleNotFound':
+          localizations.signalingResponseCode_handleNotFound,
+      'signalingResponseCode_pluginNotFound':
+          localizations.signalingResponseCode_pluginNotFound,
+      'signalingResponseCode_errorAttachingPlugin':
+          localizations.signalingResponseCode_errorAttachingPlugin,
+      'signalingResponseCode_errorSendingMessage':
+          localizations.signalingResponseCode_errorSendingMessage,
+      'signalingResponseCode_errorDetachingPlugin':
+          localizations.signalingResponseCode_errorDetachingPlugin,
+      'signalingResponseCode_unsupportedJsepType':
+          localizations.signalingResponseCode_unsupportedJsepType,
+      'signalingResponseCode_invalidSdp':
+          localizations.signalingResponseCode_invalidSdp,
+      'signalingResponseCode_invalidStream':
+          localizations.signalingResponseCode_invalidStream,
+      'signalingResponseCode_invalidElementType':
+          localizations.signalingResponseCode_invalidElementType,
+      'signalingResponseCode_sessionIdInUse':
+          localizations.signalingResponseCode_sessionIdInUse,
+      'signalingResponseCode_unexpectedAnswer':
+          localizations.signalingResponseCode_unexpectedAnswer,
+      'signalingResponseCode_tokenNotFound':
+          localizations.signalingResponseCode_tokenNotFound,
+      'signalingResponseCode_wrongWebrtcState':
+          localizations.signalingResponseCode_wrongWebrtcState,
+      'signalingResponseCode_notAcceptingNewSessions':
+          localizations.signalingResponseCode_notAcceptingNewSessions,
+      'signalingResponseCode_notFoundRoutesInReplyFromBE':
+          localizations.signalingResponseCode_notFoundRoutesInReplyFromBE,
       'favorites_SnackBar_deleted': (name) =>
           localizations.favorites_SnackBar_deleted(name),
       'login_Button_otpSigninVerifyRepeatInterval': (seconds) =>

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -925,6 +925,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_AboutText_FCMPushNotificationToken => 'FCM Push Notification Token';
 
   @override
+  String get settings_AboutText_AppSessionIdentifier => 'Application session identifier';
+
+  @override
   String get settings_AccountDeleteConfirmDialog_content => 'Are you sure you want to delete account?';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -925,6 +925,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_AboutText_FCMPushNotificationToken => 'Token di Notifica Push FCM';
 
   @override
+  String get settings_AboutText_AppSessionIdentifier => 'Identificatore della sessione dell\'applicazione';
+
+  @override
   String get settings_AccountDeleteConfirmDialog_content => 'Sei sicuro di voler eliminare l\'account?';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -925,6 +925,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settings_AboutText_FCMPushNotificationToken => 'Токен для Push-повідомлень FCM';
 
   @override
+  String get settings_AboutText_AppSessionIdentifier => 'Ідентифікатор сесії застосунку';
+
+  @override
   String get settings_AccountDeleteConfirmDialog_content => 'Ви впевнені, що хочете видалити обліковий запис?';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -669,6 +669,8 @@
   "@settings_AboutText_StoreVersion": {},
   "settings_AboutText_FCMPushNotificationToken": "FCM Push Notification Token",
   "@settings_AboutText_FCMPushNotificationToken": {},
+  "settings_AboutText_AppSessionIdentifier": "Application session identifier",
+  "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AccountDeleteConfirmDialog_content": "Are you sure you want to delete account?",
   "@settings_AccountDeleteConfirmDialog_content": {},
   "settings_AccountDeleteConfirmDialog_title": "Confirm delete account",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -669,6 +669,8 @@
   "@settings_AboutText_StoreVersion": {},
   "settings_AboutText_FCMPushNotificationToken": "Token di Notifica Push FCM",
   "@settings_AboutText_FCMPushNotificationToken": {},
+  "settings_AboutText_AppSessionIdentifier": "Identificatore della sessione dell'applicazione",
+  "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AccountDeleteConfirmDialog_content": "Sei sicuro di voler eliminare l'account?",
   "@settings_AccountDeleteConfirmDialog_content": {},
   "settings_AccountDeleteConfirmDialog_title": "Conferma eliminazione account",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -669,6 +669,8 @@
   "@settings_AboutText_StoreVersion": {},
   "settings_AboutText_FCMPushNotificationToken": "Токен для Push-повідомлень FCM",
   "@settings_AboutText_FCMPushNotificationToken": {},
+  "settings_AboutText_AppSessionIdentifier": "Ідентифікатор сесії застосунку",
+  "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AccountDeleteConfirmDialog_content": "Ви впевнені, що хочете видалити обліковий запис?",
   "@settings_AccountDeleteConfirmDialog_content": {},
   "settings_AccountDeleteConfirmDialog_title": "Підтвердіть видалення облікового запису",


### PR DESCRIPTION
- Move app ID retrieval to a dedicated App ID provider, allowing the application to function without Firebase when not needed and accommodating cases where Google services are unavailable.

- Integrate the app session identifier to enable targeted filtering in the remote logging system.