### PR TITLE
refactor: allow nullable ThemeSvgAsset for onboarding logos

### DIFF
--- a/lib/theme/extension/logo_assets.dart
+++ b/lib/theme/extension/logo_assets.dart
@@ -8,8 +8,8 @@ class LogoAssets extends ThemeExtension<LogoAssets> {
     required this.secondaryOnboarding,
   });
 
-  final ThemeSvgAsset primaryOnboarding;
-  final ThemeSvgAsset secondaryOnboarding;
+  final ThemeSvgAsset? primaryOnboarding;
+  final ThemeSvgAsset? secondaryOnboarding;
 
   @override
   ThemeExtension<LogoAssets> copyWith({

--- a/lib/theme/factory/styles/logo_assets_factory.dart
+++ b/lib/theme/factory/styles/logo_assets_factory.dart
@@ -22,8 +22,8 @@ class LogoAssetsFactory implements ThemeStyleFactory<LogoAssets> {
         secondaryOnboardingLogo.imageSource?.uri ?? secondaryOnboardingLogo.uri;
 
     return LogoAssets(
-      primaryOnboarding: primaryOnboardingLogoUri!.toThemeSvgAsset()!,
-      secondaryOnboarding: secondaryOnboardingLogoUri!.toThemeSvgAsset()!,
+      primaryOnboarding: primaryOnboardingLogoUri?.toThemeSvgAsset(),
+      secondaryOnboarding: secondaryOnboardingLogoUri?.toThemeSvgAsset(),
     );
   }
 }


### PR DESCRIPTION
This PR refactors the LogoAssets class to allow nullable ThemeSvgAsset properties for onboarding logos, removing the previous requirement that these assets must always be non-null.

Converts primaryOnboarding and secondaryOnboarding fields from required non-null to nullable
Updates the factory logic to handle null URI values gracefully by using null-aware operators
Removes force unwrapping operations that could cause runtime crashes