### PR TITLE
feat: add new CallScreen style factory with actions support, JSON schema updates, and docs

### DIFF
--- a/assets/themes/original.page.dark.config.json
+++ b/assets/themes/original.page.dark.config.json
@@ -55,6 +55,89 @@
         },
         "color": "#EEF3F6"
       }
+    },
+    "actions": {
+      "callStart": {
+        "backgroundColor": "#75B943",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#66DDE0E3",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "hangup": {
+        "backgroundColor": "#E74C3C",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#66DDE0E3",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "transfer": {
+        "backgroundColor": "#123752",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#66DDE0E3",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "camera": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "muted": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "speaker": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "held": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "swap": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "key": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      }
     }
   }
 }

--- a/assets/themes/original.page.light.config.json
+++ b/assets/themes/original.page.light.config.json
@@ -55,6 +55,89 @@
         },
         "color": "#EEF3F6"
       }
+    },
+    "actions": {
+      "callStart": {
+        "backgroundColor": "#75B943",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#66DDE0E3",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "hangup": {
+        "backgroundColor": "#E74C3C",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#66DDE0E3",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "transfer": {
+        "backgroundColor": "#123752",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#66DDE0E3",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "camera": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "muted": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "speaker": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "held": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "swap": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      },
+      "key": {
+        "backgroundColor": "#66FFFFFF",
+        "foregroundColor": "#FFFFFFFF",
+        "textColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF",
+        "disabledBackgroundColor": "#33FFFFFF",
+        "disabledForegroundColor": "#848581",
+        "disabledIconColor": "#848581"
+      }
     }
   }
 }

--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -1,140 +1,363 @@
-# Setup Special Page Configuration
+
+# Page Configuration
+
+This document describes the **page-level appearance configuration** used by the app. It covers the Login, About, Call (Dialing), and Keypad pages, and explains how to structure JSON for each section, including color and typography options, and the new **Call Actions** area.
+
+> This file supersedes previous versions of `page_configuration.md`. It reflects the current DTOs in `theme_page_config.dart` (Freezed models).
+
+---
 
 ## Table of Contents
