### PR TITLE
fix: migrate TabBarTheme to TabBarThemeData for Flutter 3.32 Stable

### DIFF
--- a/lib/theme/factory/theme_data/tab_bar_theme_data_factory.dart
+++ b/lib/theme/factory/theme_data/tab_bar_theme_data_factory.dart
@@ -4,22 +4,23 @@ import 'package:webtrit_phone/theme/theme.dart';
 
 import '../theme_style_factory.dart';
 
-class TabBarThemeDataFactory implements ThemeStyleFactory<TabBarTheme> {
+class TabBarThemeDataFactory implements ThemeStyleFactory<TabBarThemeData> {
   TabBarThemeDataFactory(this.colors, this.config);
 
   final ColorScheme colors;
   final ExtTabBarWidgetConfig? config;
 
   @override
-  TabBarTheme create() {
+  TabBarThemeData create() {
     final unselectedLabelColor = config?.unSelectedItemColor?.toColor() ?? colors.onSurface;
     const dividerColor = Colors.transparent;
     final labelColor = colors.onPrimary;
 
-    return TabBarTheme(
+    return TabBarThemeData(
       unselectedLabelColor: unselectedLabelColor,
       dividerColor: dividerColor,
       labelColor: labelColor,
+      indicatorColor: colors.primary,
     );
   }
 }

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -114,7 +114,7 @@ class ThemeStyleFactoryProvider {
     return BottomNavigationBarThemeDataFactory(colorScheme, widgetConfig.bar.bottomNavigationBar).create();
   }
 
-  TabBarTheme createTabBarTheme() {
+  TabBarThemeData createTabBarTheme() {
     return TabBarThemeDataFactory(colorScheme, widgetConfig.bar.extTabBar).create();
   }
 

--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -114,7 +114,6 @@ class ThemeProvider extends InheritedWidget {
       primaryColorDark: colorScheme.onSecondaryContainer,
       scaffoldBackgroundColor: colorScheme.surfaceBright,
       unselectedWidgetColor: colorScheme.onSurface,
-      indicatorColor: colorScheme.primary,
       appBarTheme: style.createAppBarTheme(),
       tabBarTheme: style.createTabBarTheme(),
       bottomNavigationBarTheme: style.createBottomNavigationBarThemeData(),


### PR DESCRIPTION
Updated the `TabBarThemeDataFactory` implementation to return `TabBarThemeData` instead of the deprecated `TabBarTheme`, aligning with Flutter 3.32 (stable channel) requirements.
