### PR TITLE
chore: reduce logging verbosity across core components

### DIFF
--- a/lib/app/app_bloc_observer.dart
+++ b/lib/app/app_bloc_observer.dart
@@ -7,25 +7,25 @@ class AppBlocObserver extends BlocObserver {
   @override
   void onCreate(BlocBase bloc) {
     super.onCreate(bloc);
-    _logger.fine('onCreate $bloc');
+    _logger.finest('onCreate $bloc');
   }
 
   @override
   void onEvent(Bloc bloc, Object? event) {
     super.onEvent(bloc, event);
-    _logger.fine('onEvent $bloc: $event');
+    _logger.finest('onEvent $bloc: $event');
   }
 
   @override
   void onChange(BlocBase bloc, Change change) {
     super.onChange(bloc, change);
-    _logger.fine('onChange $bloc: $change');
+    _logger.finest('onChange $bloc: $change');
   }
 
   @override
   onTransition(Bloc bloc, Transition transition) {
     super.onTransition(bloc, transition);
-    _logger.fine('onTransition $bloc: $transition');
+    _logger.finest('onTransition $bloc: $transition');
   }
 
   @override
@@ -37,6 +37,6 @@ class AppBlocObserver extends BlocObserver {
   @override
   void onClose(BlocBase bloc) {
     super.onClose(bloc);
-    _logger.fine('onClose $bloc');
+    _logger.finest('onClose $bloc');
   }
 }

--- a/lib/app/router/app_router_observer.dart
+++ b/lib/app/router/app_router_observer.dart
@@ -15,37 +15,37 @@ class AppRouterObserver extends AutoRouterObserver {
   @override
   void didChangeTabRoute(TabPageRoute route, TabPageRoute previousRoute) {
     super.didChangeTabRoute(route, previousRoute);
-    _logger.fine(() => 'didChangeTabRoute: $route / $previousRoute');
+    _logger.fine(() => 'didChangeTabRoute: ${route.name} / ${previousRoute.name}');
   }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    _logger.fine(() => 'didPush: $route / $previousRoute');
+    _logger.fine(() => 'didPush: ${route.settings.name} / ${previousRoute?.settings.name}');
   }
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
-    _logger.fine(() => 'didPop: $route / $previousRoute');
+    _logger.fine(() => 'didPop: ${route.settings.name} / ${previousRoute?.settings.name}');
   }
 
   @override
   void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didRemove(route, previousRoute);
-    _logger.fine(() => 'didRemove: $route / $previousRoute');
+    _logger.fine(() => 'didRemove: ${route.settings.name} / ${route.settings.name}');
   }
 
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    _logger.fine(() => 'didReplace newRoute: $newRoute oldRoute: $oldRoute');
+    _logger.fine(() => 'didReplace newRoute: ${newRoute?.settings.name} oldRoute: ${oldRoute?.settings.name}');
   }
 
   @override
   void didStartUserGesture(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didStartUserGesture(route, previousRoute);
-    _logger.fine(() => 'didStartUserGesture: $route / $previousRoute');
+    _logger.fine(() => 'didStartUserGesture: ${route.settings.name} / ${previousRoute?.settings.name}');
   }
 
   @override

