### PR TITLE
fix: retry CallRoutingCubit load on network restore and handle missing state

### DIFF
--- a/lib/app/notifications/models/notification.dart
+++ b/lib/app/notifications/models/notification.dart
@@ -126,3 +126,12 @@ class DefaultErrorNotification extends ErrorNotification {
     }
   }
 }
+
+class NoInternetConnectionNotification extends ErrorNotification {
+  const NoInternetConnectionNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.common_noInternetConnection_message;
+  }
+}

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -16,6 +16,7 @@ import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/services/services.dart';
 
 @RoutePage()
 class MainShell extends StatefulWidget {
@@ -418,6 +419,7 @@ class _MainShellState extends State<MainShell> {
                     context.read<UserRepository>(),
                     context.read<LinesStateRepository>(),
                     context.read<AppPreferences>(),
+                    context.read<ConnectivityService>(),
                   ),
                 ),
               ],

--- a/lib/features/call/call.dart
+++ b/lib/features/call/call.dart
@@ -1,4 +1,5 @@
 export 'bloc/call_bloc.dart';
+export 'controllers/controllers.dart';
 export 'models/models.dart';
 export 'services/services.dart';
 export 'utils/utils.dart';

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -1,0 +1,80 @@
+import 'package:logging/logging.dart';
+
+import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
+import 'package:webtrit_phone/app/notifications/models/notification.dart';
+import 'package:webtrit_phone/features/call/call.dart';
+import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
+
+class CallController {
+  CallController({
+    required this.callBloc,
+    required this.callRoutingCubit,
+    required this.notificationsBloc,
+    Logger? logger,
+  }) : _logger = logger ?? Logger('CallController');
+
+  final CallBloc callBloc;
+  final CallRoutingCubit callRoutingCubit;
+  final NotificationsBloc notificationsBloc;
+  final Logger _logger;
+
+  /// Creates a new call using the current call routing state.
+  ///
+  /// Handles caller ID logic and available line validation.
+  void createCall({
+    required String destination,
+    String? displayName,
+    bool video = false,
+    String? fromNumber,
+  }) {
+    final callRoutingState = callRoutingCubit.state;
+    if (callRoutingState == null) {
+      _logger.warning('Call routing state is null, cannot create call.');
+      notificationsBloc.add(
+        const NotificationsSubmitted(NoInternetConnectionNotification()),
+      );
+      return;
+    }
+
+    // Determine fromNumber based on routing settings
+    final shouldUseMainLine = fromNumber == callRoutingState.mainNumber;
+    if (shouldUseMainLine) {
+      fromNumber = null;
+    } else {
+      fromNumber ??= callRoutingCubit.getFromNumber(destination);
+    }
+
+    // Check line availability
+    final hasIdleMainLine = callRoutingState.hasIdleMainLine;
+    final hasIdleGuestLine = callRoutingState.hasIdleGuestLine;
+
+    final noIdleMain = fromNumber == null && !hasIdleMainLine;
+    final noIdleGuest = fromNumber != null && !hasIdleGuestLine;
+
+    if (noIdleMain || noIdleGuest) {
+      _logger.warning('Cannot create call: no idle lines available.');
+      notificationsBloc.add(
+        const NotificationsSubmitted(CallUndefinedLineNotification()),
+      );
+      return;
+    }
+
+    // All checks passed, create call
+    callBloc.add(
+      CallControlEvent.started(
+        number: destination,
+        video: video,
+        displayName: displayName,
+        fromNumber: fromNumber,
+      ),
+    );
+  }
+
+  /// Submits a blind transfer for the given destination.
+  ///
+  /// Optionally calls [onTransferSubmitted] (e.g. for popping router stack).
+  void submitTransfer(String destination) {
+    _logger.info('Submitting blind transfer to $destination');
+    callBloc.add(CallControlEvent.blindTransferSubmitted(number: destination));
+  }
+}

--- a/lib/features/call/controllers/controllers.dart
+++ b/lib/features/call/controllers/controllers.dart
@@ -1,0 +1,1 @@
+export 'call_controller.dart';

--- a/lib/features/call_routing/cubit/call_routing_cubit.dart
+++ b/lib/features/call_routing/cubit/call_routing_cubit.dart
@@ -8,6 +8,8 @@ import 'package:webtrit_phone/data/app_preferences.dart';
 import 'package:webtrit_phone/models/lines_state.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
