### PR TITLE
refactor: use session repository as SSOT instead of direct AppBloc communication

### DIFF
--- a/lib/app/notifications/models/notification.dart
+++ b/lib/app/notifications/models/notification.dart
@@ -6,7 +6,7 @@ import 'package:auto_route/auto_route.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
 
-import 'package:webtrit_phone/features/messaging/messaging.dart';
+import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/failures/failures.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
@@ -54,6 +54,16 @@ class ErrorMessageNotification extends ErrorNotification {
 
   @override
   String l10n(BuildContext context) => message;
+}
+
+/// Default notification for account-related errors
+class AccountErrorNotification extends ErrorNotification {
+  const AccountErrorNotification(this.accountErrorCode);
+
+  final AccountErrorCode accountErrorCode;
+
+  @override
+  String l10n(BuildContext context) => accountErrorCode.l10n(context);
 }
 
 /// Default notification for handled exceptions

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -38,11 +38,7 @@ class AppRouter extends RootStackRouter {
   final LoginEmbedded? _launchLoginEmbedded;
   final BottomMenuFeature _bottomMenuFeature;
 
-  String? get coreUrl => _appBloc.state.coreUrl;
-
-  String? get token => _appBloc.state.token;
-
-  String? get userId => _appBloc.state.userId;
+  Session get session => _appBloc.state.session;
 
   bool get appPermissionsDenied => _appPermissions.isDenied;
 
@@ -58,8 +54,6 @@ class AppRouter extends RootStackRouter {
   /// If the user views the agreement and does not accept it, the status
   /// is updated to `declined`, ensuring the user does not see the screen again automatically.
   bool get appContactsAgreementUnaccepted => _appBloc.state.contactsAgreementStatus.isPending;
-
-  bool get appLoggedIn => coreUrl != null && token != null && userId != null;
 
   /// Retrieves the initial tab  for the main screen.
   ///
@@ -343,7 +337,7 @@ class AppRouter extends RootStackRouter {
   void onLoginScreenPageRouteGuardNavigation(NavigationResolver resolver, StackRouter router) {
     _logger.fine(_onNavigationLoggerMessage('onLoginScreenPageRouteGuardNavigation', resolver));
 
-    if (appLoggedIn) {
+    if (session.isLoggedIn) {
       resolver.next(false);
       router.replaceAll(
         [const MainShellRoute()],
@@ -395,7 +389,7 @@ class AppRouter extends RootStackRouter {
   void onMainShellRouteGuardNavigation(NavigationResolver resolver, StackRouter router) {
     _logger.fine(_onNavigationLoggerMessage('onMainShellRouteGuardNavigation', resolver));
 
-    if (appLoggedIn) {
+    if (session.isLoggedIn) {
       final contactsSourceTypes = _bottomMenuFeature.getTabEnabled(MainFlavor.contacts)?.toContacts?.contactSourceTypes;
       final localContactsSourceTypeEnabled = contactsSourceTypes?.contains(ContactSourceType.local) == true;
 

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -61,7 +61,6 @@ class _MainShellState extends State<MainShell> {
     context.read<AppLogger>().regenerateRemoteLabels();
 
     _sessionGuard = RouterLogoutSessionGuard(performLogout: () {
-      // context.read<AppBloc>().add(const AppLogouted());
       context.read<SessionRepository>().logout();
     }, onPreLogout: () {
       final notification = ErrorMessageNotification(context.l10n.notifications_errorSnackBar_sessionExpired);

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -14,20 +14,7 @@ import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 
 class App extends StatefulWidget {
-  const App({
-    super.key,
-    required this.appPreferences,
-    required this.secureStorage,
-    required this.appDatabase,
-    required this.appPermissions,
-    required this.appThemes,
-  });
-
-  final AppPreferences appPreferences;
-  final SecureStorage secureStorage;
-  final AppDatabase appDatabase;
-  final AppPermissions appPermissions;
-  final AppThemes appThemes;
+  const App({super.key});
 
   @override
   State<App> createState() => _AppState();
@@ -44,14 +31,13 @@ class _AppState extends State<App> {
     final featureAccess = FeatureAccess();
 
     appBloc = AppBloc(
-      appPreferences: widget.appPreferences,
-      secureStorage: widget.secureStorage,
-      appDatabase: widget.appDatabase,
-      appThemes: widget.appThemes,
+      appPreferences: context.read<AppPreferences>(),
+      appThemes: context.read<AppThemes>(),
+      sessionRepository: context.read<SessionRepository>(),
     );
     _appRouter = AppRouter(
       appBloc,
-      widget.appPermissions,
+      context.read<AppPermissions>(),
       featureAccess.loginFeature.embeddedLaunchConfiguration?.customLoginFeature,
       featureAccess.bottomMenuFeature,
     );

--- a/lib/blocs/app/app_bloc.dart
+++ b/lib/blocs/app/app_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:bloc/bloc.dart';
@@ -11,6 +13,7 @@ import 'package:webtrit_api/webtrit_api.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/auth/session_repository.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
@@ -25,95 +28,67 @@ final _logger = Logger('AppBloc');
 class AppBloc extends Bloc<AppEvent, AppState> {
   AppBloc({
     required this.appPreferences,
-    required this.secureStorage,
-    required this.appDatabase,
+    required this.sessionRepository,
     @visibleForTesting this.createWebtritApiClient = defaultCreateWebtritApiClient,
     required AppThemes appThemes,
   }) : super(AppState(
-          coreUrl: secureStorage.readCoreUrl(),
-          tenantId: secureStorage.readTenantId(),
-          token: secureStorage.readToken(),
-          userId: secureStorage.readUserId(),
+          /// Important to manage routing and navigation in AppRouter
+          session: sessionRepository.getCurrent() ?? const Session(),
           themeSettings: appThemes.values.first.settings,
           themeMode: appPreferences.getThemeMode(),
           locale: appPreferences.getLocale(),
           userAgreementStatus: appPreferences.getUserAgreementStatus(),
           contactsAgreementStatus: appPreferences.getContactsAgreementStatus(),
         )) {
-    on<AppLogined>(_onLogined, transformer: sequential());
-    on<AppLogouted>(_onLogouted, transformer: sequential());
-    on<AppLogoutedTeardown>(_onLogoutedTeardown, transformer: sequential());
+    on<_SessionUpdated>(_onSessionUpdated, transformer: sequential());
+    // on<AppLogoutedTeardown>(_onLogoutedTeardown, transformer: sequential());
     on<AppThemeSettingsChanged>(_onThemeSettingsChanged, transformer: droppable());
     on<AppThemeModeChanged>(_onThemeModeChanged, transformer: droppable());
     on<AppLocaleChanged>(_onLocaleChanged, transformer: droppable());
     on<AppAgreementAccepted>(_onUserAgreementAccepted, transformer: droppable());
+
+    _subscribeSession();
   }
 
   final AppPreferences appPreferences;
-  final SecureStorage secureStorage;
-  final AppDatabase appDatabase;
   final WebtritApiClientFactory createWebtritApiClient;
+  final SessionRepository sessionRepository;
 
-  Future<void> _cleanUpUserData() async {
-    await appPreferences.clear();
+  late final StreamSubscription<Session?> _sessionSub;
 
-    await secureStorage.deleteCoreUrl();
-    await secureStorage.deleteTenantId();
-    await secureStorage.deleteToken();
-    await secureStorage.deleteUserId();
-
-    await appDatabase.deleteEverything();
-  }
-
-  void _onLogined(AppLogined event, Emitter<AppState> emit) async {
-    // Check if the user is re-logging in.
-    // Example: logging in with a deeplink while already logged with another account.
-    // In this case, clear the database and preferences.
-    final isRelogin = state.token != null;
-    if (isRelogin) await _cleanUpUserData();
-
-    await secureStorage.writeCoreUrl(event.coreUrl);
-    await secureStorage.writeTenantId(event.tenantId);
-    await secureStorage.writeToken(event.token);
-    await secureStorage.writeUserId(event.userId);
-
-    await appPreferences.setSystemInfo(event.systemInfo);
-
-    emit(state.copyWith(
-      coreUrl: event.coreUrl,
-      tenantId: event.tenantId,
-      token: event.token,
-      userId: event.userId,
-    ));
-
-    FirebaseCrashlytics.instance.setUserIdentifier(event.userId).ignore();
-    FirebaseCrashlytics.instance.setCustomKey('coreUrl', event.coreUrl).ignore();
-    FirebaseCrashlytics.instance.setCustomKey('tenantId', event.tenantId).ignore();
-  }
-
-  void _onLogouted(AppLogouted event, Emitter<AppState> emit) async {
-    final token = state.token;
-    final coreUrl = state.coreUrl;
-
-    if (token != null && coreUrl != null && event.checkTokenForError) {
-      try {
-        final client = createWebtritApiClient(coreUrl, state.tenantId ?? '');
-        await client.getUserInfo(token, options: const RequestOptions(retries: 0));
-      } on RequestFailure catch (e) {
-        final errorCode = AccountErrorCode.values.firstWhereOrNull((it) => it.value == e.error?.code);
-        emit(state.copyWith(accountErrorCode: errorCode));
-      } catch (e) {
-        _logger.severe('_onLogouted', e);
-      }
+  @override
+  void onChange(Change<AppState> change) {
+    /// Trigger when user transitions from logged out to logged in
+    if (!change.currentState.session.isLoggedIn && change.nextState.session.isLoggedIn) {
+      _onSessionLoggedIn(change.nextState.session);
     }
 
-    await _cleanUpUserData();
-
-    emit(state.copyWith(coreUrl: null, tenantId: null, token: null, userId: null));
+    /// Trigger when user transitions from logged in to logged out
+    if (change.currentState.session.isLoggedIn && !change.nextState.session.isLoggedIn) {
+      _onSessionLoggedOut(change.currentState.session);
+    }
+    super.onChange(change);
   }
 
-  void _onLogoutedTeardown(AppLogoutedTeardown event, Emitter<AppState> emit) async {
-    emit(state.copyWith(accountErrorCode: null));
+  void _onSessionLoggedIn(Session session) {
+    FirebaseCrashlytics.instance.setUserIdentifier(session.userId).ignore();
+    FirebaseCrashlytics.instance.setCustomKey('tenantId', session.tenantId).ignore();
+    FirebaseCrashlytics.instance.setCustomKey('coreUrl', session.coreUrl!).ignore();
+  }
+
+  void _onSessionLoggedOut(Session session) {
+    _logger.info('User logged out: ${session.userId}');
+  }
+
+  void _subscribeSession() {
+    _sessionSub = sessionRepository.watch().listen(
+          (session) => add(_SessionUpdated(session)),
+          onError: (e, st) => _logger.severe('authSessionRepository.watch', e, st),
+        );
+  }
+
+  void _onSessionUpdated(_SessionUpdated event, Emitter<AppState> emit) async {
+    emit(state.copyWith(session: event.session ?? const Session()));
   }
 
   void _onThemeSettingsChanged(AppThemeSettingsChanged event, Emitter<AppState> emit) {
@@ -140,11 +115,15 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     emit(state.copyWith(locale: locale));
   }
 
+  /// Handles unauthorized errors for the active session.
+  /// Logs out only if the failing request used the current token,
+  /// avoiding accidental logout from outdated tokens (e.g. after re-login).
+  // TODO: Consider moving this logic to another place, like a middleware or interceptor.
   void maybeHandleError(Object error) {
     if (error is RequestFailure) {
       if (error.statusCode == HttpStatus.unauthorized) {
-        if (state.token != null && state.token == error.token) {
-          add(const AppLogouted());
+        if (state.session.isLoggedIn && state.session.token == error.token) {
+          sessionRepository.logout();
         }
       }
     }
@@ -155,8 +134,9 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     Emitter<AppState> emit,
   ) {
     return event.map(
-        updateUserAgreement: (event) => __onUpdateUserAgreementStatus(event, emit),
-        updateContactsAgreement: (event) => __onContactsUserAgreementStatus(event, emit));
+      updateUserAgreement: (event) => __onUpdateUserAgreementStatus(event, emit),
+      updateContactsAgreement: (event) => __onContactsUserAgreementStatus(event, emit),
+    );
   }
 
   Future<void> __onUpdateUserAgreementStatus(
@@ -173,5 +153,11 @@ class AppBloc extends Bloc<AppEvent, AppState> {
   ) async {
     await appPreferences.setContactsAgreementStatus(event.status);
     emit(state.copyWith(contactsAgreementStatus: event.status));
+  }
+
+  @override
+  Future<void> close() async {
+    await _sessionSub.cancel();
+    return super.close();
   }
 }

--- a/lib/blocs/app/app_bloc.dart
+++ b/lib/blocs/app/app_bloc.dart
@@ -41,7 +41,6 @@ class AppBloc extends Bloc<AppEvent, AppState> {
           contactsAgreementStatus: appPreferences.getContactsAgreementStatus(),
         )) {
     on<_SessionUpdated>(_onSessionUpdated, transformer: sequential());
-    // on<AppLogoutedTeardown>(_onLogoutedTeardown, transformer: sequential());
     on<AppThemeSettingsChanged>(_onThemeSettingsChanged, transformer: droppable());
     on<AppThemeModeChanged>(_onThemeModeChanged, transformer: droppable());
     on<AppLocaleChanged>(_onLocaleChanged, transformer: droppable());

--- a/lib/blocs/app/app_bloc.freezed.dart
+++ b/lib/blocs/app/app_bloc.freezed.dart
@@ -15,144 +15,41 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
-mixin _$AppLogined {
-  String get coreUrl => throw _privateConstructorUsedError;
-  String get tenantId => throw _privateConstructorUsedError;
-  String get token => throw _privateConstructorUsedError;
-  String get userId => throw _privateConstructorUsedError;
-  WebtritSystemInfo get systemInfo => throw _privateConstructorUsedError;
+mixin _$SessionUpdated {
+  Session? get session => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 
-class _$AppLoginedImpl implements _AppLogined {
-  const _$AppLoginedImpl(
-      {required this.coreUrl,
-      required this.tenantId,
-      required this.token,
-      required this.userId,
-      required this.systemInfo});
+class _$_SessionUpdatedImpl implements __SessionUpdated {
+  const _$_SessionUpdatedImpl(this.session);
 
   @override
-  final String coreUrl;
-  @override
-  final String tenantId;
-  @override
-  final String token;
-  @override
-  final String userId;
-  @override
-  final WebtritSystemInfo systemInfo;
+  final Session? session;
 
   @override
   String toString() {
-    return 'AppLogined(coreUrl: $coreUrl, tenantId: $tenantId, token: $token, userId: $userId, systemInfo: $systemInfo)';
+    return '_SessionUpdated(session: $session)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AppLoginedImpl &&
-            (identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl) &&
-            (identical(other.tenantId, tenantId) ||
-                other.tenantId == tenantId) &&
-            (identical(other.token, token) || other.token == token) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.systemInfo, systemInfo) ||
-                other.systemInfo == systemInfo));
+            other is _$_SessionUpdatedImpl &&
+            (identical(other.session, session) || other.session == session));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, coreUrl, tenantId, token, userId, systemInfo);
+  int get hashCode => Object.hash(runtimeType, session);
 }
 
-abstract class _AppLogined implements AppLogined {
-  const factory _AppLogined(
-      {required final String coreUrl,
-      required final String tenantId,
-      required final String token,
-      required final String userId,
-      required final WebtritSystemInfo systemInfo}) = _$AppLoginedImpl;
+abstract class __SessionUpdated implements _SessionUpdated {
+  const factory __SessionUpdated(final Session? session) =
+      _$_SessionUpdatedImpl;
 
   @override
-  String get coreUrl;
-  @override
-  String get tenantId;
-  @override
-  String get token;
-  @override
-  String get userId;
-  @override
-  WebtritSystemInfo get systemInfo;
-}
-
-/// @nodoc
-mixin _$AppLogouted {
-  bool get checkTokenForError => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-
-class _$AppLogoutedImpl implements _AppLogouted {
-  const _$AppLogoutedImpl({this.checkTokenForError = false});
-
-  @override
-  @JsonKey()
-  final bool checkTokenForError;
-
-  @override
-  String toString() {
-    return 'AppLogouted(checkTokenForError: $checkTokenForError)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$AppLogoutedImpl &&
-            (identical(other.checkTokenForError, checkTokenForError) ||
-                other.checkTokenForError == checkTokenForError));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, checkTokenForError);
-}
-
-abstract class _AppLogouted implements AppLogouted {
-  const factory _AppLogouted({final bool checkTokenForError}) =
-      _$AppLogoutedImpl;
-
-  @override
-  bool get checkTokenForError;
-}
-
-/// @nodoc
-mixin _$AppLogoutedTeardown {}
-
-/// @nodoc
-
-class _$AppLogoutTeardownImpl implements _AppLogoutTeardown {
-  const _$AppLogoutTeardownImpl();
-
-  @override
-  String toString() {
-    return 'AppLogoutedTeardown()';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$AppLogoutTeardownImpl);
-  }
-
-  @override
-  int get hashCode => runtimeType.hashCode;
-}
-
-abstract class _AppLogoutTeardown implements AppLogoutedTeardown {
-  const factory _AppLogoutTeardown() = _$AppLogoutTeardownImpl;
+  Session? get session;
 }
 
 /// @nodoc
@@ -515,11 +412,7 @@ abstract class _ContactsAppAgreementUpdate implements AppAgreementAccepted {
 
 /// @nodoc
 mixin _$AppState {
-  String? get coreUrl => throw _privateConstructorUsedError;
-  String? get tenantId => throw _privateConstructorUsedError;
-  String? get token => throw _privateConstructorUsedError;
-  String? get userId => throw _privateConstructorUsedError;
-  AccountErrorCode? get accountErrorCode => throw _privateConstructorUsedError;
+  Session get session => throw _privateConstructorUsedError;
   ThemeSettings get themeSettings => throw _privateConstructorUsedError;
   ThemeMode get themeMode => throw _privateConstructorUsedError;
   Locale get locale => throw _privateConstructorUsedError;
@@ -540,17 +433,14 @@ abstract class $AppStateCopyWith<$Res> {
       _$AppStateCopyWithImpl<$Res, AppState>;
   @useResult
   $Res call(
-      {String? coreUrl,
-      String? tenantId,
-      String? token,
-      String? userId,
-      AccountErrorCode? accountErrorCode,
+      {Session session,
       ThemeSettings themeSettings,
       ThemeMode themeMode,
       Locale locale,
       AgreementStatus userAgreementStatus,
       AgreementStatus contactsAgreementStatus});
 
+  $SessionCopyWith<$Res> get session;
   $ThemeSettingsCopyWith<$Res> get themeSettings;
 }
 
@@ -569,11 +459,7 @@ class _$AppStateCopyWithImpl<$Res, $Val extends AppState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? coreUrl = freezed,
-    Object? tenantId = freezed,
-    Object? token = freezed,
-    Object? userId = freezed,
-    Object? accountErrorCode = freezed,
+    Object? session = null,
     Object? themeSettings = null,
     Object? themeMode = null,
     Object? locale = null,
@@ -581,26 +467,10 @@ class _$AppStateCopyWithImpl<$Res, $Val extends AppState>
     Object? contactsAgreementStatus = null,
   }) {
     return _then(_value.copyWith(
-      coreUrl: freezed == coreUrl
-          ? _value.coreUrl
-          : coreUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      tenantId: freezed == tenantId
-          ? _value.tenantId
-          : tenantId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      token: freezed == token
-          ? _value.token
-          : token // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userId: freezed == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      accountErrorCode: freezed == accountErrorCode
-          ? _value.accountErrorCode
-          : accountErrorCode // ignore: cast_nullable_to_non_nullable
-              as AccountErrorCode?,
+      session: null == session
+          ? _value.session
+          : session // ignore: cast_nullable_to_non_nullable
+              as Session,
       themeSettings: null == themeSettings
           ? _value.themeSettings
           : themeSettings // ignore: cast_nullable_to_non_nullable
@@ -628,6 +498,16 @@ class _$AppStateCopyWithImpl<$Res, $Val extends AppState>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
+  $SessionCopyWith<$Res> get session {
+    return $SessionCopyWith<$Res>(_value.session, (value) {
+      return _then(_value.copyWith(session: value) as $Val);
+    });
+  }
+
+  /// Create a copy of AppState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
   $ThemeSettingsCopyWith<$Res> get themeSettings {
     return $ThemeSettingsCopyWith<$Res>(_value.themeSettings, (value) {
       return _then(_value.copyWith(themeSettings: value) as $Val);
@@ -644,17 +524,15 @@ abstract class _$$AppStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String? coreUrl,
-      String? tenantId,
-      String? token,
-      String? userId,
-      AccountErrorCode? accountErrorCode,
+      {Session session,
       ThemeSettings themeSettings,
       ThemeMode themeMode,
       Locale locale,
       AgreementStatus userAgreementStatus,
       AgreementStatus contactsAgreementStatus});
 
+  @override
+  $SessionCopyWith<$Res> get session;
   @override
   $ThemeSettingsCopyWith<$Res> get themeSettings;
 }
@@ -672,11 +550,7 @@ class __$$AppStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? coreUrl = freezed,
-    Object? tenantId = freezed,
-    Object? token = freezed,
-    Object? userId = freezed,
-    Object? accountErrorCode = freezed,
+    Object? session = null,
     Object? themeSettings = null,
     Object? themeMode = null,
     Object? locale = null,
@@ -684,26 +558,10 @@ class __$$AppStateImplCopyWithImpl<$Res>
     Object? contactsAgreementStatus = null,
   }) {
     return _then(_$AppStateImpl(
-      coreUrl: freezed == coreUrl
-          ? _value.coreUrl
-          : coreUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      tenantId: freezed == tenantId
-          ? _value.tenantId
-          : tenantId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      token: freezed == token
-          ? _value.token
-          : token // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userId: freezed == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      accountErrorCode: freezed == accountErrorCode
-          ? _value.accountErrorCode
-          : accountErrorCode // ignore: cast_nullable_to_non_nullable
-              as AccountErrorCode?,
+      session: null == session
+          ? _value.session
+          : session // ignore: cast_nullable_to_non_nullable
+              as Session,
       themeSettings: null == themeSettings
           ? _value.themeSettings
           : themeSettings // ignore: cast_nullable_to_non_nullable
@@ -732,11 +590,7 @@ class __$$AppStateImplCopyWithImpl<$Res>
 
 class _$AppStateImpl extends _AppState {
   const _$AppStateImpl(
-      {this.coreUrl,
-      this.tenantId,
-      this.token,
-      this.userId,
-      this.accountErrorCode,
+      {this.session = const Session(),
       required this.themeSettings,
       required this.themeMode,
       required this.locale,
@@ -745,15 +599,8 @@ class _$AppStateImpl extends _AppState {
       : super._();
 
   @override
-  final String? coreUrl;
-  @override
-  final String? tenantId;
-  @override
-  final String? token;
-  @override
-  final String? userId;
-  @override
-  final AccountErrorCode? accountErrorCode;
+  @JsonKey()
+  final Session session;
   @override
   final ThemeSettings themeSettings;
   @override
@@ -767,7 +614,7 @@ class _$AppStateImpl extends _AppState {
 
   @override
   String toString() {
-    return 'AppState(coreUrl: $coreUrl, tenantId: $tenantId, token: $token, userId: $userId, accountErrorCode: $accountErrorCode, themeSettings: $themeSettings, themeMode: $themeMode, locale: $locale, userAgreementStatus: $userAgreementStatus, contactsAgreementStatus: $contactsAgreementStatus)';
+    return 'AppState(session: $session, themeSettings: $themeSettings, themeMode: $themeMode, locale: $locale, userAgreementStatus: $userAgreementStatus, contactsAgreementStatus: $contactsAgreementStatus)';
   }
 
   @override
@@ -775,13 +622,7 @@ class _$AppStateImpl extends _AppState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$AppStateImpl &&
-            (identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl) &&
-            (identical(other.tenantId, tenantId) ||
-                other.tenantId == tenantId) &&
-            (identical(other.token, token) || other.token == token) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.accountErrorCode, accountErrorCode) ||
-                other.accountErrorCode == accountErrorCode) &&
+            (identical(other.session, session) || other.session == session) &&
             (identical(other.themeSettings, themeSettings) ||
                 other.themeSettings == themeSettings) &&
             (identical(other.themeMode, themeMode) ||
@@ -795,18 +636,8 @@ class _$AppStateImpl extends _AppState {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      coreUrl,
-      tenantId,
-      token,
-      userId,
-      accountErrorCode,
-      themeSettings,
-      themeMode,
-      locale,
-      userAgreementStatus,
-      contactsAgreementStatus);
+  int get hashCode => Object.hash(runtimeType, session, themeSettings,
+      themeMode, locale, userAgreementStatus, contactsAgreementStatus);
 
   /// Create a copy of AppState
   /// with the given fields replaced by the non-null parameter values.
@@ -819,11 +650,7 @@ class _$AppStateImpl extends _AppState {
 
 abstract class _AppState extends AppState {
   const factory _AppState(
-      {final String? coreUrl,
-      final String? tenantId,
-      final String? token,
-      final String? userId,
-      final AccountErrorCode? accountErrorCode,
+      {final Session session,
       required final ThemeSettings themeSettings,
       required final ThemeMode themeMode,
       required final Locale locale,
@@ -832,15 +659,7 @@ abstract class _AppState extends AppState {
   const _AppState._() : super._();
 
   @override
-  String? get coreUrl;
-  @override
-  String? get tenantId;
-  @override
-  String? get token;
-  @override
-  String? get userId;
-  @override
-  AccountErrorCode? get accountErrorCode;
+  Session get session;
   @override
   ThemeSettings get themeSettings;
   @override

--- a/lib/blocs/app/app_event.dart
+++ b/lib/blocs/app/app_event.dart
@@ -5,26 +5,8 @@ abstract class AppEvent {
 }
 
 @Freezed(copyWith: false)
-class AppLogined with _$AppLogined implements AppEvent {
-  const factory AppLogined({
-    required String coreUrl,
-    required String tenantId,
-    required String token,
-    required String userId,
-    required WebtritSystemInfo systemInfo,
-  }) = _AppLogined;
-}
-
-@Freezed(copyWith: false)
-class AppLogouted with _$AppLogouted implements AppEvent {
-  const factory AppLogouted({
-    @Default(false) bool checkTokenForError,
-  }) = _AppLogouted;
-}
-
-@Freezed(copyWith: false)
-class AppLogoutedTeardown with _$AppLogoutedTeardown implements AppEvent {
-  const factory AppLogoutedTeardown() = _AppLogoutTeardown;
+class _SessionUpdated with _$SessionUpdated implements AppEvent {
+  const factory _SessionUpdated(Session? session) = __SessionUpdated;
 }
 
 @Freezed(copyWith: false)

--- a/lib/blocs/app/app_state.dart
+++ b/lib/blocs/app/app_state.dart
@@ -5,11 +5,7 @@ class AppState with _$AppState {
   const AppState._();
 
   const factory AppState({
-    String? coreUrl,
-    String? tenantId,
-    String? token,
-    String? userId,
-    AccountErrorCode? accountErrorCode,
+    @Default(Session()) Session session,
     required ThemeSettings themeSettings,
     required ThemeMode themeMode,
     required Locale locale,
@@ -22,6 +18,4 @@ class AppState with _$AppState {
   ThemeMode get effectiveThemeMode => isThemeModeSupported ? themeMode : ThemeMode.light;
 
   Locale? get effectiveLocale => locale == LocaleExtension.defaultNull ? null : locale;
-
-  bool get isLoggedIn => coreUrl != null && token != null;
 }

--- a/lib/features/autoprovision/view/autoprovision_screen.dart
+++ b/lib/features/autoprovision/view/autoprovision_screen.dart
@@ -11,6 +11,8 @@ import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 
 class AutoprovisionScreen extends StatefulWidget {
   const AutoprovisionScreen({super.key});
@@ -21,6 +23,9 @@ class AutoprovisionScreen extends StatefulWidget {
 
 class _AutoprovisionScreenState extends State<AutoprovisionScreen> {
   late final appBloc = context.read<AppBloc>();
+
+  // TODO: Move to the bloc
+  late final sessionRepository = context.read<SessionRepository>();
   late final callBloc = context.readOrNull<CallBloc>();
   late final notificationsBloc = context.read<NotificationsBloc>();
   late final autoprovisionCubit = context.read<AutoprovisionCubit>();
@@ -68,23 +73,16 @@ class _AutoprovisionScreenState extends State<AutoprovisionScreen> {
     final token = state.token;
     final userId = state.userId;
     final tenantId = state.tenantId;
-    final systemInfo = state.systemInfo;
 
-    final loginEvent = AppLogined(
-      coreUrl: coreUrl,
-      token: token,
-      userId: userId,
-      tenantId: tenantId,
-      systemInfo: systemInfo,
-    );
+    final session = Session(coreUrl: coreUrl, token: token, userId: userId, tenantId: tenantId);
 
     if (router.canPop()) {
       await router.maybePop();
 
       // Logout if the session exists
-      if (appBloc.state.token != null) {
-        appBloc.add(const AppLogouted());
-        await appBloc.stream.firstWhere((element) => element.token == null);
+      if (appBloc.state.session.isLoggedIn) {
+        await sessionRepository.logout();
+        await appBloc.stream.firstWhere((element) => element.session.isLoggedIn);
       }
 
       // Wait until Callkeep is uninitialized, if needed
@@ -93,12 +91,12 @@ class _AutoprovisionScreenState extends State<AutoprovisionScreen> {
       }
 
       // Login with the new session
-      appBloc.add(loginEvent);
-      await appBloc.stream.firstWhere((element) => element.token == token);
+      await sessionRepository.save(session);
+      await appBloc.stream.firstWhere((element) => element.session.token == token);
     } else {
       // For the case when the app is launched with the autoprovision screen as initial route.
-      appBloc.add(loginEvent);
-      await appBloc.stream.firstWhere((element) => element.token == token);
+      await sessionRepository.save(session);
+      await appBloc.stream.firstWhere((element) => element.session.token == token);
       // Then will be redirected by router reevaluation and redirect inside [onAutoprovisionScreenPageRouteGuardNavigation]
     }
 

--- a/lib/features/autoprovision/view/autoprovision_screen.dart
+++ b/lib/features/autoprovision/view/autoprovision_screen.dart
@@ -82,7 +82,7 @@ class _AutoprovisionScreenState extends State<AutoprovisionScreen> {
       // Logout if the session exists
       if (appBloc.state.session.isLoggedIn) {
         await sessionRepository.logout();
-        await appBloc.stream.firstWhere((element) => element.session.isLoggedIn);
+        await appBloc.stream.firstWhere((element) => !element.session.isLoggedIn);
       }
 
       // Wait until Callkeep is uninitialized, if needed

--- a/lib/features/autoprovision/view/autoprovision_screen_page.dart
+++ b/lib/features/autoprovision/view/autoprovision_screen_page.dart
@@ -28,14 +28,14 @@ class AutoprovisionScreenPage extends StatelessWidget {
     // Explicitly cast to string,
     // coz value are verified by the router guard [onAutoprovisionScreenPageRouteGuardNavigation]
     final configToken = this.configToken!;
-    final oldToken = context.read<AppBloc>().state.token;
+    final oldToken = context.read<AppBloc>().state.session.token;
 
     final tenantId = this.tenantId ?? '';
-    final oldTenant = context.read<AppBloc>().state.tenantId ?? '';
+    final oldTenant = context.read<AppBloc>().state.session.tenantId;
 
     const defaultCoreUrl = EnvironmentConfig.CORE_URL ?? EnvironmentConfig.DEMO_CORE_URL;
     final coreUrl = this.coreUrl;
-    final oldCoreUrl = context.read<AppBloc>().state.coreUrl;
+    final oldCoreUrl = context.read<AppBloc>().state.session.coreUrl;
 
     const coreVersionConstraint = EnvironmentConfig.CORE_VERSION_CONSTRAINT;
     final config = AutoprovisionConfig(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -285,7 +285,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   void _handleSignalingSessionError({
     required CallServiceState previous,
     required CallServiceState current,
-  }) async {
+  }) {
     final signalingChanged = previous.signalingClientStatus != current.signalingClientStatus ||
         previous.lastSignalingDisconnectCode != current.lastSignalingDisconnectCode;
 
@@ -302,7 +302,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           'Signaling session listener: session is missing ${current.lastSignalingDisconnectCode}',
         );
 
-        await _notifyAccountErrorSafely();
+        unawaited(_notifyAccountErrorSafely());
         sessionRepository.logout().catchError((e, st) {
           _logger.warning('Logout failed after sessionMissedError', e, st);
         });

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -13,8 +13,9 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
+import 'package:webtrit_api/webtrit_api.dart';
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
@@ -48,6 +49,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   final CallLogsRepository callLogsRepository;
   final CallPullRepository callPullRepository;
+  final UserRepository userRepository;
+  final SessionRepository sessionRepository;
   final LinesStateRepository linesStateRepository;
   final Function(Notification) submitNotification;
 
@@ -81,6 +84,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required this.callLogsRepository,
     required this.callPullRepository,
     required this.linesStateRepository,
+    required this.sessionRepository,
+    required this.userRepository,
     required this.submitNotification,
     required this.callkeep,
     required this.callkeepConnections,
@@ -273,6 +278,52 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final guestLineState = guestLineInUse ? LineState.inUse : LineState.idle;
 
     linesStateRepository.setState(LinesState(mainLines: mainLinesState, guestLine: guestLineState));
+    _handleSignalingSessionError(
+        previous: change.currentState.callServiceState, current: change.nextState.callServiceState);
+  }
+
+  void _handleSignalingSessionError({
+    required CallServiceState previous,
+    required CallServiceState current,
+  }) async {
+    final signalingChanged = previous.signalingClientStatus != current.signalingClientStatus ||
+        previous.lastSignalingDisconnectCode != current.lastSignalingDisconnectCode;
+
+    if (!signalingChanged) return;
+
+    if (current.signalingClientStatus == SignalingClientStatus.disconnect &&
+        current.lastSignalingDisconnectCode is int) {
+      final code = SignalingDisconnectCode.values.byCode(
+        current.lastSignalingDisconnectCode as int,
+      );
+
+      if (code == SignalingDisconnectCode.sessionMissedError) {
+        _logger.info(
+          'Signaling session listener: session is missing ${current.lastSignalingDisconnectCode}',
+        );
+
+        await _notifyAccountErrorSafely();
+        sessionRepository.logout().catchError((e, st) {
+          _logger.warning('Logout failed after sessionMissedError', e, st);
+        });
+      }
+    }
+  }
+
+  // TODO: Consider moving this method to a separate repository
+  Future<void> _notifyAccountErrorSafely() async {
+    try {
+      await userRepository.getInfo(true);
+    } on RequestFailure catch (e, st) {
+      final errorCode = AccountErrorCode.values.firstWhereOrNull((it) => it.value == e.error?.code);
+      if (errorCode != null) {
+        submitNotification(AccountErrorNotification(errorCode));
+      } else {
+        _logger.fine('Account error code not mapped: ${e.error?.code}', e, st);
+      }
+    } catch (e, st) {
+      _logger.warning('Unexpected error during account info refresh', e, st);
+    }
   }
 
   //

--- a/lib/features/call/view/call_shell.dart
+++ b/lib/features/call/view/call_shell.dart
@@ -2,20 +2,13 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:auto_route/auto_route.dart';
-import 'package:logging/logging.dart';
-
-import 'package:webtrit_signaling/webtrit_signaling.dart';
 
 import 'package:webtrit_phone/app/router/app_router.dart';
-import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/features/orientations/orientations.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
-import 'package:webtrit_phone/models/models.dart';
 
 import '../call.dart';
 import 'call_active_thumbnail.dart';
-
-final _logger = Logger('CallShell');
 
 class CallShell extends StatefulWidget {
   const CallShell({
@@ -36,29 +29,7 @@ class _CallShellState extends State<CallShell> {
 
   @override
   Widget build(BuildContext context) {
-    return signalingListener(displayListener(widget.child));
-  }
-
-  Widget signalingListener(Widget child) {
-    return BlocListener<CallBloc, CallState>(
-      listenWhen: (previous, current) =>
-          previous.callServiceState.signalingClientStatus != current.callServiceState.signalingClientStatus ||
-          previous.callServiceState.lastSignalingDisconnectCode != current.callServiceState.lastSignalingDisconnectCode,
-      listener: (context, state) {
-        final signalingClientStatus = state.callServiceState.signalingClientStatus;
-        final signalingDisconnectCode = state.callServiceState.lastSignalingDisconnectCode;
-
-        // Listen to signaling session expired error
-        if (signalingClientStatus == SignalingClientStatus.disconnect && signalingDisconnectCode is int) {
-          final code = SignalingDisconnectCode.values.byCode(signalingDisconnectCode);
-          if (code == SignalingDisconnectCode.sessionMissedError) {
-            _logger.info('Signaling session listener: session is missing $signalingDisconnectCode');
-            context.read<AppBloc>().add(const AppLogouted(checkTokenForError: true));
-          }
-        }
-      },
-      child: child,
-    );
+    return displayListener(widget.child);
   }
 
   Widget displayListener(Widget child) {

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -13,6 +13,7 @@ import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/mappers/mappers.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 import '../login.dart';
@@ -31,12 +32,16 @@ class LoginCubit extends Cubit<LoginState> with SystemInfoApiMapper {
     required this.packageInfo,
     required this.appInfo,
     required this.platformInfo,
+    required this.sessionRepository,
   }) : super(const LoginState());
 
   final WebtritApiClientFactory createWebtritApiClient;
   final HttpRequestExecutorFactory createHttpRequestExecutor;
   final NotificationsBloc notificationsBloc;
   final PlatformInfo platformInfo;
+
+  // TODO: Replace by AuthRepository in next iteration
+  final SessionRepository sessionRepository;
   final PackageInfo packageInfo;
   final AppInfo appInfo;
 
@@ -59,6 +64,24 @@ class LoginCubit extends Cubit<LoginState> with SystemInfoApiMapper {
   bool get isDemoModeEnabled => coreUrlFromEnvironment == null;
 
   bool get isCredentialsRequestUrlEnabled => credentialsRequestUrl != null;
+
+  @override
+  void onChange(Change<LoginState> change) {
+    if (change.nextState.coreUrl != null &&
+        change.nextState.tenantId != null &&
+        change.nextState.token != null &&
+        change.nextState.userId != null &&
+        change.nextState.systemInfo != null) {
+      sessionRepository.save(Session(
+        coreUrl: change.nextState.coreUrl!,
+        tenantId: change.nextState.tenantId!,
+        token: change.nextState.token!,
+        userId: change.nextState.userId!,
+      ));
+    }
+
+    super.onChange(change);
+  }
 
   void launchLinkableElement(LinkableElement link) async {
     final url = Uri.parse(link.url);

--- a/lib/features/login/view/login_router_page.dart
+++ b/lib/features/login/view/login_router_page.dart
@@ -5,11 +5,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
-import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 
 bool whenLoginRouterPageChange(LoginState previous, LoginState current) {
   return (previous.mode != current.mode) ||
@@ -40,25 +40,7 @@ class LoginRouterPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final declarativeAutoRouter = BlocConsumer<LoginCubit, LoginState>(
-      listener: (context, state) {
-        final coreUrl = state.coreUrl;
-        final tenantId = state.tenantId;
-        final token = state.token;
-        final userId = state.userId;
-        final systemInfo = state.systemInfo;
-
-        if (coreUrl != null && tenantId != null && token != null && userId != null && systemInfo != null) {
-          final event = AppLogined(
-            coreUrl: coreUrl,
-            tenantId: tenantId,
-            token: token,
-            userId: userId,
-            systemInfo: systemInfo,
-          );
-          context.read<AppBloc>().add(event);
-        }
-      },
+    final declarativeAutoRouter = BlocBuilder<LoginCubit, LoginState>(
       buildWhen: whenLoginRouterPageChange,
       builder: (context, state) {
         return AutoRouter.declarative(
@@ -113,6 +95,7 @@ class LoginRouterPage extends StatelessWidget {
       packageInfo: context.read<PackageInfo>(),
       appInfo: context.read<AppInfo>(),
       platformInfo: context.read<PlatformInfo>(),
+      sessionRepository: context.read<SessionRepository>(),
     );
     if (_launchEmbedded != null) {
       login.setEmbedded(_launchEmbedded);

--- a/lib/features/main/view/main_screen.dart
+++ b/lib/features/main/view/main_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:webtrit_phone/blocs/app/app_bloc.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 
 import '../main.dart';
 
@@ -38,7 +38,7 @@ class MainScreen extends StatelessWidget {
                 : null,
             onLogoutPressed: () {
               Navigator.of(context).maybePop();
-              context.read<AppBloc>().add(const AppLogouted());
+              context.read<SessionRepository>().logout();
             },
           );
         }

--- a/lib/features/main/view/main_screen_page.dart
+++ b/lib/features/main/view/main_screen_page.dart
@@ -99,22 +99,12 @@ class MainScreenPage extends StatelessWidget {
           : autoTabsRouter,
     );
 
-    final accountErrorListener = BlocListener<AppBloc, AppState>(
-      listenWhen: (previous, current) =>
-          previous.accountErrorCode != current.accountErrorCode && current.accountErrorCode != null,
-      listener: (BuildContext context, state) {
-        context.showErrorSnackBar(state.accountErrorCode!.l10n(context));
-        context.read<AppBloc>().add(const AppLogoutedTeardown());
-      },
-      child: provider,
-    );
-
     return BlocBuilder<CallPullCubit, List<PullableCall>>(
       builder: (context, state) {
         return AppBarParams(
           systemNotificationsEnabled: systemNotificationsEnabled,
           pullableCalls: state,
-          child: accountErrorListener,
+          child: provider,
         );
       },
     );

--- a/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
+++ b/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
@@ -18,7 +18,7 @@ class ChatConversationScreen extends StatefulWidget {
 }
 
 class _ChatConversationScreenState extends State<ChatConversationScreen> {
-  late final userId = context.read<AppBloc>().state.userId!;
+  late final userId = context.read<AppBloc>().state.session.userId;
   late final messagingBloc = context.read<MessagingBloc>();
   late final conversationCubit = context.read<ConversationCubit>();
 

--- a/lib/features/messaging/features/conversations/widgets/conversations_list.dart
+++ b/lib/features/messaging/features/conversations/widgets/conversations_list.dart
@@ -17,7 +17,7 @@ class ConversationsList extends StatefulWidget {
 }
 
 class _ConversationsListState extends State<ConversationsList> {
-  late final userId = context.read<AppBloc>().state.userId!;
+  late final userId = context.read<AppBloc>().state.session.userId;
 
   final chatsSearchController = TextEditingController();
   final smsSearchController = TextEditingController();

--- a/lib/features/messaging/features/sms_conversation/view/sms_conversation_screen.dart
+++ b/lib/features/messaging/features/sms_conversation/view/sms_conversation_screen.dart
@@ -20,7 +20,7 @@ class SmsConversationScreen extends StatefulWidget {
 }
 
 class _SmsConversationScreenState extends State<SmsConversationScreen> {
-  late final userId = context.read<AppBloc>().state.userId!;
+  late final userId = context.read<AppBloc>().state.session.userId;
   late final messagingBloc = context.read<MessagingBloc>();
   late final conversationCubit = context.read<SmsConversationCubit>();
   late final contactsRepo = context.read<ContactsRepository>();

--- a/lib/features/messaging/widgets/messaging_shell.dart
+++ b/lib/features/messaging/widgets/messaging_shell.dart
@@ -48,7 +48,7 @@ class _MessagingShellState extends State<MessagingShell> {
       if (connectionStatus == ConnectionStatus.initial) messagingBloc.add(const Connect());
 
       pushService ??= MessagingPushService(
-        context.read<AppBloc>().state.userId!,
+        context.read<AppBloc>().state.session.userId,
         context.read<ChatsRepository>(),
         context.read<SmsRepository>(),
         context.read<ContactsRepository>(),

--- a/lib/features/settings/view/settings_screen_page.dart
+++ b/lib/features/settings/view/settings_screen_page.dart
@@ -27,6 +27,7 @@ class SettingsScreenPage extends StatelessWidget {
           appBloc: context.read<AppBloc>(),
           userRepository: context.read<UserRepository>(),
           voicemailRepository: context.read<VoicemailRepository>(),
+          sessionRepository: context.read(),
         );
       },
       child: widget,

--- a/lib/models/auth/auth.dart
+++ b/lib/models/auth/auth.dart
@@ -1,1 +1,2 @@
 export 'external_page_token.dart';
+export 'session.dart';

--- a/lib/models/auth/session.dart
+++ b/lib/models/auth/session.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session.freezed.dart';
+
+part 'session.g.dart';
+
+@freezed
+class Session with _$Session {
+  const Session._();
+
+  const factory Session({
+    String? coreUrl,
+    String? token,
+    @Default('') String tenantId,
+    @Default('') String userId,
+  }) = _Session;
+
+  factory Session.fromJson(Map<String, dynamic> json) => _$SessionFromJson(json);
+
+  bool get isLoggedIn => coreUrl != null && token != null;
+}

--- a/lib/models/auth/session.freezed.dart
+++ b/lib/models/auth/session.freezed.dart
@@ -1,0 +1,219 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Session _$SessionFromJson(Map<String, dynamic> json) {
+  return _Session.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Session {
+  String? get coreUrl => throw _privateConstructorUsedError;
+  String? get token => throw _privateConstructorUsedError;
+  String get tenantId => throw _privateConstructorUsedError;
+  String get userId => throw _privateConstructorUsedError;
+
+  /// Serializes this Session to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SessionCopyWith<Session> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SessionCopyWith<$Res> {
+  factory $SessionCopyWith(Session value, $Res Function(Session) then) =
+      _$SessionCopyWithImpl<$Res, Session>;
+  @useResult
+  $Res call({String? coreUrl, String? token, String tenantId, String userId});
+}
+
+/// @nodoc
+class _$SessionCopyWithImpl<$Res, $Val extends Session>
+    implements $SessionCopyWith<$Res> {
+  _$SessionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? coreUrl = freezed,
+    Object? token = freezed,
+    Object? tenantId = null,
+    Object? userId = null,
+  }) {
+    return _then(_value.copyWith(
+      coreUrl: freezed == coreUrl
+          ? _value.coreUrl
+          : coreUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      token: freezed == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String?,
+      tenantId: null == tenantId
+          ? _value.tenantId
+          : tenantId // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SessionImplCopyWith<$Res> implements $SessionCopyWith<$Res> {
+  factory _$$SessionImplCopyWith(
+          _$SessionImpl value, $Res Function(_$SessionImpl) then) =
+      __$$SessionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? coreUrl, String? token, String tenantId, String userId});
+}
+
+/// @nodoc
+class __$$SessionImplCopyWithImpl<$Res>
+    extends _$SessionCopyWithImpl<$Res, _$SessionImpl>
+    implements _$$SessionImplCopyWith<$Res> {
+  __$$SessionImplCopyWithImpl(
+      _$SessionImpl _value, $Res Function(_$SessionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? coreUrl = freezed,
+    Object? token = freezed,
+    Object? tenantId = null,
+    Object? userId = null,
+  }) {
+    return _then(_$SessionImpl(
+      coreUrl: freezed == coreUrl
+          ? _value.coreUrl
+          : coreUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      token: freezed == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String?,
+      tenantId: null == tenantId
+          ? _value.tenantId
+          : tenantId // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SessionImpl extends _Session {
+  const _$SessionImpl(
+      {this.coreUrl, this.token, this.tenantId = '', this.userId = ''})
+      : super._();
+
+  factory _$SessionImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SessionImplFromJson(json);
+
+  @override
+  final String? coreUrl;
+  @override
+  final String? token;
+  @override
+  @JsonKey()
+  final String tenantId;
+  @override
+  @JsonKey()
+  final String userId;
+
+  @override
+  String toString() {
+    return 'Session(coreUrl: $coreUrl, token: $token, tenantId: $tenantId, userId: $userId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SessionImpl &&
+            (identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl) &&
+            (identical(other.token, token) || other.token == token) &&
+            (identical(other.tenantId, tenantId) ||
+                other.tenantId == tenantId) &&
+            (identical(other.userId, userId) || other.userId == userId));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, coreUrl, token, tenantId, userId);
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SessionImplCopyWith<_$SessionImpl> get copyWith =>
+      __$$SessionImplCopyWithImpl<_$SessionImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SessionImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Session extends Session {
+  const factory _Session(
+      {final String? coreUrl,
+      final String? token,
+      final String tenantId,
+      final String userId}) = _$SessionImpl;
+  const _Session._() : super._();
+
+  factory _Session.fromJson(Map<String, dynamic> json) = _$SessionImpl.fromJson;
+
+  @override
+  String? get coreUrl;
+  @override
+  String? get token;
+  @override
+  String get tenantId;
+  @override
+  String get userId;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SessionImplCopyWith<_$SessionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/models/auth/session.g.dart
+++ b/lib/models/auth/session.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'session.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SessionImpl _$$SessionImplFromJson(Map<String, dynamic> json) =>
+    _$SessionImpl(
+      coreUrl: json['coreUrl'] as String?,
+      token: json['token'] as String?,
+      tenantId: json['tenantId'] as String? ?? '',
+      userId: json['userId'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$$SessionImplToJson(_$SessionImpl instance) =>
+    <String, dynamic>{
+      'coreUrl': instance.coreUrl,
+      'token': instance.token,
+      'tenantId': instance.tenantId,
+      'userId': instance.userId,
+    };

--- a/lib/repositories/auth/auth.dart
+++ b/lib/repositories/auth/auth.dart
@@ -1,0 +1,1 @@
+export 'session_repository.dart';

--- a/lib/repositories/auth/session_repository.dart
+++ b/lib/repositories/auth/session_repository.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import 'package:webtrit_api/webtrit_api.dart';
+
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/utils/utils.dart';
+
+final _logger = Logger('SessionRepository');
+
+abstract class SessionRepository {
+  bool get isSignedIn;
+
+  /// Emits current session and all further updates.
+  Stream<Session?> watch();
+
+  /// Re-read session from storage and emit if changed.
+  Future<void> reload();
+
+  /// Persist a session (overwrites storage) and emit updated value.
+  Future<void> save(Session session);
+
+  /// Return current session snapshot from storage.
+  Session? getCurrent();
+
+  /// Logout user locally and revoke remote session asynchronously.
+  Future<void> logout();
+
+  /// Clear all local app/session data and emit updated value.
+  Future<void> clean();
+}
+
+class SessionRepositoryImpl implements SessionRepository {
+  SessionRepositoryImpl({
+    required this.secureStorage,
+    required this.appPreferences,
+    required this.appDatabase,
+    this.sessionCleanupWorker,
+    this.createApiClient = defaultCreateWebtritApiClient,
+  }) {
+    _sessionController.add(getCurrent());
+  }
+
+  final SecureStorage secureStorage;
+  final AppPreferences appPreferences;
+  final AppDatabase appDatabase;
+  final WebtritApiClientFactory createApiClient;
+  final SessionCleanupWorker? sessionCleanupWorker;
+
+  final _sessionController = StreamController<Session?>.broadcast();
+
+  @override
+  Stream<Session?> watch() => _sessionController.stream;
+
+  @override
+  bool get isSignedIn => getCurrent().isLoggedIn;
+
+  @override
+  Future<void> save(Session session) async {
+    final currentSession = getCurrent();
+
+    final isReLogin = currentSession.isLoggedIn;
+    if (isReLogin) await logout();
+
+    await secureStorage.writeUserId(session.userId);
+    await secureStorage.writeTenantId(session.tenantId);
+
+    if (session.coreUrl != null) {
+      await secureStorage.writeCoreUrl(session.coreUrl!);
+    } else {
+      await secureStorage.deleteCoreUrl();
+    }
+
+    if (session.token != null) {
+      await secureStorage.writeToken(session.token!);
+    } else {
+      await secureStorage.deleteToken();
+    }
+
+    _sessionController.add(getCurrent());
+  }
+
+  @override
+  Session getCurrent() {
+    final coreUrl = secureStorage.readCoreUrl();
+    final tenantId = secureStorage.readTenantId() ?? '';
+    final token = secureStorage.readToken();
+    final userId = secureStorage.readUserId() ?? '';
+
+    return Session(
+      coreUrl: coreUrl,
+      token: token,
+      tenantId: tenantId,
+      userId: userId,
+    );
+  }
+
+  @override
+  Future<void> clean() async {
+    await appPreferences.clear();
+    await secureStorage.deleteCoreUrl();
+    await secureStorage.deleteTenantId();
+    await secureStorage.deleteToken();
+    await secureStorage.deleteUserId();
+    await appDatabase.deleteEverything();
+
+    _sessionController.add(getCurrent());
+  }
+
+  @override
+  Future<void> logout() async {
+    final session = getCurrent();
+    if (!session.isLoggedIn) return;
+
+    // Clear local state first to immediately notify routing/UI about logout.
+    await clean();
+
+    // Revoke remote session in background (do not block UX).
+    unawaited(_revokeRemote(session));
+  }
+
+  Future<void> _revokeRemote(Session s) async {
+    final coreUrl = s.coreUrl;
+    final token = s.token;
+    if (coreUrl == null || token == null) return;
+
+    final client = createApiClient(coreUrl, s.tenantId);
+    try {
+      await client.deleteSession(token, options: RequestOptions.withExtraRetries());
+    } on UserNotFoundException catch (e, st) {
+      _logger.fine('Remote session already revoked or never existed', e, st);
+      return;
+    } on UnauthorizedException catch (e, st) {
+      _logger.fine('Remote session already revoked or never existed', e, st);
+      return;
+    } on RequestFailure catch (e, st) {
+      sessionCleanupWorker?.saveFailedSession(e.url, token: token);
+      _logger.warning('Queued token revoke retry', e, st);
+      rethrow;
+    } catch (e, st) {
+      _logger.severe('Unexpected error during remote revoke', e, st);
+    }
+  }
+
+  @override
+  Future<void> reload() async {
+    _sessionController.add(getCurrent());
+  }
+
+  Future<void> dispose() async {
+    await _sessionController.close();
+  }
+}

--- a/lib/repositories/repositories.dart
+++ b/lib/repositories/repositories.dart
@@ -1,6 +1,7 @@
 export 'account/user_repository.dart';
 export 'app/app_repository.dart';
 export 'app_analytics/app_analytics_repository.dart';
+export 'auth/auth.dart';
 export 'call_logs/call_logs_repository.dart';
 export 'call_to_actions/call_to_actions_repository.dart';
 export 'contacts/contacts_repository.dart';

--- a/screenshots/lib/mocks/mock_app_bloc.dart
+++ b/screenshots/lib/mocks/mock_app_bloc.dart
@@ -6,8 +6,6 @@ import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/models/agreement_status.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 
-import '../data/data.dart';
-
 class MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {
   MockAppBloc();
 
@@ -21,7 +19,6 @@ class MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {
       mock,
       const Stream<AppState>.empty(),
       initialState: AppState(
-        userId: dSessionUserId,
         themeSettings: themeSettings,
         themeMode: themeMode,
         locale: locale,


### PR DESCRIPTION
This PR implements a session repository pattern to centralize authentication state management, replacing direct AppBloc communication. The SessionRepository now serves as the single source of truth for session data, handling login/logout operations and session persistence.

Key changes:

Introduced SessionRepository with complete session lifecycle management
Replaced AppBloc session fields with a single Session model
Moved logout logic from UserRepository and AppBloc to SessionRepository