--- a/lib/blocs/external_contacts_sync/external_contacts_sync_bloc.dart
+++ b/lib/blocs/external_contacts_sync/external_contacts_sync_bloc.dart
@@ -31,7 +31,7 @@ class ExternalContactsSyncBloc extends Bloc<ExternalContactsSyncEvent, ExternalC
   final AppDatabase appDatabase;
 
   void _onStarted(ExternalContactsSyncStarted event, Emitter<ExternalContactsSyncState> emit) async {
-    _logger.info('_onStarted');
+    _logger.finer('_onStarted');
 
     final externalContactsForEachFuture = emit.onEach<List<ExternalContact>>(
       externalContactsRepository.contacts(),
@@ -45,7 +45,7 @@ class ExternalContactsSyncBloc extends Bloc<ExternalContactsSyncEvent, ExternalC
   }
 
   void _onRefreshed(ExternalContactsSyncRefreshed event, Emitter<ExternalContactsSyncState> emit) async {
-    _logger.info('_onRefreshed');
+    _logger.finer('_onRefreshed');
 
     emit(const ExternalContactsSyncRefreshInProgress());
     try {
@@ -62,7 +62,7 @@ class ExternalContactsSyncBloc extends Bloc<ExternalContactsSyncEvent, ExternalC
     int retryCount = 0,
     UserInfo? userInfo,
   }) async {
-    _logger.info('_onUpdated contacts count:${event.contacts.length}');
+    _logger.finer('_onUpdated contacts count:${event.contacts.length}');
 
     try {
       userInfo ??= await userRepository.getInfo();

--- a/lib/blocs/local_contacts_sync/local_contacts_sync_bloc.dart
+++ b/lib/blocs/local_contacts_sync/local_contacts_sync_bloc.dart
@@ -33,7 +33,7 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
 
   @override
   Future<void> close() async {
-    _logger.info('close');
+    _logger.finer('close');
 
     WidgetsBinding.instance.removeObserver(this);
     await super.close();
@@ -41,7 +41,7 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    _logger.info('didChangeAppLifecycleState: $state');
+    _logger.finer('didChangeAppLifecycleState: $state');
 
     if (PlatformInfo().isAndroid) {
       if (state == AppLifecycleState.resumed && this.state is LocalContactsSyncPermissionFailure) {
@@ -51,7 +51,7 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
   }
 
   void _onStarted(LocalContactsSyncStarted event, Emitter<LocalContactsSyncState> emit) async {
-    _logger.info('_onStarted');
+    _logger.finer('_onStarted');
 
     if (!await localContactsRepository.requestPermission()) {
       _logger.warning('_onStarted permission failure');
@@ -70,7 +70,7 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
   }
 
   void _onRefreshed(LocalContactsSyncRefreshed event, Emitter<LocalContactsSyncState> emit) async {
-    _logger.info('_onRefreshed');
+    _logger.finer('_onRefreshed');
 
     emit(const LocalContactsSyncRefreshInProgress());
     try {
@@ -82,7 +82,7 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
   }
 
   Future _onUpdated(_LocalContactsSyncUpdated event, Emitter<LocalContactsSyncState> emit, {int retryCount = 0}) async {
-    _logger.info('_onUpdated contacts count:${event.contacts.length}');
+    _logger.finer('_onUpdated contacts count:${event.contacts.length}');
 
     try {
       await appDatabase.transaction(() async {

--- a/lib/features/call_to_actions/bloc/call_to_actions_cubit.dart
+++ b/lib/features/call_to_actions/bloc/call_to_actions_cubit.dart
@@ -43,7 +43,7 @@ class CallToActionsCubit extends Cubit<CallToActionsCubitState> {
 
   Future<void> getActions(MainFlavor flavor) async {
     if (state.flavor == flavor) {
-      _logger.fine('Flavor $flavor is already set.');
+      _logger.finest('Flavor $flavor is already set.');
       return;
     }
 
@@ -53,7 +53,7 @@ class CallToActionsCubit extends Cubit<CallToActionsCubitState> {
     if (state.actions[flavor] == null) {
       await _loadFlavorActions(flavor, state.locale);
     } else {
-      _logger.fine('Actions for flavor $flavor already loaded.');
+      _logger.finest('Actions for flavor $flavor already loaded.');
     }
   }
 

--- a/lib/features/main/widgets/main_screen_route_observer.dart
+++ b/lib/features/main/widgets/main_screen_route_observer.dart
@@ -13,14 +13,14 @@ class MainScreenNavigatorObserver extends AutoRouterObserver {
 
   @override
   void didInitTabRoute(TabPageRoute route, TabPageRoute? previousRoute) {
-    _logger.info('didInitTabRoute: ${route.routeInfo.name}');
+    _logger.finest('didInitTabRoute: ${route.routeInfo.name}');
     _mainScreenRouteStateRepository.setActiveTabPage(route.routeInfo.name);
     super.didInitTabRoute(route, previousRoute);
   }
 
   @override
   void didChangeTabRoute(TabPageRoute route, TabPageRoute previousRoute) {
-    _logger.info('didchangeTabRoute: ${route.routeInfo.name}');
+    _logger.finest('didChangeTabRoute: ${route.routeInfo.name}');
     _mainScreenRouteStateRepository.setActiveTabPage(route.routeInfo.name);
     super.didChangeTabRoute(route, previousRoute);
   }
@@ -28,7 +28,7 @@ class MainScreenNavigatorObserver extends AutoRouterObserver {
   @override
   void didPush(Route route, Route? previousRoute) {
     final args = route.data?.route.args;
-    _logger.info('didPush: ${route.settings.name}');
+    _logger.finest('didPush: ${route.settings.name}');
     _mainScreenRouteStateRepository.setLastRouteArgs(args);
     super.didPush(route, previousRoute);
   }
@@ -36,7 +36,7 @@ class MainScreenNavigatorObserver extends AutoRouterObserver {
   @override
   void didPop(Route route, Route? previousRoute) {
     final args = previousRoute?.data?.route.args;
-    _logger.info('didPop: ${route.settings.name}');
+    _logger.finest('didPop: ${route.settings.name}');
     _mainScreenRouteStateRepository.setLastRouteArgs(args);
     super.didPop(route, previousRoute);
   }

--- a/lib/features/messaging/services/chats_outbox_worker.dart
+++ b/lib/features/messaging/services/chats_outbox_worker.dart
@@ -25,7 +25,7 @@ class ChatsOutboxWorker {
   bool _disposed = false;
 
   init() {
-    _logger.info('Initialising...');
+    _logger.fine('Initialising...');
 
     /// Continuously processes messages, edits, deletes, and read cursors from the outbox repository
     /// until the worker is disposed. The loop runs every second.
@@ -49,7 +49,7 @@ class ChatsOutboxWorker {
   }
 
   dispose() {
-    _logger.info('Disposing...');
+    _logger.fine('Disposing...');
     _disposed = true;
   }
 
@@ -83,7 +83,7 @@ class ChatsOutboxWorker {
       if (chat != null) await _chatsRepository.upsertChat(chat);
       await _chatsRepository.upsertMessage(message);
       await _outboxRepository.deleteOutboxMessage(outboxEntry.idKey);
-      _logger.info('Processed new message: ${message.id}');
+      _logger.fine('Processed new message: ${message.id}');
     } catch (e, s) {
       _logger.severe('Error processing new message, attempt: ${outboxEntry.sendAttempts}', e, s);
       if (outboxEntry.sendAttempts > 5) {
@@ -112,7 +112,7 @@ class ChatsOutboxWorker {
       final message = await channel.editChatMessage(messageEdit);
       await _chatsRepository.upsertMessage(message);
       await _outboxRepository.deleteOutboxMessageEdit(messageEdit.id);
-      _logger.info('Processed edit message: ${message.id}');
+      _logger.fine('Processed edit message: ${message.id}');
     } catch (e, s) {
       _logger.severe('Error processing message edit, attempt: ${messageEdit.sendAttempts}', e, s);
       if (messageEdit.sendAttempts > 5) {
@@ -141,7 +141,7 @@ class ChatsOutboxWorker {
       final message = await channel.deleteChatMessage(messageDelete);
       await _chatsRepository.upsertMessage(message);
       await _outboxRepository.deleteOutboxMessageDelete(messageDelete.id);
-      _logger.info('Processed delete message: ${message.id}');
+      _logger.fine('Processed delete message: ${message.id}');
     } catch (e, s) {
       _logger.severe('Error processing message delete, attempt: ${messageDelete.sendAttempts}', e, s);
       if (messageDelete.sendAttempts > 5) {
@@ -171,7 +171,7 @@ class ChatsOutboxWorker {
       final cursor = await channel.setChatReadCursor(readCursor);
       await _chatsRepository.upsertChatMessageReadCursor(cursor);
       await _outboxRepository.deleteOutboxReadCursor(readCursor.chatId);
-      _logger.info('Processed read cursor: ${readCursor.chatId}');
+      _logger.fine('Processed read cursor: ${readCursor.chatId}');
     } catch (e, s) {
       _logger.severe('Error processing read cursor, attempt: ${readCursor.sendAttempts}', e, s);
       if (readCursor.sendAttempts > 5) {

--- a/lib/features/messaging/services/chats_sync_worker.dart
+++ b/lib/features/messaging/services/chats_sync_worker.dart
@@ -50,7 +50,7 @@ class ChatsSyncWorker {
   final Map<int, StreamSubscription> _conversationSyncSubs = {};
 
   Future init() async {
-    _logger.info('Initialising...');
+    _logger.fine('Initialising...');
     _closeSubs();
     _conversationsSyncSub = _conversationsSyncStream().listen(
       (e) {
@@ -59,19 +59,19 @@ class ChatsSyncWorker {
           _logger.warning('conversations sync error:', error, stackTrace);
           onError(error);
         } else {
-          _logger.info('conversations sync event: $e');
+          _logger.fine('conversations sync event: $e');
         }
       },
     );
   }
 
   Future dispose() async {
-    _logger.info('Disposing...');
+    _logger.fine('Disposing...');
     _closeSubs();
   }
 
   Future _conversationSubscribe(int id) async {
-    _logger.info('Subscribing to conversation $id');
+    _logger.fine('Subscribing to conversation $id');
 
     PhoenixChannel? channel = client.getChatChannel(id);
 
@@ -92,7 +92,7 @@ class ChatsSyncWorker {
             _logger.warning('conversation sync error: $id', error, stackTrace);
             onError(error);
           } else {
-            _logger.info('conversation sync event: $id $e');
+            _logger.fine('conversation sync event: $id $e');
           }
         },
       ),
@@ -100,7 +100,7 @@ class ChatsSyncWorker {
   }
 
   Future _conversationUnsubscribe(int id) async {
-    _logger.info('Unsubscribing from $id');
+    _logger.fine('Unsubscribing from $id');
     _conversationSyncSubs.remove(id)?.cancel();
     await client.getChatChannel(id)?.leave().future;
   }

--- a/lib/features/push_tokens/bloc/push_tokens_bloc.dart
+++ b/lib/features/push_tokens/bloc/push_tokens_bloc.dart
@@ -73,7 +73,7 @@ class PushTokensBloc extends Bloc<PushTokensEvent, PushTokensState> implements P
 
     final fcmToken = await _backoffRetries.execute<String?>(
       (attempt) async {
-        _logger.info('_retrieveAndStoreFcmToken attempt $attempt');
+        _logger.fine('_retrieveAndStoreFcmToken attempt $attempt');
         return await firebaseMessaging.getToken(vapidKey: vapidKey);
       },
       shouldRetry: (e, attempt) {
@@ -92,7 +92,7 @@ class PushTokensBloc extends Bloc<PushTokensEvent, PushTokensState> implements P
   Future<void> _retrieveAndStoreApnsToken() async {
     final apnsToken = await _backoffRetries.execute<String?>(
       (attempt) async {
-        _logger.info('_retrieveAndStoreApnsToken attempt $attempt');
+        _logger.fine('_retrieveAndStoreApnsToken attempt $attempt');
         return await firebaseMessaging.getAPNSToken();
       },
       shouldRetry: (e, attempt) {
@@ -112,7 +112,7 @@ class PushTokensBloc extends Bloc<PushTokensEvent, PushTokensState> implements P
     try {
       await _backoffRetries.execute<void>(
         (attempt) async {
-          _logger.info('_onInsertedOrUpdated attempt $attempt');
+          _logger.fine('_onInsertedOrUpdated attempt $attempt');
           await pushTokensRepository.insertOrUpdatePushToken(event.type, event.value);
         },
         shouldRetry: (e, attempt) {
@@ -127,7 +127,7 @@ class PushTokensBloc extends Bloc<PushTokensEvent, PushTokensState> implements P
         secureStorage.writeFCMPushToken(event.value);
       }
 
-      _logger.info('Push token inserted or updated: ${event.type} ${event.value}');
+      _logger.fine('Push token inserted or updated: ${event.type} ${event.value}');
     } catch (e, stackTrace) {
       _logger.warning('_onInsertedOrUpdated', e, stackTrace);
     }

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -41,7 +41,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   }
 
   void _emitCombinedStatus([PushTokensState? initialPushTokens, CallState? initialCall]) {
-    _logger.info('emitCombinedStatus: $_lastPushTokensState, $_lastCallState');
+    _logger.finest('emitCombinedStatus: $_lastPushTokensState, $_lastCallState');
 
     final pushTokens = initialPushTokens ?? _lastPushTokensState;
     final call = initialCall ?? _lastCallState;

--- a/lib/widgets/safe_network_image.dart
+++ b/lib/widgets/safe_network_image.dart
@@ -38,7 +38,8 @@ class _SafeNetworkImageState extends State<SafeNetworkImage> {
               if (mounted) setState(() => _isLoaded = true);
             },
             onError: (error, stackTrace) {
-              _logger.warning('Error loading image: $error', error);
+              // Log the error for debugging purposes
+              _logger.finest('Error loading image: $error', error);
               if (mounted) setState(() => _hasError = true);
             },
           ),

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -157,7 +157,7 @@ class WebtritSignalingClient {
   //
 
   void _wscStreamOnData(dynamic data) {
-    _logger.finer('_wsOnData: $data');
+    _logger.fine('_wsOnData: $data');
 
     final Map<String, dynamic> messageJson = jsonDecode(data);
     _onMessage(messageJson);
@@ -278,7 +278,7 @@ class WebtritSignalingClient {
   }
 
   void _addData(dynamic data) {
-    _logger.finer(() => '_addData add: $data');
+    _logger.fine(() => '_addData add: $data');
 
     _wsc.sink.add(data);
   }


### PR DESCRIPTION
- Downgraded BlocObserver logs from fine to finest
- Reduced log level for WebSocket data events
- Downgraded image loading error log from warning to finest
- Replaced route observer logs with formatted route names
- Lowered push token logs from info to fine
- Reduced log level for ChatsSyncWorker and ChatsOutboxWorker
- Downgraded MainScreenNavigatorObserver logs to finest
- Lowered flavor check logs to finest
- Reduced verbosity in ExternalContactsSync logs