### PR TITLE
fix(logging): prevent crash on DioException in FilteredLogzIoAppender

### DIFF
--- a/lib/common/logging/filtered_logz_io_appender.dart
+++ b/lib/common/logging/filtered_logz_io_appender.dart
@@ -29,7 +29,7 @@ class FilteredLogzIoAppender extends LogzIoApiAppender {
       if (RemoteLogFilter._shouldIgnoreDioError(e)) {
         _logger.info('Ignoring LogzIO DioException: $e');
       } else {
-        rethrow;
+        _logger.warning('LogzIO DioException (not ignored): $e');
       }
     }
   }


### PR DESCRIPTION
Removed the `rethrow` from the `sendLogEventsWithDio` method in the logging system.

❓ Why:

Throwing errors from logging (Logger.log, Logger.info, etc.) is not standard practice, because:
	•	Logging is a secondary concern and should never crash the app.
	•	If rethrow is kept, any unhandled error in sendLogEventsWithDio may bubble up and crash the app, especially since logging is often used without try-catch.
