### PR TITLE
refactor: allow 'refactor/' prefix in branch name validation

### DIFF
--- a/tool/scripts/branch-name-check.sh
+++ b/tool/scripts/branch-name-check.sh
@@ -5,7 +5,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "🔍 Current branch: $BRANCH"
 
-if ! [[ "$BRANCH" =~ ^(feature|fix|chore|build|style|docs)/.+$ ]]; then
+if ! [[ "$BRANCH" =~ ^(feature|refactor|fix|chore|build|style|docs)/.+$ ]]; then
   echo "❌ Invalid branch name: '$BRANCH'"
   echo "💡 Use: feature/name, fix/bug-name, etc."
   exit 1


### PR DESCRIPTION
Updated branch name validation to accept the `refactor/` prefix in addition to existing allowed prefixes (`feature`, `fix`, `chore`, `build`, `style`, `docs`).
