### PR TITLE
refactor: migrate RadioListTile to RadioGroup to remove deprecated groupValue usage

### DIFF
--- a/lib/features/settings/features/language/view/language_screen.dart
+++ b/lib/features/settings/features/language/view/language_screen.dart
@@ -20,6 +20,7 @@ class LanguageScreen extends StatelessWidget {
       LocaleExtension.defaultNull,
       ...AppLocalizations.supportedLocales,
     ];
+
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.settings_ListViewTileTitle_language),
@@ -27,18 +28,22 @@ class LanguageScreen extends StatelessWidget {
       ),
       body: BlocBuilder<AppBloc, AppState>(
         builder: (context, state) {
-          return ListView.separated(
-            itemBuilder: (context, index) {
-              final locale = locales[index];
-              return RadioListTile<Locale>(
-                value: locale,
-                groupValue: state.locale,
-                onChanged: (value) => context.read<AppBloc>().add(AppLocaleChanged(value!)),
-                title: Text(locale.l10n(context)),
-              );
+          return RadioGroup<Locale?>(
+            groupValue: state.locale,
+            onChanged: (value) {
+              context.read<AppBloc>().add(AppLocaleChanged(value ?? LocaleExtension.defaultNull));
             },
-            separatorBuilder: (context, index) => const ListTileSeparator(),
-            itemCount: locales.length,
+            child: ListView.separated(
+              itemCount: locales.length,
+              separatorBuilder: (context, index) => const ListTileSeparator(),
+              itemBuilder: (context, index) {
+                final locale = locales[index];
+                return RadioListTile<Locale?>(
+                  value: locale,
+                  title: Text(locale.l10n(context)),
+                );
+              },
+            ),
           );
         },
       ),

--- a/lib/features/settings/features/theme_mode/view/theme_mode_screen.dart
+++ b/lib/features/settings/features/theme_mode/view/theme_mode_screen.dart
@@ -17,6 +17,7 @@ class ThemeModeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const themeModes = ThemeMode.values;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.settings_ListViewTileTitle_themeMode),
@@ -24,20 +25,24 @@ class ThemeModeScreen extends StatelessWidget {
       ),
       body: BlocBuilder<AppBloc, AppState>(
         builder: (context, state) {
-          return ListView.separated(
-            itemBuilder: (context, index) {
-              final themeMode = themeModes[index];
-              return RadioListTile<ThemeMode>(
-                value: themeMode,
-                groupValue: state.effectiveThemeMode,
-                onChanged: !state.isThemeModeSupported
-                    ? null
-                    : (value) => context.read<AppBloc>().add(AppThemeModeChanged(value!)),
-                title: Text(themeMode.l10n(context)),
-              );
+          return RadioGroup<ThemeMode>(
+            groupValue: state.effectiveThemeMode,
+            onChanged: (ThemeMode? value) {
+              if (!state.isThemeModeSupported || value == null) return;
+              context.read<AppBloc>().add(AppThemeModeChanged(value));
             },
-            separatorBuilder: (context, index) => const ListTileSeparator(),
-            itemCount: themeModes.length,
+            child: ListView.separated(
+              itemCount: themeModes.length,
+              separatorBuilder: (context, index) => const ListTileSeparator(),
+              itemBuilder: (context, index) {
+                final themeMode = themeModes[index];
+                return RadioListTile<ThemeMode>(
+                  value: themeMode,
+                  title: Text(themeMode.l10n(context)),
+                  enabled: state.isThemeModeSupported,
+                );
+              },
+            ),
           );
         },
       ),


### PR DESCRIPTION
This PR refactors two settings screens to use RadioGroup wrapper around RadioListTile widgets instead of the deprecated groupValue parameter directly on RadioListTile.

Wraps existing RadioListTile widgets with RadioGroup for centralized value management
Removes deprecated groupValue and onChanged parameters from individual RadioListTile widgets
Updates type annotations to handle nullable values appropriately