### PR TITLE
fix: enhance peer connection retrieval with optional waiting flag and improved logging

### DIFF
--- a/lib/features/call/models/models.dart
+++ b/lib/features/call/models/models.dart
@@ -4,6 +4,7 @@ export 'call_display.dart';
 export 'call_status.dart';
 export 'jsep_value.dart';
 export 'notification.dart';
-export 'signaling_client_status.dart';
 export 'processing_status.dart';
+export 'signaling_client_status.dart';
 export 'transfer.dart';
+export 'uncompleted_peer_connection_exception.dart';

--- a/lib/features/call/models/uncompleted_peer_connection_exception.dart
+++ b/lib/features/call/models/uncompleted_peer_connection_exception.dart
@@ -1,0 +1,8 @@
+class UncompletedPeerConnectionException implements Exception {
+  final String message;
+
+  UncompletedPeerConnectionException(this.message);
+
+  @override
+  String toString() => 'UncompletedPeerConnectionException: $message';
+}


### PR DESCRIPTION
- Added an optional allowWaiting parameter to _peerConnectionRetrieve, allowing control over waiting behavior.
- Improved logging for different retrieval scenarios, including handling of uncompleted futures.
- Ensured proper exception handling and timeout management.