### PR TITLE
feat: implement CallErrorReporter with logging, notification dispatch, and signaling error handling

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -330,6 +330,7 @@ class _MainShellState extends State<MainShell> {
                 webRtcOptionsBuilder: WebrtcOptionsWithAppSettingsBuilder(appPreferences),
                 userMediaBuilder: userMediaBuilder,
                 contactNameResolver: contactNameResolver,
+                callErrorReporter: DefaultCallErrorReporter((n) => notificationsBloc.add(NotificationsSubmitted(n))),
                 iceFilter: FilterWithAppSettings(appPreferences),
                 peerConnectionPolicyApplier: pearConnectionPolicyApplier,
               )..add(const CallStarted());

--- a/lib/features/call/utils/utils.dart
+++ b/lib/features/call/utils/utils.dart
@@ -7,3 +7,4 @@ export 'sdp_munger.dart';
 export 'user_media_builder.dart';
 export 'video_constraints_builder.dart';
 export 'webrtc_options_builder.dart';
+export 'сall_error_reporter.dart';

--- a/lib/features/call/utils/сall_error_reporter.dart
+++ b/lib/features/call/utils/сall_error_reporter.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+
+import 'package:webtrit_phone/app/notifications/models/notification.dart';
+
+import '../models/notification.dart';
+import 'user_media_builder.dart';
+
+final _logger = Logger('CallBloc:SignalingErrorReporter');
+
+/// Interface for reporting errors that occur during call processing.
+///
+/// This abstraction allows injecting different error reporting strategies,
+/// such as production or mock implementations.
+abstract interface class CallErrorReporter {
+  /// Handles an error that occurred during the call lifecycle.
+  ///
+  /// The [error] is the caught exception or object.
+  /// The [stack] is the optional stack trace associated with the error.
+  /// The [context] describes where or why the error occurred — useful for logging.
+  void handle(Object error, StackTrace? stack, String context);
+}
+
+/// Default implementation of [CallErrorReporter] for handling and reporting
+/// call-related and signaling-related errors.
+///
+/// This class logs every error, determines whether to notify the user,
+/// and sends the appropriate [Notification] via the injected [submitNotification] function.
+class DefaultCallErrorReporter implements CallErrorReporter {
+  /// Creates a new instance of [DefaultCallErrorReporter].
+  ///
+  /// Requires a [submitNotification] callback that handles user notifications.
+  const DefaultCallErrorReporter(this.submitNotification);
+
+  /// A function used to dispatch user-facing notifications.
+  final void Function(Notification) submitNotification;
+
+  @override
+  void handle(Object error, StackTrace? stack, String context) {
+    // Always log the error with context and stack trace
+    _logger.warning('[$context] $error', error, stack);
+
+    if (error is WebtritSignalingTransactionTerminateByDisconnectException) {
+      final code = SignalingDisconnectCode.values.byCode(error.closeCode ?? -1);
+      if (_shouldNotifyOnDisconnect(code)) {
+        submitNotification(DefaultErrorNotification(error));
+      }
+      return;
+    }
+
+    if (error is UserMediaError) {
+      submitNotification(const CallUserMediaErrorNotification());
+    } else if (error is SDPConfigurationError) {
+      submitNotification(const CallSdpConfigurationErrorNotification());
+    } else if (error is TimeoutException) {
+      submitNotification(const CallNegotiationTimeoutNotification());
+    } else {
+      submitNotification(DefaultErrorNotification(error));
+    }
+  }
+
+  /// Determines whether a disconnect code should trigger user notification.
+  ///
+  /// Only specific disconnect reasons are considered important enough to notify the user.
+  bool _shouldNotifyOnDisconnect(SignalingDisconnectCode code) {
+    return switch (code) {
+      SignalingDisconnectCode.requestExecuteError => true,
+      SignalingDisconnectCode.controllerBillingError => true,
+      SignalingDisconnectCode.controllerBillingAccountMissedError => true,
+      SignalingDisconnectCode.controllerBillingAccountCredentialsMissedError => true,
+      SignalingDisconnectCode.signalingMessageError => true,
+      _ => false,
+    };
+  }
+}


### PR DESCRIPTION
Handles WebtritSignalingTransactionTerminateByDisconnectException (e.g. code 4610) that may occur due to concurrency between client and server (e.g. hangup on wrong line).
These cases are now logged but no longer shown to the user as critical errors.