### PR TITLE
feat: implement reconnect strategies with JS callback and native fallback for SPA recovery

### DIFF
--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -76,6 +76,14 @@
           "titleL10n": "main_BottomNavigationBarItemLabel_embedded",
           "icon": "0xe2ce",
           "embeddedResourceId": 2
+        },
+        {
+          "enabled": false,
+          "initial": false,
+          "type": "embedded",
+          "titleL10n": "main_BottomNavigationBarItemLabel_embedded_spa_example",
+          "icon": "0xe2ce",
+          "embeddedResourceId": 9
         }
       ]
     },
@@ -284,6 +292,15 @@
     {
       "id": 8,
       "uri": "https://webtrit-app.web.app/example/example_embedded_media_query.html"
+    },
+    {
+      "id": 9,
+      "uri": "https://webtrit-app.web.app/example/example_embedded_spa.html",
+      "enableConsoleLogCapture": true,
+      "reconnectStrategy": "softReload",
+      "payload": [
+        "coreToken"
+      ]
     }
   ]
 }

--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -297,7 +297,7 @@
       "id": 9,
       "uri": "https://webtrit-app.web.app/example/example_embedded_spa.html",
       "enableConsoleLogCapture": true,
-      "reconnectStrategy": "softReload",
+      "reconnectStrategy": "notifyOnly",
       "payload": [
         "coreToken"
       ]

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -230,16 +230,16 @@ class FeatureAccess {
     // If strategy is not provided, default to hard reload.
     final reconnectStrategy = embeddedDataResource?.reconnectStrategy != null
         ? ReconnectStrategy.values.byName(embeddedDataResource!.reconnectStrategy!)
-        : ReconnectStrategy.hardReload;
+        : ReconnectStrategy.softReload;
 
     // Return a ConfigData instance if a valid resource URL is found, otherwise return null.
     return embeddedDataResource?.uriOrNull != null
         ? EmbeddedData(
             id: embeddedDataResource!.id,
             uri: embeddedDataResource.uriOrNull!,
+            reconnectStrategy: reconnectStrategy,
             titleL10n: item.titleL10n,
             enableConsoleLogCapture: embeddedDataResource.enableConsoleLogCapture,
-            reconnectStrategy: reconnectStrategy,
           )
         : null;
   }
@@ -368,15 +368,22 @@ class FeatureAccess {
     return TermsFeature(EmbeddedData(
       id: termsResource.id,
       uri: termsResource.uriOrNull!,
+      reconnectStrategy: ReconnectStrategy.softReload,
       titleL10n: termsResource.toolbar.titleL10n,
     ));
   }
 
   static EmbeddedFeature _tryConfigureEmbeddedFeature(AppConfig appConfig) {
     final embeddedResources = appConfig.embeddedResources.map((resource) {
+      // If strategy is not provided, default to hard reload.
+      final reconnectStrategy = resource.reconnectStrategy != null
+          ? ReconnectStrategy.values.byName(resource.reconnectStrategy!)
+          : ReconnectStrategy.softReload;
+
       return EmbeddedData(
         id: resource.id,
         uri: Uri.parse(resource.uri),
+        reconnectStrategy: reconnectStrategy,
         payload: resource.payload.map((it) => EmbeddedPayloadData.values.byName(it)).toList(),
       );
     }).toList();

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -227,9 +227,20 @@ class FeatureAccess {
       return _tryConfigureTermsFeature(appConfig).configData;
     }
 
+    // If strategy is not provided, default to hard reload.
+    final reconnectStrategy = embeddedDataResource?.reconnectStrategy != null
+        ? ReconnectStrategy.values.byName(embeddedDataResource!.reconnectStrategy!)
+        : ReconnectStrategy.hardReload;
+
     // Return a ConfigData instance if a valid resource URL is found, otherwise return null.
     return embeddedDataResource?.uriOrNull != null
-        ? EmbeddedData(id: embeddedDataResource!.id, uri: embeddedDataResource.uriOrNull!, titleL10n: item.titleL10n)
+        ? EmbeddedData(
+            id: embeddedDataResource!.id,
+            uri: embeddedDataResource.uriOrNull!,
+            titleL10n: item.titleL10n,
+            enableConsoleLogCapture: embeddedDataResource.enableConsoleLogCapture,
+            reconnectStrategy: reconnectStrategy,
+          )
         : null;
   }
 
