### PR TITLE
feat: add connectivity recovery strategy support to LoginSignupEmbeddedRequestScreen

### DIFF
--- a/lib/features/login/features/login_signup/view/login_signup_embedded_request_screen_page.dart
+++ b/lib/features/login/features/login_signup/view/login_signup_embedded_request_screen_page.dart
@@ -3,10 +3,13 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 
+import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/theme/models/models.dart';
-import 'package:webtrit_phone/widgets/webview/webview.dart';
+import 'package:webtrit_phone/utils/utils.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
 
 import 'login_signup_embedded_request_screen.dart';
 
@@ -43,6 +46,7 @@ class LoginSignupEmbeddedRequestScreenPage extends StatelessWidget {
               ? LoginSignupEmbeddedRequestScreen(
                   initialUrl: Uri.parse(content),
                   pageInjectionStrategyBuilder: _createInjectionStrategy(locale),
+                  connectivityRecoveryStrategyBuilder: () => _createConnectivityRecoveryStrategy(embeddedData),
                 )
               : LoginSignupEmbeddedRequestScreen(
                   initialUrl: Uri.dataFromString(
@@ -51,6 +55,7 @@ class LoginSignupEmbeddedRequestScreenPage extends StatelessWidget {
                     encoding: Encoding.getByName('utf-8'),
                   ),
                   pageInjectionStrategyBuilder: _createInjectionStrategy(locale),
+                  connectivityRecoveryStrategyBuilder: () => _createConnectivityRecoveryStrategy(embeddedData),
                 );
         } else {
           return const Center(
@@ -68,5 +73,16 @@ class LoginSignupEmbeddedRequestScreenPage extends StatelessWidget {
             'locale': locale.languageCode,
           },
         );
+  }
+
+  ConnectivityRecoveryStrategy _createConnectivityRecoveryStrategy(EmbeddedData data) {
+    return ConnectivityRecoveryStrategy.create(
+      initialUri: data.uri,
+      type: data.reconnectStrategy,
+      connectivityStream: Connectivity().onConnectivityChanged,
+      connectivityCheckerBuilder: () => const DefaultConnectivityChecker(
+        connectivityCheckUrl: EnvironmentConfig.CONNECTIVITY_CHECK_URL,
+      ),
+    );
   }
 }

--- a/screenshots/lib/screenshots/login_signup_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_signup_screen_screenshot.dart
@@ -57,6 +57,9 @@ class LoginSignUpScreenshot extends StatelessWidget {
           pageInjectionStrategyBuilder: () {
             return DefaultPayloadInjectionStrategy();
           },
+          connectivityRecoveryStrategyBuilder: () {
+            return NoneConnectivityRecoveryStrategy();
+          },
         ),
         currentLoginType: LoginType.signup,
         supportedLoginTypes: supportedLoginTypes,


### PR DESCRIPTION
This PR adds connectivity recovery strategy support to the LoginSignupEmbeddedRequestScreen, enabling the webview to handle network connectivity issues and automatically recover from connection failures.

- Adds ConnectivityRecoveryStrategy integration to handle network disconnections and recovery
- Updates WebViewContainer to use the new connectivity recovery mechanism instead of the previous page load success tracking
- Modifies error handling logic to respect the connectivity recovery strategy's state and configuration