### PR TITLE
fix: handle SDP renegotiation failure by filtering unsupported audio codecs on client

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2602,8 +2602,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         final pcState = peerConnection.signalingState;
         logger.fine(() => 'onRenegotiationNeeded signalingState: $pcState');
         if (pcState != null) {
+          final negotiatedRemoteSdp = (await peerConnection.getRemoteDescription())!;
           final localDescription = await peerConnection.createOffer({});
-          sdpMunger?.apply(localDescription);
+          // Munges SDP to remove unsupported codecs from local offer
+          // based on the last negotiated remote SDP.
+          sdpMunger?.apply(localDescription, negotiatedRemoteSdp);
 
           final updateRequest = UpdateRequest(
             transaction: WebtritSignalingClient.generateTransactionId(),


### PR DESCRIPTION
Removes non-negotiated audio codecs (e.g. opus) from remote SDP during renegotiation using SDPModBuilder to ensure compatibility with previously established media tracks.