@@ -560,6 +571,7 @@ class SystemNotificationsFeature {
 
   // Check if the core system supports system notifications and push sending.
   bool get coreSystemSupport => _coreSupportedFeatures.contains(kSystemNotificationsFeatureFlag);
+
   bool get coreSystemPushSupport => _coreSupportedFeatures.contains(kSystemNotificationsPushFeatureFlag);
 
   /// Check if the system notifications feature is enabled and supported by the remote system.

--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -3,10 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
-import 'package:webview_flutter/webview_flutter.dart';
 
 import '../bloc/embedded_cubit.dart';
 
@@ -17,11 +18,19 @@ class EmbeddedScreen extends StatefulWidget {
     required this.initialUri,
     required this.appBar,
     this.shouldForwardPop = true,
+    this.reconnectStrategy,
+    this.enableConsoleLogCapture,
     super.key,
   });
 
   final Uri initialUri;
   final PreferredSizeWidget appBar;
+
+  /// If true, the console log will be captured and forwarded to the logger.
+  final bool? enableConsoleLogCapture;
+
+  /// The strategy to apply when the network reconnects.
+  final ReconnectStrategy? reconnectStrategy;
 
   /// If true, the pop action will be forwarded to the WebView if backstack is available.
   final bool shouldForwardPop;