+import 'package:webtrit_phone/services/services.dart';
+
 part 'call_routing_state.dart';
 
 class CallRoutingCubit extends Cubit<CallRoutingState?> {
@@ -15,17 +17,37 @@ class CallRoutingCubit extends Cubit<CallRoutingState?> {
     this._userRepository,
     this._linesStateRepository,
     this._appPreferences,
+    this._connectivityService,
   ) : super(null) {
-    _infoSub = _userRepository
-        .getInfoAndListen()
-        .combineLatest(_linesStateRepository.getStateAndListen(), _combineInfo)
-        .listen(emit);
+    _init();
   }
 
   final LinesStateRepository _linesStateRepository;
   final UserRepository _userRepository;
   final AppPreferences _appPreferences;
-  late final StreamSubscription _infoSub;
+  final ConnectivityService _connectivityService;
+
+  StreamSubscription? _infoSub;
+  late final StreamSubscription<bool> _connectivitySub;
+
+  Future<void> _init() async {
+    _connectivitySub = _connectivityService.connectionStream.listen(_onConnectionChanged);
+    final connected = await _connectivityService.checkConnection();
+    if (connected) _startInfoSubscription();
+  }
+
+  void _onConnectionChanged(bool connected) {
+    if (connected && _infoSub == null) {
+      _startInfoSubscription();
+    }
+  }
+
+  void _startInfoSubscription() {
+    _infoSub = _userRepository
+        .getInfoAndListen()
+        .combineLatest(_linesStateRepository.getStateAndListen(), _combineInfo)
+        .listen(emit);
+  }
 
   CallRoutingState _combineInfo(UserInfo userInfo, LinesState linesState) {
     final mainNumber = userInfo.numbers.main;
@@ -73,8 +95,9 @@ class CallRoutingCubit extends Cubit<CallRoutingState?> {
   }
 
   @override
-  Future<void> close() {
-    _infoSub.cancel();
+  Future<void> close() async {
+    await _infoSub?.cancel();
+    await _connectivitySub.cancel();
     return super.close();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:webtrit_phone/bootstrap.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/services/services.dart';
 
 void main() {
   final logger = Logger('run_app');
@@ -130,6 +131,13 @@ class RootApp extends StatelessWidget {
           create: (context) {
             return AppPath();
           },
+        ),
+        // Services
+        Provider<ConnectivityService>(
+          create: (context) {
+            return ConnectivityServiceImpl();
+          },
+          dispose: (context, value) => value.dispose(),
         ),
       ],
       child: MultiRepositoryProvider(

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'package:webtrit_phone/utils/utils.dart';
+
+abstract class ConnectivityService {
+  Stream<bool> get connectionStream;
+
+  Future<bool> checkConnection();
+
+  void dispose();
+}
+
+class ConnectivityServiceImpl implements ConnectivityService {
+  ConnectivityServiceImpl({
+    HttpRequestExecutorFactory createHttpRequestExecutor = defaultCreateHttpRequestExecutor,
+  }) : _createHttpRequestExecutor = createHttpRequestExecutor {
+    _connectivitySubscription = _connectivity.onConnectivityChanged.listen(_handleConnectivityChange);
+  }
+
+  final Connectivity _connectivity = Connectivity();
+  final StreamController<bool> _controller = StreamController<bool>.broadcast();
+  late final StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
+  final HttpRequestExecutorFactory _createHttpRequestExecutor;
+
+  @override
+  Stream<bool> get connectionStream => _controller.stream;
+
+  @override
+  Future<bool> checkConnection() async {
+    final result = await _connectivity.checkConnectivity();
+    if (result.contains(ConnectivityResult.none) || result.isEmpty) {
+      return false;
+    }
+
+    final executor = _createHttpRequestExecutor();
+    try {
+      await executor.execute(method: 'GET', url: 'https://www.google.com/generate_204');
+      return true;
+    } catch (_) {
+      return false;
+    } finally {
+      executor.close();
+    }
+  }
+
+  Future<void> _handleConnectivityChange(List<ConnectivityResult> result) async {
+    final connected = await checkConnection();
+    _controller.add(connected);
+  }
+
+  @override
+  void dispose() {
+    _connectivitySubscription.cancel();
+    _controller.close();
+  }
+}

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -15,6 +15,7 @@ abstract class ConnectivityService {
 class ConnectivityServiceImpl implements ConnectivityService {
   ConnectivityServiceImpl({
     HttpRequestExecutorFactory createHttpRequestExecutor = defaultCreateHttpRequestExecutor,
+    this.connectivityCheckUrl = 'https://www.google.com/generate_204',
   }) : _createHttpRequestExecutor = createHttpRequestExecutor {
     _connectivitySubscription = _connectivity.onConnectivityChanged.listen(_handleConnectivityChange);
   }
@@ -23,6 +24,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
   final StreamController<bool> _controller = StreamController<bool>.broadcast();
   late final StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
   final HttpRequestExecutorFactory _createHttpRequestExecutor;
+  final String connectivityCheckUrl;
 
   @override
   Stream<bool> get connectionStream => _controller.stream;
@@ -36,7 +38,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
 
     final executor = _createHttpRequestExecutor();
     try {
-      await executor.execute(method: 'GET', url: 'https://www.google.com/generate_204');
+      await executor.execute(method: 'GET', url: connectivityCheckUrl);
       return true;
     } catch (_) {
       return false;

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -1,0 +1,1 @@
+export 'connectivity_service.dart';


### PR DESCRIPTION
**Problem**

If the app is initialized without an internet connection, and during that time the CallRoutingCubit attempts to load data, it fails with an error and never retries again.

As a result, even if the internet becomes available later, any attempt to place a call is silently ignored due to this check:

<pre>
final callRoutingCubit = context.read&lt;CallRoutingCubit&gt;();
final callRoutingState = callRoutingCubit.state;
if (callRoutingState == null) return;
</pre>

**Solution**
	•	Introduced a global ConnectivityService to monitor network status.
	•	CallRoutingCubit now automatically retries to fetch data when internet connectivity is restored.
	•	Moved duplicated call logic into a centralized CallController class for better reuse and maintainability.

