### PR TITLE
refactor: update device info and provide user agent via utility

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -55,7 +55,7 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
       final appPreferences = await AppPreferencesFactory.init();
       final featureAccess = FeatureAccess.init(appThemes.appConfig, appPreferences);
       final appInfo = await AppInfo.init(FirebaseAppIdProvider());
-      final deviceInfo = await DeviceInfo.init();
+      final deviceInfo = await DeviceInfoFactory.init();
       final packageInfo = await PackageInfoFactory.init();
 
       await AppThemes.init();
@@ -152,7 +152,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   // Initialize the logger for handling Firebase Cloud Messaging (FCM) in the background isolate.
   await AppInfo.init(const SharedPreferencesAppIdProvider());
   final appInfo = await AppInfo.init(FirebaseAppIdProvider());
-  final deviceInfo = await DeviceInfo.init();
+  final deviceInfo = await DeviceInfoFactory.init();
   final packageInfo = await PackageInfoFactory.init();
 
   await AppLogger.init(

--- a/lib/data/device_info.dart
+++ b/lib/data/device_info.dart
@@ -8,190 +8,122 @@ import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('DeviceInfo');
 
-class DeviceInfo {
+abstract class DeviceInfo {
+  Map<String, dynamic> get data;
+
+  String get manufacturer;
+
+  String get model;
+
+  String get systemName;
+
+  String get systemVersion;
+}
+
+class DeviceInfoFactory {
   static late DeviceInfo _instance;
 
   static Future<DeviceInfo> init() async {
     final deviceInfoPlugin = DeviceInfoPlugin();
-
     late final Map<String, dynamic> deviceData;
     try {
       if (kIsWeb) {
-        deviceData = _readWebBrowserInfo(await deviceInfoPlugin.webBrowserInfo);
+        deviceData = _DeviceInfoImpl.readWebBrowserInfo(await deviceInfoPlugin.webBrowserInfo);
+      } else if (Platform.isAndroid) {
+        deviceData = _DeviceInfoImpl.readAndroidBuildData(await deviceInfoPlugin.androidInfo);
+      } else if (Platform.isIOS) {
+        deviceData = _DeviceInfoImpl.readIosDeviceInfo(await deviceInfoPlugin.iosInfo);
+      } else if (Platform.isLinux) {
+        deviceData = _DeviceInfoImpl.readLinuxDeviceInfo(await deviceInfoPlugin.linuxInfo);
+      } else if (Platform.isMacOS) {
+        deviceData = _DeviceInfoImpl.readMacOsDeviceInfo(await deviceInfoPlugin.macOsInfo);
+      } else if (Platform.isWindows) {
+        deviceData = _DeviceInfoImpl.readWindowsDeviceInfo(await deviceInfoPlugin.windowsInfo);
       } else {
-        if (Platform.isAndroid) {
-          deviceData = _readAndroidBuildData(await deviceInfoPlugin.androidInfo);
-        } else if (Platform.isIOS) {
-          deviceData = _readIosDeviceInfo(await deviceInfoPlugin.iosInfo);
-        } else if (Platform.isLinux) {
-          deviceData = _readLinuxDeviceInfo(await deviceInfoPlugin.linuxInfo);
-        } else if (Platform.isMacOS) {
-          deviceData = _readMacOsDeviceInfo(await deviceInfoPlugin.macOsInfo);
-        } else if (Platform.isWindows) {
-          deviceData = _readWindowsDeviceInfo(await deviceInfoPlugin.windowsInfo);
-        } else {
-          deviceData = <String, dynamic>{
-            'error': 'unknown platform',
-          };
-        }
+        deviceData = {'error': 'unknown platform'};
       }
     } on PlatformException {
-      deviceData = <String, dynamic>{
-        'error': 'failed to get platform version',
-      };
+      deviceData = {'error': 'failed to get platform version'};
     }
-    _instance = DeviceInfo._(deviceData);
+    _instance = _DeviceInfoImpl(deviceData);
     return _instance;
   }
 
-  factory DeviceInfo() {
-    return _instance;
-  }
+  static DeviceInfo get instance => _instance;
+}
 
-  DeviceInfo._(this.data) {
+class _DeviceInfoImpl implements DeviceInfo {
+  @override
+  final Map<String, dynamic> data;
+
+  _DeviceInfoImpl(this.data) {
     for (final entry in data.entries) {
       _logger.finest(() => '${entry.key}: ${entry.value}');
     }
   }
 
-  final Map<String, dynamic> data;
-
+  @override
   String get manufacturer => data['manufacturer'] ?? 'unknown';
 
+  @override
   String get model => data['model'] ?? 'unknown';
 
+  @override
   String get systemName => data['systemName'] ?? 'unknown';
 
+  @override
   String get systemVersion => data['systemVersion'] ?? 'unknown';
 
-  static Map<String, dynamic> _readWebBrowserInfo(WebBrowserInfo data) {
-    return <String, dynamic>{
-      'browserName': data.browserName.name,
-      'appCodeName': data.appCodeName,
-      'appName': data.appName,
-      'appVersion': data.appVersion,
-      'deviceMemory': data.deviceMemory,
-      'language': data.language,
-      'languages': data.languages,
-      'platform': data.platform,
-      'product': data.product,
-      'productSub': data.productSub,
-      'userAgent': data.userAgent,
-      'vendor': data.vendor,
-      'vendorSub': data.vendorSub,
-      'hardwareConcurrency': data.hardwareConcurrency,
-      'maxTouchPoints': data.maxTouchPoints,
-    };
-  }
+  static Map<String, dynamic> readWebBrowserInfo(WebBrowserInfo data) => {
+        'browserName': data.browserName.name,
+        'appCodeName': data.appCodeName,
+        'appName': data.appName,
+        'appVersion': data.appVersion,
+        'deviceMemory': data.deviceMemory,
+        'language': data.language,
+        'languages': data.languages,
+        'platform': data.platform,
+        'product': data.product,
+        'productSub': data.productSub,
+        'userAgent': data.userAgent,
+        'vendor': data.vendor,
+        'vendorSub': data.vendorSub,
+        'hardwareConcurrency': data.hardwareConcurrency,
+        'maxTouchPoints': data.maxTouchPoints,
+      };
 
-  static Map<String, dynamic> _readAndroidBuildData(AndroidDeviceInfo build) {
-    return <String, dynamic>{
-      'version.securityPatch': build.version.securityPatch,
-      'version.sdkInt': build.version.sdkInt,
-      'version.release': build.version.release,
-      'version.previewSdkInt': build.version.previewSdkInt,
-      'version.incremental': build.version.incremental,
-      'version.codename': build.version.codename,
-      'version.baseOS': build.version.baseOS,
-      'board': build.board,
-      'bootloader': build.bootloader,
-      'brand': build.brand,
-      'device': build.device,
-      'display': build.display,
-      'fingerprint': build.fingerprint,
-      'hardware': build.hardware,
-      'host': build.host,
-      'id': build.id,
-      'manufacturer': build.manufacturer,
-      'model': build.model,
-      'product': build.product,
-      'supported32BitAbis': build.supported32BitAbis,
-      'supported64BitAbis': build.supported64BitAbis,
-      'supportedAbis': build.supportedAbis,
-      'tags': build.tags,
-      'type': build.type,
-      'isPhysicalDevice': build.isPhysicalDevice,
-      'systemFeatures': build.systemFeatures,
-      'serialNumber': build.serialNumber,
-      'isLowRamDevice': build.isLowRamDevice,
-    };
-  }
+  static Map<String, dynamic> readAndroidBuildData(AndroidDeviceInfo build) => {
+        'manufacturer': build.manufacturer,
+        'model': build.model,
+        'systemName': 'Android',
+        'systemVersion': build.version.release,
+      };
 
-  static Map<String, dynamic> _readIosDeviceInfo(IosDeviceInfo data) {
-    return <String, dynamic>{
-      'name': data.name,
-      'systemName': data.systemName,
-      'systemVersion': data.systemVersion,
-      'model': data.model,
-      'localizedModel': data.localizedModel,
-      'identifierForVendor': data.identifierForVendor,
-      'isPhysicalDevice': data.isPhysicalDevice,
-      'utsname.sysname:': data.utsname.sysname,
-      'utsname.nodename:': data.utsname.nodename,
-      'utsname.release:': data.utsname.release,
-      'utsname.version:': data.utsname.version,
-      'utsname.machine:': data.utsname.machine,
-    };
-  }
+  static Map<String, dynamic> readIosDeviceInfo(IosDeviceInfo data) => {
+        'manufacturer': 'Apple',
+        'model': data.model,
+        'systemName': data.systemName,
+        'systemVersion': data.systemVersion,
+      };
 
-  static Map<String, dynamic> _readLinuxDeviceInfo(LinuxDeviceInfo data) {
-    return <String, dynamic>{
-      'name': data.name,
-      'version': data.version,
-      'id': data.id,
-      'idLike': data.idLike,
-      'versionCodename': data.versionCodename,
-      'versionId': data.versionId,
-      'prettyName': data.prettyName,
-      'buildId': data.buildId,
-      'variant': data.variant,
-      'variantId': data.variantId,
-      'machineId': data.machineId,
-    };
-  }
+  static Map<String, dynamic> readLinuxDeviceInfo(LinuxDeviceInfo data) => {
+        'manufacturer': 'Linux',
+        'model': data.variant ?? 'unknown',
+        'systemName': data.name,
+        'systemVersion': data.version,
+      };
 
-  static Map<String, dynamic> _readMacOsDeviceInfo(MacOsDeviceInfo data) {
-    return <String, dynamic>{
-      'computerName': data.computerName,
-      'hostName': data.hostName,
-      'arch': data.arch,
-      'model': data.model,
-      'kernelVersion': data.kernelVersion,
-      'osRelease': data.osRelease,
-      'activeCPUs': data.activeCPUs,
-      'memorySize': data.memorySize,
-      'cpuFrequency': data.cpuFrequency,
-      'systemGUID': data.systemGUID,
-    };
-  }
+  static Map<String, dynamic> readMacOsDeviceInfo(MacOsDeviceInfo data) => {
+        'manufacturer': 'Apple',
+        'model': data.model,
+        'systemName': 'macOS',
+        'systemVersion': data.osRelease,
+      };
 
-  static Map<String, dynamic> _readWindowsDeviceInfo(WindowsDeviceInfo data) {
-    return <String, dynamic>{
-      'numberOfCores': data.numberOfCores,
-      'computerName': data.computerName,
-      'systemMemoryInMegabytes': data.systemMemoryInMegabytes,
-      'userName': data.userName,
-      'majorVersion': data.majorVersion,
-      'minorVersion': data.minorVersion,
-      'buildNumber': data.buildNumber,
-      'platformId': data.platformId,
-      'csdVersion': data.csdVersion,
-      'servicePackMajor': data.servicePackMajor,
-      'servicePackMinor': data.servicePackMinor,
-      'suitMask': data.suitMask,
-      'productType': data.productType,
-      'reserved': data.reserved,
-      'buildLab': data.buildLab,
-      'buildLabEx': data.buildLabEx,
-      'digitalProductId': data.digitalProductId,
-      'displayVersion': data.displayVersion,
-      'editionId': data.editionId,
-      'installDate': data.installDate,
-      'productId': data.productId,
-      'productName': data.productName,
-      'registeredOwner': data.registeredOwner,
-      'releaseId': data.releaseId,
-      'deviceId': data.deviceId,
-    };
-  }
+  static Map<String, dynamic> readWindowsDeviceInfo(WindowsDeviceInfo data) => {
+        'manufacturer': 'Microsoft',
+        'model': data.productName,
+        'systemName': 'Windows',
+        'systemVersion': data.displayVersion,
+      };
 }

--- a/lib/features/call/services/background_call_isolate.dart
+++ b/lib/features/call/services/background_call_isolate.dart
@@ -28,7 +28,7 @@ Future<void> _initializeDependencies() async {
 
   // Data classes
   _appInfo ??= await AppInfo.init(const SharedPreferencesAppIdProvider());
-  _deviceInfo ??= await DeviceInfo.init();
+  _deviceInfo ??= await DeviceInfoFactory.init();
   _packageInfo ??= await PackageInfoFactory.init();
   _appLogger ??= await AppLogger.init(
     remoteConfigService: _remoteConfigService!,

--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../bloc/embedded_cubit.dart';
@@ -26,7 +28,7 @@ class EmbeddedScreen extends StatelessWidget {
         builder: (context, state) => WebViewScaffold(
           initialUri: initialUri,
           showToolbar: false,
-          packageInfo: context.read<PackageInfo>(),
+          userAgent: UserAgent.of(context),
         ),
       ),
     );

--- a/lib/features/login/features/login_embedded/view/login_embedded_screen.dart
+++ b/lib/features/login/features/login_embedded/view/login_embedded_screen.dart
@@ -3,10 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
-import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/theme/extension/extension.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../extensions/extensions.dart';
@@ -73,8 +73,7 @@ class LoginEmbeddedScreen extends StatelessWidget {
                 ),
               ],
             ),
-            // TODO(Serdun): Move PackageInfo dependency to constructor
-            packageInfo: context.read<PackageInfo>(),
+            userAgent: UserAgent.of(context),
           );
         },
       ),

