### PR TITLE
fix: prevent duplicates by generating safe fallback sourceId

### DIFF
--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -184,4 +184,11 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
 
     return query.go();
   }
+
+  Future<int> deleteContactsWithNullSourceId(ContactSourceTypeEnum sourceType) {
+    return (delete(contactsTable)
+          ..where((t) => t.sourceType.equals(sourceType.index))
+          ..where((t) => t.sourceId.isNull()))
+        .go();
+  }
 }


### PR DESCRIPTION
Add fallback sourceId generation for contacts when server does not provide a stable ID