### PR TITLE
refactor: clean up embedded page handling

### DIFF
--- a/lib/features/embedded/view/embedded_screen.dart
+++ b/lib/features/embedded/view/embedded_screen.dart
@@ -20,10 +20,10 @@ class EmbeddedScreen extends StatefulWidget {
     required this.mediaQueryMetricsData,
     required this.deviceInfoData,
     required this.appBar,
-    this.shouldForwardPop = true,
-    this.enableLogCapture = false,
     required this.connectivityRecoveryStrategyBuilder,
     required this.pageInjectionStrategyBuilder,
+    this.shouldForwardPop = true,
+    this.enableLogCapture = true,
     super.key,
   });
 
@@ -32,17 +32,17 @@ class EmbeddedScreen extends StatefulWidget {
   final Map<String, String>? deviceInfoData;
   final PreferredSizeWidget appBar;
 
-  /// If true, the console log will be captured and forwarded to the logger.
-  final bool enableLogCapture;
-
-  /// If true, the pop action will be forwarded to the WebView if backstack is available.
-  final bool shouldForwardPop;
-
   /// Builder for creating the page injection strategy.
   final PageInjectionStrategyBuilder pageInjectionStrategyBuilder;
 
   /// Builder for creating the connectivity recovery strategy.
   final ConnectivityRecoveryStrategyBuilder connectivityRecoveryStrategyBuilder;
+
+  /// If true, the console log will be captured and forwarded to the logger.
+  final bool enableLogCapture;
+
+  /// If true, the pop action will be forwarded to the WebView if backstack is available.
+  final bool shouldForwardPop;
 
   @override
   State<EmbeddedScreen> createState() => _EmbeddedScreenState();

--- a/lib/features/embedded/view/embedded_screen_page.dart
+++ b/lib/features/embedded/view/embedded_screen_page.dart
@@ -46,10 +46,11 @@ class EmbeddedScreenPage extends StatelessWidget {
         initialUri: data.uri,
         mediaQueryMetricsData: context.mediaQueryMetrics,
         deviceInfoData: context.read<AppLabelsProvider>().build(),
-        enableLogCapture: data.enableConsoleLogCapture,
         appBar: _buildAppBar(context),
         pageInjectionStrategyBuilder: _defaultPageInjectionStrategy,
         connectivityRecoveryStrategyBuilder: () => _createConnectivityRecoveryStrategy(data),
+        // TODO: Use to embedded configuration option to enable/disable log capture.
+        enableLogCapture: true,
       ),
     );
   }

--- a/lib/features/embedded/view/embedded_screen_page.dart
+++ b/lib/features/embedded/view/embedded_screen_page.dart
@@ -49,7 +49,7 @@ class EmbeddedScreenPage extends StatelessWidget {
         appBar: _buildAppBar(context),
         pageInjectionStrategyBuilder: _defaultPageInjectionStrategy,
         connectivityRecoveryStrategyBuilder: () => _createConnectivityRecoveryStrategy(data),
-        // TODO: Use to embedded configuration option to enable/disable log capture.
+        // TODO: Use embedded configuration option to enable/disable log capture.
         enableLogCapture: true,
       ),
     );

--- a/lib/features/embedded/view/embedded_tab_page.dart
+++ b/lib/features/embedded/view/embedded_tab_page.dart
@@ -53,7 +53,7 @@ class EmbeddedTabPage extends StatelessWidget {
             pageInjectionStrategyBuilder: _defaultPageInjectionStrategy,
             connectivityRecoveryStrategyBuilder: () => _createConnectivityRecoveryStrategy(data.data!),
             shouldForwardPop: tabActive,
-            // TODO: Use to embedded configuration option to enable/disable log capture.
+            // TODO: Use embedded configuration option to enable/disable log capture.
             enableLogCapture: true,
           );
         },

--- a/lib/features/embedded/view/embedded_tab_page.dart
+++ b/lib/features/embedded/view/embedded_tab_page.dart
@@ -49,11 +49,12 @@ class EmbeddedTabPage extends StatelessWidget {
             initialUri: data.data!.uri,
             mediaQueryMetricsData: context.mediaQueryMetrics,
             deviceInfoData: context.read<AppLabelsProvider>().build(),
-            enableLogCapture: data.data?.enableConsoleLogCapture ?? false,
             appBar: _buildAppBar(context, data.titleL10n),
             pageInjectionStrategyBuilder: _defaultPageInjectionStrategy,
             connectivityRecoveryStrategyBuilder: () => _createConnectivityRecoveryStrategy(data.data!),
             shouldForwardPop: tabActive,
+            // TODO: Use to embedded configuration option to enable/disable log capture.
+            enableLogCapture: true,
           );
         },
       ),

--- a/lib/widgets/webview/webview_injection_builders.dart
+++ b/lib/widgets/webview/webview_injection_builders.dart
@@ -65,7 +65,10 @@ class PageInjectionBuilders {
   }) {
     final strategies = <PageInjectionStrategy>[];
 
-    strategies.addAll(custom);
+    // Should be included first to capture logs from other injections.
+    if (includeConsoleLogging) {
+      strategies.add(consoleLogging());
+    }
 
     if (mediaQueryMetricsData != null) {
       strategies.add(mediaQuery(mediaQueryMetricsData));
@@ -75,9 +78,7 @@ class PageInjectionBuilders {
       strategies.add(deviceInfo(deviceInfoData));
     }
 
-    if (includeConsoleLogging) {
-      strategies.add(consoleLogging());
-    }
+    strategies.addAll(custom);
 
     return strategies;
   }


### PR DESCRIPTION
This PR refactors embedded page handling by reorganizing console logging injection and adjusting default log capture behavior. The changes ensure console logging is initialized first to capture logs from other injections and temporarily hardcodes log capture to be enabled.

Reordered console logging injection to be first in the injection strategy list
Changed default enableLogCapture from false to true and hardcoded it in embedded pages
Reorganized field declarations in EmbeddedScreen class