### PR TITLE
fix: fallback to video flag when remote stream is unavailable to indicate original incoming call type

### DIFF
--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -153,7 +153,7 @@ class ActiveCall with _$ActiveCall {
 
   bool get wasHungUp => hungUpTime != null;
 
-  bool get remoteVideo => remoteStream?.getVideoTracks().isNotEmpty ?? false;
+  bool get remoteVideo => remoteStream?.getVideoTracks().isNotEmpty ?? video;
 
   bool get localVideo => localStream?.getVideoTracks().isNotEmpty ?? false;
 


### PR DESCRIPTION
Allows showing video icon for incoming calls even before the remote stream is available

Note: switching from video to audio before answer is not yet handled and requires signaling update