### PR TITLE
feat: add handling of SslAuthError

### DIFF
--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -64,7 +64,7 @@ import 'app_localizations_uk.g.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -87,17 +87,17 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
     Locale('it'),
-    Locale('uk'),
+    Locale('uk')
   ];
 
   /// Shown when a web self-care password is expired. By default, such passwords may be created in an expired state or set to expire after a period of time. The user must log in to the self-care portal and set a new password. Until refreshed, access to related services is restricted.
@@ -1185,9 +1185,7 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'An incompatible instance version provided, please contact the administrator of your system (actual: {actual}, supported: {supportedConstraint})'**
   String login_CoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  );
+      String actual, String supportedConstraint);
 
   /// Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty.
   ///
@@ -1500,10 +1498,8 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Incompatible WebTrit Cloud Backend version, please contact the administrator of your system.\n\nInstance version:\n{actual}\n\nSupported version:\n{supportedConstraint}'**
   String
-  main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  );
+      main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
+          String actual, String supportedConstraint);
 
   /// No description provided for @main_CompatibilityIssueDialog_title.
   ///
@@ -2104,16 +2100,14 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Disconnected from the core with the code: {codeName}'**
   String notifications_errorSnackBar_signalingDisconnectWithCodeName(
-    String codeName,
-  );
+      String codeName);
 
   /// Shown in a notification or snackbar when the app is disconnected from the WebTrit core and a system-provided reason string is available. Context: occurs when the signaling/WebSocket connection is closed with a system-level reason (e.g. network error, TLS/handshake failure, server-initiated disconnect). Advise the user to check their network, retry, or reauthenticate if the problem persists.
   ///
   /// In en, this message translates to:
   /// **'Disconnected from the core due to the following reason: {reason}'**
   String notifications_errorSnackBar_signalingDisconnectWithSystemReason(
-    String reason,
-  );
+      String reason);
 
   /// Shown in a notification or snackbar when the app's signaling session for the signed-in user is lost or rejected and re-authentication is required. Typical causes: expired or revoked access/refresh tokens, failed token refresh, authentication rejected by the core (e.g. SIP/WebTrit 401 Unauthorized), or the signaling server closing the session. Advise the user to sign in again to restore full functionality.
   ///
@@ -2138,8 +2132,7 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Registration with the remote VoIP system failed due to the following reason: {reason}'**
   String notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason(
-    String reason,
-  );
+      String reason);
 
   /// Shown in a notification or snackbar when authentication with the remote VoIP/SIP system fails or the service is unavailable. Typical causes: authentication rejection (invalid/expired credentials), remote service maintenance or outage, or transient network/TLS issues. Advise the user to verify account credentials, retry later, and contact their administrator or support if the problem persists.
   ///
@@ -3736,6 +3729,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Web resource error'**
   String get webRegistration_ErrorAcknowledgeDialog_title;
+
+  /// Title shown on the generic WebView error screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong'**
+  String get webview_defaultError_title;
+
+  /// Error description with numeric code for the generic WebView error screen.
+  ///
+  /// In en, this message translates to:
+  /// **'{description} (code: {code})'**
+  String webview_defaultError_details(String description, int code);
+
+  /// Button label to reload the WebView after a generic error.
+  ///
+  /// In en, this message translates to:
+  /// **'Reload'**
+  String get webview_defaultError_reload;
+
+  /// Title for SSL authentication error screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Your connection is not private'**
+  String get webview_sslError_title;
+
+  /// Body message for SSL authentication error.
+  ///
+  /// In en, this message translates to:
+  /// **'The certificate for this site isn\'t trusted. The page can\'t be shown.'**
+  String get webview_sslError_message;
+
+  /// Primary action button label on SSL error screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Try again'**
+  String get webview_sslError_tryAgain;
+
+  /// Secondary action button label to open SSL details bottom sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Details'**
+  String get webview_sslError_details;
+
+  /// Label for SSL error type in the details sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Type'**
+  String get webview_sslError_details_type;
+
+  /// Label for failing URL in the details sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'URL'**
+  String get webview_sslError_details_url;
 }
 
 class _AppLocalizationsDelegate
