### PR TITLE
refactor: unify image source into a single structure

### DIFF
--- a/lib/theme/factory/styles/about_screen_style_factory.dart
+++ b/lib/theme/factory/styles/about_screen_style_factory.dart
@@ -12,8 +12,11 @@ class AboutScreenStyleFactory implements ThemeStyleFactory<AboutScreenStyles> {
 
   @override
   AboutScreenStyles create() {
-    final picturePath = config?.picture;
-    final picture = picturePath?.toThemeSvgAsset();
+    final imageSource = config?.imageSource?.uri ??
+        // TODO: Remove after migrating all themes to use imageSource
+        // ignore: deprecated_member_use
+        config?.picture;
+    final picture = imageSource?.toThemeSvgAsset();
 
     return AboutScreenStyles(
       primary: AboutScreenStyle(

--- a/lib/theme/factory/styles/logo_assets_factory.dart
+++ b/lib/theme/factory/styles/logo_assets_factory.dart
@@ -9,12 +9,21 @@ class LogoAssetsFactory implements ThemeStyleFactory<LogoAssets> {
 
   @override
   LogoAssets create() {
-    final primaryOnboardingLogoPath = config.primaryOnboardingLogo;
-    final secondaryOnboardingLogoPath = config.secondaryOnboardingLogo;
+    final primaryOnboardingLogo = config.primaryOnboardingLogo;
+    final secondaryOnboardingLogo = config.secondaryOnboardingLogo;
+
+    final primaryOnboardingLogoUri =
+        // TODO: Remove after migrating all themes to use imageSource
+        // ignore: deprecated_member_use
+        primaryOnboardingLogo.imageSource?.uri ?? primaryOnboardingLogo.uri;
+    final secondaryOnboardingLogoUri =
+        // TODO: Remove after migrating all themes to use imageSource
+        // ignore: deprecated_member_use
+        secondaryOnboardingLogo.imageSource?.uri ?? secondaryOnboardingLogo.uri;
 
     return LogoAssets(
-      primaryOnboarding: primaryOnboardingLogoPath.uri.toThemeSvgAsset()!,
-      secondaryOnboarding: secondaryOnboardingLogoPath.uri.toThemeSvgAsset()!,
+      primaryOnboarding: primaryOnboardingLogoUri!.toThemeSvgAsset()!,
+      secondaryOnboarding: secondaryOnboardingLogoUri!.toThemeSvgAsset()!,
     );
   }
 }

--- a/lib/theme/factory/styles/onboarding_logo_style_factory.dart
+++ b/lib/theme/factory/styles/onboarding_logo_style_factory.dart
@@ -16,7 +16,16 @@ class OnboardingLogoStyleFactory implements ThemeStyleFactory<OnboardingLogoStyl
   OnboardingLogoStyles create() {
     final textStyleColor = imageAssetConfig?.labelColor.toColor() ?? colors.onPrimary;
 
-    final onboardingLogoLoginConfig = loginPageConfig?.picture ?? imageAssetConfig?.uri;
+    final loginPageConfigUri = imageAssetConfig?.imageSource?.uri ??
+        // TODO: Remove after migrating all themes to use imageSource
+        // ignore: deprecated_member_use
+        imageAssetConfig?.uri;
+    final imageAssetConfigUri = loginPageConfig?.imageSource?.uri ??
+        // TODO: Remove after migrating all themes to use imageSource
+        // ignore: deprecated_member_use
+        loginPageConfig?.picture;
+
+    final onboardingLogoLoginConfig = loginPageConfigUri ?? imageAssetConfigUri;
     final widthFactor = loginPageConfig?.scale ?? imageAssetConfig?.widthFactor;
     final textStyle = TextStyle(color: textStyleColor, fontWeight: FontWeight.w600);
 

--- a/lib/theme/factory/styles/onboarding_picture_logo_style_factory.dart
+++ b/lib/theme/factory/styles/onboarding_picture_logo_style_factory.dart
@@ -16,7 +16,16 @@ class OnboardingPictureLogoStyleFactory implements ThemeStyleFactory<OnboardingP
   OnboardingPictureLogoStyles create() {
     final textStyleColor = imageAssetConfig?.labelColor.toColor() ?? colors.onPrimary;
 
-    final primaryOnboardingLogoPath = loginPageConfig?.picture ?? imageAssetConfig?.uri;
+    final loginPageConfigUri = loginPageConfig?.imageSource?.uri ??
+        // TODO: Remove after migrating all themes to use imageSource
+        // ignore: deprecated_member_use
+        loginPageConfig?.picture;
+    final imageAssetConfigUri = imageAssetConfig?.imageSource?.uri ??
+        // TODO: Remove after migrating all themes to use imageSource
+        // ignore: deprecated_member_use
+        imageAssetConfig?.uri;
+
+    final primaryOnboardingLogoPath = loginPageConfigUri ?? imageAssetConfigUri;
     final widthFactor = loginPageConfig?.scale ?? imageAssetConfig?.widthFactor;
 
     final textStyle = TextStyle(color: textStyleColor, fontWeight: FontWeight.w600);

--- a/packages/webtrit_appearance_theme/lib/models/features_config/metadata.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/metadata.dart
@@ -27,6 +27,9 @@ class Metadata with _$Metadata {
   /// Returns `null` if the key does not exist or the value is not a string.
   String? getString(String key) => attributes[key] as String?;
 
+  /// Retrieves an integer value associated with the given [key].
+  bool? getBool(String key) => attributes[key] as bool?;
+
   /// Creates a new `Metadata` instance with an updated key-value pair in `attributes`.
   ///
   /// This method does not mutate the existing object but instead returns a modified copy.

--- a/packages/webtrit_appearance_theme/lib/models/models.dart
+++ b/packages/webtrit_appearance_theme/lib/models/models.dart
@@ -2,6 +2,7 @@ export 'color_scheme.config.dart';
 export 'common/common.dart';
 export 'custom_color.dart';
 export 'features_config/features_config.dart';
+export 'resources/resources.dart';
 export 'theme_page_config.dart';
 export 'theme_settings.dart';
 export 'theme_widget_config.dart';

--- a/packages/webtrit_appearance_theme/lib/models/resources/image_source.dart
+++ b/packages/webtrit_appearance_theme/lib/models/resources/image_source.dart
@@ -1,0 +1,97 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../features_config/metadata.dart';
+
+part 'image_source.freezed.dart';
+
+part 'image_source.g.dart';
+
+/// Represents a reference to an image resource that can come
+/// from different environments: backend storage, local assets,
+/// remote URLs, or build-time generated files.
+///
+/// # Typical fields
+/// - [id]: backend asset ID, mandatory for server-side references.
+/// - [uri]: unified location for the resource, can be `asset://`, `https://`, `file://`, etc.
+/// - [ref]: semantic type of reference (defaults to "asset").
+/// - [metadata]: freeform map for build-time/tooling hints (CLI, pipelines, etc.).
+///
+/// # Use cases:
+///
+/// ## 1. Preview in Configurator (Browser/UI)
+/// - `id` comes from backend.
+/// - `uri` is a **signed URL** with TTL, generated server-side.
+/// - UI can render the image directly from `uri`.
+///
+/// ```json
+/// {
+///   "id": "xxxx",
+///   "uri": "https://firebasestorage.googleapis.com/.../logo.svg?token=abcd"
+/// }
+/// ```
+///
+/// ## 2. Production Build (CLI / App bundle)
+/// - CLI downloads remote `uri` and replaces it with a local `file://` or `asset://` path.
+/// - `id` remains for traceability, but `uri` points to bundled asset.
+///
+/// ```json
+/// {
+///   "id": "xxxx",
+///   "uri": "asset://assets/logo.svg"
+/// }
+/// ```
+///
+/// ## 3. Remote Only (do not bundle locally)
+/// - Some resources may stay remote (e.g., CDN branding assets).
+/// - Marked with `metadata.preserveRemote = true`.
+/// - CLI should **not replace** the URL with local path.
+///
+/// ```json
+/// {
+///   "id": "xxxx",
+///   "uri": "https://cdn.example.com/logo.svg",
+///   "metadata": { "preserveRemote": true }
+/// }
+/// ```
+///
+/// ## 4. Local file reference (during development)
+/// - A developer can point to a file in the local FS with `file://`.
+/// - Not recommended for production, but useful in dev/debug tooling.
+///
+/// ```json
+/// {
+///   "id": "local123",
+///   "uri": "file:///Users/me/project/assets/logo.svg"
+/// }
+/// ```
+@freezed
+class ImageSource with _$ImageSource {
+  const ImageSource._();
+
+  const factory ImageSource({
+    /// Backend asset ID (unique identifier in storage).
+    /// Required for backend-side linking, optional in dev or local-only assets.
+    String? id,
+
+    /// Unified URI pointing to the resource.
+    /// Examples:
+    /// - `asset://assets/logo.svg` (bundled asset inside the app)
+    /// - `https://...` (signed URL or CDN reference)
+    /// - `file://...` (local file reference, dev only)
+    String? uri,
+
+    /// Semantic type of reference (default = "asset").
+    /// Can be extended in future (e.g., "cdn", "inline").
+    @JsonKey(name: r'$ref') @Default('asset') String ref,
+
+    /// Freeform metadata for build tools / CLI / pipelines.
+    /// Example: `{ "preserveRemote": true }`
+    @Default(Metadata()) Metadata metadata,
+  }) = _ImageSource;
+
+  factory ImageSource.fromJson(Map<String, dynamic> json) => _$ImageSourceFromJson(json);
+
+  /// Whether the remote URI should be preserved
+  /// (i.e., not downloaded and replaced with a local path).
+  bool get preserveRemote => metadata.getBool('preserveRemote') == true;
+}

--- a/packages/webtrit_appearance_theme/lib/models/resources/image_source.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/resources/image_source.freezed.dart
@@ -1,0 +1,292 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'image_source.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ImageSource _$ImageSourceFromJson(Map<String, dynamic> json) {
+  return _ImageSource.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ImageSource {
+  /// Backend asset ID (unique identifier in storage).
+  /// Required for backend-side linking, optional in dev or local-only assets.
+  String? get id => throw _privateConstructorUsedError;
+
+  /// Unified URI pointing to the resource.
+  /// Examples:
+  /// - `asset://assets/logo.svg` (bundled asset inside the app)
+  /// - `https://...` (signed URL or CDN reference)
+  /// - `file://...` (local file reference, dev only)
+  String? get uri => throw _privateConstructorUsedError;
+
+  /// Semantic type of reference (default = "asset").
+  /// Can be extended in future (e.g., "cdn", "inline").
+  @JsonKey(name: r'$ref')
+  String get ref => throw _privateConstructorUsedError;
+
+  /// Freeform metadata for build tools / CLI / pipelines.
+  /// Example: `{ "preserveRemote": true }`
+  Metadata get metadata => throw _privateConstructorUsedError;
+
+  /// Serializes this ImageSource to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ImageSource
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ImageSourceCopyWith<ImageSource> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ImageSourceCopyWith<$Res> {
+  factory $ImageSourceCopyWith(
+          ImageSource value, $Res Function(ImageSource) then) =
+      _$ImageSourceCopyWithImpl<$Res, ImageSource>;
+  @useResult
+  $Res call(
+      {String? id,
+      String? uri,
+      @JsonKey(name: r'$ref') String ref,
+      Metadata metadata});
+
+  $MetadataCopyWith<$Res> get metadata;
+}
+
+/// @nodoc
+class _$ImageSourceCopyWithImpl<$Res, $Val extends ImageSource>
+    implements $ImageSourceCopyWith<$Res> {
+  _$ImageSourceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ImageSource
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? uri = freezed,
+    Object? ref = null,
+    Object? metadata = null,
+  }) {
+    return _then(_value.copyWith(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      uri: freezed == uri
+          ? _value.uri
+          : uri // ignore: cast_nullable_to_non_nullable
+              as String?,
+      ref: null == ref
+          ? _value.ref
+          : ref // ignore: cast_nullable_to_non_nullable
+              as String,
+      metadata: null == metadata
+          ? _value.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as Metadata,
+    ) as $Val);
+  }
+
+  /// Create a copy of ImageSource
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $MetadataCopyWith<$Res> get metadata {
+    return $MetadataCopyWith<$Res>(_value.metadata, (value) {
+      return _then(_value.copyWith(metadata: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ImageSourceImplCopyWith<$Res>
+    implements $ImageSourceCopyWith<$Res> {
+  factory _$$ImageSourceImplCopyWith(
+          _$ImageSourceImpl value, $Res Function(_$ImageSourceImpl) then) =
+      __$$ImageSourceImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? id,
+      String? uri,
+      @JsonKey(name: r'$ref') String ref,
+      Metadata metadata});
+
+  @override
+  $MetadataCopyWith<$Res> get metadata;
+}
+
+/// @nodoc
+class __$$ImageSourceImplCopyWithImpl<$Res>
+    extends _$ImageSourceCopyWithImpl<$Res, _$ImageSourceImpl>
+    implements _$$ImageSourceImplCopyWith<$Res> {
+  __$$ImageSourceImplCopyWithImpl(
+      _$ImageSourceImpl _value, $Res Function(_$ImageSourceImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ImageSource
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? uri = freezed,
+    Object? ref = null,
+    Object? metadata = null,
+  }) {
+    return _then(_$ImageSourceImpl(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      uri: freezed == uri
+          ? _value.uri
+          : uri // ignore: cast_nullable_to_non_nullable
+              as String?,
+      ref: null == ref
+          ? _value.ref
+          : ref // ignore: cast_nullable_to_non_nullable
+              as String,
+      metadata: null == metadata
+          ? _value.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as Metadata,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ImageSourceImpl extends _ImageSource {
+  const _$ImageSourceImpl(
+      {this.id,
+      this.uri,
+      @JsonKey(name: r'$ref') this.ref = 'asset',
+      this.metadata = const Metadata()})
+      : super._();
+
+  factory _$ImageSourceImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ImageSourceImplFromJson(json);
+
+  /// Backend asset ID (unique identifier in storage).
+  /// Required for backend-side linking, optional in dev or local-only assets.
+  @override
+  final String? id;
+
+  /// Unified URI pointing to the resource.
+  /// Examples:
+  /// - `asset://assets/logo.svg` (bundled asset inside the app)
+  /// - `https://...` (signed URL or CDN reference)
+  /// - `file://...` (local file reference, dev only)
+  @override
+  final String? uri;
+
+  /// Semantic type of reference (default = "asset").
+  /// Can be extended in future (e.g., "cdn", "inline").
+  @override
+  @JsonKey(name: r'$ref')
+  final String ref;
+
+  /// Freeform metadata for build tools / CLI / pipelines.
+  /// Example: `{ "preserveRemote": true }`
+  @override
+  @JsonKey()
+  final Metadata metadata;
+
+  @override
+  String toString() {
+    return 'ImageSource(id: $id, uri: $uri, ref: $ref, metadata: $metadata)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ImageSourceImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.uri, uri) || other.uri == uri) &&
+            (identical(other.ref, ref) || other.ref == ref) &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, uri, ref, metadata);
+
+  /// Create a copy of ImageSource
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ImageSourceImplCopyWith<_$ImageSourceImpl> get copyWith =>
+      __$$ImageSourceImplCopyWithImpl<_$ImageSourceImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ImageSourceImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ImageSource extends ImageSource {
+  const factory _ImageSource(
+      {final String? id,
+      final String? uri,
+      @JsonKey(name: r'$ref') final String ref,
+      final Metadata metadata}) = _$ImageSourceImpl;
+  const _ImageSource._() : super._();
+
+  factory _ImageSource.fromJson(Map<String, dynamic> json) =
+      _$ImageSourceImpl.fromJson;
+
+  /// Backend asset ID (unique identifier in storage).
+  /// Required for backend-side linking, optional in dev or local-only assets.
+  @override
+  String? get id;
+
+  /// Unified URI pointing to the resource.
+  /// Examples:
+  /// - `asset://assets/logo.svg` (bundled asset inside the app)
+  /// - `https://...` (signed URL or CDN reference)
+  /// - `file://...` (local file reference, dev only)
+  @override
+  String? get uri;
+
+  /// Semantic type of reference (default = "asset").
+  /// Can be extended in future (e.g., "cdn", "inline").
+  @override
+  @JsonKey(name: r'$ref')
+  String get ref;
+
+  /// Freeform metadata for build tools / CLI / pipelines.
+  /// Example: `{ "preserveRemote": true }`
+  @override
+  Metadata get metadata;
+
+  /// Create a copy of ImageSource
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ImageSourceImplCopyWith<_$ImageSourceImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/webtrit_appearance_theme/lib/models/resources/image_source.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/resources/image_source.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'image_source.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ImageSourceImpl _$$ImageSourceImplFromJson(Map<String, dynamic> json) =>
+    _$ImageSourceImpl(
+      id: json['id'] as String?,
+      uri: json['uri'] as String?,
+      ref: json[r'$ref'] as String? ?? 'asset',
+      metadata: json['metadata'] == null
+          ? const Metadata()
+          : Metadata.fromJson(json['metadata'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$ImageSourceImplToJson(_$ImageSourceImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'uri': instance.uri,
+      r'$ref': instance.ref,
+      'metadata': instance.metadata,
+    };

--- a/packages/webtrit_appearance_theme/lib/models/resources/resources.dart
+++ b/packages/webtrit_appearance_theme/lib/models/resources/resources.dart
@@ -1,0 +1,1 @@
+export 'image_source.dart';

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -1,8 +1,9 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import 'common/common.dart';
 import 'features_config/elevated_button_style_type.dart';
 import 'features_config/metadata.dart';
+import 'common/common.dart';
+import 'resources/image_source.dart';
 import 'theme_widget_config.dart';
 
 part 'theme_page_config.freezed.dart';
@@ -44,8 +45,11 @@ class ThemePageConfig with _$ThemePageConfig {
 class LoginPageConfig with _$LoginPageConfig {
   @JsonSerializable(explicitToJson: true)
   const factory LoginPageConfig({
+    /// Structured image source for the picture/logo.
+    ImageSource? imageSource,
+
     /// Path or URL to the picture/logo displayed on the login page.
-    String? picture,
+    @Deprecated('Use structured ImageSource instead') String? picture,
 
     /// Scaling factor for the displayed picture/logo.
     double? scale,
@@ -95,8 +99,11 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig {
 class AboutPageConfig with _$AboutPageConfig {
   @JsonSerializable(explicitToJson: true)
   const factory AboutPageConfig({
+    /// Structured image source for the picture/logo.
+    ImageSource? imageSource,
+
     /// Path or URL to the picture/logo displayed on the About page.
-    String? picture,
+    @Deprecated('Use structured ImageSource instead') String? picture,
 
     /// Metadata section with additional information such as version, build number, etc.
     @Default(Metadata()) Metadata metadata,

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -293,7 +293,11 @@ LoginPageConfig _$LoginPageConfigFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$LoginPageConfig {
+  /// Structured image source for the picture/logo.
+  ImageSource? get imageSource => throw _privateConstructorUsedError;
+
   /// Path or URL to the picture/logo displayed on the login page.
+  @Deprecated('Use structured ImageSource instead')
   String? get picture => throw _privateConstructorUsedError;
 
   /// Scaling factor for the displayed picture/logo.
@@ -326,12 +330,14 @@ abstract class $LoginPageConfigCopyWith<$Res> {
       _$LoginPageConfigCopyWithImpl<$Res, LoginPageConfig>;
   @useResult
   $Res call(
-      {String? picture,
+      {ImageSource? imageSource,
+      @Deprecated('Use structured ImageSource instead') String? picture,
       double? scale,
       String? labelColor,
       LoginModeSelectPageConfig modeSelect,
       Metadata metadata});
 
+  $ImageSourceCopyWith<$Res>? get imageSource;
   $LoginModeSelectPageConfigCopyWith<$Res> get modeSelect;
   $MetadataCopyWith<$Res> get metadata;
 }
@@ -351,6 +357,7 @@ class _$LoginPageConfigCopyWithImpl<$Res, $Val extends LoginPageConfig>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? imageSource = freezed,
     Object? picture = freezed,
     Object? scale = freezed,
     Object? labelColor = freezed,
@@ -358,6 +365,10 @@ class _$LoginPageConfigCopyWithImpl<$Res, $Val extends LoginPageConfig>
     Object? metadata = null,
   }) {
     return _then(_value.copyWith(
+      imageSource: freezed == imageSource
+          ? _value.imageSource
+          : imageSource // ignore: cast_nullable_to_non_nullable
+              as ImageSource?,
       picture: freezed == picture
           ? _value.picture
           : picture // ignore: cast_nullable_to_non_nullable
@@ -379,6 +390,20 @@ class _$LoginPageConfigCopyWithImpl<$Res, $Val extends LoginPageConfig>
           : metadata // ignore: cast_nullable_to_non_nullable
               as Metadata,
     ) as $Val);
+  }
+
+  /// Create a copy of LoginPageConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ImageSourceCopyWith<$Res>? get imageSource {
+    if (_value.imageSource == null) {
+      return null;
+    }
+
+    return $ImageSourceCopyWith<$Res>(_value.imageSource!, (value) {
+      return _then(_value.copyWith(imageSource: value) as $Val);
+    });
   }
 
   /// Create a copy of LoginPageConfig
@@ -411,12 +436,15 @@ abstract class _$$LoginPageConfigImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String? picture,
+      {ImageSource? imageSource,
+      @Deprecated('Use structured ImageSource instead') String? picture,
       double? scale,
       String? labelColor,
       LoginModeSelectPageConfig modeSelect,
       Metadata metadata});
 
+  @override
+  $ImageSourceCopyWith<$Res>? get imageSource;
   @override
   $LoginModeSelectPageConfigCopyWith<$Res> get modeSelect;
   @override
@@ -436,6 +464,7 @@ class __$$LoginPageConfigImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? imageSource = freezed,
     Object? picture = freezed,
     Object? scale = freezed,
     Object? labelColor = freezed,
@@ -443,6 +472,10 @@ class __$$LoginPageConfigImplCopyWithImpl<$Res>
     Object? metadata = null,
   }) {
     return _then(_$LoginPageConfigImpl(
+      imageSource: freezed == imageSource
+          ? _value.imageSource
+          : imageSource // ignore: cast_nullable_to_non_nullable
+              as ImageSource?,
       picture: freezed == picture
           ? _value.picture
           : picture // ignore: cast_nullable_to_non_nullable
@@ -472,7 +505,8 @@ class __$$LoginPageConfigImplCopyWithImpl<$Res>
 @JsonSerializable(explicitToJson: true)
 class _$LoginPageConfigImpl implements _LoginPageConfig {
   const _$LoginPageConfigImpl(
-      {this.picture,
+      {this.imageSource,
+      @Deprecated('Use structured ImageSource instead') this.picture,
       this.scale,
       this.labelColor,
       this.modeSelect = const LoginModeSelectPageConfig(),
@@ -481,8 +515,13 @@ class _$LoginPageConfigImpl implements _LoginPageConfig {
   factory _$LoginPageConfigImpl.fromJson(Map<String, dynamic> json) =>
       _$$LoginPageConfigImplFromJson(json);
 
+  /// Structured image source for the picture/logo.
+  @override
+  final ImageSource? imageSource;
+
   /// Path or URL to the picture/logo displayed on the login page.
   @override
+  @Deprecated('Use structured ImageSource instead')
   final String? picture;
 
   /// Scaling factor for the displayed picture/logo.
@@ -505,7 +544,7 @@ class _$LoginPageConfigImpl implements _LoginPageConfig {
 
   @override
   String toString() {
-    return 'LoginPageConfig(picture: $picture, scale: $scale, labelColor: $labelColor, modeSelect: $modeSelect, metadata: $metadata)';
+    return 'LoginPageConfig(imageSource: $imageSource, picture: $picture, scale: $scale, labelColor: $labelColor, modeSelect: $modeSelect, metadata: $metadata)';
   }
 
   @override
@@ -513,6 +552,8 @@ class _$LoginPageConfigImpl implements _LoginPageConfig {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$LoginPageConfigImpl &&
+            (identical(other.imageSource, imageSource) ||
+                other.imageSource == imageSource) &&
             (identical(other.picture, picture) || other.picture == picture) &&
             (identical(other.scale, scale) || other.scale == scale) &&
             (identical(other.labelColor, labelColor) ||
@@ -525,8 +566,8 @@ class _$LoginPageConfigImpl implements _LoginPageConfig {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, picture, scale, labelColor, modeSelect, metadata);
+  int get hashCode => Object.hash(runtimeType, imageSource, picture, scale,
+      labelColor, modeSelect, metadata);
 
   /// Create a copy of LoginPageConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -547,7 +588,8 @@ class _$LoginPageConfigImpl implements _LoginPageConfig {
 
 abstract class _LoginPageConfig implements LoginPageConfig {
   const factory _LoginPageConfig(
-      {final String? picture,
+      {final ImageSource? imageSource,
+      @Deprecated('Use structured ImageSource instead') final String? picture,
       final double? scale,
       final String? labelColor,
       final LoginModeSelectPageConfig modeSelect,
@@ -556,8 +598,13 @@ abstract class _LoginPageConfig implements LoginPageConfig {
   factory _LoginPageConfig.fromJson(Map<String, dynamic> json) =
       _$LoginPageConfigImpl.fromJson;
 
+  /// Structured image source for the picture/logo.
+  @override
+  ImageSource? get imageSource;
+
   /// Path or URL to the picture/logo displayed on the login page.
   @override
+  @Deprecated('Use structured ImageSource instead')
   String? get picture;
 
   /// Scaling factor for the displayed picture/logo.
@@ -820,7 +867,11 @@ AboutPageConfig _$AboutPageConfigFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$AboutPageConfig {
+  /// Structured image source for the picture/logo.
+  ImageSource? get imageSource => throw _privateConstructorUsedError;
+
   /// Path or URL to the picture/logo displayed on the About page.
+  @Deprecated('Use structured ImageSource instead')
   String? get picture => throw _privateConstructorUsedError;
 
   /// Metadata section with additional information such as version, build number, etc.
@@ -842,8 +893,12 @@ abstract class $AboutPageConfigCopyWith<$Res> {
           AboutPageConfig value, $Res Function(AboutPageConfig) then) =
       _$AboutPageConfigCopyWithImpl<$Res, AboutPageConfig>;
   @useResult
-  $Res call({String? picture, Metadata metadata});
+  $Res call(
+      {ImageSource? imageSource,
+      @Deprecated('Use structured ImageSource instead') String? picture,
+      Metadata metadata});
 
+  $ImageSourceCopyWith<$Res>? get imageSource;
   $MetadataCopyWith<$Res> get metadata;
 }
 
@@ -862,10 +917,15 @@ class _$AboutPageConfigCopyWithImpl<$Res, $Val extends AboutPageConfig>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? imageSource = freezed,
     Object? picture = freezed,
     Object? metadata = null,
   }) {
     return _then(_value.copyWith(
+      imageSource: freezed == imageSource
+          ? _value.imageSource
+          : imageSource // ignore: cast_nullable_to_non_nullable
+              as ImageSource?,
       picture: freezed == picture
           ? _value.picture
           : picture // ignore: cast_nullable_to_non_nullable
@@ -875,6 +935,20 @@ class _$AboutPageConfigCopyWithImpl<$Res, $Val extends AboutPageConfig>
           : metadata // ignore: cast_nullable_to_non_nullable
               as Metadata,
     ) as $Val);
+  }
+
+  /// Create a copy of AboutPageConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ImageSourceCopyWith<$Res>? get imageSource {
+    if (_value.imageSource == null) {
+      return null;
+    }
+
+    return $ImageSourceCopyWith<$Res>(_value.imageSource!, (value) {
+      return _then(_value.copyWith(imageSource: value) as $Val);
+    });
   }
 
   /// Create a copy of AboutPageConfig
@@ -896,8 +970,13 @@ abstract class _$$AboutPageConfigImplCopyWith<$Res>
       __$$AboutPageConfigImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String? picture, Metadata metadata});
+  $Res call(
+      {ImageSource? imageSource,
+      @Deprecated('Use structured ImageSource instead') String? picture,
+      Metadata metadata});
 
+  @override
+  $ImageSourceCopyWith<$Res>? get imageSource;
   @override
   $MetadataCopyWith<$Res> get metadata;
 }
@@ -915,10 +994,15 @@ class __$$AboutPageConfigImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? imageSource = freezed,
     Object? picture = freezed,
     Object? metadata = null,
   }) {
     return _then(_$AboutPageConfigImpl(
+      imageSource: freezed == imageSource
+          ? _value.imageSource
+          : imageSource // ignore: cast_nullable_to_non_nullable
+              as ImageSource?,
       picture: freezed == picture
           ? _value.picture
           : picture // ignore: cast_nullable_to_non_nullable
@@ -935,13 +1019,21 @@ class __$$AboutPageConfigImplCopyWithImpl<$Res>
 
 @JsonSerializable(explicitToJson: true)
 class _$AboutPageConfigImpl implements _AboutPageConfig {
-  const _$AboutPageConfigImpl({this.picture, this.metadata = const Metadata()});
+  const _$AboutPageConfigImpl(
+      {this.imageSource,
+      @Deprecated('Use structured ImageSource instead') this.picture,
+      this.metadata = const Metadata()});
 
   factory _$AboutPageConfigImpl.fromJson(Map<String, dynamic> json) =>
       _$$AboutPageConfigImplFromJson(json);
 
+  /// Structured image source for the picture/logo.
+  @override
+  final ImageSource? imageSource;
+
   /// Path or URL to the picture/logo displayed on the About page.
   @override
+  @Deprecated('Use structured ImageSource instead')
   final String? picture;
 
   /// Metadata section with additional information such as version, build number, etc.
@@ -951,7 +1043,7 @@ class _$AboutPageConfigImpl implements _AboutPageConfig {
 
   @override
   String toString() {
-    return 'AboutPageConfig(picture: $picture, metadata: $metadata)';
+    return 'AboutPageConfig(imageSource: $imageSource, picture: $picture, metadata: $metadata)';
   }
 
   @override
@@ -959,6 +1051,8 @@ class _$AboutPageConfigImpl implements _AboutPageConfig {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$AboutPageConfigImpl &&
+            (identical(other.imageSource, imageSource) ||
+                other.imageSource == imageSource) &&
             (identical(other.picture, picture) || other.picture == picture) &&
             (identical(other.metadata, metadata) ||
                 other.metadata == metadata));
@@ -966,7 +1060,7 @@ class _$AboutPageConfigImpl implements _AboutPageConfig {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, picture, metadata);
+  int get hashCode => Object.hash(runtimeType, imageSource, picture, metadata);
 
   /// Create a copy of AboutPageConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -987,13 +1081,20 @@ class _$AboutPageConfigImpl implements _AboutPageConfig {
 
 abstract class _AboutPageConfig implements AboutPageConfig {
   const factory _AboutPageConfig(
-      {final String? picture, final Metadata metadata}) = _$AboutPageConfigImpl;
+      {final ImageSource? imageSource,
+      @Deprecated('Use structured ImageSource instead') final String? picture,
+      final Metadata metadata}) = _$AboutPageConfigImpl;
 
   factory _AboutPageConfig.fromJson(Map<String, dynamic> json) =
       _$AboutPageConfigImpl.fromJson;
 
+  /// Structured image source for the picture/logo.
+  @override
+  ImageSource? get imageSource;
+
   /// Path or URL to the picture/logo displayed on the About page.
   @override
+  @Deprecated('Use structured ImageSource instead')
   String? get picture;
 
   /// Metadata section with additional information such as version, build number, etc.

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -35,6 +35,9 @@ Map<String, dynamic> _$$ThemePageConfigImplToJson(
 _$LoginPageConfigImpl _$$LoginPageConfigImplFromJson(
         Map<String, dynamic> json) =>
     _$LoginPageConfigImpl(
+      imageSource: json['imageSource'] == null
+          ? null
+          : ImageSource.fromJson(json['imageSource'] as Map<String, dynamic>),
       picture: json['picture'] as String?,
       scale: (json['scale'] as num?)?.toDouble(),
       labelColor: json['labelColor'] as String?,
@@ -50,6 +53,7 @@ _$LoginPageConfigImpl _$$LoginPageConfigImplFromJson(
 Map<String, dynamic> _$$LoginPageConfigImplToJson(
         _$LoginPageConfigImpl instance) =>
     <String, dynamic>{
+      'imageSource': instance.imageSource?.toJson(),
       'picture': instance.picture,
       'scale': instance.scale,
       'labelColor': instance.labelColor,
@@ -93,6 +97,9 @@ const _$ElevatedButtonStyleTypeEnumMap = {
 _$AboutPageConfigImpl _$$AboutPageConfigImplFromJson(
         Map<String, dynamic> json) =>
     _$AboutPageConfigImpl(
+      imageSource: json['imageSource'] == null
+          ? null
+          : ImageSource.fromJson(json['imageSource'] as Map<String, dynamic>),
       picture: json['picture'] as String?,
       metadata: json['metadata'] == null
           ? const Metadata()
@@ -102,6 +109,7 @@ _$AboutPageConfigImpl _$$AboutPageConfigImplFromJson(
 Map<String, dynamic> _$$AboutPageConfigImplToJson(
         _$AboutPageConfigImpl instance) =>
     <String, dynamic>{
+      'imageSource': instance.imageSource?.toJson(),
       'picture': instance.picture,
       'metadata': instance.metadata.toJson(),
     };

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
@@ -3,6 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'common/leading_avatar_style_config.dart';
 import 'custom_color.dart';
 import 'features_config/metadata.dart';
+import 'resources/image_source.dart';
 
 part 'theme_widget_config.freezed.dart';
 
@@ -150,8 +151,9 @@ class CallActionsWidgetConfig with _$CallActionsWidgetConfig {
 class ImageAssetsConfig with _$ImageAssetsConfig {
   @JsonSerializable(explicitToJson: true)
   const factory ImageAssetsConfig({
-    @Default(ImageAssetConfig(uri: 'asset://assets/primary_onboardin_logo.svg')) ImageAssetConfig primaryOnboardingLogo,
-    @Default(ImageAssetConfig(uri: 'asset://assets/secondary_onboardin_logo.svg'))
+    @Default(ImageAssetConfig(imageSource: ImageSource(uri: 'asset://assets/primary_onboardin_logo.svg')))
+    ImageAssetConfig primaryOnboardingLogo,
+    @Default(ImageAssetConfig(imageSource: ImageSource(uri: 'asset://assets/secondary_onboardin_logo.svg')))
     ImageAssetConfig secondaryOnboardingLogo,
     @Default(AppIconWidgetConfig()) AppIconWidgetConfig appIcon,
     @Default(LeadingAvatarStyleConfig()) LeadingAvatarStyleConfig leadingAvatarStyle,
@@ -170,10 +172,11 @@ class ImageAssetsConfig with _$ImageAssetsConfig {
 class ImageAssetConfig with _$ImageAssetConfig {
   @JsonSerializable(explicitToJson: true)
   const factory ImageAssetConfig({
-    required String uri,
+    ImageSource? imageSource,
     @Default(1.0) double widthFactor,
     @Default('#FFFFFF') String labelColor,
     @Default(Metadata()) Metadata metadata,
+    @Deprecated('Use source.uri instead') String? uri,
   }) = _ImageAssetConfig;
 
   factory ImageAssetConfig.fromJson(Map<String, dynamic> json) => _$ImageAssetConfigFromJson(json);

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
@@ -2816,9 +2816,11 @@ class __$$ImageAssetsConfigImplCopyWithImpl<$Res>
 class _$ImageAssetsConfigImpl implements _ImageAssetsConfig {
   const _$ImageAssetsConfigImpl(
       {this.primaryOnboardingLogo = const ImageAssetConfig(
-          uri: 'asset://assets/primary_onboardin_logo.svg'),
+          imageSource:
+              ImageSource(uri: 'asset://assets/primary_onboardin_logo.svg')),
       this.secondaryOnboardingLogo = const ImageAssetConfig(
-          uri: 'asset://assets/secondary_onboardin_logo.svg'),
+          imageSource:
+              ImageSource(uri: 'asset://assets/secondary_onboardin_logo.svg')),
       this.appIcon = const AppIconWidgetConfig(),
       this.leadingAvatarStyle = const LeadingAvatarStyleConfig()});
 
@@ -2914,10 +2916,12 @@ ImageAssetConfig _$ImageAssetConfigFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$ImageAssetConfig {
-  String get uri => throw _privateConstructorUsedError;
+  ImageSource? get imageSource => throw _privateConstructorUsedError;
   double get widthFactor => throw _privateConstructorUsedError;
   String get labelColor => throw _privateConstructorUsedError;
   Metadata get metadata => throw _privateConstructorUsedError;
+  @Deprecated('Use source.uri instead')
+  String? get uri => throw _privateConstructorUsedError;
 
   /// Serializes this ImageAssetConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -2936,8 +2940,13 @@ abstract class $ImageAssetConfigCopyWith<$Res> {
       _$ImageAssetConfigCopyWithImpl<$Res, ImageAssetConfig>;
   @useResult
   $Res call(
-      {String uri, double widthFactor, String labelColor, Metadata metadata});
+      {ImageSource? imageSource,
+      double widthFactor,
+      String labelColor,
+      Metadata metadata,
+      @Deprecated('Use source.uri instead') String? uri});
 
+  $ImageSourceCopyWith<$Res>? get imageSource;
   $MetadataCopyWith<$Res> get metadata;
 }
 
@@ -2956,16 +2965,17 @@ class _$ImageAssetConfigCopyWithImpl<$Res, $Val extends ImageAssetConfig>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? uri = null,
+    Object? imageSource = freezed,
     Object? widthFactor = null,
     Object? labelColor = null,
     Object? metadata = null,
+    Object? uri = freezed,
   }) {
     return _then(_value.copyWith(
-      uri: null == uri
-          ? _value.uri
-          : uri // ignore: cast_nullable_to_non_nullable
-              as String,
+      imageSource: freezed == imageSource
+          ? _value.imageSource
+          : imageSource // ignore: cast_nullable_to_non_nullable
+              as ImageSource?,
       widthFactor: null == widthFactor
           ? _value.widthFactor
           : widthFactor // ignore: cast_nullable_to_non_nullable
@@ -2978,7 +2988,25 @@ class _$ImageAssetConfigCopyWithImpl<$Res, $Val extends ImageAssetConfig>
           ? _value.metadata
           : metadata // ignore: cast_nullable_to_non_nullable
               as Metadata,
+      uri: freezed == uri
+          ? _value.uri
+          : uri // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
+  }
+
+  /// Create a copy of ImageAssetConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ImageSourceCopyWith<$Res>? get imageSource {
+    if (_value.imageSource == null) {
+      return null;
+    }
+
+    return $ImageSourceCopyWith<$Res>(_value.imageSource!, (value) {
+      return _then(_value.copyWith(imageSource: value) as $Val);
+    });
   }
 
   /// Create a copy of ImageAssetConfig
@@ -3001,8 +3029,14 @@ abstract class _$$ImageAssetConfigImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String uri, double widthFactor, String labelColor, Metadata metadata});
+      {ImageSource? imageSource,
+      double widthFactor,
+      String labelColor,
+      Metadata metadata,
+      @Deprecated('Use source.uri instead') String? uri});
 
+  @override
+  $ImageSourceCopyWith<$Res>? get imageSource;
   @override
   $MetadataCopyWith<$Res> get metadata;
 }
@@ -3020,16 +3054,17 @@ class __$$ImageAssetConfigImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? uri = null,
+    Object? imageSource = freezed,
     Object? widthFactor = null,
     Object? labelColor = null,
     Object? metadata = null,
+    Object? uri = freezed,
   }) {
     return _then(_$ImageAssetConfigImpl(
-      uri: null == uri
-          ? _value.uri
-          : uri // ignore: cast_nullable_to_non_nullable
-              as String,
+      imageSource: freezed == imageSource
+          ? _value.imageSource
+          : imageSource // ignore: cast_nullable_to_non_nullable
+              as ImageSource?,
       widthFactor: null == widthFactor
           ? _value.widthFactor
           : widthFactor // ignore: cast_nullable_to_non_nullable
@@ -3042,6 +3077,10 @@ class __$$ImageAssetConfigImplCopyWithImpl<$Res>
           ? _value.metadata
           : metadata // ignore: cast_nullable_to_non_nullable
               as Metadata,
+      uri: freezed == uri
+          ? _value.uri
+          : uri // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -3051,16 +3090,17 @@ class __$$ImageAssetConfigImplCopyWithImpl<$Res>
 @JsonSerializable(explicitToJson: true)
 class _$ImageAssetConfigImpl implements _ImageAssetConfig {
   const _$ImageAssetConfigImpl(
-      {required this.uri,
+      {this.imageSource,
       this.widthFactor = 1.0,
       this.labelColor = '#FFFFFF',
-      this.metadata = const Metadata()});
+      this.metadata = const Metadata(),
+      @Deprecated('Use source.uri instead') this.uri});
 
   factory _$ImageAssetConfigImpl.fromJson(Map<String, dynamic> json) =>
       _$$ImageAssetConfigImplFromJson(json);
 
   @override
-  final String uri;
+  final ImageSource? imageSource;
   @override
   @JsonKey()
   final double widthFactor;
@@ -3070,10 +3110,13 @@ class _$ImageAssetConfigImpl implements _ImageAssetConfig {
   @override
   @JsonKey()
   final Metadata metadata;
+  @override
+  @Deprecated('Use source.uri instead')
+  final String? uri;
 
   @override
   String toString() {
-    return 'ImageAssetConfig(uri: $uri, widthFactor: $widthFactor, labelColor: $labelColor, metadata: $metadata)';
+    return 'ImageAssetConfig(imageSource: $imageSource, widthFactor: $widthFactor, labelColor: $labelColor, metadata: $metadata, uri: $uri)';
   }
 
   @override
@@ -3081,19 +3124,21 @@ class _$ImageAssetConfigImpl implements _ImageAssetConfig {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ImageAssetConfigImpl &&
-            (identical(other.uri, uri) || other.uri == uri) &&
+            (identical(other.imageSource, imageSource) ||
+                other.imageSource == imageSource) &&
             (identical(other.widthFactor, widthFactor) ||
                 other.widthFactor == widthFactor) &&
             (identical(other.labelColor, labelColor) ||
                 other.labelColor == labelColor) &&
             (identical(other.metadata, metadata) ||
-                other.metadata == metadata));
+                other.metadata == metadata) &&
+            (identical(other.uri, uri) || other.uri == uri));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, uri, widthFactor, labelColor, metadata);
+  int get hashCode => Object.hash(
+      runtimeType, imageSource, widthFactor, labelColor, metadata, uri);
 
   /// Create a copy of ImageAssetConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -3114,22 +3159,27 @@ class _$ImageAssetConfigImpl implements _ImageAssetConfig {
 
 abstract class _ImageAssetConfig implements ImageAssetConfig {
   const factory _ImageAssetConfig(
-      {required final String uri,
-      final double widthFactor,
-      final String labelColor,
-      final Metadata metadata}) = _$ImageAssetConfigImpl;
+          {final ImageSource? imageSource,
+          final double widthFactor,
+          final String labelColor,
+          final Metadata metadata,
+          @Deprecated('Use source.uri instead') final String? uri}) =
+      _$ImageAssetConfigImpl;
 
   factory _ImageAssetConfig.fromJson(Map<String, dynamic> json) =
       _$ImageAssetConfigImpl.fromJson;
 
   @override
-  String get uri;
+  ImageSource? get imageSource;
   @override
   double get widthFactor;
   @override
   String get labelColor;
   @override
   Metadata get metadata;
+  @override
+  @Deprecated('Use source.uri instead')
+  String? get uri;
 
   /// Create a copy of ImageAssetConfig
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
@@ -245,12 +245,14 @@ _$ImageAssetsConfigImpl _$$ImageAssetsConfigImplFromJson(
     _$ImageAssetsConfigImpl(
       primaryOnboardingLogo: json['primaryOnboardingLogo'] == null
           ? const ImageAssetConfig(
-              uri: 'asset://assets/primary_onboardin_logo.svg')
+              imageSource:
+                  ImageSource(uri: 'asset://assets/primary_onboardin_logo.svg'))
           : ImageAssetConfig.fromJson(
               json['primaryOnboardingLogo'] as Map<String, dynamic>),
       secondaryOnboardingLogo: json['secondaryOnboardingLogo'] == null
           ? const ImageAssetConfig(
-              uri: 'asset://assets/secondary_onboardin_logo.svg')
+              imageSource: ImageSource(
+                  uri: 'asset://assets/secondary_onboardin_logo.svg'))
           : ImageAssetConfig.fromJson(
               json['secondaryOnboardingLogo'] as Map<String, dynamic>),
       appIcon: json['appIcon'] == null
@@ -275,21 +277,25 @@ Map<String, dynamic> _$$ImageAssetsConfigImplToJson(
 _$ImageAssetConfigImpl _$$ImageAssetConfigImplFromJson(
         Map<String, dynamic> json) =>
     _$ImageAssetConfigImpl(
-      uri: json['uri'] as String,
+      imageSource: json['imageSource'] == null
+          ? null
+          : ImageSource.fromJson(json['imageSource'] as Map<String, dynamic>),
       widthFactor: (json['widthFactor'] as num?)?.toDouble() ?? 1.0,
       labelColor: json['labelColor'] as String? ?? '#FFFFFF',
       metadata: json['metadata'] == null
           ? const Metadata()
           : Metadata.fromJson(json['metadata'] as Map<String, dynamic>),
+      uri: json['uri'] as String?,
     );
 
 Map<String, dynamic> _$$ImageAssetConfigImplToJson(
         _$ImageAssetConfigImpl instance) =>
     <String, dynamic>{
-      'uri': instance.uri,
+      'imageSource': instance.imageSource?.toJson(),
       'widthFactor': instance.widthFactor,
       'labelColor': instance.labelColor,
       'metadata': instance.metadata.toJson(),
+      'uri': instance.uri,
     };
 
 _$AppIconWidgetConfigImpl _$$AppIconWidgetConfigImplFromJson(


### PR DESCRIPTION
This PR refactors image source handling by unifying image references into a single ImageSource structure. The refactor introduces a new ImageSource class that encapsulates URI, ID, reference type, and metadata for images, while maintaining backward compatibility with the existing uri field through deprecation.

Introduces a new ImageSource class with comprehensive documentation and metadata support
Updates all image configuration classes to use the new ImageSource structure while keeping deprecated uri fields
Modifies factory classes to handle both new and deprecated image source patterns