### PR TITLE
feat: add build flavors and update documentation for build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The application offers extensive customization options:
   - [Embedded pages](docs/embedded_pages.md) –  Implements embedded pages that extend the WebTrit app with custom web content.
 
 ## Development & Build
-
+ - **Build and run**: See the [Build and Run](docs/build.md) documentation for details on how to build and run the application.
+ - **Flavors**: See the [Build Flavors](docs/flavors.md) documentation for details on how to configure and use build flavors.
  - **Make Commands**: See the  [Make Commands](docs/make_file.md) for available build and automation commands.
 
 # Testing

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,51 +1,135 @@
-# Build Instructions
+# 🛠 WebTrit Shared Makefile Build Process
 
-This document provides commands for building the Flutter application for different platforms.
+This documentation describes the structure, logic, and usage of the [
+`makefile.shared`](https://github.com/WebTrit/webtrit_phone_tools/blob/main/Makefile.shared) used in WebTrit projects.  
+It handles conditional build and run logic based on configuration version and Dart defines.
 
-## Table of Contents
-- [Android](#android)
-- [iOS](#ios)
-- [Web](#web)
-- [Notes](#notes)
-
-## Android
-
-To build an Android release app bundle, use the following command:
-
-```bash
-WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH=<path to keystore folder> && \
-flutter build appbundle --dart-define-from-file=dart_define.json
-```
-
-- Ensure that `WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH` is set correctly.
-- The `dart_define.json` file should contain all necessary environment variables.
-
-## iOS
-
-To build an iOS release IPA, run:
-
-```bash
-flutter build ipa --dart-define-from-file=dart_define.json
-```
-
-- Make sure you have configured the necessary provisioning profiles and signing certificates.
-
-## Web
-
-To build the web version of the application, use:
-
-```bash
-flutter build web --dart-define-from-file=dart_define.json
-
-dart run tool/extenvsubst.dart dart_define.json build/web/index.html
-```
-
-- The `extenvsubst.dart` script processes environment variables inside `index.html` after the build completes.
+➡️ For a detailed reference of the internal structure, see
+the [shared_makefile_reference.md](https://github.com/WebTrit/webtrit_phone_tools/blob/main/docs/shared_makefile_reference.md)
 
 ---
 
-## Notes
-- Ensure Flutter and all necessary dependencies are properly installed.
-- Use `flutter clean` before rebuilding if issues arise.
-- If using Firebase, verify that configurations are correctly set for each platform.
+## 🔗 Inclusion
+
+The shared logic is included in the local project Makefile as follows:
+
+```makefile
+# ===========================
+# Include Shared Makefile Logic
+# ===========================
+
+TOOLS_MAKEFILE := makefile.shared
+
+ifeq (,$(wildcard $(TOOLS_MAKEFILE)))
+$(shell curl -sSL https://raw.githubusercontent.com/WebTrit/webtrit_phone_tools/refs/heads/main/Makefile.shared -o $(TOOLS_MAKEFILE))
+endif
+
+include $(TOOLS_MAKEFILE)
+```
+
+---
+
+## 🧩 Version-based Flavor Selection  [Flavors](flavors.md).
+
+The build logic dynamically adapts to the `VERSION` specified in the root-level `build.config` file:
+
+```sh
+VERSION=0.0.2
+```
+
+This versioning file is located at the root of the project and was introduced to ensure **backward compatibility** with
+older versions that do not use flavors.
+
+Depending on this version:
+
+* `legacy`: flavors are not used
+* `v0.0.1`: only deeplink flavor is applied
+* `v0.0.2+`: both deeplink and SMS flavors are combined
+
+The version logic is delegated to the included shared `makefile.shared`, allowing central control of behavior per
+version.
+
+> ℹ️ In the future, iOS flavor support may be added similarly for consistency
+
+---
+
+## 🧠 Dart Defines Based Flavor Computation
+
+Values are parsed from `dart_define.json`:
+
+* `WEBTRIT_APP_LINK_DOMAIN` → determines deeplink flavor
+* `WEBTRIT_CALL_TRIGGER_MECHANISM_SMS` → determines smsReceiver flavor
+
+### Combined:
+
+```
+--flavor deeplinkssmsReceiverDisabled
+```
+
+Flavors are used to conditionally include Android permissions, services, or receivers based on features enabled for the
+client — ensuring no unnecessary permissions are requested.
+
+---
+
+## ⚙️ Build Commands
+
+The following targets are available:
+
+| Target                       | Description                                |
+|------------------------------|--------------------------------------------|
+| `make build`                 | Builds the app with default platform (APK) |
+| `make build-apk`             | Builds Android APK                         |
+| `make build-appbundle`       | Builds Android App Bundle                  |
+| `make build-ios`             | Builds iOS app                             |
+| `make build-ios-config-only` | iOS config-only build                      |
+
+### Optional Parameters:
+
+* `build_name` — passed as `--build-name`
+* `build_number` — passed as `--build-number`
+* `release=true` — adds `--release`
+* `no_codesign=true` — disables iOS codesign
+* `config_only=true` — used for iOS config-only
+
+---
+
+## ▶️ Run Commands
+
+| Target         | Description                        |
+|----------------|------------------------------------|
+| `make run`     | Runs the app with default platform |
+| `make run-apk` | Runs on Android with APK build     |
+| `make run-ios` | Runs on iOS                        |
+
+Flavor selection is auto-applied unless legacy version.
+
+---
+
+## 💻 Development Workflow Notes
+
+While the [`makefile.shared`](https://github.com/WebTrit/webtrit_phone_tools/blob/main/Makefile.shared) handles builds
+and flavor logic very well, **during development you may need to adjust your environment manually** to work efficiently
+with flavors.
+
+### Options:
+
+* ⚙️ **IDE Configuration**:
+
+  In IntelliJ IDEA or Android Studio, configure a custom **Run/Debug Configuration** to use `make` with your desired
+  target (e.g., `run-apk`) and working directory set to the root project.
+
+* 🧪 **Manual Flavor Selection**:
+
+  Alternatively, when running from the IDE without using `make`, you must manually pass the correct `--flavor` (e.g.,
+  `--flavor deeplinkssmsReceiverDisabled`) in your launch configuration to match the current `dart_define.json`.
+
+### Tip:
+
+For easier debugging and local development:
+
+* Stick to a single flavor during development (e.g., the one most commonly enabled)
+* Or create a helper shell script that wraps the `flutter run` with computed flavors
+
+> 🧠 The Makefile works best for **CI/CD and structured builds**, but for day-to-day development, some manual steps are
+> currently needed.
 

--- a/docs/flavors.md
+++ b/docs/flavors.md
@@ -1,0 +1,94 @@
+# 🏦 Android Flavors
+
+## What are Flavors?
+
+**Flavors** allow building multiple versions of an app with different configurations, resources, or features — without
+duplicating code. In the context of WebTrit, they are used to conditionally include permissions or components such as
+receivers, based on the client’s enabled features. This helps avoid requesting unnecessary permissions.
+
+Currently, WebTrit uses several flavors for:
+
+* **deeplinks** — to enable or disable deep link support
+* **smsReceiver** — to enable or disable incoming call triggers via SMS
+
+---
+
+## Flavor Structure
+
+```groovy
+productFlavors {
+    // Deep link support
+    deeplinks {
+        dimension "deeplinks"
+        resValue "string", "APP_LINK_DOMAIN", dartDefine.WEBTRIT_APP_LINK_DOMAIN
+    }
+    deeplinksDisabled {
+        dimension "deeplinks"
+    }
+
+    // Incoming call trigger via SMS
+    smsReceiver {
+        dimension "smsTriggerIncomingCall"
+    }
+    smsReceiverDisabled {
+        dimension "smsTriggerIncomingCall"
+    }
+}
+```
+
+> ℹ️ Flavors are defined only for **Android**. They are currently not used on iOS, so a workaround is added in the
+> Makefile for compatibility. In the future, iOS flavor support should also be implemented.
+
+---
+
+## How Flavors Are Selected
+
+They are automatically determined based on values from `dart_define.json`.
+
+> 🔧 Flavor selection logic is delegated to `makefile.shared`, which is included in the local Makefile.
+
+| Dart Define Field                    | Value           | Applied Flavor        |
+|--------------------------------------|-----------------|-----------------------|
+| `WEBTRIT_APP_LINK_DOMAIN`            | non-empty       | `deeplinks`           |
+|                                      | empty/missing   | `deeplinksDisabled`   |
+| `WEBTRIT_CALL_TRIGGER_MECHANISM_SMS` | `"true"`        | `smsReceiver`         |
+|                                      | `"false"`/other | `smsReceiverDisabled` |
+
+The generated argument will look like:
+
+```sh
+--flavor deeplinkssmsReceiverDisabled
+```
+
+---
+
+## Special Notes
+
+The build version used for compatibility is stored in `build.config` at the project root. This file is added
+specifically for **backward compatibility**.
+
+* For `VERSION < 0.0.1` (legacy), flavors are **not used**
+* For `VERSION = 0.0.1`, only the deeplink flavor is used
+* For `VERSION ≥ 0.0.2`, both (deeplink + sms) flavors are applied
+
+This ensures compatibility with older builds that don’t support flavors.
+
+---
+
+## Examples
+
+### Build APK with both features enabled:
+
+```sh
+make build-apk
+```
+
+### Run the app on a device with the computed flavors:
+
+```sh
+make run-apk
+```
+
+> ⚠️ In development environments (e.g., IntelliJ IDEA), you must manually specify the combined flavor (e.g.,
+`deeplinkssmsReceiver`) in your run configuration or use `make run` directly.
+> 📄 For more details on how the build system works, see  [build](build.md)..md.


### PR DESCRIPTION
Add documentation explaining flavors and how to build the project. The “Make commands” section in the README is outdated and should be cleaned up along with the local makefile. Perform cleanup after merge.