@@ -3767,9 +3814,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -1135,6 +1135,16 @@ class AppLocalizationsMapper {
           localizations.webRegistration_ErrorAcknowledgeDialogActions_skip,
       'webRegistration_ErrorAcknowledgeDialog_title':
           localizations.webRegistration_ErrorAcknowledgeDialog_title,
+      'webview_defaultError_title': localizations.webview_defaultError_title,
+      'webview_defaultError_reload': localizations.webview_defaultError_reload,
+      'webview_sslError_title': localizations.webview_sslError_title,
+      'webview_sslError_message': localizations.webview_sslError_message,
+      'webview_sslError_tryAgain': localizations.webview_sslError_tryAgain,
+      'webview_sslError_details': localizations.webview_sslError_details,
+      'webview_sslError_details_type':
+          localizations.webview_sslError_details_type,
+      'webview_sslError_details_url':
+          localizations.webview_sslError_details_url,
       'default_UnknownExceptionError': (error) =>
           localizations.default_UnknownExceptionError(error),
       'favorites_SnackBar_deleted': (name) =>
@@ -1191,6 +1201,8 @@ class AppLocalizationsMapper {
           localizations.user_agreement_checkbox_text(url),
       'user_agreement_description': (appName) =>
           localizations.user_agreement_description(appName),
+      'webview_defaultError_details': (description, code) =>
+          localizations.webview_defaultError_details(description, code),
     };
   }
 }

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -621,9 +621,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String login_CoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  ) {
+      String actual, String supportedConstraint) {
     return 'An incompatible instance version provided, please contact the administrator of your system (actual: $actual, supported: $supportedConstraint)';
   }
 
@@ -811,10 +809,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String
-  main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  ) {
+      main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
+          String actual, String supportedConstraint) {
     return 'Incompatible WebTrit Cloud Backend version, please contact the administrator of your system.\n\nInstance version:\n$actual\n\nSupported version:\n$supportedConstraint';
   }
 
@@ -1158,15 +1154,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String notifications_errorSnackBar_signalingDisconnectWithCodeName(
-    String codeName,
-  ) {
+      String codeName) {
     return 'Disconnected from the core with the code: $codeName';
   }
 
   @override
   String notifications_errorSnackBar_signalingDisconnectWithSystemReason(
-    String reason,
-  ) {
+      String reason) {
     return 'Disconnected from the core due to the following reason: $reason';
   }
 
@@ -1184,8 +1178,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason(
-    String reason,
-  ) {
+      String reason) {
     return 'Registration with the remote VoIP system failed due to the following reason: $reason';
   }
 
@@ -2137,4 +2130,34 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get webRegistration_ErrorAcknowledgeDialog_title =>
       'Web resource error';
+
+  @override
+  String get webview_defaultError_title => 'Something went wrong';
+
+  @override
+  String webview_defaultError_details(String description, int code) {
+    return '$description (code: $code)';
+  }
+
+  @override
+  String get webview_defaultError_reload => 'Reload';
+
+  @override
+  String get webview_sslError_title => 'Your connection is not private';
+
+  @override
+  String get webview_sslError_message =>
+      'The certificate for this site isn\'t trusted. The page can\'t be shown.';
+
+  @override
+  String get webview_sslError_tryAgain => 'Try again';
+
+  @override
+  String get webview_sslError_details => 'Details';
+
+  @override
+  String get webview_sslError_details_type => 'Type';
+
+  @override
+  String get webview_sslError_details_url => 'URL';
 }

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -638,9 +638,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String login_CoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  ) {
+      String actual, String supportedConstraint) {
     return 'È stata fornita una versione di richiesta incompatibile, contattare l\'amministratore del sistema (actual:$actual, supported:$supportedConstraint)';
   }
 
@@ -832,10 +830,8 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String
-  main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  ) {
+      main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
+          String actual, String supportedConstraint) {
     return 'Versione di WebTrit Cloud Backend incompatibile, si prega di contattare l\'amministratore del sistema.\n\nVersione dell\'istanza:\n$actual\n\nVersione supportata:\n$supportedConstraint\n';
   }
 
@@ -1180,15 +1176,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String notifications_errorSnackBar_signalingDisconnectWithCodeName(
-    String codeName,
-  ) {
+      String codeName) {
     return 'Disconnesso dal core con codice: $codeName';
   }
 
   @override
   String notifications_errorSnackBar_signalingDisconnectWithSystemReason(
-    String reason,
-  ) {
+      String reason) {
     return 'Disconnesso dal nucleo con ragione: $reason';
   }
 
