### PR TITLE
feat: add additonal labels for log filtering

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -50,6 +50,9 @@ class _MainShellState extends State<MainShell> {
         ),
       ),
     );
+
+    // After authentication, regenerate the labels to include core URL and tenant ID in remote logging labels
+    context.read<AppLogger>().regenerateRemoteLabels();
   }
 
   @override

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -58,9 +58,9 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
       final appInfo = await AppInfo.init(FirebaseAppIdProvider());
       final deviceInfo = await DeviceInfoFactory.init();
       final packageInfo = await PackageInfoFactory.init();
+      final secureStorage = await SecureStorage.init();
 
       await AppPermissions.init(featureAccess);
-      await SecureStorage.init();
       await AppCertificates.init();
       await AppTime.init();
       await SessionCleanupWorker.init();
@@ -69,6 +69,7 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
         packageInfo: packageInfo,
         deviceInfo: deviceInfo,
         appInfo: appInfo,
+        secureStorage: secureStorage,
       );
 
       await _initCallkeep(appPreferences);
@@ -147,12 +148,14 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   final appInfo = await AppInfo.init(const SharedPreferencesAppIdProvider());
   final deviceInfo = await DeviceInfoFactory.init();
   final packageInfo = await PackageInfoFactory.init();
+  final secureStorage = await SecureStorage.init();
 
   await AppLogger.init(
     remoteConfigService: remoteCacheConfigService,
     packageInfo: packageInfo,
     deviceInfo: deviceInfo,
     appInfo: appInfo,
+    secureStorage: secureStorage,
   );
 
   final appNotification = AppRemoteNotification.fromFCM(message);

--- a/lib/common/logging/logzio_logging_service.dart
+++ b/lib/common/logging/logzio_logging_service.dart
@@ -5,6 +5,8 @@ import 'filtered_logz_io_appender.dart';
 import 'remote_formatter.dart';
 import 'remote_logging_service.dart';
 
+final _logger = Logger('LogzioLoggingService');
+
 class LogzioLoggingService implements RemoteLoggingService {
   LogzioLoggingService({
     required this.url,
@@ -20,6 +22,7 @@ class LogzioLoggingService implements RemoteLoggingService {
 
   @override
   void initialize(Map<String, String> labels) {
+    _logger.finest('Initializing with url: $url, token: $token, bufferSize: $bufferSize labels: $labels');
     final remoteFormatter = AnonymizingFormatter(
       anonymizationTypes: AnonymizationType.full,
       wrappedFormatter: const RemoteFormatter(),

--- a/lib/features/call/services/services_isolate.dart
+++ b/lib/features/call/services/services_isolate.dart
@@ -33,16 +33,15 @@ Future<void> _initializeCommonDependencies() async {
   _appInfo ??= await AppInfo.init(const SharedPreferencesAppIdProvider());
   _deviceInfo ??= await DeviceInfoFactory.init();
   _packageInfo ??= await PackageInfoFactory.init();
+  _secureStorage = await SecureStorage.init();
   _appLogger ??= await AppLogger.init(
     remoteConfigService: _remoteConfigService!,
     packageInfo: _packageInfo!,
     deviceInfo: _deviceInfo!,
     appInfo: _appInfo!,
+    secureStorage: _secureStorage!,
   );
   _appCertificates ??= await AppCertificates.init();
-
-  // Always create a new instance to avoid caching issues
-  _secureStorage = await SecureStorage.init();
 
   _callLogsRepository ??= CallLogsRepository(appDatabase: await IsolateDatabase.create());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,6 +85,11 @@ void main() {
             return AppPermissions();
           },
         ),
+        Provider<AppLogger>(
+          create: (context) {
+            return AppLogger();
+          },
+        ),
       ],
       child: MultiRepositoryProvider(
         providers: [


### PR DESCRIPTION
AppLogger still generates labels upon instance creation, ensuring initial context is available.
However, a new method has been added to allow regenerating these labels dynamically — for example, after user authorization when additional context (e.g. core URL, tenant id) becomes available.