--- a/lib/features/permissions/view/permissions_screen_page.dart
+++ b/lib/features/permissions/view/permissions_screen_page.dart
@@ -17,8 +17,8 @@ class PermissionsScreenPage extends StatelessWidget {
     final provider = BlocProvider(
       create: (context) => PermissionsCubit(
         appPreferences: context.read<AppPreferences>(),
-        appPermissions: AppPermissions(),
-        deviceInfo: DeviceInfo(),
+        appPermissions: context.read<AppPermissions>(),
+        deviceInfo: context.read<DeviceInfo>(),
       ),
       child: widget,
     );

--- a/lib/features/settings/features/about/view/webview_about_screen.dart
+++ b/lib/features/settings/features/about/view/webview_about_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 
-import 'package:provider/provider.dart';
-
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 class WebAboutScreen extends StatelessWidget {
@@ -30,7 +29,7 @@ class WebAboutScreen extends StatelessWidget {
         'buildNumber': packageInfo.buildNumber,
         'coreUrl': infoRepository.coreUrl.toString(),
       }),
-      packageInfo: context.read<PackageInfo>(),
+      userAgent: UserAgent.of(context),
     );
   }
 }

--- a/lib/features/settings/features/help/view/help_screen.dart
+++ b/lib/features/settings/features/help/view/help_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 
-import 'package:provider/provider.dart';
-
-import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 class HelpScreen extends StatelessWidget {
@@ -19,7 +17,7 @@ class HelpScreen extends StatelessWidget {
     final widget = WebViewScaffold(
       title: Text(context.l10n.settings_ListViewTileTitle_help),
       initialUri: initialUri,
-      packageInfo: context.read<PackageInfo>(),
+      userAgent: UserAgent.of(context),
     );
     return widget;
   }

--- a/lib/features/settings/features/self_config/view/self_config_screen.dart
+++ b/lib/features/settings/features/self_config/view/self_config_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 
-import 'package:provider/provider.dart';
-
-import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 class SelfConfigScreen extends StatelessWidget {
@@ -16,7 +14,7 @@ class SelfConfigScreen extends StatelessWidget {
     return Scaffold(
       body: WebViewScaffold(
         title: Text(context.l10n.settings_ListViewTileTitle_self_config),
-        packageInfo: context.read<PackageInfo>(),
+        userAgent: UserAgent.of(context),
         initialUri: url,
       ),
     );

--- a/lib/features/terms_conditions/view/terms_conditions_screen.dart
+++ b/lib/features/terms_conditions/view/terms_conditions_screen.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:provider/provider.dart';
-
-import 'package:webtrit_phone/data/data.dart';
-import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 class TermsConditionsScreen extends StatelessWidget {
@@ -17,9 +14,8 @@ class TermsConditionsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return WebViewScaffold(
-      title: Text(context.l10n.settings_ListViewTileTitle_termsConditions),
       initialUri: initialUri,
-      packageInfo: context.read<PackageInfo>(),
+      userAgent: UserAgent.of(context),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,11 @@ void main() {
             return PackageInfoFactory.instance;
           },
         ),
+        Provider<DeviceInfo>(
+          create: (context) {
+            return DeviceInfoFactory.instance;
+          },
+        ),
         Provider<AppPreferences>(
           create: (context) {
             return AppPreferencesFactory.instance;

--- a/lib/utils/user_agent.dart
+++ b/lib/utils/user_agent.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:webtrit_phone/data/data.dart';
+
+class UserAgent {
+  static String of(BuildContext context) {
+    final packageInfo = context.read<PackageInfo>();
+    final deviceInfo = context.read<DeviceInfo>();
+    
+    return '${packageInfo.appName}/${packageInfo.version} (${deviceInfo.systemName}; ${deviceInfo.systemVersion})';
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -6,5 +6,6 @@ export 'og_preview.dart';
 export 'orientations.dart';
 export 'path_provider/path_provider.dart';
 export 'regexes.dart';
+export 'user_agent.dart';
 export 'webtrit_api_client.dart';
 export 'webtrit_signaling_utils.dart';

--- a/lib/widgets/webview_scaffold.dart
+++ b/lib/widgets/webview_scaffold.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webview_flutter/webview_flutter.dart';
 
-import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
@@ -25,7 +23,7 @@ class WebViewScaffold extends StatefulWidget {
     this.errorBuilder,
     this.showToolbar = true,
     this.builder,
-    required this.packageInfo,
+    required this.userAgent,
   });
 
   final Widget? title;
@@ -35,7 +33,7 @@ class WebViewScaffold extends StatefulWidget {
   final bool showToolbar;
   final Widget? Function(BuildContext context, WebResourceError error, WebViewController controller)? errorBuilder;
   final TransitionBuilder? builder;
-  final PackageInfo packageInfo;
+  final String userAgent;
 
   @override
   State<WebViewScaffold> createState() => _WebViewScaffoldState();
@@ -69,14 +67,10 @@ class _WebViewScaffoldState extends State<WebViewScaffold> {
     super.initState();
 
     _webViewController = WebViewController();
-
-    final userAgent = '${widget.packageInfo.appName}/${widget.packageInfo.version} '
-        '(${Platform.operatingSystem}; ${Platform.operatingSystemVersion})';
-
     () async {
       if (!kIsWeb) {
         await Future.wait([
-          _webViewController.setUserAgent(userAgent),
+          _webViewController.setUserAgent(widget.userAgent),
           _webViewController.enableZoom(false),
           _webViewController.setJavaScriptMode(JavaScriptMode.unrestricted),
           for (var MapEntry(key: name, value: onMessageReceived) in widget.javaScriptChannels.entries)


### PR DESCRIPTION
- Added an interface for DeviceInfo to enable mock data creation for testing
- Provided DeviceInfo via an InheritedWidget instead of accessing it through a singleton
- Moved user agent handling to the WebView constructor and a utility function for generating it based on the DeviceInfo data class