### PR TITLE
feat: move voicemail item to services group

### DIFF
--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -72,6 +72,18 @@
   "settingsConfig": {
     "sections": [
       {
+        "titleL10n": "settings_ListViewTileTitle_features",
+        "enabled": true,
+        "items": [
+          {
+            "enabled": true,
+            "type": "voicemail",
+            "titleL10n": "settings_ListViewTileTitle_voicemail",
+            "icon": "0xe6c1"
+          }
+        ]
+      },
+      {
         "titleL10n": "settings_ListViewTileTitle_settings",
         "enabled": true,
         "items": [
@@ -86,12 +98,6 @@
             "type": "mediaSettings",
             "titleL10n": "settings_ListViewTileTitle_mediaSettings",
             "icon": "0xf1cf"
-          },
-          {
-            "enabled": true,
-            "type": "voicemail",
-            "titleL10n": "settings_ListViewTileTitle_voicemail",
-            "icon": "0xe6c1"
           },
           {
             "enabled": true,

--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -73,10 +73,10 @@
     "sections": [
       {
         "titleL10n": "settings_ListViewTileTitle_features",
-        "enabled": true,
+        "enabled": false,
         "items": [
           {
-            "enabled": true,
+            "enabled": false,
             "type": "voicemail",
             "titleL10n": "settings_ListViewTileTitle_voicemail",
             "icon": "0xe6c1"

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -182,12 +182,15 @@ class FeatureAccess {
         items.add(settingItem);
       }
 
-      settingSections.add(
-        SettingsSection(
-          titleL10n: section.titleL10n,
-          items: items,
-        ),
-      );
+      // Skip empty sections
+      if (items.isNotEmpty) {
+        settingSections.add(
+          SettingsSection(
+            titleL10n: section.titleL10n,
+            items: items,
+          ),
+        );
+      }
     }
 
     return SettingsFeature(settingSections, preferences);

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2923,6 +2923,12 @@ abstract class AppLocalizations {
   /// **'SETTINGS'**
   String get settings_ListViewTileTitle_settings;
 
+  /// No description provided for @settings_ListViewTileTitle_features.
+  ///
+  /// In en, this message translates to:
+  /// **'SERVICES'**
+  String get settings_ListViewTileTitle_features;
+
   /// No description provided for @settings_ListViewTileTitle_termsConditions.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -895,6 +895,8 @@ class AppLocalizationsMapper {
           localizations.settings_ListViewTileTitle_self_config,
       'settings_ListViewTileTitle_settings':
           localizations.settings_ListViewTileTitle_settings,
+      'settings_ListViewTileTitle_features':
+          localizations.settings_ListViewTileTitle_features,
       'settings_ListViewTileTitle_termsConditions':
           localizations.settings_ListViewTileTitle_termsConditions,
       'settings_ListViewTileTitle_themeMode':

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1464,6 +1464,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_ListViewTileTitle_settings => 'SETTINGS';
 
   @override
+  String get settings_ListViewTileTitle_features => 'SERVICES';
+
+  @override
   String get settings_ListViewTileTitle_termsConditions => 'Terms and conditions';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1464,6 +1464,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_ListViewTileTitle_settings => 'IMPOSTAZIONI';
 
   @override
+  String get settings_ListViewTileTitle_features => 'SERVIZI';
+
+  @override
   String get settings_ListViewTileTitle_termsConditions => 'Termini e condizioni';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1464,6 +1464,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settings_ListViewTileTitle_settings => 'НАЛАШТУВАННЯ';
 
   @override
+  String get settings_ListViewTileTitle_features => 'СЕРВІСИ';
+
+  @override
   String get settings_ListViewTileTitle_termsConditions => 'Умови та положення';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1084,6 +1084,8 @@
   "@settings_ListViewTileTitle_self_config": {},
   "settings_ListViewTileTitle_settings": "SETTINGS",
   "@settings_ListViewTileTitle_settings": {},
+  "settings_ListViewTileTitle_features": "SERVICES",
+  "@settings_ListViewTileTitle_features": {},
   "settings_ListViewTileTitle_termsConditions": "Terms and conditions",
   "@settings_ListViewTileTitle_termsConditions": {},
   "settings_ListViewTileTitle_themeMode": "Theme mode",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1084,6 +1084,8 @@
   "@settings_ListViewTileTitle_self_config": {},
   "settings_ListViewTileTitle_settings": "IMPOSTAZIONI",
   "@settings_ListViewTileTitle_settings": {},
+  "settings_ListViewTileTitle_features": "SERVIZI",
+  "@settings_ListViewTileTitle_features": {},
   "settings_ListViewTileTitle_termsConditions": "Termini e condizioni",
   "@settings_ListViewTileTitle_termsConditions": {},
   "settings_ListViewTileTitle_themeMode": "Modalità tema",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1084,6 +1084,8 @@
   "@settings_ListViewTileTitle_self_config": {},
   "settings_ListViewTileTitle_settings": "НАЛАШТУВАННЯ",
   "@settings_ListViewTileTitle_settings": {},
+  "settings_ListViewTileTitle_features": "СЕРВІСИ",
+  "@settings_ListViewTileTitle_features": {},
   "settings_ListViewTileTitle_termsConditions": "Умови та положення",
   "@settings_ListViewTileTitle_termsConditions": {},
   "settings_ListViewTileTitle_themeMode": "Режим теми",


### PR DESCRIPTION
•	Added translations for voicemail and settings updates
•	Updated app configuration
•	Implemented logic to skip empty groups in the settings menu