### PR TITLE
refactor: extract Google Fonts preloading into private helper with timeout handling

### DIFF
--- a/lib/data/app_themes.dart
+++ b/lib/data/app_themes.dart
@@ -14,6 +14,8 @@ final Logger _logger = Logger('AppThemes');
 class AppThemes {
   static late AppThemes _instance;
 
+  static const _fontPreloadTimeout = Duration(seconds: 3);
+
   static Future<AppThemes> init() async {
     final themeColorSchemeLightConfigJson = await _getJson(Assets.themes.originalColorSchemeLightConfig);
     final themeColorSchemeDarkConfigJson = await _getJson(Assets.themes.originalColorSchemeDarkConfig);
@@ -48,21 +50,38 @@ class AppThemes {
 
     final themes = [AppTheme(settings: settings)];
 
-    try {
-      final lightFontFamily = themeWidgetLightConfig.fonts.fontFamily;
-      final darkFontFamily = themeWidgetDarkConfig.fonts.fontFamily;
-
-      // Preload Google Fonts for preventing flickering during the first render
-      await GoogleFonts.pendingFonts([
-        if (lightFontFamily != null) GoogleFonts.getFont(lightFontFamily),
-        if (darkFontFamily != null) GoogleFonts.getFont(darkFontFamily),
-      ]);
-    } catch (e) {
-      _logger.finest('Failed to preload Google Fonts: $e');
-    }
+    await _preloadFonts(themeWidgetLightConfig, themeWidgetDarkConfig);
 
     _instance = AppThemes._(themes, appConfig);
     return _instance;
+  }
+
+  // TODO(offline-fonts): In the future, run flutter pub run google_fonts:update
+  // to bundle the required TTF fonts into assets and update pubspec.yaml.
+  // After that, set GoogleFonts.config.allowRuntimeFetching = false
+  // permanently to avoid any network dependency.
+  static Future<void> _preloadFonts(
+    ThemeWidgetConfig lightConfig,
+    ThemeWidgetConfig darkConfig,
+  ) async {
+    GoogleFonts.config.allowRuntimeFetching = true;
+
+    try {
+      final families = <String>{
+        if (lightConfig.fonts.fontFamily != null) lightConfig.fonts.fontFamily!,
+        if (darkConfig.fonts.fontFamily != null) darkConfig.fonts.fontFamily!,
+      }.toList();
+
+      if (families.isEmpty) return;
+
+      await GoogleFonts.pendingFonts([for (final font in families) GoogleFonts.getFont(font)])
+          .timeout(_fontPreloadTimeout, onTimeout: () {
+        _logger.warning('Preloading Google Fonts timed out ($_fontPreloadTimeout)');
+        return const [];
+      });
+    } catch (e, st) {
+      _logger.finest('Failed to preload Google Fonts: $e\n$st');
+    }
   }
 
   static Future<dynamic> _getJson(String path) async {


### PR DESCRIPTION
This refactor extracts Google Fonts preloading logic into a private helper method with improved error handling and timeout functionality.

Extracts font preloading into a dedicated _preloadFonts helper method for better code organization
Adds timeout handling (3 seconds) to prevent hanging when loading Google Fonts
Improves error logging by including stack traces