### PR TITLE
fix: webrtc crash on g729a in remote sdp

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -394,6 +394,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                             callkeep: _callkeep,
                             callkeepConnections: _callkeepConnections,
                             sdpMunger: ModifyWithEncodingSettings(appPreferences, encodingConfig),
+                            sdpSanitizer: RemoteSdpSanitizer(),
                             webRtcOptionsBuilder: WebrtcOptionsWithAppSettingsBuilder(appPreferences),
                             userMediaBuilder: userMediaBuilder,
                             contactNameResolver: contactNameResolver,

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -58,6 +58,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final CallkeepConnections callkeepConnections;
 
   final SDPMunger? sdpMunger;
+  final SdpSanitizer? sdpSanitizer;
   final WebrtcOptionsBuilder? webRtcOptionsBuilder;
   final IceFilter? iceFilter;
   final UserMediaBuilder userMediaBuilder;
@@ -93,6 +94,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required this.contactNameResolver,
     required this.callErrorReporter,
     this.sdpMunger,
+    this.sdpSanitizer,
     this.webRtcOptionsBuilder,
     this.iceFilter,
     this.peerConnectionPolicyApplier,
@@ -994,6 +996,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         _logger.warning('__onCallSignalingEventProgress: peerConnection is null - most likely some permissions issue');
       } else {
         final remoteDescription = jsep.toDescription();
+        sdpSanitizer?.apply(remoteDescription);
         await peerConnection.setRemoteDescription(remoteDescription);
       }
     } else {
@@ -1030,6 +1033,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final pc = await _peerConnectionRetrieve(event.callId);
     if (jsep != null && pc != null) {
       final remoteDescription = jsep.toDescription();
+      sdpSanitizer?.apply(remoteDescription);
       await pc.setRemoteDescription(remoteDescription);
     }
   }
@@ -1118,6 +1122,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       final jsep = event.jsep;
       if (jsep != null) {
         final remoteDescription = jsep.toDescription();
+        sdpSanitizer?.apply(remoteDescription);
         await state.performOnActiveCall(event.callId, (activeCall) async {
           final peerConnection = await _peerConnectionRetrieve(activeCall.callId);
           if (peerConnection == null) {
@@ -1982,6 +1987,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }));
 
       final remoteDescription = offer.toDescription();
+      sdpSanitizer?.apply(remoteDescription);
       await peerConnection.setRemoteDescription(remoteDescription);
       final localDescription = await peerConnection.createAnswer({});
       sdpMunger?.apply(localDescription);

--- a/lib/features/call/utils/sdp_sanitizer.dart
+++ b/lib/features/call/utils/sdp_sanitizer.dart
@@ -1,0 +1,27 @@
+import 'package:logging/logging.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+import 'package:webtrit_phone/features/call/utils/utils.dart';
+
+final _logger = Logger('SdpSanitizer');
+
+abstract class SdpSanitizer {
+  void apply(RTCSessionDescription description);
+}
+
+class RemoteSdpSanitizer implements SdpSanitizer {
+  @override
+  void apply(RTCSessionDescription description) {
+    final originalSdp = description.sdp;
+    if (originalSdp == null) return;
+
+    final builder = SDPModBuilder(sdp: originalSdp);
+    builder.removeG729a();
+    final sanitizedSdp = builder.sdp;
+
+    if (sanitizedSdp != originalSdp) {
+      _logger.info('Sdp sanitazer applied');
+      description.sdp = sanitizedSdp;
+    }
+  }
+}

--- a/lib/features/call/utils/utils.dart
+++ b/lib/features/call/utils/utils.dart
@@ -5,6 +5,7 @@ export 'ice_filter.dart';
 export 'peer_connection_policy_applier.dart';
 export 'sdp_mod_builder.dart';
 export 'sdp_munger.dart';
+export 'sdp_sanitizer.dart';
 export 'user_media_builder.dart';
 export 'video_constraints_builder.dart';
 export 'webrtc_options_builder.dart';


### PR DESCRIPTION
Contains workaround for case when WebRTC crashes if remote sdp contains 'G729a' payload