### PR TITLE
fix: contact screen same key error

### DIFF
--- a/lib/features/contact/view/contact_screen.dart
+++ b/lib/features/contact/view/contact_screen.dart
@@ -137,58 +137,61 @@ class _ContactScreenState extends State<ContactScreen> {
                             height: 16,
                           ),
                           for (final contactPhone in contact.phones)
-                            ContactPhoneTile(
-                              key: contactPhoneTileKey,
-                              number: contactPhone.number,
-                              label: contactPhone.label,
-                              favorite: contactPhone.favorite,
-                              callNumbers: callRoutingState?.allNumbers ?? [],
-                              onFavoriteChanged: widget.favoriteEnabled
-                                  ? (isFavorite) {
-                                      toggleFavorite(
-                                        isFavorite: isFavorite,
-                                        contactPhone: contactPhone,
-                                      );
-                                    }
-                                  : null,
-                              onAudioPressed: () => _callController.createCall(
-                                destination: contactPhone.number,
-                                displayName: contact.maybeName,
-                                video: false,
-                              ),
-                              onVideoPressed: widget.videoEnabled
-                                  ? () => _callController.createCall(
-                                        destination: contactPhone.number,
-                                        displayName: contact.maybeName,
-                                        video: true,
-                                      )
-                                  : null,
-                              onTransferPressed: widget.transferEnabled && hasActiveCall
-                                  ? () {
-                                      _callController.submitTransfer(contactPhone.number);
-                                      context.router.maybePop();
-                                    }
-                                  : null,
-                              onInitiatedTransferPressed: widget.transferEnabled && callState.isBlingTransferInitiated
-                                  ? () {
-                                      _callController.submitTransfer(contactPhone.number);
-                                      context.router.maybePop();
-                                    }
-                                  : null,
-                              onSendSmsPressed: widget.smsEnabled && contactSmsNumbers.contains(contactPhone.number)
-                                  ? () => sendSms(
-                                        userSmsNumbers: userSmsNumbers,
-                                        contactPhoneNumber: contactPhone.number,
-                                        contactSourceId: contactSourceId,
-                                      )
-                                  : null,
-                              onCallLogPressed: () => openCallLog(
+                            SizedBox(
+                              key: ValueKey(contactPhone),
+                              child: ContactPhoneTile(
+                                key: contactPhoneTileKey,
                                 number: contactPhone.number,
-                              ),
-                              onCallFrom: (fromNumber) => _callController.createCall(
-                                destination: contactPhone.number,
-                                displayName: contact.maybeName,
-                                fromNumber: fromNumber,
+                                label: contactPhone.label,
+                                favorite: contactPhone.favorite,
+                                callNumbers: callRoutingState?.allNumbers ?? [],
+                                onFavoriteChanged: widget.favoriteEnabled
+                                    ? (isFavorite) {
+                                        toggleFavorite(
+                                          isFavorite: isFavorite,
+                                          contactPhone: contactPhone,
+                                        );
+                                      }
+                                    : null,
+                                onAudioPressed: () => _callController.createCall(
+                                  destination: contactPhone.number,
+                                  displayName: contact.maybeName,
+                                  video: false,
+                                ),
+                                onVideoPressed: widget.videoEnabled
+                                    ? () => _callController.createCall(
+                                          destination: contactPhone.number,
+                                          displayName: contact.maybeName,
+                                          video: true,
+                                        )
+                                    : null,
+                                onTransferPressed: widget.transferEnabled && hasActiveCall
+                                    ? () {
+                                        _callController.submitTransfer(contactPhone.number);
+                                        context.router.maybePop();
+                                      }
+                                    : null,
+                                onInitiatedTransferPressed: widget.transferEnabled && callState.isBlingTransferInitiated
+                                    ? () {
+                                        _callController.submitTransfer(contactPhone.number);
+                                        context.router.maybePop();
+                                      }
+                                    : null,
+                                onSendSmsPressed: widget.smsEnabled && contactSmsNumbers.contains(contactPhone.number)
+                                    ? () => sendSms(
+                                          userSmsNumbers: userSmsNumbers,
+                                          contactPhoneNumber: contactPhone.number,
+                                          contactSourceId: contactSourceId,
+                                        )
+                                    : null,
+                                onCallLogPressed: () => openCallLog(
+                                  number: contactPhone.number,
+                                ),
+                                onCallFrom: (fromNumber) => _callController.createCall(
+                                  destination: contactPhone.number,
+                                  displayName: contact.maybeName,
+                                  fromNumber: fromNumber,
+                                ),
                               ),
                             ),
                           for (final contactEmail in contact.emails)


### PR DESCRIPTION
This pull request introduces a minor improvement to the rendering of contact phone tiles in the `ContactScreen`. The main change is wrapping each `ContactPhoneTile` in a `SizedBox` with a unique `ValueKey` to prevent listview errors that happens when its childs have same key.