### PR TITLE
feat: add flavor-based control to enable or disable Android deeplinks via dart-define configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -139,6 +139,83 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    flavorDimensions "deeplinks"
+
+    productFlavors {
+        // Flavor with deep link support enabled
+        // This flavor defines the APP_LINK_DOMAIN string resource,
+        // which is used for configuring app links and intent filters.
+        // The value is injected from Dart's --dart-define at build time.
+        deeplinks {
+            dimension "deeplinks"
+            resValue "string", "APP_LINK_DOMAIN", dartDefine.WEBTRIT_APP_LINK_DOMAIN
+        }
+
+        // Flavor with deep link support disabled
+        // No APP_LINK_DOMAIN is defined here, so deep link functionality
+        // can be excluded from the AndroidManifest or handled differently.
+        deeplinksDisabled {
+            dimension "deeplinks"
+        }
+    }
+
+    // Task to normalize APK and AAB output file paths and names for CI/CD
+    tasks.register("normalizeReleaseOutputs") {
+        doLast {
+            // Locate directory where Flutter outputs APKs
+            def flutterApk = layout.buildDirectory.dir("outputs/flutter-apk").get().asFile
+            // Define standard destination path for CI to pick up the APK
+            def fixedApkDest = layout.buildDirectory.dir("outputs/apk/release").get().asFile
+            def foundApk = false
+
+            if (flutterApk.exists()) {
+                flutterApk.eachFile { f ->
+                    if (f.name.endsWith(".apk")) {
+                        // Copy and rename to a standardized filename
+                        copy {
+                            from f
+                            into fixedApkDest
+                            rename { "app-release.apk" }
+                        }
+                        println "Copied APK → ${fixedApkDest}/app-release.apk"
+                        foundApk = true
+                    }
+                }
+            }
+
+            // Locate directory that contains flavor-specific AAB build outputs
+            def bundleDir = layout.buildDirectory.dir("outputs/bundle").get().asFile
+            // Define standard destination path for CI to pick up the AAB
+            def fixedBundleDest = layout.buildDirectory.dir("outputs/bundle/release").get().asFile
+            def foundAab = false
+
+            if (bundleDir.exists()) {
+                bundleDir.eachDir { flavorDir ->
+                    flavorDir.eachFile { f ->
+                        if (f.name.endsWith(".aab")) {
+                            copy {
+                                from f
+                                into fixedBundleDest
+                                rename { "app-release.aab" }
+                            }
+                            println "Copied AAB → ${fixedBundleDest}/app-release.aab"
+                            foundAab = true
+                        }
+                    }
+                }
+            }
+
+            if (!foundApk) println "No .apk found in flutter-apk/"
+            if (!foundAab) println "No .aab found in bundle/*/release/"
+        }
+    }
+
+    tasks.configureEach { task ->
+        if (task.name ==~ /bundle.*Release/ || task.name ==~ /assemble.*Release/) {
+            task.finalizedBy("normalizeReleaseOutputs")
+        }
+    }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }
@@ -154,7 +231,6 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
 
-        resValue "string", "APP_LINK_DOMAIN", dartDefine.WEBTRIT_APP_LINK_DOMAIN
         resValue "string", "APP_NAME", dartDefine.WEBTRIT_APP_NAME
     }
 

--- a/android/app/src/deeplinks/AndroidManifest.xml
+++ b/android/app/src/deeplinks/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity android:name=".MainActivity">
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="true" />
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="@string/APP_LINK_DOMAIN" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -75,18 +75,6 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
-            <!-- Set up app links -->
-            <meta-data
-                android:name="flutter_deeplinking_enabled"
-                android:value="true" />
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="http"/>
-                <data android:scheme="https" />
-                <data android:host="@string/APP_LINK_DOMAIN"/>
-            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/build.config
+++ b/build.config
@@ -1,3 +1,3 @@
 # Configuration version used to control build behavior.
 # If missing or lower than 0.0.0, flavors are disabled for backward compatibility.
-VERSION=0.0.0
+VERSION=0.0.1

--- a/dart_define.json
+++ b/dart_define.json
@@ -6,6 +6,7 @@
   "WEBTRIT_APP_DEMO_CORE_URL": "http://192.168.10.100:4000",
   "_WEBTRIT_APP_CORE_VERSION_CONSTRAINT": "",
   "WEBTRIT_APP_LINK_DOMAIN": "app.webtrit.com",
+  "_WEBTRIT_APP_LINK_DOMAIN_DESCRIPTION": "If provided, enables Android App Links integration via intent-filter. Must match assetlinks.json configuration on the target domain. This functionality is configured via Android flavors — if the value is non-empty, the 'deeplinks' flavor is selected automatically.",
   "WEBTRIT_APP_NAME": "WebTrit",
   "_WEBTRIT_APP_ABOUT_URL": "",
   "WEBTRIT_APP_SALES_EMAIL": "sales@webtrit.com",

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -65,6 +65,8 @@ class _AppState extends State<App> {
 
   @override
   Widget build(BuildContext context) {
+    final isDeepLinkEnabled = EnvironmentConfig.APP_LINK_DOMAIN.isNotEmpty;
+
     final materialApp = BlocBuilder<AppBloc, AppState>(
       buildWhen: (previous, current) => previous.themeSettings != current.themeSettings,
       builder: (context, state) {
@@ -88,7 +90,7 @@ class _AppState extends State<App> {
                 theme: themeProvider.light(),
                 darkTheme: themeProvider.dark(),
                 routerConfig: _appRouter.config(
-                  deepLinkBuilder: _appRouter.deepLinkBuilder,
+                  deepLinkBuilder: isDeepLinkEnabled ? _appRouter.deepLinkBuilder : null,
                   navigatorObservers: () => [
                     AppRouterObserver(),
                     context.read<AppAnalyticsRepository>().createObserver(),


### PR DESCRIPTION
This PR introduces flavors to enable controlled merging of AndroidManifests. It ensures Play Store compatibility by eliminating warnings related to unconfigured or partially configured deeplinks.

This is the first step toward a broader flavor system, starting with deeplinks and SMS-triggered permissions. Defining flavors allows us to isolate and include manifest declarations (e.g. <intent-filter>, <receiver>) only when required by specific clients.

Flavors cannot be selected via dart-define alone — they must be passed explicitly using the --flavor flag during the build. To address this, we now handle flavor resolution via Makefile logic.

Follow-ups
	•	This change requires updating external build tools, such as: [webtrit_phone_builder](https://github.com/WebTrit/webtrit_phone_builder/pull/8)
	•	We’ll also need to ensure backward compatibility for existing environments or CI flows that don’t pass --flavor.

**_Do not merge until backward compatibility is reviewed and addressed._**