@@ -1206,8 +1200,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason(
-    String reason,
-  ) {
+      String reason) {
     return 'La registrazione con il sistema VoIP remoto è fallita con il motivo: $reason';
   }
 
@@ -2183,4 +2176,34 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get webRegistration_ErrorAcknowledgeDialog_title =>
       'Web resource error';
+
+  @override
+  String get webview_defaultError_title => 'Qualcosa è andato storto';
+
+  @override
+  String webview_defaultError_details(String description, int code) {
+    return '$description (codice: $code)';
+  }
+
+  @override
+  String get webview_defaultError_reload => 'Ricarica';
+
+  @override
+  String get webview_sslError_title => 'La tua connessione non è privata';
+
+  @override
+  String get webview_sslError_message =>
+      'Il certificato di questo sito non è considerato attendibile. La pagina non può essere visualizzata.';
+
+  @override
+  String get webview_sslError_tryAgain => 'Riprova';
+
+  @override
+  String get webview_sslError_details => 'Dettagli';
+
+  @override
+  String get webview_sslError_details_type => 'Tipo';
+
+  @override
+  String get webview_sslError_details_url => 'URL';
 }

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -631,9 +631,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String login_CoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  ) {
+      String actual, String supportedConstraint) {
     return 'Непідтримувана версія екземпляра, будь ласка, зверніться до адміністратора вашої системи (фактична: $actual, підтримувана: $supportedConstraint)';
   }
 
@@ -827,10 +825,8 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String
-  main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
-    String actual,
-    String supportedConstraint,
-  ) {
+      main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
+          String actual, String supportedConstraint) {
     return 'Несумісна версія WebTrit Cloud Backend, будь ласка, зв\'яжіться з адміністратором вашої системи.\n\nВерсія екземпляру:\n$actual\n\nПідтримувана версія:\n$supportedConstraint\n';
   }
 
@@ -1174,15 +1170,13 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String notifications_errorSnackBar_signalingDisconnectWithCodeName(
-    String codeName,
-  ) {
+      String codeName) {
     return 'Від’єднано від ядра за кодом: $codeName';
   }
 
   @override
   String notifications_errorSnackBar_signalingDisconnectWithSystemReason(
-    String reason,
-  ) {
+      String reason) {
     return 'Від’єднано від ядра з причини: $reason';
   }
 
@@ -1200,8 +1194,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason(
-    String reason,
-  ) {
+      String reason) {
     return 'Помилка реєстрації у віддаленій системі VoIP з причини: $reason';
   }
 
@@ -2167,4 +2160,34 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get webRegistration_ErrorAcknowledgeDialog_title =>
       'Web resource error';
