### PR TITLE
refactor: clean up theme data and localization improvements

### DIFF
--- a/assets/themes/original.widget.dark.config.json
+++ b/assets/themes/original.widget.dark.config.json
@@ -5,7 +5,7 @@
   "imageAssets": {
     "primaryOnboardingLogo": {
       "uri": "asset://assets/primary_onboardin_logo.svg",
-      "widthFactor": 0.9
+      "widthFactor": 0.45
     },
     "secondaryOnboardingLogo": {
       "uri": "asset://assets/secondary_onboardin_logo.svg",

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -58,7 +58,6 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
       final deviceInfo = await DeviceInfoFactory.init();
       final packageInfo = await PackageInfoFactory.init();
 
-      await AppThemes.init();
       await AppPermissions.init(featureAccess);
       await SecureStorage.init();
       await AppCertificates.init();

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -182,7 +182,7 @@ class FeatureAccess {
 
   static LoginEmbedded? _toLoginEmbeddedModel(EmbeddedData? data) {
     return data?.uri != null
-        ? LoginEmbedded(titleL10n: data!.toolbar.titleL10n, showToolbar: data.toolbar.showToolbar, resource: data!.uri!)
+        ? LoginEmbedded(titleL10n: data!.toolbar.titleL10n, showToolbar: data.toolbar.showToolbar, resource: data.uri!)
         : null;
   }
 

--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:webtrit_phone/data/data.dart';
-import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 

--- a/packages/webtrit_appearance_theme/lib/models/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/app_config.dart
@@ -218,7 +218,7 @@ class AppConfigSettings with _$AppConfigSettings {
           AppConfigSettingsItem(
             enabled: true,
             type: 'encoding',
-            titleL10n: 'settings_ListViewTileTitle_call_codecs',
+            titleL10n: 'settings_ListViewTileTitle_encoding',
             icon: '0xf1cf',
           ),
           AppConfigSettingsItem(

--- a/packages/webtrit_appearance_theme/lib/models/app_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/app_config.freezed.dart
@@ -2730,7 +2730,7 @@ class _$AppConfigSettingsImpl extends _AppConfigSettings {
               AppConfigSettingsItem(
                   enabled: true,
                   type: 'encoding',
-                  titleL10n: 'settings_ListViewTileTitle_call_codecs',
+                  titleL10n: 'settings_ListViewTileTitle_encoding',
                   icon: '0xf1cf'),
               AppConfigSettingsItem(
                   enabled: true,

--- a/packages/webtrit_appearance_theme/lib/models/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/app_config.g.dart
@@ -262,7 +262,7 @@ _$AppConfigSettingsImpl _$$AppConfigSettingsImplFromJson(
                   AppConfigSettingsItem(
                       enabled: true,
                       type: 'encoding',
-                      titleL10n: 'settings_ListViewTileTitle_call_codecs',
+                      titleL10n: 'settings_ListViewTileTitle_encoding',
                       icon: '0xf1cf'),
                   AppConfigSettingsItem(
                       enabled: true,

--- a/screenshots/lib/screenshots/login_mode_select_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_mode_select_screen_screenshot.dart
@@ -15,7 +15,6 @@ class LoginModeSelectScreenScreenshot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print('LoginModeSelectScreenScreenshot: ${ context.read<FeatureAccess?>()?.loginFeature.titleL10n}');
     return BlocProvider<LoginCubit>(
       create: (context) => MockLoginCubit.loginModeSelectScreen(),
       child: LoginModeSelectScreen(

--- a/screenshots/lib/screenshots/login_signup_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_signup_screen_screenshot.dart
@@ -32,7 +32,7 @@ class LoginSignUpScreenshot extends StatelessWidget {
       create: (context) => MockLoginCubit.loginSwitchScreen(embedded: embedded.customLoginFeature),
       child: LoginSwitchScreen(
         body: LoginSignupEmbeddedRequestScreen(
-          initialUrl: embedded!.customLoginFeature.resource,
+          initialUrl: embedded.customLoginFeature.resource,
         ),
         currentLoginType: LoginType.signup,
         supportedLoginTypes: const [

--- a/screenshots/lib/widgets/screenshot_app.dart
+++ b/screenshots/lib/widgets/screenshot_app.dart
@@ -46,14 +46,14 @@ class ScreenshotApp extends StatelessWidget {
                 localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
                 title: EnvironmentConfig.APP_NAME,
-                color: themeProvider.light()!.primaryColor,
+                color: themeProvider.light().primaryColor,
                 debugShowCheckedModeBanner: false,
                 routerDelegate: ScreenshotRouterDelegate(child),
                 routeInformationParser: const _NoOpRouteInformationParser(),
                 builder: (context, child) {
                   // Ensure themes are applied to the app
                   return Theme(
-                    data: themeProvider.light()!,
+                    data: themeProvider.light(),
                     child: child!,
                   );
                 },


### PR DESCRIPTION
- Aligned the default dark mode scheme with the light mode for consistency.
- Removed redundant theme data initialization to clean up the code.
- Resolved theme data warnings for a more robust implementation.
- Standardized hex color values to upper case for uniformity.
- Added the correct localization key for the default title in the webtrit_appearance_theme.