### PR TITLE
fix: prevent navigation bar from overlapping Continue button

### DIFF
--- a/lib/features/contacts_agreement/view/contacts_agreement_screen.dart
+++ b/lib/features/contacts_agreement/view/contacts_agreement_screen.dart
@@ -63,11 +63,14 @@ class _ContactsAgreementScreenState extends State<ContactsAgreementScreen> {
                             text: context.l10n.contacts_agreement_checkbox_text,
                           ),
                           const SizedBox(height: kInset / 2),
-                          OutlinedButton(
-                            key: contactsAgreementAcceptButtonKey,
-                            onPressed: _submitAgreement,
-                            style: elevatedButtonStyles?.primary,
-                            child: Text(context.l10n.contacts_agreement_button_text),
+                          InertSafeArea(
+                            bottom: true,
+                            child: OutlinedButton(
+                              key: contactsAgreementAcceptButtonKey,
+                              onPressed: _submitAgreement,
+                              style: elevatedButtonStyles?.primary,
+                              child: Text(context.l10n.contacts_agreement_button_text),
+                            ),
                           ),
                         ],
                       ),

--- a/lib/features/permissions/view/permissions_screen.dart
+++ b/lib/features/permissions/view/permissions_screen.dart
@@ -82,7 +82,10 @@ class PermissionsScreen extends StatelessWidget {
                     minHeight: viewportConstraints.maxHeight,
                   ),
                   child: IntrinsicHeight(
-                    child: body,
+                    child: InertSafeArea(
+                      bottom: true,
+                      child: body,
+                    ),
                   ),
                 ),
               );

--- a/lib/features/permissions/widgets/permission_tips.dart
+++ b/lib/features/permissions/widgets/permission_tips.dart
@@ -4,6 +4,7 @@ import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
 
 class PermissionTips extends StatelessWidget {
   const PermissionTips({
@@ -103,7 +104,10 @@ class PermissionTips extends StatelessWidget {
                 minHeight: viewportConstraints.maxHeight,
               ),
               child: IntrinsicHeight(
-                child: body,
+                child: InertSafeArea(
+                  bottom: true,
+                  child: body,
+                ),
               ),
             ),
           );

--- a/lib/features/user_agreement/view/user_agreement_screen.dart
+++ b/lib/features/user_agreement/view/user_agreement_screen.dart
@@ -71,7 +71,7 @@ class _UserAgreementScreenState extends State<UserAgreementScreen> {
                       onPressed: agreementStatus.isAccepted ? _submitAgreement : null,
                       style: elevatedButtonStyles?.primary,
                       child: Text(context.l10n.user_agreement_button_text),
-                    )
+                    ),
                   ],
                 ),
               );
@@ -82,7 +82,10 @@ class _UserAgreementScreenState extends State<UserAgreementScreen> {
                     minHeight: viewportConstraints.maxHeight,
                   ),
                   child: IntrinsicHeight(
-                    child: body,
+                    child: InertSafeArea(
+                      bottom: true,
+                      child: body,
+                    ),
                   ),
                 ),
               );

--- a/lib/widgets/inert_safe_area.dart
+++ b/lib/widgets/inert_safe_area.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+
+class InertSafeArea extends SafeArea {
+  const InertSafeArea({
+    super.key,
+    required super.child,
+    super.minimum = EdgeInsets.zero,
+    super.maintainBottomViewPadding = false,
+    super.left = false,
+    super.top = false,
+    super.right = false,
+    super.bottom = false,
+  });
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -8,6 +8,7 @@ export 'copy_to_clipboard.dart';
 export 'embedded_request_error.dart';
 export 'fade_id.dart';
 export 'history_fetch_indicator.dart';
+export 'inert_safe_area.dart';
 export 'keypad_key_button.dart';
 export 'leading_avatar.dart';
 export 'linkify.dart';


### PR DESCRIPTION
This PR fixes a UI issue where the navigation bar was overlapping with Continue buttons in various screens. The solution introduces a new InertSafeArea widget that provides controlled safe area padding only at the bottom of the screen.

Creates a new InertSafeArea widget that extends SafeArea with customized defaults
Applies bottom safe area padding to prevent navigation bar overlap in multiple screens
Updates widget exports to include the new component