### PR TITLE
fix: safely trigger CDRs sync worker after call ends

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -14,6 +14,7 @@ import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/app/session/session.dart';
 import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/app_localizations.g.mapper.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -401,6 +402,10 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                             contactRepository: context.read<ContactsRepository>(),
                           );
 
+                          // Try to get CDRs sync worker to trigger immediate sync after call ends
+                          // If CDRs feature is disabled, the worker will be null and no sync will be performed
+                          final cdrsSyncWorker = context.readOrNull<CdrsSyncWorker>();
+
                           return CallBloc(
                             coreUrl: appBloc.state.session.coreUrl!,
                             tenantId: appBloc.state.session.tenantId,
@@ -423,7 +428,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                                 DefaultCallErrorReporter((n) => notificationsBloc.add(NotificationsSubmitted(n))),
                             iceFilter: FilterWithAppSettings(appPreferences),
                             peerConnectionPolicyApplier: pearConnectionPolicyApplier,
-                            onCallEnded: () => context.read<CdrsSyncWorker>().forceSync(const Duration(seconds: 1)),
+                            onCallEnded: () => cdrsSyncWorker?.forceSync(const Duration(seconds: 1)),
                           )..add(const CallStarted());
                         },
                       ),


### PR DESCRIPTION
This PR fixes a potential crash by safely accessing the CDRs sync worker when a call ends. The change prevents null reference exceptions when the CDRs feature is disabled.

Replaces direct context.read access with null-safe context.readOrNull
Adds null-safe call to forceSync method using optional chaining
