### PR TITLE
feat: disable camera toggle when video calls are not enabled via CallConfig

### DIFF
--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -287,9 +287,9 @@ class FeatureAccess {
 
     return CallFeature(
       callConfig: CallConfig(
-        videoEnable: callConfig.videoEnabled,
-        enableBlindTransfer: transferConfig.enableBlindTransfer,
-        enableAttendedTransfer: transferConfig.enableAttendedTransfer,
+        isVideoCallEnabled: callConfig.videoEnabled,
+        isBlindTransferEnabled: transferConfig.enableBlindTransfer,
+        isAttendedTransferEnabled: transferConfig.enableAttendedTransfer,
       ),
       encoding: EncodingConfig(
           bypassConfig: encodingConfig.bypassConfig,

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -286,8 +286,8 @@ class FeatureAccess {
     final peerConnectionConfig = appConfig.callConfig.peerConnection;
 
     return CallFeature(
-      videoEnable: callConfig.videoEnabled,
-      transfer: TransferConfig(
+      callConfig: CallConfig(
+        videoEnable: callConfig.videoEnabled,
         enableBlindTransfer: transferConfig.enableBlindTransfer,
         enableAttendedTransfer: transferConfig.enableAttendedTransfer,
       ),
@@ -439,14 +439,12 @@ class SettingsFeature {
 }
 
 class CallFeature {
-  final bool videoEnable;
-  final TransferConfig transfer;
+  final CallConfig callConfig;
   final EncodingConfig encoding;
   final PeerConnectionSettings peerConnection;
 
   CallFeature({
-    required this.videoEnable,
-    required this.transfer,
+    required this.callConfig,
     required this.encoding,
     required this.peerConnection,
   });

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -14,7 +14,7 @@ class CallActiveScaffold extends StatefulWidget {
     required this.speaker,
     required this.callStatus,
     required this.activeCalls,
-    required this.transferConfig,
+    required this.callConfig,
     required this.localePlaceholderBuilder,
     required this.remotePlaceholderBuilder,
   });
@@ -22,7 +22,7 @@ class CallActiveScaffold extends StatefulWidget {
   final bool? speaker;
   final CallStatus callStatus;
   final List<ActiveCall> activeCalls;
-  final CallConfig transferConfig;
+  final CallConfig callConfig;
   final WidgetBuilder? localePlaceholderBuilder;
   final WidgetBuilder? remotePlaceholderBuilder;
 
@@ -213,7 +213,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                         setState(() {});
                                       },
                                       transferableCalls: heldCalls,
-                                      onBlindTransferInitiated: widget.transferConfig.isBlindTransferEnabled
+                                      onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
                                           ? (!activeCall.wasAccepted || activeTransfer != null
                                               ? null
                                               : () {
@@ -223,7 +223,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 })
                                           : null,
                                       // TODO (Serdun): Simplify complex condition in the widget tree.
-                                      onAttendedTransferInitiated: widget.transferConfig.isAttendedTransferEnabled
+                                      onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
                                           ? (!activeCall.wasAccepted || activeTransfer != null
                                               ? null
                                               : () {
@@ -232,7 +232,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 })
                                           : null,
                                       // TODO (Serdun): Simplify complex condition in the widget tree.
-                                      onAttendedTransferSubmitted: widget.transferConfig.isAttendedTransferEnabled
+                                      onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
                                           ? (!activeCall.wasAccepted || activeTransfer != null
                                               ? null
                                               : (ActiveCall referorCall) {

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -213,7 +213,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                         setState(() {});
                                       },
                                       transferableCalls: heldCalls,
-                                      onBlindTransferInitiated: widget.transferConfig.enableBlindTransfer
+                                      onBlindTransferInitiated: widget.transferConfig.isBlindTransferEnabled
                                           ? (!activeCall.wasAccepted || activeTransfer != null
                                               ? null
                                               : () {
@@ -223,7 +223,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 })
                                           : null,
                                       // TODO (Serdun): Simplify complex condition in the widget tree.
-                                      onAttendedTransferInitiated: widget.transferConfig.enableAttendedTransfer
+                                      onAttendedTransferInitiated: widget.transferConfig.isAttendedTransferEnabled
                                           ? (!activeCall.wasAccepted || activeTransfer != null
                                               ? null
                                               : () {
@@ -232,7 +232,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 })
                                           : null,
                                       // TODO (Serdun): Simplify complex condition in the widget tree.
-                                      onAttendedTransferSubmitted: widget.transferConfig.enableAttendedTransfer
+                                      onAttendedTransferSubmitted: widget.transferConfig.isAttendedTransferEnabled
                                           ? (!activeCall.wasAccepted || activeTransfer != null
                                               ? null
                                               : (ActiveCall referorCall) {

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -192,12 +192,14 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                       wasHungUp: activeCall.wasHungUp,
                                       cameraValue: activeCall.cameraEnabled,
                                       inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
-                                      onCameraChanged: (bool value) {
-                                        context
-                                            .read<CallBloc>()
-                                            .add(CallControlEvent.cameraEnabled(activeCall.callId, value));
-                                        setState(() {});
-                                      },
+                                      onCameraChanged: widget.callConfig.isVideoCallEnabled
+                                          ? (bool value) {
+                                              context
+                                                  .read<CallBloc>()
+                                                  .add(CallControlEvent.cameraEnabled(activeCall.callId, value));
+                                              setState(() {});
+                                            }
+                                          : null,
                                       mutedValue: activeCall.muted,
                                       onMutedChanged: (bool value) {
                                         context

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -22,7 +22,7 @@ class CallActiveScaffold extends StatefulWidget {
   final bool? speaker;
   final CallStatus callStatus;
   final List<ActiveCall> activeCalls;
-  final TransferConfig transferConfig;
+  final CallConfig transferConfig;
   final WidgetBuilder? localePlaceholderBuilder;
   final WidgetBuilder? remotePlaceholderBuilder;
 

--- a/lib/features/call/view/call_screen.dart
+++ b/lib/features/call/view/call_screen.dart
@@ -17,10 +17,10 @@ class CallScreen extends StatefulWidget {
     super.key,
     this.localePlaceholderBuilder,
     this.remotePlaceholderBuilder,
-    this.transferConfig = const CallConfig(),
+    this.callConfig = const CallConfig(),
   });
 
-  final CallConfig transferConfig;
+  final CallConfig callConfig;
 
   final WidgetBuilder? localePlaceholderBuilder;
   final WidgetBuilder? remotePlaceholderBuilder;
@@ -66,7 +66,7 @@ class _CallScreenState extends State<CallScreen> with AutoRouteAwareStateMixin {
             speaker: state.speaker,
             callStatus: state.status,
             activeCalls: state.activeCalls,
-            transferConfig: widget.transferConfig,
+            callConfig: widget.callConfig,
             localePlaceholderBuilder: widget.localePlaceholderBuilder,
             remotePlaceholderBuilder: widget.remotePlaceholderBuilder,
           );

--- a/lib/features/call/view/call_screen.dart
+++ b/lib/features/call/view/call_screen.dart
@@ -17,11 +17,7 @@ class CallScreen extends StatefulWidget {
     super.key,
     this.localePlaceholderBuilder,
     this.remotePlaceholderBuilder,
-    this.transferConfig = const CallConfig(
-      videoEnable: true,
-      enableBlindTransfer: true,
-      enableAttendedTransfer: true,
-    ),
+    this.transferConfig = const CallConfig(),
   });
 
   final CallConfig transferConfig;

--- a/lib/features/call/view/call_screen.dart
+++ b/lib/features/call/view/call_screen.dart
@@ -17,13 +17,14 @@ class CallScreen extends StatefulWidget {
     super.key,
     this.localePlaceholderBuilder,
     this.remotePlaceholderBuilder,
-    this.transferConfig = const TransferConfig(
+    this.transferConfig = const CallConfig(
+      videoEnable: true,
       enableBlindTransfer: true,
       enableAttendedTransfer: true,
     ),
   });
 
-  final TransferConfig transferConfig;
+  final CallConfig transferConfig;
 
   final WidgetBuilder? localePlaceholderBuilder;
   final WidgetBuilder? remotePlaceholderBuilder;

--- a/lib/features/call/view/call_screen_page.dart
+++ b/lib/features/call/view/call_screen_page.dart
@@ -16,7 +16,7 @@ class CallScreenPage extends StatelessWidget {
     final featureAccess = context.read<FeatureAccess>();
 
     final widget = CallScreen(
-      transferConfig: featureAccess.callFeature.transfer,
+      transferConfig: featureAccess.callFeature.callConfig,
     );
     return widget;
   }

--- a/lib/features/call/view/call_screen_page.dart
+++ b/lib/features/call/view/call_screen_page.dart
@@ -16,7 +16,7 @@ class CallScreenPage extends StatelessWidget {
     final featureAccess = context.read<FeatureAccess>();
 
     final widget = CallScreen(
-      transferConfig: featureAccess.callFeature.callConfig,
+      callConfig: featureAccess.callFeature.callConfig,
     );
     return widget;
   }

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -21,7 +21,7 @@ class CallActions extends StatefulWidget {
     required this.wasHungUp,
     required this.cameraValue,
     required this.inviteToAttendedTransfer,
-    required this.onCameraChanged,
+    this.onCameraChanged,
     required this.mutedValue,
     this.onMutedChanged,
     this.speakerValue,
@@ -50,7 +50,7 @@ class CallActions extends StatefulWidget {
   final bool wasHungUp;
   final bool cameraValue;
   final bool inviteToAttendedTransfer;
-  final ValueChanged<bool> onCameraChanged;
+  final ValueChanged<bool>? onCameraChanged;
   final bool mutedValue;
   final ValueChanged<bool>? onMutedChanged;
   final bool? speakerValue;

--- a/lib/features/contact/view/contact_screen_page.dart
+++ b/lib/features/contact/view/contact_screen_page.dart
@@ -21,8 +21,8 @@ class ContactScreenPage extends StatelessWidget {
 
     final widget = ContactScreen(
       favoriteVisible: featureAccess.bottomMenuFeature.isTabEnabled(MainFlavor.favorites),
-      transferVisible: featureAccess.callFeature.callConfig.enableBlindTransfer,
-      videoVisible: featureAccess.callFeature.callConfig.videoEnable,
+      transferVisible: featureAccess.callFeature.callConfig.isBlindTransferEnabled,
+      videoVisible: featureAccess.callFeature.callConfig.isVideoCallEnabled,
       chatsEnabled: featureAccess.messagingFeature.chatsPresent,
     );
     final provider = BlocProvider(

--- a/lib/features/contact/view/contact_screen_page.dart
+++ b/lib/features/contact/view/contact_screen_page.dart
@@ -21,8 +21,8 @@ class ContactScreenPage extends StatelessWidget {
 
     final widget = ContactScreen(
       favoriteVisible: featureAccess.bottomMenuFeature.isTabEnabled(MainFlavor.favorites),
-      transferVisible: featureAccess.callFeature.transfer.enableBlindTransfer,
-      videoVisible: featureAccess.callFeature.videoEnable,
+      transferVisible: featureAccess.callFeature.callConfig.enableBlindTransfer,
+      videoVisible: featureAccess.callFeature.callConfig.videoEnable,
       chatsEnabled: featureAccess.messagingFeature.chatsPresent,
     );
     final provider = BlocProvider(

--- a/lib/features/favorites/view/favorites_screen_page.dart
+++ b/lib/features/favorites/view/favorites_screen_page.dart
@@ -19,7 +19,7 @@ class FavoritesScreenPage extends StatelessWidget {
 
     final widget = FavoritesScreen(
       title: const Text(EnvironmentConfig.APP_NAME),
-      videoCallEnable: featureAccess.callFeature.videoEnable,
+      videoCallEnable: featureAccess.callFeature.callConfig.videoEnable,
     );
     final provider = BlocProvider(
       create: (context) => FavoritesBloc(

--- a/lib/features/favorites/view/favorites_screen_page.dart
+++ b/lib/features/favorites/view/favorites_screen_page.dart
@@ -19,7 +19,7 @@ class FavoritesScreenPage extends StatelessWidget {
 
     final widget = FavoritesScreen(
       title: const Text(EnvironmentConfig.APP_NAME),
-      videoCallEnable: featureAccess.callFeature.callConfig.videoEnable,
+      videoCallEnable: featureAccess.callFeature.callConfig.isVideoCallEnabled,
     );
     final provider = BlocProvider(
       create: (context) => FavoritesBloc(

--- a/lib/features/keypad/view/keypad_screen_page.dart
+++ b/lib/features/keypad/view/keypad_screen_page.dart
@@ -19,7 +19,7 @@ class KeypadScreenPage extends StatelessWidget {
 
     final widget = KeypadScreen(
       title: const Text(EnvironmentConfig.APP_NAME),
-      videoVisible: featureAccess.callFeature.videoEnable
+      videoVisible: featureAccess.callFeature.callConfig.videoEnable,
     );
     final provider = BlocProvider(
       create: (context) => KeypadCubit(

--- a/lib/features/keypad/view/keypad_screen_page.dart
+++ b/lib/features/keypad/view/keypad_screen_page.dart
@@ -19,7 +19,7 @@ class KeypadScreenPage extends StatelessWidget {
 
     final widget = KeypadScreen(
       title: const Text(EnvironmentConfig.APP_NAME),
-      videoVisible: featureAccess.callFeature.callConfig.videoEnable,
+      videoVisible: featureAccess.callFeature.callConfig.isVideoCallEnabled,
     );
     final provider = BlocProvider(
       create: (context) => KeypadCubit(

--- a/lib/features/recent/view/recent_screen_page.dart
+++ b/lib/features/recent/view/recent_screen_page.dart
@@ -19,7 +19,7 @@ class RecentScreenPage extends StatelessWidget {
     final featureAccess = context.read<FeatureAccess>();
 
     final widget = RecentScreen(
-      videoVisible: featureAccess.callFeature.callConfig.videoEnable,
+      videoVisible: featureAccess.callFeature.callConfig.isVideoCallEnabled,
     );
     var provider = BlocProvider(
       create: (context) {

--- a/lib/features/recent/view/recent_screen_page.dart
+++ b/lib/features/recent/view/recent_screen_page.dart
@@ -19,7 +19,7 @@ class RecentScreenPage extends StatelessWidget {
     final featureAccess = context.read<FeatureAccess>();
 
     final widget = RecentScreen(
-      videoVisible: featureAccess.callFeature.videoEnable,
+      videoVisible: featureAccess.callFeature.callConfig.videoEnable,
     );
     var provider = BlocProvider(
       create: (context) {

--- a/lib/features/recents/view/recents_screen_page.dart
+++ b/lib/features/recents/view/recents_screen_page.dart
@@ -18,7 +18,7 @@ class RecentsScreenPage extends StatelessWidget {
 
     final widget = RecentsScreen(
       title: const Text(EnvironmentConfig.APP_NAME),
-      videoCallEnable: featureAccess.callFeature.videoEnable,
+      videoCallEnable: featureAccess.callFeature.callConfig.videoEnable,
       chatsEnabled: featureAccess.messagingFeature.chatsPresent,
     );
     return widget;

--- a/lib/features/recents/view/recents_screen_page.dart
+++ b/lib/features/recents/view/recents_screen_page.dart
@@ -18,7 +18,7 @@ class RecentsScreenPage extends StatelessWidget {
 
     final widget = RecentsScreen(
       title: const Text(EnvironmentConfig.APP_NAME),
-      videoCallEnable: featureAccess.callFeature.callConfig.videoEnable,
+      videoCallEnable: featureAccess.callFeature.callConfig.isVideoCallEnabled,
       chatsEnabled: featureAccess.messagingFeature.chatsPresent,
     );
     return widget;

--- a/lib/models/feature_access/call_config.dart
+++ b/lib/models/feature_access/call_config.dart
@@ -1,14 +1,28 @@
 class CallConfig {
   const CallConfig({
-    required this.videoEnable,
-    required this.enableBlindTransfer,
-    required this.enableAttendedTransfer,
+    this.isVideoCallEnabled = true,
+    this.isAudioToVideoSwitchEnabled = true,
+    this.isBlindTransferEnabled = true,
+    this.isAttendedTransferEnabled = true,
   });
 
-  /// Call
-  final bool videoEnable;
+  /// Whether the UI should show video call functionality.
+  ///
+  /// If `true`, video call features and related UI elements are enabled and visible.
+  final bool isVideoCallEnabled;
 
-  // Transfer
-  final bool enableBlindTransfer;
-  final bool enableAttendedTransfer;
+  /// Whether the user can switch from an audio call to a video call during an active call.
+  ///
+  /// If `true`, the UI allows transitioning from audio to video.
+  final bool isAudioToVideoSwitchEnabled;
+
+  /// Whether blind transfer is available in the UI.
+  ///
+  /// If `true`, the user can transfer the call to another number without speaking to the recipient beforehand.
+  final bool isBlindTransferEnabled;
+
+  /// Whether attended transfer is available in the UI.
+  ///
+  /// If `true`, the user can talk to the recipient before transferring the call.
+  final bool isAttendedTransferEnabled;
 }

--- a/lib/models/feature_access/call_config.dart
+++ b/lib/models/feature_access/call_config.dart
@@ -1,9 +1,14 @@
-class TransferConfig {
-  const TransferConfig({
+class CallConfig {
+  const CallConfig({
+    required this.videoEnable,
     required this.enableBlindTransfer,
     required this.enableAttendedTransfer,
   });
 
+  /// Call
+  final bool videoEnable;
+
+  // Transfer
   final bool enableBlindTransfer;
   final bool enableAttendedTransfer;
 }

--- a/lib/models/feature_access/call_config.dart
+++ b/lib/models/feature_access/call_config.dart
@@ -1,3 +1,10 @@
+/// UI-level configuration for call features.
+///
+/// Controls visibility of call-related UI elements (e.g., video toggle, transfer buttons).
+/// Does **not** enforce restrictions at signaling or SDP level.
+///
+/// Note: Incoming video calls or feature negotiation (e.g., via SDP) are not affected.
+/// To apply restrictions on protocol level, integrate with `SDPMunger` or similar logic.
 class CallConfig {
   const CallConfig({
     this.isVideoCallEnabled = true,

--- a/lib/models/feature_access/feature_access.dart
+++ b/lib/models/feature_access/feature_access.dart
@@ -1,6 +1,6 @@
 export 'bottom_menu_feature.dart';
+export 'call_config.dart';
 export 'encoding_config.dart';
 export 'login_embedded.dart';
 export 'login_mode_action.dart';
 export 'settings_feature.dart';
-export 'transfer_config.dart';


### PR DESCRIPTION
Updates the onCameraChanged handler to respect CallConfig.isVideoCallEnabled. If video calls are disabled in the config, the camera toggle becomes inactive in the UI, ensuring consistent behavior with feature availability.