### PR TITLE
refactor: data class dependency injection

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -39,7 +39,7 @@ class _MainShellState extends State<MainShell> {
     _callkeep.setUp(
       CallkeepOptions(
         ios: CallkeepIOSOptions(
-          localizedName: PackageInfo().appName,
+          localizedName: context.read<PackageInfo>().appName,
           ringtoneSound: Assets.ringtones.incomingCall1,
           ringbackSound: Assets.ringtones.outgoingCall1,
           iconTemplateImageAssetName: Assets.callkeep.iosIconTemplateImage.path,

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -53,19 +53,23 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
 
       final appThemes = await AppThemes.init();
       final appPreferences = await AppPreferencesFactory.init();
-
       final featureAccess = FeatureAccess.init(appThemes.appConfig, appPreferences);
+      final appInfo = await AppInfo.init(FirebaseAppIdProvider());
+      final deviceInfo = await DeviceInfo.init();
+      final packageInfo = await PackageInfoFactory.init();
 
-      await AppInfo.init(FirebaseAppIdProvider());
-      await DeviceInfo.init();
-      await PackageInfo.init();
-      await AppLogger.init(remoteFirebaseConfigService);
       await AppThemes.init();
       await AppPermissions.init(featureAccess);
       await SecureStorage.init();
       await AppCertificates.init();
       await AppTime.init();
       await SessionCleanupWorker.init();
+      await AppLogger.init(
+        remoteConfigService: remoteFirebaseConfigService,
+        packageInfo: packageInfo,
+        deviceInfo: deviceInfo,
+        appInfo: appInfo,
+      );
 
       await _initCallkeep(appPreferences);
 
@@ -147,9 +151,16 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 
   // Initialize the logger for handling Firebase Cloud Messaging (FCM) in the background isolate.
   await AppInfo.init(const SharedPreferencesAppIdProvider());
-  await DeviceInfo.init();
-  await PackageInfo.init();
-  await AppLogger.init(remoteCacheConfigService);
+  final appInfo = await AppInfo.init(FirebaseAppIdProvider());
+  final deviceInfo = await DeviceInfo.init();
+  final packageInfo = await PackageInfoFactory.init();
+
+  await AppLogger.init(
+    remoteConfigService: remoteCacheConfigService,
+    packageInfo: packageInfo,
+    deviceInfo: deviceInfo,
+    appInfo: appInfo,
+  );
 
   final appNotification = AppRemoteNotification.fromFCM(message);
 

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -10,7 +10,12 @@ import 'package:webtrit_phone/environment_config.dart';
 class AppLogger {
   static late AppLogger _instance;
 
-  static Future<AppLogger> init(RemoteConfigService remoteConfigService) async {
+  static Future<AppLogger> init({
+    required RemoteConfigService remoteConfigService,
+    required PackageInfo packageInfo,
+    required DeviceInfo deviceInfo,
+    required AppInfo appInfo,
+  }) async {
     hierarchicalLoggingEnabled = true;
 
     Logger.root.clearListeners();
@@ -39,7 +44,7 @@ class AppLogger {
 
     if (isRemoteLoggingEnabled) {
       for (var it in remoteLoggingServices) {
-        it.initialize(await _prepareRemoteLabels());
+        it.initialize(await _prepareRemoteLabels(packageInfo, deviceInfo, appInfo));
       }
     }
 
@@ -47,11 +52,11 @@ class AppLogger {
     return _instance;
   }
 
-  static Future<Map<String, String>> _prepareRemoteLabels() async {
-    final packageInfo = PackageInfo();
-    final deviceInfo = DeviceInfo();
-    final appInfo = AppInfo();
-
+  static Future<Map<String, String>> _prepareRemoteLabels(
+    PackageInfo packageInfo,
+    DeviceInfo deviceInfo,
+    AppInfo appInfo,
+  ) async {
     return <String, String>{
       'app': packageInfo.appName,
       'appVersion': appInfo.version,

--- a/lib/data/package_info.dart
+++ b/lib/data/package_info.dart
@@ -1,26 +1,40 @@
 import 'package:package_info_plus/package_info_plus.dart' as plugin;
 
-class PackageInfo {
+abstract class PackageInfo {
+  String get appName;
+
+  String get packageName;
+
+  String get version;
+
+  String get buildNumber;
+}
+
+class PackageInfoFactory {
   static late PackageInfo _instance;
 
   static Future<PackageInfo> init() async {
-    _instance = PackageInfo._(await plugin.PackageInfo.fromPlatform());
+    _instance = PackageInfoImpl(await plugin.PackageInfo.fromPlatform());
     return _instance;
   }
 
-  factory PackageInfo() {
-    return _instance;
-  }
+  static PackageInfo get instance => _instance;
+}
 
-  const PackageInfo._(this._pluginPackageInfo);
-
+class PackageInfoImpl implements PackageInfo {
   final plugin.PackageInfo _pluginPackageInfo;
 
+  PackageInfoImpl(this._pluginPackageInfo);
+
+  @override
   String get appName => _pluginPackageInfo.appName;
 
+  @override
   String get packageName => _pluginPackageInfo.packageName;
 
+  @override
   String get version => _pluginPackageInfo.version;
 
+  @override
   String get buildNumber => _pluginPackageInfo.buildNumber;
 }

--- a/lib/features/autoprovision/cubit/autoprovision_cubit.dart
+++ b/lib/features/autoprovision/cubit/autoprovision_cubit.dart
@@ -18,13 +18,23 @@ part 'autoprovision_state.dart';
 final _logger = Logger('AutoprovisionCubit');
 
 class AutoprovisionCubit extends Cubit<AutoprovisionState> with SystemInfoApiMapper {
-  AutoprovisionCubit(this.config) : super(AutoprovisionState.initial());
+  AutoprovisionCubit({
+    required this.appInfo,
+    required this.packageInfo,
+    required this.platformInfo,
+    required this.config,
+  }) : super(AutoprovisionState.initial());
 
   final AutoprovisionConfig config;
+  final AppInfo appInfo;
+  final PackageInfo packageInfo;
+  final PlatformInfo platformInfo;
 
-  final _identifier = AppInfo().identifier;
-  final _bundleId = PackageInfo().packageName;
-  final _appType = PlatformInfo().appType;
+  get _identifier => appInfo.identifier;
+
+  get _bundleId => packageInfo.packageName;
+
+  get _appType => platformInfo.appType;
 
   WebtritApiClient _apiClient(String coreUrl, String tenantId) {
     return WebtritApiClient(Uri.parse(coreUrl), tenantId, connectionTimeout: kApiClientConnectionTimeout);

--- a/lib/features/autoprovision/view/autoprovision_screen_page.dart
+++ b/lib/features/autoprovision/view/autoprovision_screen_page.dart
@@ -4,6 +4,8 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/blocs/blocs.dart';
+import 'package:webtrit_phone/data/app_info.dart';
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/features/features.dart';
 
@@ -37,18 +39,24 @@ class AutoprovisionScreenPage extends StatelessWidget {
     final oldCoreUrl = context.read<AppBloc>().state.coreUrl;
 
     const coreVersionConstraint = EnvironmentConfig.CORE_VERSION_CONSTRAINT;
+    final config = AutoprovisionConfig(
+      configToken: configToken,
+      oldToken: oldToken,
+      tenantId: tenantId,
+      oldTenantId: oldTenant,
+      defaultCoreUrl: defaultCoreUrl,
+      coreUrl: coreUrl ?? oldCoreUrl,
+      oldCoreUrl: oldCoreUrl,
+      coreVersionConstraint: coreVersionConstraint,
+    );
 
     final widget = BlocProvider(
-      create: (context) => AutoprovisionCubit(AutoprovisionConfig(
-        configToken: configToken,
-        oldToken: oldToken,
-        tenantId: tenantId,
-        oldTenantId: oldTenant,
-        defaultCoreUrl: defaultCoreUrl,
-        coreUrl: coreUrl ?? oldCoreUrl,
-        oldCoreUrl: oldCoreUrl,
-        coreVersionConstraint: coreVersionConstraint,
-      )),
+      create: (context) => AutoprovisionCubit(
+        appInfo: context.read<AppInfo>(),
+        packageInfo: context.read<PackageInfo>(),
+        platformInfo: context.read<PlatformInfo>(),
+        config: config,
+      ),
       child: const AutoprovisionScreen(),
     );
 

--- a/lib/features/call/services/background_call_isolate.dart
+++ b/lib/features/call/services/background_call_isolate.dart
@@ -29,8 +29,13 @@ Future<void> _initializeDependencies() async {
   // Data classes
   _appInfo ??= await AppInfo.init(const SharedPreferencesAppIdProvider());
   _deviceInfo ??= await DeviceInfo.init();
-  _packageInfo ??= await PackageInfo.init();
-  _appLogger ??= await AppLogger.init(_remoteConfigService!);
+  _packageInfo ??= await PackageInfoFactory.init();
+  _appLogger ??= await AppLogger.init(
+    remoteConfigService: _remoteConfigService!,
+    packageInfo: _packageInfo!,
+    deviceInfo: _deviceInfo!,
+    appInfo: _appInfo!,
+  );
   _appPreferences ??= await AppPreferencesFactory.init();
   _appCertificates ??= await AppCertificates.init();
 

--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../bloc/embedded_cubit.dart';
@@ -25,6 +26,7 @@ class EmbeddedScreen extends StatelessWidget {
         builder: (context, state) => WebViewScaffold(
           initialUri: initialUri,
           showToolbar: false,
+          packageInfo: context.read<PackageInfo>(),
         ),
       ),
     );

--- a/lib/features/log_records_console/cubit/log_records_console_cubit.dart
+++ b/lib/features/log_records_console/cubit/log_records_console_cubit.dart
@@ -16,10 +16,14 @@ class LogRecordsConsoleCubit extends Cubit<LogRecordsConsoleState> {
   LogRecordsConsoleCubit({
     required this.logRecordsRepository,
     this.logRecordsFormatter = const DefaultLogRecordFormatter(),
+    required this.packageInfo,
+    required this.appInfo,
   }) : super(const LogRecordsConsoleState.initial());
 
   final LogRecordsRepository logRecordsRepository;
   final LogRecordFormatter logRecordsFormatter;
+  final PackageInfo packageInfo;
+  final AppInfo appInfo;
 
   void load() async {
     emit(const LogRecordsConsoleState.loading());
@@ -37,7 +41,7 @@ class LogRecordsConsoleCubit extends Cubit<LogRecordsConsoleState> {
     emit(const LogRecordsConsoleState.success([]));
   }
 
-  String get _namePrefix => '${PackageInfo().appName}_${AppInfo().identifier}_';
+  String get _namePrefix => '${packageInfo.appName}_${appInfo.identifier}_';
 
   String _timeSlug(DateTime time) =>
       '${time.year.toString()}${time.month.toString().padLeft(2, '0')}${time.day.toString().padLeft(2, '0')}'

--- a/lib/features/log_records_console/view/log_records_console_screen_page.dart
+++ b/lib/features/log_records_console/view/log_records_console_screen_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
@@ -17,6 +18,8 @@ class LogRecordsConsoleScreenPage extends StatelessWidget {
     final provider = BlocProvider(
       create: (context) => LogRecordsConsoleCubit(
         logRecordsRepository: context.read<LogRecordsRepository>(),
+        packageInfo: context.read<PackageInfo>(),
+        appInfo: context.read<AppInfo>(),
       )..load(),
       child: widget,
     );

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -24,10 +24,22 @@ class LoginCubit extends Cubit<LoginState> with SystemInfoApiMapper {
   LoginCubit({
     @visibleForTesting this.createWebtritApiClient = defaultCreateWebtritApiClient,
     required this.notificationsBloc,
+    required this.packageInfo,
+    required this.appInfo,
+    required this.platformInfo,
   }) : super(const LoginState());
 
   final WebtritApiClientFactory createWebtritApiClient;
   final NotificationsBloc notificationsBloc;
+  final PlatformInfo platformInfo;
+  final PackageInfo packageInfo;
+  final AppInfo appInfo;
+
+  String get appBundleId => packageInfo.packageName;
+
+  AppType get appType => platformInfo.appType;
+
+  String get appIdentifier => appInfo.identifier;
 
   String? get coreUrlFromEnvironment => EnvironmentConfig.CORE_URL;
 
@@ -437,54 +449,54 @@ class LoginCubit extends Cubit<LoginState> with SystemInfoApiMapper {
     final systemInfo = systemInfoFromApi(apiSystemInfo);
     return systemInfo;
   }
-}
 
-Future<SessionOtpProvisional> _createSessionOtp(
-  WebtritApiClient webtritApiClient,
-  String userRef,
-) async {
-  return await webtritApiClient.createSessionOtp(SessionOtpCredential(
-    bundleId: PackageInfo().packageName,
-    type: PlatformInfo().appType,
-    identifier: AppInfo().identifier,
-    userRef: userRef,
-  ));
-}
+  Future<SessionOtpProvisional> _createSessionOtp(
+    WebtritApiClient webtritApiClient,
+    String userRef,
+  ) async {
+    return await webtritApiClient.createSessionOtp(SessionOtpCredential(
+      bundleId: appBundleId,
+      type: appType,
+      identifier: appIdentifier,
+      userRef: userRef,
+    ));
+  }
 
-Future<SessionToken> _verifySessionOtp(
-  WebtritApiClient webtritApiClient,
-  SessionOtpProvisional sessionOtpProvisional,
-  String code,
-) async {
-  return await webtritApiClient.verifySessionOtp(sessionOtpProvisional, code);
-}
+  Future<SessionToken> _verifySessionOtp(
+    WebtritApiClient webtritApiClient,
+    SessionOtpProvisional sessionOtpProvisional,
+    String code,
+  ) async {
+    return await webtritApiClient.verifySessionOtp(sessionOtpProvisional, code);
+  }
 
-Future<SessionToken> _createSessionRequest(
-  WebtritApiClient webtritApiClient,
-  String userRef,
-  String password,
-) async {
-  return await webtritApiClient.createSession(SessionLoginCredential(
-    bundleId: PackageInfo().packageName,
-    type: PlatformInfo().appType,
-    identifier: AppInfo().identifier,
-    login: userRef,
-    password: password,
-  ));
-}
+  Future<SessionToken> _createSessionRequest(
+    WebtritApiClient webtritApiClient,
+    String userRef,
+    String password,
+  ) async {
+    return await webtritApiClient.createSession(SessionLoginCredential(
+      bundleId: appBundleId,
+      type: appType,
+      identifier: appIdentifier,
+      login: userRef,
+      password: password,
+    ));
+  }
 
-Future<SessionResult> _createUserRequest({
-  required WebtritApiClient client,
-  String? email,
-  Map<String, dynamic>? extraPayload,
-}) async {
-  return await client.createUser(
-    SessionUserCredential(
-      bundleId: PackageInfo().packageName,
-      type: PlatformInfo().appType,
-      identifier: AppInfo().identifier,
-      email: email,
-    ),
-    extraPayload: extraPayload,
-  );
+  Future<SessionResult> _createUserRequest({
+    required WebtritApiClient client,
+    String? email,
+    Map<String, dynamic>? extraPayload,
+  }) async {
+    return await client.createUser(
+      SessionUserCredential(
+        bundleId: appBundleId,
+        type: appType,
+        identifier: appIdentifier,
+        email: email,
+      ),
+      extraPayload: extraPayload,
+    );
+  }
 }

--- a/lib/features/login/features/login_embedded/view/login_embedded_screen.dart
+++ b/lib/features/login/features/login_embedded/view/login_embedded_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/theme/extension/extension.dart';
@@ -72,6 +73,8 @@ class LoginEmbeddedScreen extends StatelessWidget {
                 ),
               ],
             ),
+            // TODO(Serdun): Move PackageInfo dependency to constructor
+            packageInfo: context.read<PackageInfo>(),
           );
         },
       ),

--- a/lib/features/login/view/login_router_page.dart
+++ b/lib/features/login/view/login_router_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/blocs/blocs.dart';
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -90,7 +91,12 @@ class LoginRouterPage extends StatelessWidget {
       },
     );
 
-    final login = LoginCubit(notificationsBloc: context.read<NotificationsBloc>());
+    final login = LoginCubit(
+      notificationsBloc: context.read<NotificationsBloc>(),
+      packageInfo: context.read<PackageInfo>(),
+      appInfo: context.read<AppInfo>(),
+      platformInfo: context.read<PlatformInfo>(),
+    );
     if (_launchLoginEmbedded != null) {
       login.setCustomLogin(_launchLoginEmbedded);
     }

--- a/lib/features/main/bloc/main_bloc.dart
+++ b/lib/features/main/bloc/main_bloc.dart
@@ -14,6 +14,7 @@ import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
 part 'main_event.dart';
+
 part 'main_state.dart';
 
 // TODO: maybe split the bloc into two separate blocs: SystemInfoSyncBloc and (CoreCompatibilityBloc or MainScreenBloc)
@@ -25,7 +26,8 @@ class MainBloc extends Bloc<MainBlocEvent, MainBlocState> {
   MainBloc(
     this.systemInfoRemoteRepository,
     this.appPreferences,
-    this.coreVersionConstraint, {
+    this.coreVersionConstraint,
+    this.packageInfo, {
     this.storeInfoExtractor,
   }) : super(MainBlocState.initial()) {
     on<MainBlocInit>(_onInit, transformer: restartable());
@@ -37,6 +39,11 @@ class MainBloc extends Bloc<MainBlocEvent, MainBlocState> {
   final AppPreferences appPreferences;
   final String coreVersionConstraint;
   final StoreInfoExtractor? storeInfoExtractor;
+  final PackageInfo packageInfo;
+
+  String get appPackageName => packageInfo.packageName;
+
+  Version get appVersion => Version.parse(packageInfo.version);
 
   StreamSubscription<WebtritSystemInfo>? _systemInfoSubscription;
 
@@ -91,9 +98,6 @@ class MainBloc extends Bloc<MainBlocEvent, MainBlocState> {
       emit(state.copyWith(coreVersionState: Compatible()));
     } else {
       Uri? maybeStoreUrl;
-
-      final appPackageName = PackageInfo().packageName;
-      final appVersion = Version.parse(PackageInfo().version);
 
       StoreInfo? storeInfo;
 

--- a/lib/features/main/view/main_screen_page.dart
+++ b/lib/features/main/view/main_screen_page.dart
@@ -78,6 +78,7 @@ class MainScreenPage extends StatelessWidget {
           context.read<SystemInfoRepository>(),
           context.read<AppPreferences>(),
           EnvironmentConfig.CORE_VERSION_CONSTRAINT,
+          context.read<PackageInfo>(),
           storeInfoExtractor: StoreInfoExtractor(),
         )..add(const MainBlocInit());
       },

--- a/lib/features/settings/features/about/view/about_screen_page.dart
+++ b/lib/features/settings/features/about/view/about_screen_page.dart
@@ -20,7 +20,7 @@ class AboutScreenPage extends StatelessWidget {
     if (appAboutUrl != null) {
       final widget = WebAboutScreen(
         baseAppAboutUrl: Uri.parse(appAboutUrl),
-        packageInfo: PackageInfo(),
+        packageInfo: context.read<PackageInfo>(),
         infoRepository: context.read<SystemInfoRepository>(),
       );
       return widget;
@@ -31,7 +31,7 @@ class AboutScreenPage extends StatelessWidget {
           return AboutBloc(
             notificationsBloc: context.read<NotificationsBloc>(),
             appInfo: AppInfo(),
-            packageInfo: PackageInfo(),
+            packageInfo: context.read<PackageInfo>(),
             secureStorage: context.read<SecureStorage>(),
             infoRepository: context.read<SystemInfoRepository>(),
           )..add(const AboutStarted());

--- a/lib/features/settings/features/about/view/webview_about_screen.dart
+++ b/lib/features/settings/features/about/view/webview_about_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
+
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
@@ -28,6 +30,7 @@ class WebAboutScreen extends StatelessWidget {
         'buildNumber': packageInfo.buildNumber,
         'coreUrl': infoRepository.coreUrl.toString(),
       }),
+      packageInfo: context.read<PackageInfo>(),
     );
   }
 }

--- a/lib/features/settings/features/help/view/help_screen.dart
+++ b/lib/features/settings/features/help/view/help_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
+
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -16,6 +19,7 @@ class HelpScreen extends StatelessWidget {
     final widget = WebViewScaffold(
       title: Text(context.l10n.settings_ListViewTileTitle_help),
       initialUri: initialUri,
+      packageInfo: context.read<PackageInfo>(),
     );
     return widget;
   }

--- a/lib/features/settings/features/self_config/view/self_config_screen.dart
+++ b/lib/features/settings/features/self_config/view/self_config_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
+
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 class SelfConfigScreen extends StatelessWidget {
   const SelfConfigScreen(this.url, {super.key});
+
   final Uri url;
 
   @override
@@ -12,6 +16,7 @@ class SelfConfigScreen extends StatelessWidget {
     return Scaffold(
       body: WebViewScaffold(
         title: Text(context.l10n.settings_ListViewTileTitle_self_config),
+        packageInfo: context.read<PackageInfo>(),
         initialUri: url,
       ),
     );

--- a/lib/features/terms_conditions/view/terms_conditions_screen.dart
+++ b/lib/features/terms_conditions/view/terms_conditions_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
+
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -16,6 +19,7 @@ class TermsConditionsScreen extends StatelessWidget {
     return WebViewScaffold(
       title: Text(context.l10n.settings_ListViewTileTitle_termsConditions),
       initialUri: initialUri,
+      packageInfo: context.read<PackageInfo>(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,21 @@ void main() {
 
     return MultiProvider(
       providers: [
+        Provider<AppInfo>(
+          create: (context) {
+            return AppInfo();
+          },
+        ),
+        Provider<PlatformInfo>(
+          create: (context) {
+            return PlatformInfo();
+          },
+        ),
+        Provider<PackageInfo>(
+          create: (context) {
+            return PackageInfoFactory.instance;
+          },
+        ),
         Provider<AppPreferences>(
           create: (context) {
             return AppPreferencesFactory.instance;

--- a/lib/widgets/webview_scaffold.dart
+++ b/lib/widgets/webview_scaffold.dart
@@ -25,6 +25,7 @@ class WebViewScaffold extends StatefulWidget {
     this.errorBuilder,
     this.showToolbar = true,
     this.builder,
+    required this.packageInfo,
   });
 
   final Widget? title;
@@ -34,6 +35,7 @@ class WebViewScaffold extends StatefulWidget {
   final bool showToolbar;
   final Widget? Function(BuildContext context, WebResourceError error, WebViewController controller)? errorBuilder;
   final TransitionBuilder? builder;
+  final PackageInfo packageInfo;
 
   @override
   State<WebViewScaffold> createState() => _WebViewScaffoldState();
@@ -68,7 +70,7 @@ class _WebViewScaffoldState extends State<WebViewScaffold> {
 
     _webViewController = WebViewController();
 
-    final userAgent = '${PackageInfo().appName}/${PackageInfo().version} '
+    final userAgent = '${widget.packageInfo.appName}/${widget.packageInfo.version} '
         '(${Platform.operatingSystem}; ${Platform.operatingSystemVersion})';
 
     () async {


### PR DESCRIPTION
- Use inheritance to provide the data class instead of using singleton access.
- Use constructor injection to enable mocking of data.
- Refactor PackageInfo to allow data mocking.