@@ -41,8 +50,11 @@ class _EmbeddedScreenState extends State<EmbeddedScreen> {
   void initState() {
     final connectivityStream = Connectivity().onConnectivityChanged;
 
-    _connectivityRecoveryStrategy = SoftReloadRecoveryStrategy(connectivityStream: connectivityStream);
     _pageInjectionStrategy = DefaultPayloadInjectionStrategy();
+    _connectivityRecoveryStrategy = ConnectivityRecoveryStrategy.create(
+      type: widget.reconnectStrategy ?? ReconnectStrategy.softReload,
+      connectivityStream: connectivityStream,
+    );
 
     super.initState();
   }

--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -52,6 +52,7 @@ class _EmbeddedScreenState extends State<EmbeddedScreen> {
 
     _pageInjectionStrategy = DefaultPayloadInjectionStrategy();
     _connectivityRecoveryStrategy = ConnectivityRecoveryStrategy.create(
+      initialUri: widget.initialUri,
       type: widget.reconnectStrategy ?? ReconnectStrategy.softReload,
       connectivityStream: connectivityStream,
     );

--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -79,8 +79,7 @@ class _EmbeddedScreenState extends State<EmbeddedScreen> {
               connectivityRecoveryStrategy: _connectivityRecoveryStrategy,
               pageInjectionStrategies: [_pageInjectionStrategy],
               showToolbar: false,
-              // TODO: Move to environment config
-              enableEmbeddedLogging: true,
+              enableEmbeddedLogging: widget.enableConsoleLogCapture ?? false,
               userAgent: UserAgent.of(context),
               errorBuilder: _buildErrorBuilder(),
               onUrlChange: (url) async {

--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -41,7 +41,7 @@ class _EmbeddedScreenState extends State<EmbeddedScreen> {
   void initState() {
     final connectivityStream = Connectivity().onConnectivityChanged;
 
-    _connectivityRecoveryStrategy = DefaultConnectivityRecoveryStrategy(connectivityStream: connectivityStream);
+    _connectivityRecoveryStrategy = SoftReloadRecoveryStrategy(connectivityStream: connectivityStream);
     _pageInjectionStrategy = DefaultPayloadInjectionStrategy();
 
     super.initState();

--- a/lib/features/embedded/view/embedded_screen_page.dart
+++ b/lib/features/embedded/view/embedded_screen_page.dart
@@ -46,6 +46,8 @@ class EmbeddedScreenPage extends StatelessWidget {
       ),
       child: EmbeddedScreen(
         initialUri: data.uri,
+        reconnectStrategy: data.reconnectStrategy,
+        enableConsoleLogCapture: data.enableConsoleLogCapture,
         appBar: AppBar(
           leading: const AutoLeadingButton(),
           title: Text(context.parseL10n(data.titleL10n!)),

--- a/lib/features/embedded/view/embedded_tab_page.dart
+++ b/lib/features/embedded/view/embedded_tab_page.dart
@@ -47,6 +47,8 @@ class EmbeddedTabPage extends StatelessWidget {
 
           return EmbeddedScreen(
             initialUri: data.data!.uri,
+            reconnectStrategy: data.data?.reconnectStrategy,
+            enableConsoleLogCapture: data.data?.enableConsoleLogCapture,
             appBar: MainAppBar(
               title: Text(context.parseL10n(data.titleL10n)),
               context: context,

--- a/lib/models/embedded/embedded_data.dart
+++ b/lib/models/embedded/embedded_data.dart
@@ -1,17 +1,44 @@
 import 'embedded_payload_data.dart';
 
+/// Defines the strategy for handling reconnections in an embedded resource context.
+enum ReconnectStrategy {
+  /// Do nothing; assume page handles its own recovery
+  none,
+
+  /// Call JS bridge to notify app about reconnection (e.g., reinject token)
+  notifyOnly,
+
+  /// Reload the same URI without forcing full restart of the app
+  softReload,
+
+  /// Reloads the full WebView, discarding app state (may break SPA)
+  hardReload,
+}
+
 class EmbeddedData {
   EmbeddedData({
     required this.id,
     required this.uri,
     this.titleL10n,
     this.payload = const [],
+    this.enableConsoleLogCapture = false,
+    this.reconnectStrategy = ReconnectStrategy.hardReload,
   });
 
   /// The URI representing either a local asset file path or a remote URL.
   final int id;
+
+  /// The unique identifier for the embedded resource, used to link it with other features or components.
   final Uri uri;
+
+  /// The list of payload data to be passed to the embedded resource.
   final List<EmbeddedPayloadData> payload;
+
+  /// The flag to enable capturing `console.*` logs from inside the WebView.
+  final bool enableConsoleLogCapture;
+
+  /// The strategy to apply when the network reconnects.
+  final ReconnectStrategy reconnectStrategy;
 
   /// The key to use to look up the localized title.
   final String? titleL10n;

--- a/lib/models/embedded/embedded_data.dart
+++ b/lib/models/embedded/embedded_data.dart
@@ -19,10 +19,10 @@ class EmbeddedData {
   EmbeddedData({
     required this.id,
     required this.uri,
+    required this.reconnectStrategy,
     this.titleL10n,
     this.payload = const [],
     this.enableConsoleLogCapture = false,
-    this.reconnectStrategy = ReconnectStrategy.hardReload,
   });
 
   /// The URI representing either a local asset file path or a remote URL.

--- a/lib/utils/connectivity_checker.dart
+++ b/lib/utils/connectivity_checker.dart
@@ -1,0 +1,35 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'webtrit_http_executor.dart';
+
+abstract class ConnectivityChecker {
+  Future<bool> checkConnection();
+}
+
+class DefaultConnectivityChecker implements ConnectivityChecker {
+  const DefaultConnectivityChecker({
+    this.connectivityCheckUrl = 'https://www.google.com/generate_204',
+    this.createHttpRequestExecutor = defaultCreateHttpRequestExecutor,
+  });
+
+  final String connectivityCheckUrl;
+  final HttpRequestExecutorFactory createHttpRequestExecutor;
+
+  @override
+  Future<bool> checkConnection() async {
+    final result = await Connectivity().checkConnectivity();
+    if (result.contains(ConnectivityResult.none) || result.isEmpty) {
+      return false;
+    }
+
+    final executor = createHttpRequestExecutor();
+    try {
+      await executor.execute(method: 'GET', url: connectivityCheckUrl);
+      return true;
+    } catch (_) {
+      return false;
+    } finally {
+      executor.close();
+    }
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -13,3 +13,4 @@ export 'webtrit_api_client.dart';
 export 'webtrit_http_executor.dart';
 export 'webtrit_signaling_client.dart';
 export 'webtrit_signaling_utils.dart';
+export 'connectivity_checker.dart';

--- a/lib/widgets/webview/web_view_container.dart
+++ b/lib/widgets/webview/web_view_container.dart
@@ -600,6 +600,8 @@ abstract class ConnectivityRecoveryStrategy {
     required ReconnectStrategy type,
     required Stream<List<ConnectivityResult>> connectivityStream,
   }) {
+    _logger.fine('Creating connectivity recovery strategy: $type for $initialUri');
+
     switch (type) {
       case ReconnectStrategy.none:
         return NoneConnectivityRecoveryStrategy();

--- a/lib/widgets/webview/web_view_container.dart
+++ b/lib/widgets/webview/web_view_container.dart
@@ -711,6 +711,11 @@ class SoftReloadRecoveryStrategy implements ConnectivityRecoveryStrategy {
 
     _attempt++;
     _logger.info('Retry attempt $_attempt/$maxAttempts');
+    _onRetryAttempt();
+  }
+
+  /// Attempts to reload the WebView.
+  void _onRetryAttempt() {
     _controller.reload();
   }
 

--- a/lib/widgets/webview/web_view_container.dart
+++ b/lib/widgets/webview/web_view_container.dart
@@ -834,11 +834,15 @@ class NotifyOnlyConnectivityRecoveryStrategy extends SoftReloadRecoveryStrategy 
   NotifyOnlyConnectivityRecoveryStrategy({
     required super.connectivityStream,
     ConnectivityChecker? connectivityChecker,
+    this.reconnectCallbackFunction = 'onWebTritReconnect',
     super.retryDelay,
     super.maxAttempts,
   }) : _connectivityChecker = connectivityChecker ?? const DefaultConnectivityChecker();
 
   final ConnectivityChecker _connectivityChecker;
+
+  /// JS method to call when connectivity is restored.
+  final String reconnectCallbackFunction;
 
   @override
   void _onRetryAttempt() async {
@@ -846,9 +850,9 @@ class NotifyOnlyConnectivityRecoveryStrategy extends SoftReloadRecoveryStrategy 
     if (hasInternet && hasSuccessfulLoad) {
       _logger.info('NotifyOnlyConnectivityRecoveryStrategy: Connectivity restored, notifying WebView');
 
-      /// Wait for the next event loop to ensure the WebView is ready.
+      // Wait for the next event loop to ensure the WebView is ready.
       await Future.delayed(Duration.zero);
-      _controller.runJavaScript('window.onReconnect?.()');
+      _controller.runJavaScript('window.$reconnectCallbackFunction?.()');
       _stopRetries();
     } else {
       super._onRetryAttempt();

--- a/lib/widgets/webview/web_view_container.dart
+++ b/lib/widgets/webview/web_view_container.dart
@@ -845,6 +845,9 @@ class NotifyOnlyConnectivityRecoveryStrategy extends SoftReloadRecoveryStrategy 
     final hasInternet = await _connectivityChecker.checkConnection();
     if (hasInternet && hasSuccessfulLoad) {
       _logger.info('NotifyOnlyConnectivityRecoveryStrategy: Connectivity restored, notifying WebView');
+
+      /// Wait for the next event loop to ensure the WebView is ready.
+      await Future.delayed(Duration.zero);
       _controller.runJavaScript('window.onReconnect?.()');
       _stopRetries();
     } else {

--- a/packages/webtrit_appearance_theme/lib/models/features_config/embedded_resource.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/embedded_resource.dart
@@ -15,6 +15,9 @@ part 'embedded_resource.g.dart';
 /// - [attributes]: Optional attributes that can store additional information related to the resource, such as configuration or metadata.
 /// - [toolbar]: Optional toolbar configuration for the resource, including title and visibility. The default is an empty configuration.
 /// - [metadata]: Optional metadata associated with the resource, which can store custom data relevant to the resource's context.
+/// - [payload]: An optional list of strings that can be used to pass additional data to the embedded resource, such as parameters or identifiers.
+/// - [enableConsoleLogCapture]: A boolean flag that enables capturing `console.*` logs from inside the WebView, useful for debugging or logging purposes. The default is `false`.
+/// - [reconnectStrategy]: An optional string that defines the strategy to apply when the network
 @freezed
 class EmbeddedResource with _$EmbeddedResource {
   const EmbeddedResource._();
@@ -27,7 +30,15 @@ class EmbeddedResource with _$EmbeddedResource {
     @Default({}) Map<String, dynamic> attributes,
     @Default(ToolbarConfig()) ToolbarConfig toolbar,
     @Default(Metadata()) Metadata metadata,
+
+    /// Optional payload that can be used to pass additional data to the embedded resource.
     @Default([]) List<String> payload,
+
+    /// Enables capturing `console.*` logs from inside the WebView
+    @Default(false) bool enableConsoleLogCapture,
+
+    /// Strategy to apply when network reconnects
+    String? reconnectStrategy,
   }) = _EmbeddedResource;
 
   factory EmbeddedResource.fromJson(Map<String, dynamic> json) => _$EmbeddedResourceFromJson(json);

--- a/packages/webtrit_appearance_theme/lib/models/features_config/embedded_resource.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/embedded_resource.freezed.dart
@@ -26,7 +26,15 @@ mixin _$EmbeddedResource {
   Map<String, dynamic> get attributes => throw _privateConstructorUsedError;
   ToolbarConfig get toolbar => throw _privateConstructorUsedError;
   Metadata get metadata => throw _privateConstructorUsedError;
+
+  /// Optional payload that can be used to pass additional data to the embedded resource.
   List<String> get payload => throw _privateConstructorUsedError;
+
+  /// Enables capturing `console.*` logs from inside the WebView
+  bool get enableConsoleLogCapture => throw _privateConstructorUsedError;
+
+  /// Strategy to apply when network reconnects
+  String? get reconnectStrategy => throw _privateConstructorUsedError;
 
   /// Serializes this EmbeddedResource to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -51,7 +59,9 @@ abstract class $EmbeddedResourceCopyWith<$Res> {
       Map<String, dynamic> attributes,
       ToolbarConfig toolbar,
       Metadata metadata,
-      List<String> payload});
+      List<String> payload,
+      bool enableConsoleLogCapture,
+      String? reconnectStrategy});
 
   $ToolbarConfigCopyWith<$Res> get toolbar;
   $MetadataCopyWith<$Res> get metadata;
@@ -79,6 +89,8 @@ class _$EmbeddedResourceCopyWithImpl<$Res, $Val extends EmbeddedResource>
     Object? toolbar = null,
     Object? metadata = null,
     Object? payload = null,
+    Object? enableConsoleLogCapture = null,
+    Object? reconnectStrategy = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -109,6 +121,14 @@ class _$EmbeddedResourceCopyWithImpl<$Res, $Val extends EmbeddedResource>
           ? _value.payload
           : payload // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      enableConsoleLogCapture: null == enableConsoleLogCapture
+          ? _value.enableConsoleLogCapture
+          : enableConsoleLogCapture // ignore: cast_nullable_to_non_nullable
+              as bool,
+      reconnectStrategy: freezed == reconnectStrategy
+          ? _value.reconnectStrategy
+          : reconnectStrategy // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 
@@ -148,7 +168,9 @@ abstract class _$$EmbeddedResourceImplCopyWith<$Res>
       Map<String, dynamic> attributes,
       ToolbarConfig toolbar,
       Metadata metadata,
-      List<String> payload});
+      List<String> payload,
+      bool enableConsoleLogCapture,
+      String? reconnectStrategy});
 
   @override
   $ToolbarConfigCopyWith<$Res> get toolbar;
@@ -176,6 +198,8 @@ class __$$EmbeddedResourceImplCopyWithImpl<$Res>
     Object? toolbar = null,
     Object? metadata = null,
     Object? payload = null,
+    Object? enableConsoleLogCapture = null,
+    Object? reconnectStrategy = freezed,
   }) {
     return _then(_$EmbeddedResourceImpl(
       id: null == id
@@ -206,6 +230,14 @@ class __$$EmbeddedResourceImplCopyWithImpl<$Res>
           ? _value._payload
           : payload // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      enableConsoleLogCapture: null == enableConsoleLogCapture
+          ? _value.enableConsoleLogCapture
+          : enableConsoleLogCapture // ignore: cast_nullable_to_non_nullable
+              as bool,
+      reconnectStrategy: freezed == reconnectStrategy
+          ? _value.reconnectStrategy
+          : reconnectStrategy // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -221,7 +253,9 @@ class _$EmbeddedResourceImpl extends _EmbeddedResource {
       final Map<String, dynamic> attributes = const {},
       this.toolbar = const ToolbarConfig(),
       this.metadata = const Metadata(),
-      final List<String> payload = const []})
+      final List<String> payload = const [],
+      this.enableConsoleLogCapture = false,
+      this.reconnectStrategy})
       : _attributes = attributes,
         _payload = payload,
         super._();
@@ -251,7 +285,11 @@ class _$EmbeddedResourceImpl extends _EmbeddedResource {
   @override
   @JsonKey()
   final Metadata metadata;
+
+  /// Optional payload that can be used to pass additional data to the embedded resource.
   final List<String> _payload;
+
+  /// Optional payload that can be used to pass additional data to the embedded resource.
   @override
   @JsonKey()
   List<String> get payload {
@@ -260,9 +298,18 @@ class _$EmbeddedResourceImpl extends _EmbeddedResource {
     return EqualUnmodifiableListView(_payload);
   }
 
+  /// Enables capturing `console.*` logs from inside the WebView
+  @override
+  @JsonKey()
+  final bool enableConsoleLogCapture;
+
+  /// Strategy to apply when network reconnects
+  @override
+  final String? reconnectStrategy;
+
   @override
   String toString() {
-    return 'EmbeddedResource(id: $id, uri: $uri, type: $type, attributes: $attributes, toolbar: $toolbar, metadata: $metadata, payload: $payload)';
+    return 'EmbeddedResource(id: $id, uri: $uri, type: $type, attributes: $attributes, toolbar: $toolbar, metadata: $metadata, payload: $payload, enableConsoleLogCapture: $enableConsoleLogCapture, reconnectStrategy: $reconnectStrategy)';
   }
 
   @override
@@ -278,7 +325,12 @@ class _$EmbeddedResourceImpl extends _EmbeddedResource {
             (identical(other.toolbar, toolbar) || other.toolbar == toolbar) &&
             (identical(other.metadata, metadata) ||
                 other.metadata == metadata) &&
-            const DeepCollectionEquality().equals(other._payload, _payload));
+            const DeepCollectionEquality().equals(other._payload, _payload) &&
+            (identical(
+                    other.enableConsoleLogCapture, enableConsoleLogCapture) ||
+                other.enableConsoleLogCapture == enableConsoleLogCapture) &&
+            (identical(other.reconnectStrategy, reconnectStrategy) ||
+                other.reconnectStrategy == reconnectStrategy));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -291,7 +343,9 @@ class _$EmbeddedResourceImpl extends _EmbeddedResource {
       const DeepCollectionEquality().hash(_attributes),
       toolbar,
       metadata,
-      const DeepCollectionEquality().hash(_payload));
+      const DeepCollectionEquality().hash(_payload),
+      enableConsoleLogCapture,
+      reconnectStrategy);
 
   /// Create a copy of EmbeddedResource
   /// with the given fields replaced by the non-null parameter values.
@@ -318,7 +372,9 @@ abstract class _EmbeddedResource extends EmbeddedResource {
       final Map<String, dynamic> attributes,
       final ToolbarConfig toolbar,
       final Metadata metadata,
-      final List<String> payload}) = _$EmbeddedResourceImpl;
+      final List<String> payload,
+      final bool enableConsoleLogCapture,
+      final String? reconnectStrategy}) = _$EmbeddedResourceImpl;
   const _EmbeddedResource._() : super._();
 
   factory _EmbeddedResource.fromJson(Map<String, dynamic> json) =
@@ -336,8 +392,18 @@ abstract class _EmbeddedResource extends EmbeddedResource {
   ToolbarConfig get toolbar;
   @override
   Metadata get metadata;
+
+  /// Optional payload that can be used to pass additional data to the embedded resource.
   @override
   List<String> get payload;
+
+  /// Enables capturing `console.*` logs from inside the WebView
+  @override
+  bool get enableConsoleLogCapture;
+
+  /// Strategy to apply when network reconnects
+  @override
+  String? get reconnectStrategy;
 
   /// Create a copy of EmbeddedResource
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/webtrit_appearance_theme/lib/models/features_config/embedded_resource.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/embedded_resource.g.dart
@@ -24,6 +24,9 @@ _$EmbeddedResourceImpl _$$EmbeddedResourceImplFromJson(
               ?.map((e) => e as String)
               .toList() ??
           const [],
+      enableConsoleLogCapture:
+          json['enableConsoleLogCapture'] as bool? ?? false,
+      reconnectStrategy: json['reconnectStrategy'] as String?,
     );
 
 Map<String, dynamic> _$$EmbeddedResourceImplToJson(
@@ -36,6 +39,8 @@ Map<String, dynamic> _$$EmbeddedResourceImplToJson(
       'toolbar': instance.toolbar.toJson(),
       'metadata': instance.metadata.toJson(),
       'payload': instance.payload,
+      'enableConsoleLogCapture': instance.enableConsoleLogCapture,
+      'reconnectStrategy': instance.reconnectStrategy,
     };
 
 const _$EmbeddedResourceTypeEnumMap = {

--- a/test/embedded/soft_reload_recovery_strategy_test.dart
+++ b/test/embedded/soft_reload_recovery_strategy_test.dart
@@ -2,18 +2,26 @@ import 'dart:async';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_phone/widgets/webview/web_view_container.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class MockWebViewController extends Mock implements WebViewController {}
 
 void main() {
   group('RetryUntilSuccessStrategy', () {
-    late DefaultConnectivityRecoveryStrategy strategy;
+    late SoftReloadRecoveryStrategy strategy;
     late List<String> log;
     late StreamController<List<ConnectivityResult>> connectivityStream;
+    late WebViewController controller;
 
     setUp(() {
       log = [];
       connectivityStream = StreamController<List<ConnectivityResult>>();
+      controller = MockWebViewController();
+      when(() => controller.runJavaScript(any())).thenAnswer((_) async {});
+      when(() => controller.reload()).thenAnswer((_) => Future.value());
     });
 
     tearDown(() async {
@@ -24,17 +32,19 @@ void main() {
     test('Case 1: WiFi available, WebView loads successfully immediately', () async {
       final completer = Completer<void>();
 
-      strategy = DefaultConnectivityRecoveryStrategy(
+      strategy = SoftReloadRecoveryStrategy(
         retryDelay: const Duration(milliseconds: 100),
         maxAttempts: 5,
         connectivityStream: connectivityStream.stream,
       );
 
-      strategy.startMonitoring(tryReload: () {
+      when(() => controller.reload()).thenAnswer((_) async {
         log.add('reload');
         strategy.onPageLoadSuccess();
         completer.complete();
       });
+
+      strategy.startMonitoringForTesting(controller);
 
       connectivityStream.add([ConnectivityResult.wifi]);
 
@@ -47,21 +57,25 @@ void main() {
       final completer = Completer<void>();
       int failures = 2;
 
-      strategy = DefaultConnectivityRecoveryStrategy(
+      strategy = SoftReloadRecoveryStrategy(
         retryDelay: const Duration(milliseconds: 100),
         maxAttempts: 5,
         connectivityStream: connectivityStream.stream,
       );
 
-      strategy.startMonitoring(tryReload: () {
+      when(() => controller.reload()).thenAnswer((_) async {
         log.add('reload');
+
         if (failures > 0) {
           failures--;
+          strategy.onPageLoadFailed();
         } else {
           strategy.onPageLoadSuccess();
           completer.complete();
         }
       });
+
+      strategy.startMonitoringForTesting(controller);
 
       connectivityStream.add([ConnectivityResult.wifi]);
 
@@ -71,15 +85,13 @@ void main() {
     });
 
     test('Case 3: No WiFi — should not retry', () async {
-      strategy = DefaultConnectivityRecoveryStrategy(
+      strategy = SoftReloadRecoveryStrategy(
         retryDelay: const Duration(milliseconds: 100),
         maxAttempts: 5,
         connectivityStream: connectivityStream.stream,
       );
 
-      strategy.startMonitoring(tryReload: () {
-        log.add('reload');
-      });
+      strategy.startMonitoringForTesting(controller);
 
       connectivityStream.add([ConnectivityResult.none]);
 
@@ -92,13 +104,13 @@ void main() {
       final completer = Completer<void>();
       int attemptCount = 0;
 
-      strategy = DefaultConnectivityRecoveryStrategy(
+      strategy = SoftReloadRecoveryStrategy(
         retryDelay: const Duration(milliseconds: 100),
         maxAttempts: 10,
         connectivityStream: connectivityStream.stream,
       );
 
-      strategy.startMonitoring(tryReload: () {
+      when(() => controller.reload()).thenAnswer((_) async {
         final entry = 'reload:$attemptCount';
         log.add(entry);
         attemptCount++;
@@ -106,8 +118,12 @@ void main() {
         if (entry == 'reload:1' || entry == 'reload:5') {
           strategy.onPageLoadSuccess();
           if (entry == 'reload:5') completer.complete();
+        } else {
+          strategy.onPageLoadFailed();
         }
       });
+
+      strategy.startMonitoringForTesting(controller);
 
       connectivityStream.add([ConnectivityResult.wifi]);
       await Future.delayed(const Duration(milliseconds: 300));
@@ -120,56 +136,68 @@ void main() {
       await completer.future.timeout(const Duration(seconds: 2));
 
       expect(
-          log,
-          equals([
-            'reload:0',
-            'reload:1',
-            'reload:2',
-            'reload:3',
-            'reload:4',
-            'reload:5',
-          ]));
+        log,
+        equals([
+          'reload:0',
+          'reload:1',
+          'reload:2',
+          'reload:3',
+          'reload:4',
+          'reload:5',
+        ]),
+      );
     });
 
     test('Case 5: Max attempts reached — retries stop', () async {
-      strategy = DefaultConnectivityRecoveryStrategy(
+      strategy = SoftReloadRecoveryStrategy(
         retryDelay: const Duration(milliseconds: 100),
         maxAttempts: 3,
         connectivityStream: connectivityStream.stream,
       );
 
-      strategy.startMonitoring(tryReload: () {
+      int reloads = 0;
+
+      when(() => controller.reload()).thenAnswer((_) async {
+        reloads++;
         log.add('reload');
         strategy.onPageLoadFailed();
       });
 
+      strategy.startMonitoringForTesting(controller);
+
       connectivityStream.add([ConnectivityResult.wifi]);
 
-      await Future.delayed(const Duration(milliseconds: 500));
+      await Future.delayed(const Duration(milliseconds: 800));
 
-      expect(log.length, equals(1));
+      expect(reloads, equals(3));
+      expect(log.length, equals(3));
     });
 
     test('Case 6: Multiple calls to startMonitoring should be ignored', () async {
       final completer = Completer<void>();
+      int reloadCount = 0;
 
-      strategy = DefaultConnectivityRecoveryStrategy(
+      strategy = SoftReloadRecoveryStrategy(
         retryDelay: const Duration(milliseconds: 100),
         maxAttempts: 5,
         connectivityStream: connectivityStream.stream,
       );
 
-      int reloadCount = 0;
-
-      strategy.startMonitoring(tryReload: () {
+      final firstController = MockWebViewController();
+      when(() => firstController.reload()).thenAnswer((_) async {
         reloadCount++;
         strategy.onPageLoadSuccess();
         completer.complete();
       });
 
-      strategy.startMonitoring(tryReload: () {
+      final secondController = MockWebViewController();
+      when(() => secondController.reload()).thenAnswer((_) async {
         log.add('should-not-be-called');
       });
+
+      strategy.startMonitoringForTesting(firstController);
+
+      strategy.startMonitoringForTesting(secondController);
 
       connectivityStream.add([ConnectivityResult.wifi]);
 


### PR DESCRIPTION
This PR improves WebView reconnect handling by introducing a configurable connectivity recovery strategy and moving all reconnect behavior into well-defined, injectable components. 
This makes reconnect logic SPA-friendly and easier to adapt across environments like Econet.