-
+- [Overview](#overview)
+- [Color format & alpha (ARGB)](#color-format--alpha-argb)
+- [ThemePageConfig](#themepageconfig)
 - [Login Page](#login-page)
 - [About Page](#about-page)
 - [Call Page (Dialing)](#call-page-dialing)
-
-The special pages in the application include the login, about, and call (dialing) pages, each with
-configurable properties.
+  - [App Bar](#app-bar)
+  - [Call Info](#call-info)
+  - [Call Actions](#call-actions)
+  - [Light & Dark examples for `actions`](#light--dark-examples-for-actions)
+- [Keypad Page](#keypad-page)
 
 ---
 
-### Login Page
+## Overview
 
-The login page configuration includes:
+Page configuration is declared via Freezed DTOs and serialized as JSON. Each section is optional; when a section (or its fields) is omitted, built-in defaults from the app theme are used. This makes it easy to ship a minimal configuration and progressively override styles as needed.
 
-- `picture`: URL or asset reference for the login page image
-- `scale`: Scaling factor for the login page image
-- `labelColor`: Color of the labels on the login page
-- `modeSelect`: Configures login and signup button styles and system UI overlay
-    - `systemUiOverlayStyle`: Controls status and navigation bar appearance
-        - `statusBarColor`: Background color of the status bar
-        - `statusBarIconBrightness`: Brightness of status bar icons (`dark` | `light`)
-        - `systemNavigationBarColor`: Background color of navigation bar
-        - `systemNavigationBarIconBrightness`: Brightness of nav bar icons (`dark` | `light`)
-    - `buttonLoginStyleType`: Style for the login button (e.g., `primary`, `neutral`,
-      `neutralOnDark`)
-    - `buttonSignupStyleType`: Style for the signup button (e.g., `primary`, `neutral`,
-      `neutralOnDark`)
-- `metadata`: Additional metadata that can be used to associate external resources
+---
 
-**Example Configuration:**
+## Color format & alpha (ARGB)
+
+All color fields accept a **HEX string**:
+- `#RRGGBB` — opaque color (alpha = `FF` is assumed).
+- `#AARRGGBB` — color **with explicit alpha** (recommended if you want glassy/translucent UI). For example, `#66FFFFFF` is white at ~40% opacity.
+
+> The `toColor()` converter supports both formats. Use ARGB when you want semi-transparent call action backgrounds that blend with gradients.
+
+---
+
+## ThemePageConfig
+
+Root DTO that aggregates per-page configs:
+
+```dart
+@Freezed()
+class ThemePageConfig {
+  const factory ThemePageConfig({
+    @Default(LoginPageConfig())  LoginPageConfig login,
+    @Default(AboutPageConfig())  AboutPageConfig about,
+    @Default(CallPageConfig())   CallPageConfig dialing,
+    @Default(KeypadPageConfig()) KeypadPageConfig keypad,
+  }) = _ThemePageConfig;
+}
+```
+
+JSON example (only the `dialing` page shown for brevity):
 
 ```json
 {
-  "picture": "asset://assets/login_background.png",
-  "scale": 1.2,
-  "labelColor": "#FFFFFF",
-  "modeSelect": {
+  "dialing": { /* see sections below */ }
+}
+```
+
+---
+
+## Login Page
+
+**DTO:** `LoginPageConfig`
+
+- `imageSource`: Structured image descriptor (preferred).
+- `picture` *(deprecated)*: Raw string path/URL for the logo/picture.
+- `scale`: Optional scale factor for the picture.
+- `labelColor`: HEX/ARGB color for labels.
+- `modeSelect`: `LoginModeSelectPageConfig`
+  - `systemUiOverlayStyle`: Status/navigation bars appearance.
+  - `buttonLoginStyleType`: Enum preset for the Login button.
+  - `buttonSignupStyleType`: Enum preset for the Signup button.
+- `metadata`: `Metadata` block with arbitrary structured info.
+
+**Minimal example:**
+
+```json
+{
+  "login": {
+    "imageSource": { "asset": "assets/branding/logo.png" },
+    "labelColor": "#30302F",
+    "modeSelect": {
+      "systemUiOverlayStyle": {
+        "statusBarIconBrightness": "dark",
+        "systemNavigationBarIconBrightness": "dark"
+      },
+      "buttonLoginStyleType": "primary",
+      "buttonSignupStyleType": "primary"
+    },
+    "metadata": {}
+  }
+}
+```
+
+---
+
+## About Page
+
+**DTO:** `AboutPageConfig`
+
+- `imageSource`: Structured image source (preferred).
+- `picture` *(deprecated)*: Raw string path/URL.
+- `metadata`: Arbitrary structured info (e.g., version/build).
+
+**Minimal example:**
+
+```json
+{
+  "about": {
+    "imageSource": { "asset": "assets/branding/about.png" },
+    "metadata": {}
+  }
+}
+```
+
+---
+
+## Call Page (Dialing)
+
+**DTO:** `CallPageConfig`
+
+- `systemUiOverlayStyle`: Controls status & navigation bars.
+- `appBarStyle`: See [App Bar](#app-bar).
+- `callInfo`: See [Call Info](#call-info).
+- `actions`: See [Call Actions](#call-actions).
+
+A compact example:
+
+```json
+{
+  "dialing": {
     "systemUiOverlayStyle": {
-      "statusBarColor": "#0A0A0A",
       "statusBarIconBrightness": "dark",
-      "systemNavigationBarColor": "#0A0A0A",
-      "systemNavigationBarIconBrightness": "dark"
+      "statusBarBrightness": "light",
+      "systemNavigationBarColor": "#000000",
+      "systemNavigationBarIconBrightness": "light"
     },
-    "buttonLoginStyleType": "neutralOnDark",
-    "buttonSignupStyleType": "neutralOnDark"
-  },
-  "metadata": {}
+    "appBarStyle": {
+      "backgroundColor": null,
+      "foregroundColor": null,
+      "primary": false
+    },
+    "callInfo": {
+      "usernameTextStyle": { "fontSize": 36, "fontWeight": { "weight": 400 }, "color": "#FFFFFF" },
+      "numberTextStyle":   { "fontSize": 16, "fontWeight": { "weight": 400 }, "color": "#EEF3F6" },
+      "callStatusTextStyle": {
+        "fontSize": 14,
+        "fontWeight": { "weight": 400 },
+        "color": "#EEF3F6",
+        "fontFeatures": ["tabularFigures"]
+      },
+      "processingStatusTextStyle": {
+        "fontSize": 14,
+        "fontWeight": { "weight": 500 },
+        "color": "#EEF3F6"
+      }
+    },
+    "actions": { /* see examples below */ }
+  }
 }
 ```
 
----
+### App Bar
 
-### About Page
+**DTO:** `AppBarStyleConfig`
 
-The about page configuration includes:
+- `backgroundColor`: HEX/ARGB.
+- `foregroundColor`: HEX/ARGB.
+- `primary`: Whether the AppBar is “primary” (app-level) or page-overlay.
+- `showBackButton` *(if present in your build)*: Toggles the back chevron.
 
-- `picture`: URL or asset reference for the about page image
-- `metadata`: Additional metadata for customization
+### Call Info
 
-**Example Configuration:**
+**DTO:** `CallPageInfoConfig`
 
-```json
-{
-  "picture": "asset://assets/about_background.png",
-  "metadata": {}
-}
+- `usernameTextStyle`: `TextStyleConfig` for the main name (e.g. *displaySmall*).
+- `numberTextStyle`: Secondary line for the phone number.
+- `callStatusTextStyle`: Status (e.g., duration / incoming).
+- `processingStatusTextStyle`: For ongoing operations (e.g., “Transferring…”).
+
+### Call Actions
+
+**IMPORTANT: Nesting & placement**  
+`actions` is **not** a top-level object. It is a child of the **Call Page** (Dialing) configuration:
+
+```
+ThemePageConfig.dialing.actions  // i.e. CallPageConfig.actions
 ```
 
----
-
-### Call Page (Dialing)
-
-The call page configuration includes:
-
-- `systemUiOverlayStyle`: Controls status and navigation bar styling
-    - `statusBarColor`: Background color of the status bar
-    - `statusBarIconBrightness`: Brightness of status bar icons (`dark` | `light`)
-    - `systemNavigationBarColor`: Background color of navigation bar
-    - `systemNavigationBarIconBrightness`: Brightness of nav bar icons (`dark` | `light`)
-- `appBarStyle`: Configures the appearance of the App Bar during a call
-    - `backgroundColor`: Background color of the App Bar (hex format)
-    - `foregroundColor`: Color for icons and text in the App Bar (hex format)
-- `callInfo`: Styling for call information text
-    - `usernameTextStyle`: Text style for username
-    - `numberTextStyle`: Text style for phone number
-    - `callStatusTextStyle`: Text style for call status
-    - `processingStatusTextStyle`: Text style for processing status
-
-**Example Configuration:**
+**Correct JSON placement:**
 
 ```json
 {
-  "systemUiOverlayStyle": {
-    "statusBarColor": "#0A0A0A",
-    "statusBarIconBrightness": "dark",
-    "systemNavigationBarColor": "#0A0A0A",
-    "systemNavigationBarIconBrightness": "dark"
-  },
-  "appBarStyle": {
-    "backgroundColor": "#00000000",
-    "foregroundColor": "#EEF3F6"
-  },
-  "callInfo": {
-    "usernameTextStyle": {
-      "fontSize": 36,
-      "fontWeight": {
-        "weight": 400
-      },
-      "color": "#FFFFFF"
-    },
-    "numberTextStyle": {
-      "fontSize": 16,
-      "fontWeight": {
-        "weight": 400
-      },
-      "color": "#EEF3F6"
-    },
-    "callStatusTextStyle": {
-      "fontSize": 14,
-      "fontWeight": {
-        "weight": 400
-      },
-      "color": "#EEF3F6",
-      "fontFeatures": [
-        "tabularFigures"
-      ]
-    },
-    "processingStatusTextStyle": {
-      "fontSize": 14,
-      "fontWeight": {
-        "weight": 500
-      },
-      "color": "#EEF3F6"
+  "dialing": {
+    "actions": {
+      "callStart": { /* ElevatedButtonWidgetConfig */ },
+      "hangup":    { /* ... */ },
+      "transfer":  { /* ... */ },
+      "camera":    { /* ... */ },
+      "muted":     { /* ... */ },
+      "speaker":   { /* ... */ },
+      "held":      { /* ... */ },
+      "swap":      { /* ... */ },
+      "key":       { /* ... */ }
     }
   }
 }
 ```
+
+**DTOs:**
+- `CallPageActionsConfig` contains those fields.
+- Each field is an `ElevatedButtonWidgetConfig` with:
+  - `backgroundColor`: Button fill (HEX/ARGB).
+  - `foregroundColor`: Icon/text tint for enabled state.
+  - `textColor`: Optional explicit text color (fallbacks to `foregroundColor`).
+  - `iconColor`: Icon tint for enabled state.
+  - `disabledIconColor`: Icon tint for disabled state.
+  - `disabledBackgroundColor`: Fill when disabled.
+  - `disabledForegroundColor`: Tint when disabled.
+
+> **State handling:** Toggle-like actions (camera/muted/speaker/held) can switch appearance when `MaterialState.selected` is active. In app code, this is wired via `MaterialStatesController` and `ButtonStyle` resolvers.
+
+#### Alpha-driven “glassy” look (recommended)
+For semi-transparent circular buttons that blend with a gradient background, use ARGB:
+- Normal state: e.g., `"#66FFFFFF"` (≈40% opacity).
+- Disabled: e.g., `"#26FFFFFF"` (≈15% opacity).
+
+### Light & Dark examples for `actions`
+
+> **Note:** both examples are shown **inside** `dialing` to emphasize the correct nesting.
+
+**Light theme example (glassy neutral actions):**
+
+```json
+{
+  "dialing": {
+    "actions": {
+      "callStart": { "backgroundColor": "#75B943", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#DDE0E3",
+        "disabledForegroundColor": "#848581", "disabledIconColor": "#848581" },
+      "hangup":    { "backgroundColor": "#E74C3C", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#DDE0E3",
+        "disabledForegroundColor": "#848581", "disabledIconColor": "#848581" },
+      "transfer":  { "backgroundColor": "#123752", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#DDE0E3",
+        "disabledForegroundColor": "#848581", "disabledIconColor": "#848581" },
+
+      "camera":  { "backgroundColor": "#66FFFFFF", "foregroundColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF", "disabledBackgroundColor": "#26FFFFFF",
+        "disabledForegroundColor": "#FF848581", "disabledIconColor": "#FF848581" },
+      "muted":   { "backgroundColor": "#66FFFFFF", "foregroundColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF", "disabledBackgroundColor": "#26FFFFFF",
+        "disabledForegroundColor": "#FF848581", "disabledIconColor": "#FF848581" },
+      "speaker": { "backgroundColor": "#66FFFFFF", "foregroundColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF", "disabledBackgroundColor": "#26FFFFFF",
+        "disabledForegroundColor": "#FF848581", "disabledIconColor": "#FF848581" },
+      "held":    { "backgroundColor": "#66FFFFFF", "foregroundColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF", "disabledBackgroundColor": "#26FFFFFF",
+        "disabledForegroundColor": "#FF848581", "disabledIconColor": "#FF848581" },
+      "swap":    { "backgroundColor": "#66FFFFFF", "foregroundColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF", "disabledBackgroundColor": "#26FFFFFF",
+        "disabledForegroundColor": "#FF848581", "disabledIconColor": "#FF848581" },
+      "key":     { "backgroundColor": "#66FFFFFF", "foregroundColor": "#FFFFFFFF",
+        "iconColor": "#FFFFFFFF", "disabledBackgroundColor": "#26FFFFFF",
+        "disabledForegroundColor": "#FF848581", "disabledIconColor": "#FF848581" }
+    }
+  }
+}
+```
+
+**Dark theme example:**
+
+```json
+{
+  "dialing": {
+    "actions": {
+      "callStart": { "backgroundColor": "#34C759", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#3A3A3A",
+        "disabledForegroundColor": "#9E9E9E", "disabledIconColor": "#9E9E9E" },
+      "hangup":    { "backgroundColor": "#FF3B30", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#3A3A3A",
+        "disabledForegroundColor": "#9E9E9E", "disabledIconColor": "#9E9E9E" },
+      "transfer":  { "backgroundColor": "#2E7D32", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#3A3A3A",
+        "disabledForegroundColor": "#9E9E9E", "disabledIconColor": "#9E9E9E" },
+
+      "camera":  { "backgroundColor": "#2A2A2A", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#1F1F1F",
+        "disabledForegroundColor": "#6D6D6D", "disabledIconColor": "#9E9E9E" },
+      "muted":   { "backgroundColor": "#2A2A2A", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#1F1F1F",
+        "disabledForegroundColor": "#6D6D6D", "disabledIconColor": "#9E9E9E" },
+      "speaker": { "backgroundColor": "#2A2A2A", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#1F1F1F",
+        "disabledForegroundColor": "#6D6D6D", "disabledIconColor": "#9E9E9E" },
+      "held":    { "backgroundColor": "#2A2A2A", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#1F1F1F",
+        "disabledForegroundColor": "#6D6D6D", "disabledIconColor": "#9E9E9E" },
+      "swap":    { "backgroundColor": "#2A2A2A", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#1F1F1F",
+        "disabledForegroundColor": "#6D6D6D", "disabledIconColor": "#9E9E9E" },
+      "key":     { "backgroundColor": "#2A2A2A", "foregroundColor": "#FFFFFF",
+        "iconColor": "#FFFFFF", "disabledBackgroundColor": "#1F1F1F",
+        "disabledForegroundColor": "#6D6D6D", "disabledIconColor": "#9E9E9E" }
+    }
+  }
+}
+```
+
+---
+
+## Keypad Page
+
+**DTO:** `KeypadPageConfig`
+
+- `systemUiOverlayStyle`: Status/navigation bars appearance.
+- `textField`: `TextFieldConfig` for the number input at the top.
+- `contactName`: `TextFieldConfig` for resolved contact name.
+- `keypad`: `KeypadStyleConfig` (digits grid, spacing, paddings).
+- `actionpad`: `ActionPadWidgetConfig` (call buttons, backspace, etc.).
+
+**Minimal example:**
+
+```json
+{
+  "keypad": {
+    "systemUiOverlayStyle": {
+      "statusBarIconBrightness": "dark"
+    },
+    "textField": {
+      "textStyle": {
+        "color": "#123752",
+        "fontSize": 22
+      }
+    },
+    "contactName": {
+      "textStyle": {
+        "color": "#848581",
+        "fontSize": 14
+      }
+    },
+    "keypad": {
+      "spacing": 16
+    },
+    "actionpad": {}
+  }
+}
+```
+
+---
+
+### Notes & tips
+
+- `actions` must be nested under `dialing`. It is **not** a root-level section.
+- If `actions` are omitted for the Call page, the app falls back to theme defaults.
+- For toggle actions, ensure the widget sets `MaterialState.selected` (e.g., via `MaterialStatesController`) so the `ButtonStyle` resolvers can switch backgrounds and icon colors.
+- Keep disabled styles high-contrast enough to meet a11y guidelines on both light and dark backgrounds.

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -193,6 +193,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                         callStatus: widget.callStatus,
                                       ),
                                     CallActions(
+                                      style: style?.actions,
                                       enableInteractions: widget.callStatus == CallStatus.ready,
                                       isIncoming: activeCall.isIncoming,
                                       remoteVideo: activeCall.remoteVideo,

--- a/lib/features/call/view/call_screen_style.dart
+++ b/lib/features/call/view/call_screen_style.dart
@@ -9,11 +9,13 @@ class CallScreenStyle with Diagnosticable {
     this.systemUiOverlayStyle,
     this.appBar,
     this.callInfo,
+    this.actions,
   });
 
   final SystemUiOverlayStyle? systemUiOverlayStyle;
   final AppBarStyle? appBar;
   final CallInfoStyle? callInfo;
+  final CallScreenActionsStyle? actions;
 
   static CallScreenStyle? lerp(CallScreenStyle? a, CallScreenStyle? b, double t) {
     if (identical(a, b)) return a;
@@ -22,6 +24,7 @@ class CallScreenStyle with Diagnosticable {
       systemUiOverlayStyle: b?.systemUiOverlayStyle ?? a?.systemUiOverlayStyle,
       callInfo: CallInfoStyle.lerp(a?.callInfo, b?.callInfo, t),
       appBar: AppBarStyle.lerp(a?.appBar, b?.appBar, t),
+      actions: CallScreenActionsStyle.lerp(a?.actions, b?.actions, t),
     );
   }
 
@@ -31,7 +34,8 @@ class CallScreenStyle with Diagnosticable {
     properties
       ..add(DiagnosticsProperty<SystemUiOverlayStyle?>('systemUiOverlayStyle', systemUiOverlayStyle))
       ..add(DiagnosticsProperty<AppBarStyle?>('appBar', appBar))
-      ..add(DiagnosticsProperty<CallInfoStyle?>('callInfo', callInfo));
+      ..add(DiagnosticsProperty<CallInfoStyle?>('callInfo', callInfo))
+      ..add(DiagnosticsProperty<CallScreenActionsStyle?>('actions', actions));
   }
 }
 
@@ -70,5 +74,105 @@ class CallInfoStyle with Diagnosticable {
       ..add(DiagnosticsProperty<TextStyle?>('number', number))
       ..add(DiagnosticsProperty<TextStyle?>('callStatus', callStatus))
       ..add(DiagnosticsProperty<TextStyle?>('processingStatus', processingStatus));
+  }
+}
+
+class CallScreenActionsStyle with Diagnosticable {
+  const CallScreenActionsStyle({
+    this.callStart,
+    this.hangup,
+    this.transfer,
+    this.camera,
+    this.muted,
+    this.speaker,
+    this.held,
+    this.swap,
+    this.key,
+  });
+
+  final ButtonStyle? callStart;
+  final ButtonStyle? hangup;
+  final ButtonStyle? transfer;
+  final ButtonStyle? camera;
+  final ButtonStyle? muted;
+  final ButtonStyle? speaker;
+  final ButtonStyle? held;
+  final ButtonStyle? swap;
+  final ButtonStyle? key;
+
+  CallScreenActionsStyle copyWith({
+    ButtonStyle? callStart,
+    ButtonStyle? hangup,
+    ButtonStyle? transfer,
+    ButtonStyle? camera,
+    ButtonStyle? muted,
+    ButtonStyle? speaker,
+    ButtonStyle? held,
+    ButtonStyle? swap,
+    ButtonStyle? key,
+  }) {
+    return CallScreenActionsStyle(
+      callStart: callStart ?? this.callStart,
+      hangup: hangup ?? this.hangup,
+      transfer: transfer ?? this.transfer,
+      camera: camera ?? this.camera,
+      muted: muted ?? this.muted,
+      speaker: speaker ?? this.speaker,
+      held: held ?? this.held,
+      swap: swap ?? this.swap,
+      key: key ?? this.key,
+    );
+  }
+
+  /// Field-wise merge. `other` overrides non-null ButtonStyle parts.
+  CallScreenActionsStyle merge(CallScreenActionsStyle? other) {
+    if (other == null) return this;
+
+    ButtonStyle? mergeButtonStyle(ButtonStyle? a, ButtonStyle? b) {
+      if (a == null) return b;
+      return a.merge(b);
+    }
+
+    return CallScreenActionsStyle(
+      callStart: mergeButtonStyle(callStart, other.callStart),
+      hangup: mergeButtonStyle(hangup, other.hangup),
+      transfer: mergeButtonStyle(transfer, other.transfer),
+      camera: mergeButtonStyle(camera, other.camera),
+      muted: mergeButtonStyle(muted, other.muted),
+      speaker: mergeButtonStyle(speaker, other.speaker),
+      held: mergeButtonStyle(held, other.held),
+      swap: mergeButtonStyle(swap, other.swap),
+      key: mergeButtonStyle(key, other.key),
+    );
+  }
+
+  static CallScreenActionsStyle? lerp(CallScreenActionsStyle? a, CallScreenActionsStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return CallScreenActionsStyle(
+      callStart: ButtonStyle.lerp(a?.callStart, b?.callStart, t),
+      hangup: ButtonStyle.lerp(a?.hangup, b?.hangup, t),
+      transfer: ButtonStyle.lerp(a?.transfer, b?.transfer, t),
+      camera: ButtonStyle.lerp(a?.camera, b?.camera, t),
+      muted: ButtonStyle.lerp(a?.muted, b?.muted, t),
+      speaker: ButtonStyle.lerp(a?.speaker, b?.speaker, t),
+      held: ButtonStyle.lerp(a?.held, b?.held, t),
+      swap: ButtonStyle.lerp(a?.swap, b?.swap, t),
+      key: ButtonStyle.lerp(a?.key, b?.key, t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty<ButtonStyle?>('callStart', callStart))
+      ..add(DiagnosticsProperty<ButtonStyle?>('hangup', hangup))
+      ..add(DiagnosticsProperty<ButtonStyle?>('transfer', transfer))
+      ..add(DiagnosticsProperty<ButtonStyle?>('camera', camera))
+      ..add(DiagnosticsProperty<ButtonStyle?>('muted', muted))
+      ..add(DiagnosticsProperty<ButtonStyle?>('speaker', speaker))
+      ..add(DiagnosticsProperty<ButtonStyle?>('held', held))
+      ..add(DiagnosticsProperty<ButtonStyle?>('swap', swap))
+      ..add(DiagnosticsProperty<ButtonStyle?>('key', key));
   }
 }

--- a/lib/theme/factory/styles/call_actions_style_factory.dart
+++ b/lib/theme/factory/styles/call_actions_style_factory.dart
@@ -5,6 +5,7 @@ import 'package:webtrit_phone/theme/theme.dart';
 
 import '../theme_style_factory.dart';
 
+@Deprecated('Use CallScreenStyleFactory instead')
 class CallActionsStyleFactory implements ThemeStyleFactory<CallActionsStyles> {
   CallActionsStyleFactory(this.colors, this.config);
 

--- a/lib/theme/factory/styles/call_screen_style_factory.dart
+++ b/lib/theme/factory/styles/call_screen_style_factory.dart
@@ -7,44 +7,68 @@ import 'package:webtrit_phone/theme/extension/extension.dart';
 import '../../styles/styles.dart';
 import '../theme_style_factory.dart';
 
-class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
-  CallScreenStyleFactory(this.config, this.colors);
+const double kDisabledOpacity = 0.40;
 
-  final CallPageConfig? config;
+class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
+  CallScreenStyleFactory(
+    this.colors,
+    this.pageConfig,
+    this.legacyCallActionsConfig,
+  );
+
   final ColorScheme colors;
+  final CallPageConfig? pageConfig;
+
+  // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+  // ignore: deprecated_member_use
+  final CallActionsWidgetConfig? legacyCallActionsConfig;
 
   @override
   CallScreenStyles create() {
-    final appBarConfig = config?.appBarStyle;
-    final infoConfig = config?.callInfo;
+    final appBarCfg = pageConfig?.appBarStyle;
+    final infoCfg = pageConfig?.callInfo;
 
     return CallScreenStyles(
       primary: CallScreenStyle(
-        appBar: _toAppBarStyle(appBarConfig),
-        systemUiOverlayStyle: config?.systemUiOverlayStyle?.toSystemUiOverlayStyle(),
-        callInfo: _toCallScreenStyle(infoConfig),
+        systemUiOverlayStyle: pageConfig?.systemUiOverlayStyle?.toSystemUiOverlayStyle(),
+        appBar: _mapAppBarStyle(appBarCfg),
+        callInfo: _mapCallInfoStyle(infoCfg),
+        actions: _resolveActionsStyle(
+          fromPage: pageConfig?.actions,
+          fromLegacy: legacyCallActionsConfig,
+        ),
       ),
     );
   }
 
-  CallInfoStyle? _toCallScreenStyle(CallPageInfoConfig? cfg) {
+  AppBarStyle _mapAppBarStyle(AppBarStyleConfig? cfg) {
+    return AppBarStyle(
+      backgroundColor: cfg?.backgroundColor?.toColor() ?? Colors.transparent,
+      foregroundColor: cfg?.foregroundColor?.toColor() ?? colors.surface,
+      primary: false,
+      showBackButton: true,
+    );
+  }
+
+  CallInfoStyle? _mapCallInfoStyle(CallPageInfoConfig? cfg) {
+    if (cfg == null) return null;
     return CallInfoStyle(
-      userInfo: cfg?.usernameTextStyle?.toTextStyle(
+      userInfo: cfg.usernameTextStyle?.toTextStyle(
         fallbackColor: colors.surface,
         defaultFontSize: 24,
         defaultFontWeight: FontWeight.w400,
       ),
-      number: cfg?.numberTextStyle?.toTextStyle(
+      number: cfg.numberTextStyle?.toTextStyle(
         fallbackColor: colors.surface,
         defaultFontSize: 20,
         defaultFontWeight: FontWeight.w400,
       ),
-      callStatus: cfg?.callStatusTextStyle?.toTextStyle(
+      callStatus: cfg.callStatusTextStyle?.toTextStyle(
         fallbackColor: colors.surface,
         defaultFontSize: 16,
         defaultFontWeight: FontWeight.w400,
       ),
-      processingStatus: cfg?.processingStatusTextStyle?.toTextStyle(
+      processingStatus: cfg.processingStatusTextStyle?.toTextStyle(
         fallbackColor: colors.surface,
         defaultFontSize: 14,
         defaultFontWeight: FontWeight.w500,
@@ -52,12 +76,318 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
     );
   }
 
-  AppBarStyle? _toAppBarStyle(AppBarStyleConfig? cfg) {
-    return AppBarStyle(
-      backgroundColor: cfg?.backgroundColor?.toColor() ?? Colors.transparent,
-      foregroundColor: cfg?.foregroundColor?.toColor() ?? colors.surface,
-      primary: false,
-      showBackButton: true,
+  CallScreenActionsStyle? _resolveActionsStyle({
+    CallPageActionsConfig? fromPage,
+    // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+    // ignore: deprecated_member_use
+    CallActionsWidgetConfig? fromLegacy,
+  }) {
+    if (fromPage != null) return _mapActionsFromPage(fromPage);
+    if (fromLegacy != null) return _mapActionsFromLegacy(fromLegacy);
+    return null;
+  }
+
+  CallScreenActionsStyle _mapActionsFromPage(CallPageActionsConfig a) {
+    return CallScreenActionsStyle(
+      callStart: buildFixedButtonStyle(
+        a.callStart,
+        colors: colors,
+        fg: colors.onTertiary,
+        bg: colors.tertiary,
+        icon: colors.surface,
+      ),
+      hangup: buildFixedButtonStyle(
+        a.hangup,
+        colors: colors,
+        fg: colors.onError,
+        bg: colors.error,
+        icon: colors.surface,
+      ),
+      transfer: buildFixedButtonStyle(
+        a.transfer,
+        colors: colors,
+        fg: colors.onSecondary,
+        bg: colors.secondary,
+        icon: colors.surface,
+      ),
+      swap: buildFixedButtonStyle(
+        a.swap,
+        colors: colors,
+        fg: colors.onSurface,
+        bg: colors.surfaceContainerHigh,
+        icon: colors.onSurface,
+      ),
+      key: buildFixedButtonStyle(
+        a.key,
+        colors: colors,
+        fg: colors.onSurface,
+        bg: colors.surfaceContainer,
+        icon: colors.onSurface,
+      ),
+      camera: buildToggleButtonStyle(
+        a.camera,
+        colors: colors,
+        baseFg: colors.onSurface,
+        baseBg: colors.surfaceContainerHighest,
+        baseIcon: colors.onSurface,
+      ),
+      muted: buildToggleButtonStyle(
+        a.muted,
+        colors: colors,
+        baseFg: colors.onSurface,
+        baseBg: colors.surfaceContainerHigh,
+        baseIcon: colors.onSurface,
+      ),
+      speaker: buildToggleButtonStyle(
+        a.speaker,
+        colors: colors,
+        baseFg: colors.onSurface,
+        baseBg: colors.surfaceContainerHigh,
+        baseIcon: colors.onSurface,
+      ),
+      held: buildToggleButtonStyle(
+        a.held,
+        colors: colors,
+        baseFg: colors.onSurface,
+        baseBg: colors.surfaceContainerHigh,
+        baseIcon: colors.onSurface,
+      ),
+    );
+  }
+
+  // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+  // ignore: deprecated_member_use
+  CallScreenActionsStyle _mapActionsFromLegacy(CallActionsWidgetConfig c) {
+    final inactiveIcon = colors.surface;
+    final activeIcon = colors.onSecondaryFixedVariant;
+
+    final actionBg = colors.surface.withValues(alpha: kDisabledOpacity);
+    final activeActionBg = colors.surface;
+
+    final callStartBg = c.callStartBackgroundColor?.toColor() ?? colors.tertiary;
+    final hangupBg = c.hangupBackgroundColor?.toColor() ?? colors.error;
+    final transferBg = c.transferBackgroundColor?.toColor() ?? actionBg;
+
+    final cameraBg = c.cameraBackgroundColor?.toColor() ?? actionBg;
+    final cameraActiveBg = c.cameraActiveBackgroundColor?.toColor() ?? activeActionBg;
+
+    final mutedBg = c.mutedBackgroundColor?.toColor() ?? actionBg;
+    final mutedActiveBg = c.mutedActiveBackgroundColor?.toColor() ?? activeActionBg;
+
+    final speakerBg = c.speakerBackgroundColor?.toColor() ?? actionBg;
+    final speakerActiveBg = c.speakerActiveBackgroundColor?.toColor() ?? activeActionBg;
+
+    final heldBg = c.heldBackgroundColor?.toColor() ?? actionBg;
+    final heldActiveBg = c.heldActiveBackgroundColor?.toColor() ?? activeActionBg;
+
+    final swapBg = c.swapBackgroundColor?.toColor() ?? actionBg;
+    final keyBg = c.keyBackgroundColor?.toColor() ?? actionBg;
+
+    return CallScreenActionsStyle(
+      callStart: buildFilledLikeStyle(
+        colors: colors,
+        fg: colors.onTertiary,
+        bg: callStartBg,
+        icon: inactiveIcon,
+      ),
+      hangup: buildFilledLikeStyle(
+        colors: colors,
+        fg: colors.onError,
+        bg: hangupBg,
+        icon: inactiveIcon,
+      ),
+      transfer: buildFilledLikeStyle(
+        colors: colors,
+        fg: colors.onSecondary,
+        bg: transferBg,
+        icon: inactiveIcon,
+      ),
+      camera: buildToggleLikeStyle(
+        colors: colors,
+        bg: cameraBg,
+        activeBg: cameraActiveBg,
+        icon: inactiveIcon,
+        activeIcon: activeIcon,
+        fg: colors.surface,
+        activeFg: colors.onSurface,
+      ),
+      muted: buildToggleLikeStyle(
+        colors: colors,
+        bg: mutedBg,
+        activeBg: mutedActiveBg,
+        icon: inactiveIcon,
+        activeIcon: activeIcon,
+        fg: colors.surface,
+        activeFg: colors.onSurface,
+      ),
+      speaker: buildToggleLikeStyle(
+        colors: colors,
+        bg: speakerBg,
+        activeBg: speakerActiveBg,
+        icon: inactiveIcon,
+        activeIcon: activeIcon,
+        fg: colors.surface,
+        activeFg: colors.onSurface,
+      ),
+      held: buildToggleLikeStyle(
+        colors: colors,
+        bg: heldBg,
+        activeBg: heldActiveBg,
+        icon: inactiveIcon,
+        activeIcon: activeIcon,
+        fg: colors.surface,
+        activeFg: colors.onSurface,
+      ),
+      swap: buildFilledLikeStyle(
+        colors: colors,
+        fg: colors.surface,
+        bg: swapBg,
+        icon: inactiveIcon,
+      ),
+      key: buildFilledLikeStyle(
+        colors: colors,
+        fg: colors.surface,
+        bg: keyBg,
+        icon: inactiveIcon,
+      ),
+    );
+  }
+
+  ButtonStyle buildFixedButtonStyle(
+    ElevatedButtonWidgetConfig cfg, {
+    required ColorScheme colors,
+    required Color fg,
+    required Color bg,
+    required Color icon,
+    EdgeInsetsGeometry padding = EdgeInsets.zero,
+  }) {
+    final resolvedFg = cfg.foregroundColor?.toColor() ?? fg;
+    final resolvedFgDisabled = cfg.disabledForegroundColor?.toColor() ?? resolvedFg.withValues(alpha: kDisabledOpacity);
+
+    final resolvedBg = cfg.backgroundColor?.toColor() ?? bg;
+    final resolvedBgDisabled = cfg.disabledBackgroundColor?.toColor() ?? resolvedBg.withValues(alpha: kDisabledOpacity);
+
+    final resolvedIcon = cfg.iconColor?.toColor() ?? icon;
+    final resolvedIconDisabled = cfg.disabledIconColor?.toColor() ?? colors.surface.withValues(alpha: kDisabledOpacity);
+
+    final base = TextButton.styleFrom(
+      foregroundColor: resolvedFg,
+      backgroundColor: resolvedBg,
+      disabledForegroundColor: resolvedFgDisabled,
+      iconColor: resolvedIcon,
+      disabledIconColor: resolvedIconDisabled,
+      padding: padding,
+    );
+
+    return base.copyWith(
+      backgroundColor: WidgetStateProperty.resolveWith<Color?>(
+        (states) => states.contains(WidgetState.disabled) ? resolvedBgDisabled : resolvedBg,
+      ),
+    );
+  }
+
+  ButtonStyle buildToggleButtonStyle(
+    ElevatedButtonWidgetConfig cfg, {
+    required ColorScheme colors,
+    required Color baseFg,
+    required Color baseBg,
+    required Color baseIcon,
+    Color? activeFg,
+    Color? activeBg,
+    Color? activeIcon,
+    EdgeInsetsGeometry padding = EdgeInsets.zero,
+  }) {
+    final disFg = cfg.disabledForegroundColor?.toColor() ?? baseFg.withValues(alpha: kDisabledOpacity);
+    final disBg = cfg.disabledBackgroundColor?.toColor() ?? baseBg.withValues(alpha: kDisabledOpacity);
+    final disIcon = cfg.disabledIconColor?.toColor() ?? colors.surface.withValues(alpha: kDisabledOpacity);
+
+    final selFg = activeFg ?? colors.onSurface;
+    final selBg = activeBg ?? colors.surface;
+    final selIcon = activeIcon ?? colors.onSecondaryFixedVariant;
+
+    Color? bg(Set<WidgetState> s) {
+      if (s.contains(WidgetState.disabled)) return disBg;
+      if (s.contains(WidgetState.selected)) return selBg;
+      return cfg.backgroundColor?.toColor() ?? baseBg;
+    }
+
+    Color? fg(Set<WidgetState> s) {
+      if (s.contains(WidgetState.disabled)) return disFg;
+      if (s.contains(WidgetState.selected)) return selFg;
+      return cfg.foregroundColor?.toColor() ?? baseFg;
+    }
+
+    Color? ic(Set<WidgetState> s) {
+      if (s.contains(WidgetState.disabled)) return disIcon;
+      if (s.contains(WidgetState.selected)) return selIcon;
+      return cfg.iconColor?.toColor() ?? baseIcon;
+    }
+
+    return ButtonStyle(
+      backgroundColor: WidgetStateProperty.resolveWith(bg),
+      foregroundColor: WidgetStateProperty.resolveWith(fg),
+      iconColor: WidgetStateProperty.resolveWith(ic),
+      padding: WidgetStatePropertyAll(padding),
+    );
+  }
+
+  ButtonStyle buildFilledLikeStyle({
+    required ColorScheme colors,
+    required Color fg,
+    required Color bg,
+    required Color icon,
+    EdgeInsetsGeometry padding = EdgeInsets.zero,
+  }) {
+    return TextButton.styleFrom(
+      foregroundColor: fg,
+      backgroundColor: bg,
+      disabledForegroundColor: fg.withValues(alpha: kDisabledOpacity),
+      iconColor: icon,
+      disabledIconColor: colors.surface.withValues(alpha: kDisabledOpacity),
+      padding: padding,
+    );
+  }
+
+  ButtonStyle buildToggleLikeStyle({
+    required ColorScheme colors,
+    required Color bg,
+    required Color activeBg,
+    required Color icon,
+    required Color activeIcon,
+    required Color fg,
+    required Color activeFg,
+    EdgeInsetsGeometry padding = EdgeInsets.zero,
+    Color? disabledBackground,
+    Color? disabledForeground,
+    Color? disabledIcon,
+  }) {
+    final disabledBg = disabledBackground ?? bg.withValues(alpha: kDisabledOpacity);
+    final disabledFg = disabledForeground ?? fg.withValues(alpha: kDisabledOpacity);
+    final disabledIcon0 = disabledIcon ?? icon.withValues(alpha: kDisabledOpacity);
+
+    Color? resolveBg(Set<WidgetState> s) {
+      if (s.contains(WidgetState.disabled)) return disabledBg;
+      if (s.contains(WidgetState.selected)) return activeBg;
+      return bg;
+    }
+
+    Color? resolveFg(Set<WidgetState> s) {
+      if (s.contains(WidgetState.disabled)) return disabledFg;
+      if (s.contains(WidgetState.selected)) return activeFg;
+      return fg;
+    }
+
+    Color? resolveIcon(Set<WidgetState> s) {
+      if (s.contains(WidgetState.disabled)) return disabledIcon0;
+      if (s.contains(WidgetState.selected)) return activeIcon;
+      return icon;
+    }
+
+    return ButtonStyle(
+      backgroundColor: WidgetStateProperty.resolveWith(resolveBg),
+      foregroundColor: WidgetStateProperty.resolveWith(resolveFg),
+      iconColor: WidgetStateProperty.resolveWith(resolveIcon),
+      padding: WidgetStatePropertyAll(padding),
     );
   }
 }

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -53,6 +53,8 @@ class ThemeStyleFactoryProvider {
     final callStatusStyleFactory = CallStatusStyleFactory(colorScheme, callStatuses);
     final elevatedButtonStyleFactory = ElevatedButtonStyleFactory(colorScheme, elevatedButton);
     final textButtonStyleFactory = TextButtonStyleFactory(colorScheme);
+    // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+    // ignore: deprecated_member_use_from_same_package
     final callActionsStyleFactory = CallActionsStyleFactory(colorScheme, callActions);
     final linkifyStyleFactory = LinkifyStyleFactory(colorScheme, linkify);
     final logoAssetStyleFactory = LogoAssetsFactory(imageAssetsConfig);
@@ -72,7 +74,7 @@ class ThemeStyleFactoryProvider {
 
     // Screen-specific styles
     final aboutScreenStyleFactory = AboutScreenStyleFactory(loginPageScheme);
-    final callScreenStyleFactory = CallScreenStyleFactory(callPageScheme, colorScheme);
+    final callScreenStyleFactory = CallScreenStyleFactory(colorScheme, callPageScheme, callActions);
     final keypadScreenStyleFactory =
         KeypadScreenStyleFactory(colorScheme, config: pageConfig.keypad, textTheme: createTextTheme());
 

--- a/lib/theme/styles/app_bar_style.dart
+++ b/lib/theme/styles/app_bar_style.dart
@@ -14,6 +14,31 @@ class AppBarStyle with Diagnosticable {
   final bool primary;
   final bool showBackButton;
 
+  /// Shallow updates; null keeps current value.
+  AppBarStyle copyWith({
+    Color? backgroundColor,
+    Color? foregroundColor,
+    bool? primary,
+    bool? showBackButton,
+  }) {
+    return AppBarStyle(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      foregroundColor: foregroundColor ?? this.foregroundColor,
+      primary: primary ?? this.primary,
+      showBackButton: showBackButton ?? this.showBackButton,
+    );
+  }
+
+  AppBarStyle merge(AppBarStyle? other) {
+    if (other == null) return this;
+    return AppBarStyle(
+      backgroundColor: other.backgroundColor ?? backgroundColor,
+      foregroundColor: other.foregroundColor ?? foregroundColor,
+      primary: other.primary,
+      showBackButton: other.showBackButton,
+    );
+  }
+
   static AppBarStyle? lerp(AppBarStyle? a, AppBarStyle? b, double t) {
     if (identical(a, b)) return a;
     if (a == null && b == null) return null;
@@ -34,4 +59,21 @@ class AppBarStyle with Diagnosticable {
       ..add(FlagProperty('primary', value: primary, ifTrue: 'primary'))
       ..add(FlagProperty('showBackButton', value: showBackButton, ifTrue: 'showBackButton'));
   }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AppBarStyle &&
+        other.backgroundColor == backgroundColor &&
+        other.foregroundColor == foregroundColor &&
+        other.primary == primary &&
+        other.showBackButton == showBackButton;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        backgroundColor,
+        foregroundColor,
+        primary,
+        showBackButton,
+      );
 }

--- a/packages/webtrit_appearance_theme/analysis_options.yaml
+++ b/packages/webtrit_appearance_theme/analysis_options.yaml
@@ -9,3 +9,4 @@ analyzer:
     invalid_annotation_target: ignore
   exclude:
     - "**/*.g.dart"
+    - "**/*.freezed.dart"

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -142,9 +142,30 @@ class CallPageConfig with _$CallPageConfig {
 
     /// Style configuration for the call information area (username, number, status).
     CallPageInfoConfig? callInfo,
+
+    /// Style configuration for the action buttons area (call, hangup, mute, etc).
+    CallPageActionsConfig? actions,
   }) = _CallPageConfig;
 
   factory CallPageConfig.fromJson(Map<String, dynamic> json) => _$CallPageConfigFromJson(json);
+}
+
+@Freezed()
+class CallPageActionsConfig with _$CallPageActionsConfig {
+  @JsonSerializable(explicitToJson: true)
+  const factory CallPageActionsConfig({
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig callStart,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig hangup,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig transfer,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig camera,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig muted,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig speaker,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig held,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig swap,
+    @Default(ElevatedButtonWidgetConfig()) ElevatedButtonWidgetConfig key,
+  }) = _CallPageActionsConfig;
+
+  factory CallPageActionsConfig.fromJson(Map<String, dynamic> json) => _$CallPageActionsConfigFromJson(json);
 }
 
 /// Declarative configuration for the **Call Info section** on the call screen.

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -1125,6 +1125,9 @@ mixin _$CallPageConfig {
   /// Style configuration for the call information area (username, number, status).
   CallPageInfoConfig? get callInfo => throw _privateConstructorUsedError;
 
+  /// Style configuration for the action buttons area (call, hangup, mute, etc).
+  CallPageActionsConfig? get actions => throw _privateConstructorUsedError;
+
   /// Serializes this CallPageConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 
@@ -1144,11 +1147,13 @@ abstract class $CallPageConfigCopyWith<$Res> {
   $Res call(
       {OverlayStyleModel? systemUiOverlayStyle,
       AppBarStyleConfig? appBarStyle,
-      CallPageInfoConfig? callInfo});
+      CallPageInfoConfig? callInfo,
+      CallPageActionsConfig? actions});
 
   $OverlayStyleModelCopyWith<$Res>? get systemUiOverlayStyle;
   $AppBarStyleConfigCopyWith<$Res>? get appBarStyle;
   $CallPageInfoConfigCopyWith<$Res>? get callInfo;
+  $CallPageActionsConfigCopyWith<$Res>? get actions;
 }
 
 /// @nodoc
@@ -1169,6 +1174,7 @@ class _$CallPageConfigCopyWithImpl<$Res, $Val extends CallPageConfig>
     Object? systemUiOverlayStyle = freezed,
     Object? appBarStyle = freezed,
     Object? callInfo = freezed,
+    Object? actions = freezed,
   }) {
     return _then(_value.copyWith(
       systemUiOverlayStyle: freezed == systemUiOverlayStyle
@@ -1183,6 +1189,10 @@ class _$CallPageConfigCopyWithImpl<$Res, $Val extends CallPageConfig>
           ? _value.callInfo
           : callInfo // ignore: cast_nullable_to_non_nullable
               as CallPageInfoConfig?,
+      actions: freezed == actions
+          ? _value.actions
+          : actions // ignore: cast_nullable_to_non_nullable
+              as CallPageActionsConfig?,
     ) as $Val);
   }
 
@@ -1228,6 +1238,20 @@ class _$CallPageConfigCopyWithImpl<$Res, $Val extends CallPageConfig>
       return _then(_value.copyWith(callInfo: value) as $Val);
     });
   }
+
+  /// Create a copy of CallPageConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $CallPageActionsConfigCopyWith<$Res>? get actions {
+    if (_value.actions == null) {
+      return null;
+    }
+
+    return $CallPageActionsConfigCopyWith<$Res>(_value.actions!, (value) {
+      return _then(_value.copyWith(actions: value) as $Val);
+    });
+  }
 }
 
 /// @nodoc
@@ -1241,7 +1265,8 @@ abstract class _$$CallPageConfigImplCopyWith<$Res>
   $Res call(
       {OverlayStyleModel? systemUiOverlayStyle,
       AppBarStyleConfig? appBarStyle,
-      CallPageInfoConfig? callInfo});
+      CallPageInfoConfig? callInfo,
+      CallPageActionsConfig? actions});
 
   @override
   $OverlayStyleModelCopyWith<$Res>? get systemUiOverlayStyle;
@@ -1249,6 +1274,8 @@ abstract class _$$CallPageConfigImplCopyWith<$Res>
   $AppBarStyleConfigCopyWith<$Res>? get appBarStyle;
   @override
   $CallPageInfoConfigCopyWith<$Res>? get callInfo;
+  @override
+  $CallPageActionsConfigCopyWith<$Res>? get actions;
 }
 
 /// @nodoc
@@ -1267,6 +1294,7 @@ class __$$CallPageConfigImplCopyWithImpl<$Res>
     Object? systemUiOverlayStyle = freezed,
     Object? appBarStyle = freezed,
     Object? callInfo = freezed,
+    Object? actions = freezed,
   }) {
     return _then(_$CallPageConfigImpl(
       systemUiOverlayStyle: freezed == systemUiOverlayStyle
@@ -1281,6 +1309,10 @@ class __$$CallPageConfigImplCopyWithImpl<$Res>
           ? _value.callInfo
           : callInfo // ignore: cast_nullable_to_non_nullable
               as CallPageInfoConfig?,
+      actions: freezed == actions
+          ? _value.actions
+          : actions // ignore: cast_nullable_to_non_nullable
+              as CallPageActionsConfig?,
     ));
   }
 }
@@ -1290,7 +1322,10 @@ class __$$CallPageConfigImplCopyWithImpl<$Res>
 @JsonSerializable(explicitToJson: true)
 class _$CallPageConfigImpl implements _CallPageConfig {
   const _$CallPageConfigImpl(
-      {this.systemUiOverlayStyle, this.appBarStyle, this.callInfo});
+      {this.systemUiOverlayStyle,
+      this.appBarStyle,
+      this.callInfo,
+      this.actions});
 
   factory _$CallPageConfigImpl.fromJson(Map<String, dynamic> json) =>
       _$$CallPageConfigImplFromJson(json);
@@ -1307,9 +1342,13 @@ class _$CallPageConfigImpl implements _CallPageConfig {
   @override
   final CallPageInfoConfig? callInfo;
 
+  /// Style configuration for the action buttons area (call, hangup, mute, etc).
+  @override
+  final CallPageActionsConfig? actions;
+
   @override
   String toString() {
-    return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo)';
+    return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions)';
   }
 
   @override
@@ -1322,13 +1361,14 @@ class _$CallPageConfigImpl implements _CallPageConfig {
             (identical(other.appBarStyle, appBarStyle) ||
                 other.appBarStyle == appBarStyle) &&
             (identical(other.callInfo, callInfo) ||
-                other.callInfo == callInfo));
+                other.callInfo == callInfo) &&
+            (identical(other.actions, actions) || other.actions == actions));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, systemUiOverlayStyle, appBarStyle, callInfo);
+  int get hashCode => Object.hash(
+      runtimeType, systemUiOverlayStyle, appBarStyle, callInfo, actions);
 
   /// Create a copy of CallPageConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -1351,7 +1391,8 @@ abstract class _CallPageConfig implements CallPageConfig {
   const factory _CallPageConfig(
       {final OverlayStyleModel? systemUiOverlayStyle,
       final AppBarStyleConfig? appBarStyle,
-      final CallPageInfoConfig? callInfo}) = _$CallPageConfigImpl;
+      final CallPageInfoConfig? callInfo,
+      final CallPageActionsConfig? actions}) = _$CallPageConfigImpl;
 
   factory _CallPageConfig.fromJson(Map<String, dynamic> json) =
       _$CallPageConfigImpl.fromJson;
@@ -1368,12 +1409,467 @@ abstract class _CallPageConfig implements CallPageConfig {
   @override
   CallPageInfoConfig? get callInfo;
 
+  /// Style configuration for the action buttons area (call, hangup, mute, etc).
+  @override
+  CallPageActionsConfig? get actions;
+
   /// Create a copy of CallPageConfig
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CallPageConfigImplCopyWith<_$CallPageConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+CallPageActionsConfig _$CallPageActionsConfigFromJson(
+    Map<String, dynamic> json) {
+  return _CallPageActionsConfig.fromJson(json);
+}
+
+/// @nodoc
+mixin _$CallPageActionsConfig {
+  ElevatedButtonWidgetConfig get callStart =>
+      throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get hangup => throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get transfer => throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get camera => throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get muted => throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get speaker => throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get held => throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get swap => throw _privateConstructorUsedError;
+  ElevatedButtonWidgetConfig get key => throw _privateConstructorUsedError;
+
+  /// Serializes this CallPageActionsConfig to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CallPageActionsConfigCopyWith<CallPageActionsConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CallPageActionsConfigCopyWith<$Res> {
+  factory $CallPageActionsConfigCopyWith(CallPageActionsConfig value,
+          $Res Function(CallPageActionsConfig) then) =
+      _$CallPageActionsConfigCopyWithImpl<$Res, CallPageActionsConfig>;
+  @useResult
+  $Res call(
+      {ElevatedButtonWidgetConfig callStart,
+      ElevatedButtonWidgetConfig hangup,
+      ElevatedButtonWidgetConfig transfer,
+      ElevatedButtonWidgetConfig camera,
+      ElevatedButtonWidgetConfig muted,
+      ElevatedButtonWidgetConfig speaker,
+      ElevatedButtonWidgetConfig held,
+      ElevatedButtonWidgetConfig swap,
+      ElevatedButtonWidgetConfig key});
+
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get callStart;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get hangup;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get transfer;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get camera;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get muted;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get speaker;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get held;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get swap;
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get key;
+}
+
+/// @nodoc
+class _$CallPageActionsConfigCopyWithImpl<$Res,
+        $Val extends CallPageActionsConfig>
+    implements $CallPageActionsConfigCopyWith<$Res> {
+  _$CallPageActionsConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? callStart = null,
+    Object? hangup = null,
+    Object? transfer = null,
+    Object? camera = null,
+    Object? muted = null,
+    Object? speaker = null,
+    Object? held = null,
+    Object? swap = null,
+    Object? key = null,
+  }) {
+    return _then(_value.copyWith(
+      callStart: null == callStart
+          ? _value.callStart
+          : callStart // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      hangup: null == hangup
+          ? _value.hangup
+          : hangup // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      transfer: null == transfer
+          ? _value.transfer
+          : transfer // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      camera: null == camera
+          ? _value.camera
+          : camera // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      muted: null == muted
+          ? _value.muted
+          : muted // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      speaker: null == speaker
+          ? _value.speaker
+          : speaker // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      held: null == held
+          ? _value.held
+          : held // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      swap: null == swap
+          ? _value.swap
+          : swap // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      key: null == key
+          ? _value.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+    ) as $Val);
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get callStart {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.callStart, (value) {
+      return _then(_value.copyWith(callStart: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get hangup {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.hangup, (value) {
+      return _then(_value.copyWith(hangup: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get transfer {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.transfer, (value) {
+      return _then(_value.copyWith(transfer: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get camera {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.camera, (value) {
+      return _then(_value.copyWith(camera: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get muted {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.muted, (value) {
+      return _then(_value.copyWith(muted: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get speaker {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.speaker, (value) {
+      return _then(_value.copyWith(speaker: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get held {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.held, (value) {
+      return _then(_value.copyWith(held: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get swap {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.swap, (value) {
+      return _then(_value.copyWith(swap: value) as $Val);
+    });
+  }
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get key {
+    return $ElevatedButtonWidgetConfigCopyWith<$Res>(_value.key, (value) {
+      return _then(_value.copyWith(key: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$CallPageActionsConfigImplCopyWith<$Res>
+    implements $CallPageActionsConfigCopyWith<$Res> {
+  factory _$$CallPageActionsConfigImplCopyWith(
+          _$CallPageActionsConfigImpl value,
+          $Res Function(_$CallPageActionsConfigImpl) then) =
+      __$$CallPageActionsConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {ElevatedButtonWidgetConfig callStart,
+      ElevatedButtonWidgetConfig hangup,
+      ElevatedButtonWidgetConfig transfer,
+      ElevatedButtonWidgetConfig camera,
+      ElevatedButtonWidgetConfig muted,
+      ElevatedButtonWidgetConfig speaker,
+      ElevatedButtonWidgetConfig held,
+      ElevatedButtonWidgetConfig swap,
+      ElevatedButtonWidgetConfig key});
+
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get callStart;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get hangup;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get transfer;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get camera;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get muted;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get speaker;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get held;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get swap;
+  @override
+  $ElevatedButtonWidgetConfigCopyWith<$Res> get key;
+}
+
+/// @nodoc
+class __$$CallPageActionsConfigImplCopyWithImpl<$Res>
+    extends _$CallPageActionsConfigCopyWithImpl<$Res,
+        _$CallPageActionsConfigImpl>
+    implements _$$CallPageActionsConfigImplCopyWith<$Res> {
+  __$$CallPageActionsConfigImplCopyWithImpl(_$CallPageActionsConfigImpl _value,
+      $Res Function(_$CallPageActionsConfigImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? callStart = null,
+    Object? hangup = null,
+    Object? transfer = null,
+    Object? camera = null,
+    Object? muted = null,
+    Object? speaker = null,
+    Object? held = null,
+    Object? swap = null,
+    Object? key = null,
+  }) {
+    return _then(_$CallPageActionsConfigImpl(
+      callStart: null == callStart
+          ? _value.callStart
+          : callStart // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      hangup: null == hangup
+          ? _value.hangup
+          : hangup // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      transfer: null == transfer
+          ? _value.transfer
+          : transfer // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      camera: null == camera
+          ? _value.camera
+          : camera // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      muted: null == muted
+          ? _value.muted
+          : muted // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      speaker: null == speaker
+          ? _value.speaker
+          : speaker // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      held: null == held
+          ? _value.held
+          : held // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      swap: null == swap
+          ? _value.swap
+          : swap // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+      key: null == key
+          ? _value.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as ElevatedButtonWidgetConfig,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$CallPageActionsConfigImpl implements _CallPageActionsConfig {
+  const _$CallPageActionsConfigImpl(
+      {this.callStart = const ElevatedButtonWidgetConfig(),
+      this.hangup = const ElevatedButtonWidgetConfig(),
+      this.transfer = const ElevatedButtonWidgetConfig(),
+      this.camera = const ElevatedButtonWidgetConfig(),
+      this.muted = const ElevatedButtonWidgetConfig(),
+      this.speaker = const ElevatedButtonWidgetConfig(),
+      this.held = const ElevatedButtonWidgetConfig(),
+      this.swap = const ElevatedButtonWidgetConfig(),
+      this.key = const ElevatedButtonWidgetConfig()});
+
+  factory _$CallPageActionsConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CallPageActionsConfigImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig callStart;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig hangup;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig transfer;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig camera;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig muted;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig speaker;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig held;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig swap;
+  @override
+  @JsonKey()
+  final ElevatedButtonWidgetConfig key;
+
+  @override
+  String toString() {
+    return 'CallPageActionsConfig(callStart: $callStart, hangup: $hangup, transfer: $transfer, camera: $camera, muted: $muted, speaker: $speaker, held: $held, swap: $swap, key: $key)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CallPageActionsConfigImpl &&
+            (identical(other.callStart, callStart) ||
+                other.callStart == callStart) &&
+            (identical(other.hangup, hangup) || other.hangup == hangup) &&
+            (identical(other.transfer, transfer) ||
+                other.transfer == transfer) &&
+            (identical(other.camera, camera) || other.camera == camera) &&
+            (identical(other.muted, muted) || other.muted == muted) &&
+            (identical(other.speaker, speaker) || other.speaker == speaker) &&
+            (identical(other.held, held) || other.held == held) &&
+            (identical(other.swap, swap) || other.swap == swap) &&
+            (identical(other.key, key) || other.key == key));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, callStart, hangup, transfer,
+      camera, muted, speaker, held, swap, key);
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CallPageActionsConfigImplCopyWith<_$CallPageActionsConfigImpl>
+      get copyWith => __$$CallPageActionsConfigImplCopyWithImpl<
+          _$CallPageActionsConfigImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$CallPageActionsConfigImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _CallPageActionsConfig implements CallPageActionsConfig {
+  const factory _CallPageActionsConfig(
+      {final ElevatedButtonWidgetConfig callStart,
+      final ElevatedButtonWidgetConfig hangup,
+      final ElevatedButtonWidgetConfig transfer,
+      final ElevatedButtonWidgetConfig camera,
+      final ElevatedButtonWidgetConfig muted,
+      final ElevatedButtonWidgetConfig speaker,
+      final ElevatedButtonWidgetConfig held,
+      final ElevatedButtonWidgetConfig swap,
+      final ElevatedButtonWidgetConfig key}) = _$CallPageActionsConfigImpl;
+
+  factory _CallPageActionsConfig.fromJson(Map<String, dynamic> json) =
+      _$CallPageActionsConfigImpl.fromJson;
+
+  @override
+  ElevatedButtonWidgetConfig get callStart;
+  @override
+  ElevatedButtonWidgetConfig get hangup;
+  @override
+  ElevatedButtonWidgetConfig get transfer;
+  @override
+  ElevatedButtonWidgetConfig get camera;
+  @override
+  ElevatedButtonWidgetConfig get muted;
+  @override
+  ElevatedButtonWidgetConfig get speaker;
+  @override
+  ElevatedButtonWidgetConfig get held;
+  @override
+  ElevatedButtonWidgetConfig get swap;
+  @override
+  ElevatedButtonWidgetConfig get key;
+
+  /// Create a copy of CallPageActionsConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CallPageActionsConfigImplCopyWith<_$CallPageActionsConfigImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 CallPageInfoConfig _$CallPageInfoConfigFromJson(Map<String, dynamic> json) {

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -128,6 +128,10 @@ _$CallPageConfigImpl _$$CallPageConfigImplFromJson(Map<String, dynamic> json) =>
           ? null
           : CallPageInfoConfig.fromJson(
               json['callInfo'] as Map<String, dynamic>),
+      actions: json['actions'] == null
+          ? null
+          : CallPageActionsConfig.fromJson(
+              json['actions'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$$CallPageConfigImplToJson(
@@ -136,6 +140,62 @@ Map<String, dynamic> _$$CallPageConfigImplToJson(
       'systemUiOverlayStyle': instance.systemUiOverlayStyle?.toJson(),
       'appBarStyle': instance.appBarStyle?.toJson(),
       'callInfo': instance.callInfo?.toJson(),
+      'actions': instance.actions?.toJson(),
+    };
+
+_$CallPageActionsConfigImpl _$$CallPageActionsConfigImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CallPageActionsConfigImpl(
+      callStart: json['callStart'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['callStart'] as Map<String, dynamic>),
+      hangup: json['hangup'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['hangup'] as Map<String, dynamic>),
+      transfer: json['transfer'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['transfer'] as Map<String, dynamic>),
+      camera: json['camera'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['camera'] as Map<String, dynamic>),
+      muted: json['muted'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['muted'] as Map<String, dynamic>),
+      speaker: json['speaker'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['speaker'] as Map<String, dynamic>),
+      held: json['held'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['held'] as Map<String, dynamic>),
+      swap: json['swap'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['swap'] as Map<String, dynamic>),
+      key: json['key'] == null
+          ? const ElevatedButtonWidgetConfig()
+          : ElevatedButtonWidgetConfig.fromJson(
+              json['key'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$CallPageActionsConfigImplToJson(
+        _$CallPageActionsConfigImpl instance) =>
+    <String, dynamic>{
+      'callStart': instance.callStart.toJson(),
+      'hangup': instance.hangup.toJson(),
+      'transfer': instance.transfer.toJson(),
+      'camera': instance.camera.toJson(),
+      'muted': instance.muted.toJson(),
+      'speaker': instance.speaker.toJson(),
+      'held': instance.held.toJson(),
+      'swap': instance.swap.toJson(),
+      'key': instance.key.toJson(),
     };
 
 _$CallPageInfoConfigImpl _$$CallPageInfoConfigImplFromJson(

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
@@ -58,6 +58,8 @@ class ElevatedButtonWidgetConfig with _$ElevatedButtonWidgetConfig {
     String? textColor,
     String? iconColor,
     String? disabledIconColor,
+    String? disabledBackgroundColor,
+    String? disabledForegroundColor,
   }) = _ElevatedButtonWidgetConfig;
 
   factory ElevatedButtonWidgetConfig.fromJson(Map<String, dynamic> json) => _$ElevatedButtonWidgetConfigFromJson(json);
@@ -68,6 +70,8 @@ class GroupWidgetConfig with _$GroupWidgetConfig {
   @JsonSerializable(explicitToJson: true)
   const factory GroupWidgetConfig({
     @Default(GroupTitleListTileWidgetConfig()) GroupTitleListTileWidgetConfig groupTitleListTile,
+    // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+    // ignore: deprecated_member_use_from_same_package
     @Default(CallActionsWidgetConfig()) CallActionsWidgetConfig callActions,
   }) = _GroupWidgetConfig;
 
@@ -123,6 +127,7 @@ class GroupTitleListTileWidgetConfig with _$GroupTitleListTileWidgetConfig {
       _$GroupTitleListTileWidgetConfigFromJson(json);
 }
 
+@Deprecated('Use CallPageActionsConfig instead')
 @Freezed()
 class CallActionsWidgetConfig with _$CallActionsWidgetConfig {
   @JsonSerializable(explicitToJson: true)

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
@@ -870,6 +870,8 @@ mixin _$ElevatedButtonWidgetConfig {
   String? get textColor => throw _privateConstructorUsedError;
   String? get iconColor => throw _privateConstructorUsedError;
   String? get disabledIconColor => throw _privateConstructorUsedError;
+  String? get disabledBackgroundColor => throw _privateConstructorUsedError;
+  String? get disabledForegroundColor => throw _privateConstructorUsedError;
 
   /// Serializes this ElevatedButtonWidgetConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -893,7 +895,9 @@ abstract class $ElevatedButtonWidgetConfigCopyWith<$Res> {
       String? foregroundColor,
       String? textColor,
       String? iconColor,
-      String? disabledIconColor});
+      String? disabledIconColor,
+      String? disabledBackgroundColor,
+      String? disabledForegroundColor});
 }
 
 /// @nodoc
@@ -917,6 +921,8 @@ class _$ElevatedButtonWidgetConfigCopyWithImpl<$Res,
     Object? textColor = freezed,
     Object? iconColor = freezed,
     Object? disabledIconColor = freezed,
+    Object? disabledBackgroundColor = freezed,
+    Object? disabledForegroundColor = freezed,
   }) {
     return _then(_value.copyWith(
       backgroundColor: freezed == backgroundColor
@@ -939,6 +945,14 @@ class _$ElevatedButtonWidgetConfigCopyWithImpl<$Res,
           ? _value.disabledIconColor
           : disabledIconColor // ignore: cast_nullable_to_non_nullable
               as String?,
+      disabledBackgroundColor: freezed == disabledBackgroundColor
+          ? _value.disabledBackgroundColor
+          : disabledBackgroundColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabledForegroundColor: freezed == disabledForegroundColor
+          ? _value.disabledForegroundColor
+          : disabledForegroundColor // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 }
@@ -957,7 +971,9 @@ abstract class _$$ElevatedButtonWidgetConfigImplCopyWith<$Res>
       String? foregroundColor,
       String? textColor,
       String? iconColor,
-      String? disabledIconColor});
+      String? disabledIconColor,
+      String? disabledBackgroundColor,
+      String? disabledForegroundColor});
 }
 
 /// @nodoc
@@ -980,6 +996,8 @@ class __$$ElevatedButtonWidgetConfigImplCopyWithImpl<$Res>
     Object? textColor = freezed,
     Object? iconColor = freezed,
     Object? disabledIconColor = freezed,
+    Object? disabledBackgroundColor = freezed,
+    Object? disabledForegroundColor = freezed,
   }) {
     return _then(_$ElevatedButtonWidgetConfigImpl(
       backgroundColor: freezed == backgroundColor
@@ -1002,6 +1020,14 @@ class __$$ElevatedButtonWidgetConfigImplCopyWithImpl<$Res>
           ? _value.disabledIconColor
           : disabledIconColor // ignore: cast_nullable_to_non_nullable
               as String?,
+      disabledBackgroundColor: freezed == disabledBackgroundColor
+          ? _value.disabledBackgroundColor
+          : disabledBackgroundColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabledForegroundColor: freezed == disabledForegroundColor
+          ? _value.disabledForegroundColor
+          : disabledForegroundColor // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -1015,7 +1041,9 @@ class _$ElevatedButtonWidgetConfigImpl implements _ElevatedButtonWidgetConfig {
       this.foregroundColor,
       this.textColor,
       this.iconColor,
-      this.disabledIconColor});
+      this.disabledIconColor,
+      this.disabledBackgroundColor,
+      this.disabledForegroundColor});
 
   factory _$ElevatedButtonWidgetConfigImpl.fromJson(
           Map<String, dynamic> json) =>
@@ -1031,10 +1059,14 @@ class _$ElevatedButtonWidgetConfigImpl implements _ElevatedButtonWidgetConfig {
   final String? iconColor;
   @override
   final String? disabledIconColor;
+  @override
+  final String? disabledBackgroundColor;
+  @override
+  final String? disabledForegroundColor;
 
   @override
   String toString() {
-    return 'ElevatedButtonWidgetConfig(backgroundColor: $backgroundColor, foregroundColor: $foregroundColor, textColor: $textColor, iconColor: $iconColor, disabledIconColor: $disabledIconColor)';
+    return 'ElevatedButtonWidgetConfig(backgroundColor: $backgroundColor, foregroundColor: $foregroundColor, textColor: $textColor, iconColor: $iconColor, disabledIconColor: $disabledIconColor, disabledBackgroundColor: $disabledBackgroundColor, disabledForegroundColor: $disabledForegroundColor)';
   }
 
   @override
@@ -1051,13 +1083,26 @@ class _$ElevatedButtonWidgetConfigImpl implements _ElevatedButtonWidgetConfig {
             (identical(other.iconColor, iconColor) ||
                 other.iconColor == iconColor) &&
             (identical(other.disabledIconColor, disabledIconColor) ||
-                other.disabledIconColor == disabledIconColor));
+                other.disabledIconColor == disabledIconColor) &&
+            (identical(
+                    other.disabledBackgroundColor, disabledBackgroundColor) ||
+                other.disabledBackgroundColor == disabledBackgroundColor) &&
+            (identical(
+                    other.disabledForegroundColor, disabledForegroundColor) ||
+                other.disabledForegroundColor == disabledForegroundColor));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, backgroundColor, foregroundColor,
-      textColor, iconColor, disabledIconColor);
+  int get hashCode => Object.hash(
+      runtimeType,
+      backgroundColor,
+      foregroundColor,
+      textColor,
+      iconColor,
+      disabledIconColor,
+      disabledBackgroundColor,
+      disabledForegroundColor);
 
   /// Create a copy of ElevatedButtonWidgetConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -1079,11 +1124,14 @@ class _$ElevatedButtonWidgetConfigImpl implements _ElevatedButtonWidgetConfig {
 abstract class _ElevatedButtonWidgetConfig
     implements ElevatedButtonWidgetConfig {
   const factory _ElevatedButtonWidgetConfig(
-      {final String? backgroundColor,
-      final String? foregroundColor,
-      final String? textColor,
-      final String? iconColor,
-      final String? disabledIconColor}) = _$ElevatedButtonWidgetConfigImpl;
+          {final String? backgroundColor,
+          final String? foregroundColor,
+          final String? textColor,
+          final String? iconColor,
+          final String? disabledIconColor,
+          final String? disabledBackgroundColor,
+          final String? disabledForegroundColor}) =
+      _$ElevatedButtonWidgetConfigImpl;
 
   factory _ElevatedButtonWidgetConfig.fromJson(Map<String, dynamic> json) =
       _$ElevatedButtonWidgetConfigImpl.fromJson;
@@ -1098,6 +1146,10 @@ abstract class _ElevatedButtonWidgetConfig
   String? get iconColor;
   @override
   String? get disabledIconColor;
+  @override
+  String? get disabledBackgroundColor;
+  @override
+  String? get disabledForegroundColor;
 
   /// Create a copy of ElevatedButtonWidgetConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -1114,7 +1166,8 @@ GroupWidgetConfig _$GroupWidgetConfigFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$GroupWidgetConfig {
   GroupTitleListTileWidgetConfig get groupTitleListTile =>
-      throw _privateConstructorUsedError;
+      throw _privateConstructorUsedError; // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+// ignore: deprecated_member_use_from_same_package
   CallActionsWidgetConfig get callActions => throw _privateConstructorUsedError;
 
   /// Serializes this GroupWidgetConfig to a JSON map.
@@ -1254,6 +1307,8 @@ class _$GroupWidgetConfigImpl implements _GroupWidgetConfig {
   @override
   @JsonKey()
   final GroupTitleListTileWidgetConfig groupTitleListTile;
+// TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+// ignore: deprecated_member_use_from_same_package
   @override
   @JsonKey()
   final CallActionsWidgetConfig callActions;
@@ -1304,7 +1359,9 @@ abstract class _GroupWidgetConfig implements GroupWidgetConfig {
       _$GroupWidgetConfigImpl.fromJson;
 
   @override
-  GroupTitleListTileWidgetConfig get groupTitleListTile;
+  GroupTitleListTileWidgetConfig
+      get groupTitleListTile; // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
+// ignore: deprecated_member_use_from_same_package
   @override
   CallActionsWidgetConfig get callActions;
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
@@ -97,6 +97,8 @@ _$ElevatedButtonWidgetConfigImpl _$$ElevatedButtonWidgetConfigImplFromJson(
       textColor: json['textColor'] as String?,
       iconColor: json['iconColor'] as String?,
       disabledIconColor: json['disabledIconColor'] as String?,
+      disabledBackgroundColor: json['disabledBackgroundColor'] as String?,
+      disabledForegroundColor: json['disabledForegroundColor'] as String?,
     );
 
 Map<String, dynamic> _$$ElevatedButtonWidgetConfigImplToJson(
@@ -107,6 +109,8 @@ Map<String, dynamic> _$$ElevatedButtonWidgetConfigImplToJson(
       'textColor': instance.textColor,
       'iconColor': instance.iconColor,
       'disabledIconColor': instance.disabledIconColor,
+      'disabledBackgroundColor': instance.disabledBackgroundColor,
+      'disabledForegroundColor': instance.disabledForegroundColor,
     };
 
 _$GroupWidgetConfigImpl _$$GroupWidgetConfigImplFromJson(


### PR DESCRIPTION
This PR introduces comprehensive enhancements to the call screen theming system, adding a new CallPageActionsConfig for styling call action buttons with support for disabled states, updating the documentation, and deprecating legacy configurations while maintaining backward compatibility.

Adds new CallPageActionsConfig and CallScreenActionsStyle for better call action button theming
Extends ElevatedButtonWidgetConfig with disabled foreground/background color properties
Updates documentation with detailed examples and restructures page configuration guide