+
+  @override
+  String get webview_defaultError_title => 'Щось пішло не так';
+
+  @override
+  String webview_defaultError_details(String description, int code) {
+    return '$description (код: $code)';
+  }
+
+  @override
+  String get webview_defaultError_reload => 'Перезавантажити';
+
+  @override
+  String get webview_sslError_title => 'Ваше з’єднання не є приватним';
+
+  @override
+  String get webview_sslError_message =>
+      'Сертифікат цього сайту не є надійним. Сторінку неможливо відобразити.';
+
+  @override
+  String get webview_sslError_tryAgain => 'Спробувати ще раз';
+
+  @override
+  String get webview_sslError_details => 'Деталі';
+
+  @override
+  String get webview_sslError_details_type => 'Тип';
+
+  @override
+  String get webview_sslError_details_url => 'URL';
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1644,5 +1644,51 @@
   "webRegistration_ErrorAcknowledgeDialog_title": "Web resource error",
   "@webRegistration_ErrorAcknowledgeDialog_title": {
     "description": "Title of the dialog shown when an error occurs while loading or registering with a required web resource (e.g. invalid link, unreachable server, or failed provisioning)."
+  },
+  "webview_defaultError_title": "Something went wrong",
+  "@webview_defaultError_title": {
+    "description": "Title shown on the generic WebView error screen."
+  },
+  "webview_defaultError_details": "{description} (code: {code})",
+  "@webview_defaultError_details": {
+    "description": "Error description with numeric code for the generic WebView error screen.",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "net::ERR_CONNECTION_TIMED_OUT"
+      },
+      "code": {
+        "type": "int",
+        "example": "-2"
+      }
+    }
+  },
+  "webview_defaultError_reload": "Reload",
+  "@webview_defaultError_reload": {
+    "description": "Button label to reload the WebView after a generic error."
+  },
+  "webview_sslError_title": "Your connection is not private",
+  "@webview_sslError_title": {
+    "description": "Title for SSL authentication error screen."
+  },
+  "webview_sslError_message": "The certificate for this site isn't trusted. The page can't be shown.",
+  "@webview_sslError_message": {
+    "description": "Body message for SSL authentication error."
+  },
+  "webview_sslError_tryAgain": "Try again",
+  "@webview_sslError_tryAgain": {
+    "description": "Primary action button label on SSL error screen."
+  },
+  "webview_sslError_details": "Details",
+  "@webview_sslError_details": {
+    "description": "Secondary action button label to open SSL details bottom sheet."
+  },
+  "webview_sslError_details_type": "Type",
+  "@webview_sslError_details_type": {
+    "description": "Label for SSL error type in the details sheet."
+  },
+  "webview_sslError_details_url": "URL",
+  "@webview_sslError_details_url": {
+    "description": "Label for failing URL in the details sheet."
   }
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1644,5 +1644,51 @@
   "webRegistration_ErrorAcknowledgeDialog_title": "Web resource error",
   "@webRegistration_ErrorAcknowledgeDialog_title": {
     "description": "Title of the dialog shown when an error occurs while loading or registering with a required web resource (e.g. invalid link, unreachable server, or failed provisioning)."
+  },
+  "webview_defaultError_title": "Qualcosa è andato storto",
+  "@webview_defaultError_title": {
+    "description": "Title shown on the generic WebView error screen."
+  },
+  "webview_defaultError_details": "{description} (codice: {code})",
+  "@webview_defaultError_details": {
+    "description": "Error description with numeric code for the generic WebView error screen.",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "net::ERR_CONNECTION_TIMED_OUT"
+      },
+      "code": {
+        "type": "int",
+        "example": "-2"
+      }
+    }
+  },
+  "webview_defaultError_reload": "Ricarica",
+  "@webview_defaultError_reload": {
+    "description": "Button label to reload the WebView after a generic error."
+  },
+  "webview_sslError_title": "La tua connessione non è privata",
+  "@webview_sslError_title": {
+    "description": "Title for SSL authentication error screen."
+  },
+  "webview_sslError_message": "Il certificato di questo sito non è considerato attendibile. La pagina non può essere visualizzata.",
+  "@webview_sslError_message": {
+    "description": "Body message for SSL authentication error."
+  },
+  "webview_sslError_tryAgain": "Riprova",
+  "@webview_sslError_tryAgain": {
+    "description": "Primary action button label on SSL error screen."
+  },
+  "webview_sslError_details": "Dettagli",
+  "@webview_sslError_details": {
+    "description": "Secondary action button label to open SSL details bottom sheet."
+  },
+  "webview_sslError_details_type": "Tipo",
+  "@webview_sslError_details_type": {
+    "description": "Label for SSL error type in the details sheet."
+  },
+  "webview_sslError_details_url": "URL",
+  "@webview_sslError_details_url": {
+    "description": "Label for failing URL in the details sheet."
   }
 }

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1644,5 +1644,51 @@
   "webRegistration_ErrorAcknowledgeDialog_title": "Web resource error",
   "@webRegistration_ErrorAcknowledgeDialog_title": {
     "description": "Title of the dialog shown when an error occurs while loading or registering with a required web resource (e.g. invalid link, unreachable server, or failed provisioning)."
+  },
+  "webview_defaultError_title": "Щось пішло не так",
+  "@webview_defaultError_title": {
+    "description": "Title shown on the generic WebView error screen."
+  },
+  "webview_defaultError_details": "{description} (код: {code})",
+  "@webview_defaultError_details": {
+    "description": "Error description with numeric code for the generic WebView error screen.",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "net::ERR_CONNECTION_TIMED_OUT"
+      },
+      "code": {
+        "type": "int",
+        "example": "-2"
+      }
+    }
+  },
+  "webview_defaultError_reload": "Перезавантажити",
+  "@webview_defaultError_reload": {
+    "description": "Button label to reload the WebView after a generic error."
+  },
+  "webview_sslError_title": "Ваше з’єднання не є приватним",
+  "@webview_sslError_title": {
+    "description": "Title for SSL authentication error screen."
+  },
+  "webview_sslError_message": "Сертифікат цього сайту не є надійним. Сторінку неможливо відобразити.",
+  "@webview_sslError_message": {
+    "description": "Body message for SSL authentication error."
+  },
+  "webview_sslError_tryAgain": "Спробувати ще раз",
+  "@webview_sslError_tryAgain": {
+    "description": "Primary action button label on SSL error screen."
+  },
+  "webview_sslError_details": "Деталі",
+  "@webview_sslError_details": {
+    "description": "Secondary action button label to open SSL details bottom sheet."
+  },
+  "webview_sslError_details_type": "Тип",
+  "@webview_sslError_details_type": {
+    "description": "Label for SSL error type in the details sheet."
+  },
+  "webview_sslError_details_url": "URL",
+  "@webview_sslError_details_url": {
+    "description": "Label for failing URL in the details sheet."
   }
 }

