### PR TITLE
fix: downgrade auto route to 9.3.0+1

### DIFF
--- a/lib/features/call/view/call_shell.dart
+++ b/lib/features/call/view/call_shell.dart
@@ -154,7 +154,7 @@ class _CallShellState extends State<CallShell> {
   ///
   /// MainShellRoute uses MainShellRoute.name as its path.
   void _backToMainScreen(StackRouter router) {
-    router.navigatePath(MainShellRoute.name);
+    router.navigateNamed(MainShellRoute.name);
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,18 +90,18 @@ packages:
     dependency: "direct main"
     description:
       name: auto_route
-      sha256: "89bc5d17d8c575399891194b8cd02b39f52a8512c730052f17ebe443cdcb9109"
+      sha256: "1d1bd908a1fec327719326d5d0791edd37f16caff6493c01003689fb03315ad7"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "9.3.0+1"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      sha256: "8e622d26dc6be4bf496d47969e3e9ba555c3abcf2290da6abfa43cbd4f57fa52"
+      sha256: c2e359d8932986d4d1bcad7a428143f81384ce10fef8d4aa5bc29e1f83766a46
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "9.3.1"
   bloc:
     dependency: "direct main"
     description:
@@ -119,7 +119,7 @@ packages:
     source: hosted
     version: "0.2.5"
   bloc_test:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: bloc_test
       sha256: "165a6ec950d9252ebe36dc5335f2e6eb13055f33d56db0eeb7642768849b43d2"
@@ -1825,7 +1825,7 @@ packages:
       path: "../webtrit_callkeep/webtrit_callkeep"
       relative: true
     source: path
-    version: "0.0.0+0"
+    version: "0.0.1+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:
@@ -1860,7 +1860,7 @@ packages:
       path: "../webtrit_callkeep/webtrit_callkeep_platform_interface"
       relative: true
     source: path
-    version: "0.0.0+0"
+    version: "0.3.5+0"
   webtrit_callkeep_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  auto_route: ^10.0.1
+  auto_route: 9.3.0+1
   bloc: ^8.1.4
   bloc_concurrency: ^0.2.5
   characters: ^1.3.0
@@ -114,7 +114,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  auto_route_generator: ^10.0.1
+  auto_route_generator: 9.3.1
   build_runner: ^2.4.15
   flutter_gen_runner: ^5.10.0
   flutter_launcher_icons: ^0.14.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,10 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+  # TODO(Serdun): Upgrade to a version higher than auto_route 10.0.1 once available.
+  # Be sure to test nested routing with ReevaluateListenable — currently, in 10.0.1,
+  # changing the language causes the navigation stack to break after reevaluation.
+  # Temporarily using auto_route 9.3.0+1 due to this issue.
   auto_route: 9.3.0+1
   bloc: ^8.1.4
   bloc_concurrency: ^0.2.5
@@ -114,6 +118,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  # Using auto_route_generator 9.3.1 to match auto_route 9.3.0+1 due to routing issues in 10.0.1+
   auto_route_generator: 9.3.1
   build_runner: ^2.4.15
   flutter_gen_runner: ^5.10.0

--- a/screenshots/pubspec.lock
+++ b/screenshots/pubspec.lock
@@ -1585,7 +1585,7 @@ packages:
       path: "../../webtrit_callkeep/webtrit_callkeep"
       relative: true
     source: path
-    version: "0.0.0+0"
+    version: "0.0.1+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:
@@ -1620,7 +1620,7 @@ packages:
       path: "../../webtrit_callkeep/webtrit_callkeep_platform_interface"
       relative: true
     source: path
-    version: "0.0.0+0"
+    version: "0.3.5+0"
   webtrit_callkeep_web:
     dependency: transitive
     description:


### PR DESCRIPTION
The auto_route version 10.0.1 introduces a critical issue with nested routes and ReevaluateListenable.
When ReevaluateListenable.stream(appBloc.stream) triggers (e.g. after changing language), the navigation stack breaks due to a key reservation error.