### PR TITLE
fix: undefined line error on 3.29 update

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1160,24 +1160,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     final callId = WebtritSignalingClient.generateCallId();
 
-    final callkeepError = await callkeep.startCall(
-      callId,
-      event.handle,
-      displayNameOrContactIdentifier: event.displayName,
-      hasVideo: event.video,
-      proximityEnabled: !event.video,
-    );
-
-    if (callkeepError != null) {
-      if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
-        final Uri telLaunchUri = Uri(scheme: 'tel', path: event.handle.value);
-        launchUrl(telLaunchUri);
-      } else {
-        _logger.warning('__onCallControlEventStarted callkeepError: $callkeepError');
-      }
-      return;
-    }
-
     final newCall = ActiveCall(
       direction: CallDirection.outgoing,
       line: line,
@@ -1190,6 +1172,26 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
 
     emit(state.copyWithPushActiveCall(newCall).copyWith(minimized: false));
+
+    final callkeepError = await callkeep.startCall(
+      callId,
+      event.handle,
+      displayNameOrContactIdentifier: event.displayName,
+      hasVideo: event.video,
+      proximityEnabled: !event.video,
+    );
+
+    if (callkeepError != null) {
+      emit(state.copyWithPopActiveCall(callId));
+
+      if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
+        final Uri telLaunchUri = Uri(scheme: 'tel', path: event.handle.value);
+        launchUrl(telLaunchUri);
+      } else {
+        _logger.warning('__onCallControlEventStarted callkeepError: $callkeepError');
+      }
+      return;
+    }
   }
 
   /// Submitting the answer intent to system when answer button is pressed from app ui


### PR DESCRIPTION
fix: undefined line error on 3.29 update caused by new sync native bindings, that cause start of __onCallPerformEventStarted execution before new call is emited in __onCallControlEventStarted