--- a/lib/widgets/webview/_widgets/_default_web_view_error_view.dart
+++ b/lib/widgets/webview/_widgets/_default_web_view_error_view.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+/// A common fallback widget for WebView errors when no custom [errorBuilder] is provided.
+class DefaultWebViewErrorView extends StatelessWidget {
+  const DefaultWebViewErrorView({
+    super.key,
+    required this.error,
+    required this.onReload,
+  });
+
+  final WebResourceError error;
+  final VoidCallback onReload;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+            const SizedBox(height: 16),
+            Text(
+              context.l10n.webview_defaultError_title,
+              style: theme.textTheme.titleMedium?.copyWith(color: theme.colorScheme.error),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              context.l10n.webview_defaultError_details(
+                error.description,
+                error.errorCode,
+              ),
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onReload,
+              icon: const Icon(Icons.refresh),
+              label: Text(context.l10n.webview_defaultError_reload),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/webview/_widgets/_ssl_auth_error_view.dart
+++ b/lib/widgets/webview/_widgets/_ssl_auth_error_view.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+class SslAuthErrorView extends StatelessWidget {
+  const SslAuthErrorView({
+    super.key,
+    required this.error,
+    required this.onReload,
+    this.failingUrl,
+  });
+
+  final SslAuthError error;
+  final VoidCallback onReload;
+  final String? failingUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final url = failingUrl ?? '';
+
+    return Container(
+      color: theme.colorScheme.surface,
+      width: double.infinity,
+      height: double.infinity,
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.security_rounded, size: 56, color: theme.colorScheme.error),
+              const SizedBox(height: 16),
+              Text(
+                context.l10n.webview_sslError_title,
+                style: theme.textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                context.l10n.webview_sslError_message,
+                style: theme.textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              if (url.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Text(
+                  url,
+                  style: theme.textTheme.bodySmall,
+                  textAlign: TextAlign.center,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                alignment: WrapAlignment.center,
+                children: [
+                  FilledButton(
+                    onPressed: onReload,
+                    child: Text(context.l10n.webview_sslError_tryAgain),
+                  ),
+                  OutlinedButton(
+                    onPressed: () => _showSslDetails(context, error),
+                    child: Text(context.l10n.webview_sslError_details),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showSslDetails(BuildContext context, SslAuthError error) {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (_) => Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            ListTile(
+              title: Text(context.l10n.webview_sslError_details_type),
+              subtitle: Text(error.toString()),
+            ),
+            if (failingUrl != null)
+              ListTile(
+                title: Text(context.l10n.webview_sslError_details_url),
+                subtitle: Text(failingUrl!),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/webview/_widgets/_widgets.dart
+++ b/lib/widgets/webview/_widgets/_widgets.dart
@@ -1,0 +1,2 @@
+export '_ssl_auth_error_view.dart';
+export '_default_web_view_error_view.dart';


### PR DESCRIPTION
This PR adds handling for SSL authentication errors in the WebView container, providing users with a dedicated error screen and recovery options when SSL certificate issues occur.

Adds new SslAuthError handling with dedicated UI components
Introduces fallback error handling for generic WebView errors
Adds localized strings for SSL and generic error messages