### PR TITLE
refactor: remove Firebase component usage from side isolates and update documentation

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -106,11 +106,17 @@ Future<void> _initCallkeep(AppPreferences appPreferences) async {
   }
 }
 
-@pragma('vm:entry-point')
+/// Initializes Firebase for background services. This initialization must be called in an isolate
+/// when Firebase components are used. For more details, refer to the Firebase documentation:
+/// https://firebase.google.com/docs/cloud-messaging/flutter/receive
 Future<void> _initFirebase() async {
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } catch (e) {
+    Logger('Firebase').severe('Error in _initFirebase', e);
+  }
 }
 
 Future<void> _initFirebaseMessaging() async {
@@ -149,8 +155,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   final remoteCacheConfigService = await DefaultRemoteCacheConfigService.init();
 
   // Initialize the logger for handling Firebase Cloud Messaging (FCM) in the background isolate.
-  await AppInfo.init(const SharedPreferencesAppIdProvider());
-  final appInfo = await AppInfo.init(FirebaseAppIdProvider());
+  final appInfo = await AppInfo.init(const SharedPreferencesAppIdProvider());
   final deviceInfo = await DeviceInfoFactory.init();
   final packageInfo = await PackageInfoFactory.init();
 

--- a/lib/common/app_id_provider.dart
+++ b/lib/common/app_id_provider.dart
@@ -9,12 +9,15 @@ const _appIdKey = 'app_id_key';
 
 final Logger _logger = Logger('AppIdProvider');
 
+/// Abstract class for providing app ID. It supports fetching the ID and listening for changes in the ID.
 abstract class AppIdProvider {
   Future<String> getId();
 
   Stream<String> get onIdChange;
 }
 
+/// Implementation of AppIdProvider using Firebase installations service.
+/// This provider retrieves the Firebase installation ID and handles changes in the ID.
 class FirebaseAppIdProvider implements AppIdProvider {
   final _idChangeController = StreamController<String>.broadcast();
 
@@ -69,6 +72,8 @@ class FirebaseAppIdProvider implements AppIdProvider {
   }
 }
 
+/// AppIdProvider implementation using SharedPreferences. This is used when the app ID is already provided
+/// in the main isolate and is shared across other isolates for consistency.
 class SharedPreferencesAppIdProvider implements AppIdProvider {
   const SharedPreferencesAppIdProvider();
 


### PR DESCRIPTION
- Removed Firebase component usage from side isolates for better isolation of Firebase services.
- Added a brief documentation update to clarify initialization requirements for background services.