### PR TITLE
feat: add and integrate RemoteSdpSanitizer for remote SDP cleanup

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -250,6 +250,7 @@ class _MainShellState extends State<MainShell> {
                 callkeep: _callkeep,
                 callkeepConnections: _callkeepConnections,
                 sdpMunger: ModifyWithEncodingSettings(appPreferences, encodingConfig),
+                sdpSanitizer: RemoteSdpSanitizer(),
                 audioConstraintsBuilder: AudioConstraintsWithAppSettingsBuilder(appPreferences),
                 videoConstraintsBuilder: VideoConstraintsWithAppSettingsBuilder(appPreferences),
                 webRtcOptionsBuilder: WebrtcOptionsWithAppSettingsBuilder(appPreferences),

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -53,6 +53,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final CallkeepConnections callkeepConnections;
 
   final SDPMunger? sdpMunger;
+  final SdpSanitizer? sdpSanitizer;
+
   final AudioConstraintsBuilder? audioConstraintsBuilder;
   final VideoConstraintsBuilder? videoConstraintsBuilder;
   final WebrtcOptionsBuilder? webRtcOptionsBuilder;
@@ -78,6 +80,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required this.callkeep,
     required this.callkeepConnections,
     this.sdpMunger,
+    this.sdpSanitizer,
     this.audioConstraintsBuilder,
     this.videoConstraintsBuilder,
     this.webRtcOptionsBuilder,
@@ -857,6 +860,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         _logger.warning('__onCallSignalingEventProgress: peerConnection is null - most likely some permissions issue');
       } else {
         final remoteDescription = jsep.toDescription();
+        sdpSanitizer?.apply(remoteDescription);
         await peerConnection.setRemoteDescription(remoteDescription);
       }
     } else {
@@ -893,6 +897,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final pc = await _peerConnectionRetrieve(event.callId);
     if (jsep != null && pc != null) {
       final remoteDescription = jsep.toDescription();
+      sdpSanitizer?.apply(remoteDescription);
       await pc.setRemoteDescription(remoteDescription);
     }
   }
@@ -984,6 +989,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           if (peerConnection == null) {
             _logger.warning('__onCallSignalingEventUpdating: peerConnection is null - most likely some state issue');
           } else {
+            sdpSanitizer?.apply(remoteDescription);
             await peerConnection.setRemoteDescription(remoteDescription);
             final localDescription = await peerConnection.createAnswer({});
             sdpMunger?.apply(localDescription);
@@ -1799,6 +1805,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }));
 
       final remoteDescription = offer.toDescription();
+      sdpSanitizer?.apply(remoteDescription);
       await peerConnection.setRemoteDescription(remoteDescription);
       final localDescription = await peerConnection.createAnswer({});
       sdpMunger?.apply(localDescription);

--- a/lib/features/call/utils/sdp_sanitizer.dart
+++ b/lib/features/call/utils/sdp_sanitizer.dart
@@ -1,0 +1,35 @@
+// ignore_for_file: avoid_function_literals_in_foreach_calls
+
+import 'package:logging/logging.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+import 'package:webtrit_phone/features/call/utils/utils.dart';
+
+final _logger = Logger('SdpSanitizer');
+
+abstract class SdpSanitizer {
+  void apply(RTCSessionDescription description);
+}
+
+class RemoteSdpSanitizer implements SdpSanitizer {
+  @override
+  void apply(RTCSessionDescription description) {
+    final originalSdp = description.sdp;
+    if (originalSdp == null) {
+      _logger.fine('Remote SDP is null, skipping clean');
+      return;
+    }
+
+    _logger.fine('Original remote SDP: $originalSdp');
+
+    final builder = SDPModBuilder(sdp: originalSdp)..clean();
+    final cleanedSdp = builder.sdp;
+
+    if (cleanedSdp != originalSdp) {
+      _logger.info('Clean SDP: $cleanedSdp');
+      description.sdp = cleanedSdp;
+    } else {
+      _logger.fine('Remote SDP is already clean. No changes made.');
+    }
+  }
+}

--- a/lib/features/call/utils/utils.dart
+++ b/lib/features/call/utils/utils.dart
@@ -1,6 +1,7 @@
+export 'audio_constraints_builder.dart';
+export 'ice_filter.dart';
 export 'sdp_mod_builder.dart';
 export 'sdp_munger.dart';
-export 'audio_constraints_builder.dart';
+export 'sdp_sanitizer.dart';
 export 'video_constraints_builder.dart';
 export 'webrtc_options_builder.dart';
-export 'ice_filter.dart';


### PR DESCRIPTION
- Introduced `SdpSanitizer` abstraction and `RemoteSdpSanitizer` implementation for cleaning unsupported or invalid SDP fields.
- Integrated `sdpSanitizer` into call flow to sanitize remote SDP before applying it via `setRemoteDescription`.
- Ensures better compatibility with services that do not support certain parameters