### PR TITLE
feat: add support for opening external links from WebView

### DIFF
--- a/docs/embedded_pages.md
+++ b/docs/embedded_pages.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This documentation describes how to integrate embedded web pages into the WebTrit Call App using a WebView. These pages can extend the app with client-specific features. Embedded pages are configured via `app.config.json`, and can appear as a bottom menu tab or a settings item.
+This documentation describes how to integrate embedded web pages into the WebTrit Call App using a
+WebView. These pages can extend the app with client-specific features. Embedded pages are configured
+via `app.config.json`, and can appear as a bottom menu tab or a settings item.
 
 ## App Configuration
 
@@ -11,25 +13,27 @@ Embedded pages are declared in the app configuration. A typical setup includes t
 1. **Reference in `mainConfig.bottomMenu.tabs` or settings section:**
 
 ```json
-"bottomMenu": {
-  "cacheSelectedTab": true,
-  "tabs": [
     {
-      "enabled": true,
-      "initial": false,
-      "type": "favorites",
-      "titleL10n": "main_BottomNavigationBarItemLabel_favorites",
-      "icon": "0xe5fd"
-    },
-    {
-      "enabled": true,
-      "initial": false,
-      "type": "embedded",
-      "titleL10n": "embedded_TabTitle",
-      "icon": "0xe2ce",
-      "embeddedResourceId": 2
-    }
-  ]
+  "bottomMenu": {
+    "cacheSelectedTab": true,
+    "tabs": [
+      {
+        "enabled": true,
+        "initial": false,
+        "type": "favorites",
+        "titleL10n": "main_BottomNavigationBarItemLabel_favorites",
+        "icon": "0xe5fd"
+      },
+      {
+        "enabled": true,
+        "initial": false,
+        "type": "embedded",
+        "titleL10n": "embedded_TabTitle",
+        "icon": "0xe2ce",
+        "embeddedResourceId": 2
+      }
+    ]
+  }
 }
 ```
 
@@ -39,7 +43,9 @@ Embedded pages are declared in the app configuration. A typical setup includes t
 {
   "id": 2,
   "uri": "https://webtrit-app.web.app/example/example_embedded_payload_data.html",
-  "payload": ["coreToken"],
+  "payload": [
+    "coreToken"
+  ],
   "toolbar": {
     "showToolbar": false
   }
@@ -48,17 +54,20 @@ Embedded pages are declared in the app configuration. A typical setup includes t
 
 ## Payload Injection
 
-The `payload` field defines which dynamic data will be injected into the embedded web page. Supported values:
+The `payload` field defines which dynamic data will be injected into the embedded web page.
+Supported values:
 
 * `userId`
 * `coreToken`
 * `externalPageToken`
 
-If any of the requested payload values are unavailable (e.g., `externalPageToken`), they are fetched automatically from the server before the page is loaded.
+If any of the requested payload values are unavailable (e.g., `externalPageToken`), they are fetched
+automatically from the server before the page is loaded.
 
 ### JavaScript Entry Point
 
-Once the page is fully loaded and ready, the Flutter app executes JavaScript to deliver the payload. This is the single point of integration for web developers:
+Once the page is fully loaded and ready, the Flutter app executes JavaScript to deliver the payload.
+This is the single point of integration for web developers:
 
 ```javascript
 if (typeof window.onPayloadDataReady === 'function') {
@@ -66,7 +75,8 @@ if (typeof window.onPayloadDataReady === 'function') {
 }
 ```
 
-The `payload` is a key-value map, passed as the first and only argument to `window.onPayloadDataReady`.
+The `payload` is a key-value map, passed as the first and only argument to
+`window.onPayloadDataReady`.
 
 ### Example Payload
 
@@ -114,6 +124,47 @@ This integration is ideal for:
 * Authorization flows
 * Embedded help pages or forms
 
+## External Navigation Protocol
+
+To open links **outside of the embedded WebView** (e.g., in the user's default browser), the WebTrit
+app supports a custom URI scheme.
+
+### Default Behavior
+
+Links opened **inside the app WebView** can be written as usual:
+
+```html
+
+<li><a href="https://webtrit.com">Home</a></li>
+```
+
+This will load the page inside the WebView context.
+
+### External Browser Navigation
+
+To explicitly open a link **in the system browser**, use the following format:
+
+```html
+
+<li><a href="app://openInExternalBrowser?url=https://webtrit.com">Home</a></li>
+```
+
+- `app://` — indicates an internal instruction to the WebTrit app.
+- `openInExternalBrowser` — command that triggers external navigation.
+- `url` — target URL to be opened in the browser, provided as a query parameter.
+
+### Use Case Example
+
+```html
+<a href="app://openInExternalBrowser?url=https://www.webtrit.com">Visit Webtrit Website</a>
+```
+
+This link will be intercepted by the app and launched in the system's default browser, not in the
+embedded WebView.
+
 ## Summary
 
-By declaring embedded resources and referencing them in app config, clients can extend the WebTrit app with dynamic web content that securely receives contextual data like tokens or user IDs. The app ensures robust error handling, retry logic, and clear communication via the `onPayloadDataReady` JavaScript function.
+By declaring embedded resources and referencing them in app config, clients can extend the WebTrit
+app with dynamic web content that securely receives contextual data like tokens or user IDs. The app
+ensures robust error handling, retry logic, and clear communication via the `onPayloadDataReady`
+JavaScript function.

--- a/lib/widgets/web_view_container.dart
+++ b/lib/widgets/web_view_container.dart
@@ -242,7 +242,7 @@ class _WebViewContainerState extends State<WebViewContainer> with WidgetStateMix
     if (isExternalBrowserRequest) {
       final targetUrl = uri?.queryParameters[_kNavigationRequestParamUrl];
       if (targetUrl?.isEmpty ?? true) {
-        _logger.warning('Missing or empty external URL');
+        _logger.warning('Missing or empty external URL in request: ${request.url}');
         return NavigationDecision.prevent;
       }
 


### PR DESCRIPTION
Introduces a custom URI scheme (app://openInExternalBrowser?url=...) to explicitly mark links that should be opened outside of the WebView using the system browser. This improves link handling by separating internal navigation from external actions.