### PR TITLE
feat: support defining cleartext HTTP allowed domains via dart-define

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,14 +41,65 @@ if (project.hasProperty('dart-defines')) {
             }
 }
 
-def dartDefine = [
-        WEBTRIT_APP_LINK_DOMAIN: projectPropertyDartDefines['WEBTRIT_APP_LINK_DOMAIN'] ?: 'app.webtrit.com',
-        WEBTRIT_APP_NAME       : projectPropertyDartDefines['WEBTRIT_APP_NAME'] ?: 'WebTrit',
-]
+def dartDefine = [WEBTRIT_APP_LINK_DOMAIN: projectPropertyDartDefines['WEBTRIT_APP_LINK_DOMAIN'] ?: 'app.webtrit.com',
+                  WEBTRIT_APP_NAME       : projectPropertyDartDefines['WEBTRIT_APP_NAME'] ?: 'WebTrit',]
 
-def envDefine = [
-        WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH: projectPropertyDartDefines['WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH'] ?: '',
-]
+def envDefine = [WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH: projectPropertyDartDefines['WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH'] ?: '',
+                 WEBTRIT_ANDROID_HTTP_ALLOWED_DOMAINS        : projectPropertyDartDefines['WEBTRIT_ANDROID_HTTP_ALLOWED_DOMAINS'] ?: '',]
+
+def generateNetworkSecurityConfig = tasks.register("generateNetworkSecurityConfig") {
+    doLast {
+        // Parse and validate domain definitions passed from dart-define; reject any malformed entries
+        def rawDomainDefs = (envDefine['WEBTRIT_ANDROID_HTTP_ALLOWED_DOMAINS'] ?: '').split(';')
+
+        def invalidDomains = []
+        // Transform raw semicolon-separated input into a list of [domain, includeSubdomains] entries,
+        // applying validation and using false as default for includeSubdomains
+        def domainEntries = rawDomainDefs
+                .collect { it.trim() }
+                .findAll { it }
+                .collect { entry ->
+                    def parts = entry.split(',')
+                    def domain = parts[0].trim()
+                    def includeSub = (parts.size() > 1) ? parts[1].trim().toLowerCase() == 'true' : false
+                    def isValid = !domain.contains('/') && !domain.contains(':') && !domain.startsWith('http')
+                    if (!isValid) {
+                        invalidDomains << entry
+                    }
+                    return [domain: domain, includeSubdomains: includeSub, isValid: isValid]
+                }
+                .findAll { it.isValid }
+
+        // Stop build if any invalid domains are detected
+        if (!invalidDomains.isEmpty()) {
+            throw new GradleException("❌ Invalid domain entries found in WEBTRIT_ANDROID_HTTP_ALLOWED_DOMAINS:\n${invalidDomains.join('\n')}")
+        }
+
+        // Exit early if no valid domains were provided
+        if (domainEntries.isEmpty()) {
+            println "⚠️  No valid HTTP domain entries defined, skipping network_security_config.xml generation."
+            return
+        }
+
+        // Generate the network_security_config.xml content
+        def xmlContent = new StringBuilder()
+        xmlContent << '<?xml version="1.0" encoding="utf-8"?>\n'
+        xmlContent << '<network-security-config>\n'
+        domainEntries.each { entry ->
+            xmlContent << '    <domain-config cleartextTrafficPermitted="true">\n'
+            xmlContent << "        <domain includeSubdomains=\"${entry.includeSubdomains}\">${entry.domain}</domain>\n"
+            xmlContent << '    </domain-config>\n'
+        }
+        xmlContent << '    <base-config cleartextTrafficPermitted="false" />\n'
+        xmlContent << '</network-security-config>\n'
+
+        def outputFile = file("$projectDir/src/main/res/xml/network_security_config.xml")
+        outputFile.parentFile.mkdirs()
+        outputFile.text = xmlContent.toString()
+
+        println "✅  Generated network_security_config.xml with entries: ${domainEntries}"
+    }
+}
 
 def keystoreMetadata
 def keystoreFile
@@ -120,6 +171,7 @@ android {
             signingConfig signingConfigs.release
         }
     }
+    preBuild.dependsOn generateNetworkSecurityConfig
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,7 +46,8 @@
         android:label="@string/APP_NAME"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:allowBackup="false">
+        android:allowBackup="false"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/dart_define.json
+++ b/dart_define.json
@@ -12,5 +12,9 @@
   "WEBTRIT_APP_FCM_VAPID_KEY": "BPBbn4Fc-PNQA5_mSj623NYDEGa5lqFLKVZ9qcfLPp2zrot2Vb5GzCx-3IbhKi1EsFuzgHY11BOpkXvZqXq-5w4",
   "_WEBTRIT_APP_REMOTE_LOGZIO_LOGGING_URL": "",
   "_WEBTRIT_APP_REMOTE_LOGZIO_LOGGING_TOKEN": "",
-  "_WEBTRIT_APP_REMOTE_LOGZIO_LOGGING_BUFFER_SIZE": ""
+  "_WEBTRIT_APP_REMOTE_LOGZIO_LOGGING_BUFFER_SIZE": "",
+  "_WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH": "",
+  "_WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH_DESCRIPTION": "Optional path to directory containing upload-keystore-metadata.json and keystore file. Used to configure Android release signing automatically. If not provided, fallback to key.properties will be used.",
+  "WEBTRIT_ANDROID_HTTP_ALLOWED_DOMAINS": "127.0.0.1",
+  "_WEBTRIT_ANDROID_HTTP_ALLOWED_DOMAINS_DESCRIPTION": "List of HTTP domains allowed for cleartext (non-HTTPS) traffic on Android. Use format: 'domain,includeSubdomains' (optional), separated by semicolons. Example: '127.0.0.1,false;dev.api.com,true;local.test'. If 'includeSubdomains' is omitted, it defaults to false. '127.0.0.1' is required for just_audio to enable local proxy features like headers and caching."
 }


### PR DESCRIPTION
Enable configuration of allowed cleartext HTTP domains on Android via dart-define