### PR TITLE
refactor: correctly restore initial tab based on last selected bottom menu tab

### DIFF
--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -60,10 +60,10 @@ class AppRouter extends RootStackRouter {
 
   bool get appLoggedIn => coreUrl != null && token != null && userId != null;
 
-  /// Retrieves the initial tab path for the main screen.
+  /// Retrieves the initial tab  for the main screen.
   ///
   /// This getter determines the initial tab to display on the main screen
-  String? get _mainInitialTabPath => _bottomMenuFeature.activeTab.path();
+  BottomMenuTab get _mainInitialTab => _bottomMenuFeature.activeTab;
 
   @override
   List<AutoRoute> get routes => [
@@ -158,11 +158,6 @@ class AppRouter extends RootStackRouter {
                   page: MainScreenPageRoute.page,
                   path: '',
                   children: [
-                    if (_mainInitialTabPath != null)
-                      RedirectRoute(
-                        path: '',
-                        redirectTo: _mainInitialTabPath!,
-                      ),
                     AutoRoute(
                       page: FavoritesRouterPageRoute.page,
                       path: MainFlavor.favorites.name,
@@ -398,7 +393,18 @@ class AppRouter extends RootStackRouter {
           [const PermissionsScreenPageRoute()],
         );
       } else {
-        resolver.next(true);
+        resolver.overrideNext(children: [
+          MainScreenPageRoute(children: [
+            switch (_mainInitialTab.flavor) {
+              MainFlavor.favorites => const FavoritesRouterPageRoute(),
+              MainFlavor.recents => const RecentsRouterPageRoute(),
+              MainFlavor.contacts => const ContactsRouterPageRoute(),
+              MainFlavor.keypad => const KeypadScreenPageRoute(),
+              MainFlavor.embedded => EmbeddedTabPageRoute(id: _mainInitialTab.toEmbedded!.id),
+              MainFlavor.messaging => const ConversationsScreenPageRoute(),
+            },
+          ])
+        ]);
       }
     } else {
       resolver.next(false);


### PR DESCRIPTION
Fix dynamic tab redirection after login/logout by replacing RedirectRoute with resolver.overrideNext() inside the navigation guard.
_mainInitialTabPath is now used imperatively to restore the last active tab.