### PR TITLE
fix: add configurable bodySafeAreaSides to LoginSignupVerifyScreenPage for embedded flow control

### DIFF
--- a/lib/app/router/app_router.gr.dart
+++ b/lib/app/router/app_router.gr.dart
@@ -29,8 +29,7 @@ class AboutScreenPageRoute extends PageRouteInfo<void> {
 /// generated route for
 /// [AppShell]
 class AppShellRoute extends PageRouteInfo<void> {
-  const AppShellRoute({List<PageRouteInfo>? children})
-      : super(AppShellRoute.name, initialChildren: children);
+  const AppShellRoute({List<PageRouteInfo>? children}) : super(AppShellRoute.name, initialChildren: children);
 
   static const String name = 'AppShellRoute';
 
@@ -44,8 +43,7 @@ class AppShellRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [AutoprovisionScreenPage]
-class AutoprovisionScreenPageRoute
-    extends PageRouteInfo<AutoprovisionScreenPageRouteArgs> {
+class AutoprovisionScreenPageRoute extends PageRouteInfo<AutoprovisionScreenPageRouteArgs> {
   AutoprovisionScreenPageRoute({
     String? configToken,
     String? tenantId,
@@ -110,14 +108,11 @@ class AutoprovisionScreenPageRouteArgs {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! AutoprovisionScreenPageRouteArgs) return false;
-    return configToken == other.configToken &&
-        tenantId == other.tenantId &&
-        coreUrl == other.coreUrl;
+    return configToken == other.configToken && tenantId == other.tenantId && coreUrl == other.coreUrl;
   }
 
   @override
-  int get hashCode =>
-      configToken.hashCode ^ tenantId.hashCode ^ coreUrl.hashCode;
+  int get hashCode => configToken.hashCode ^ tenantId.hashCode ^ coreUrl.hashCode;
 }
 
 /// generated route for
@@ -140,8 +135,7 @@ class CallLogScreenPageRoute extends PageRouteInfo<CallLogScreenPageRouteArgs> {
     builder: (data) {
       final pathParams = data.inheritedPathParams;
       final args = data.argsAs<CallLogScreenPageRouteArgs>(
-        orElse: () =>
-            CallLogScreenPageRouteArgs(number: pathParams.getString('number')),
+        orElse: () => CallLogScreenPageRouteArgs(number: pathParams.getString('number')),
       );
       return CallLogScreenPage(args.number);
     },
@@ -187,8 +181,7 @@ class CallScreenPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [CallToActionsWebPage]
-class CallToActionsWebPageRoute
-    extends PageRouteInfo<CallToActionsWebPageRouteArgs> {
+class CallToActionsWebPageRoute extends PageRouteInfo<CallToActionsWebPageRouteArgs> {
   CallToActionsWebPageRoute({
     required Uri initialUrl,
     List<PageRouteInfo>? children,
@@ -248,8 +241,7 @@ class CallerIdSettingsScreenPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [ChatConversationScreenPage]
-class ChatConversationScreenPageRoute
-    extends PageRouteInfo<ChatConversationScreenPageRouteArgs> {
+class ChatConversationScreenPageRoute extends PageRouteInfo<ChatConversationScreenPageRouteArgs> {
   ChatConversationScreenPageRoute({
     String? participantId,
     int? chatId,
@@ -386,8 +378,7 @@ class ContactsRouterPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [ContactsScreenPage]
-class ContactsScreenPageRoute
-    extends PageRouteInfo<ContactsScreenPageRouteArgs> {
+class ContactsScreenPageRoute extends PageRouteInfo<ContactsScreenPageRouteArgs> {
   ContactsScreenPageRoute({
     required List<ContactSourceType> sourceTypes,
     List<PageRouteInfo>? children,
@@ -463,8 +454,7 @@ class DiagnosticScreenPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [EmbeddedScreenPage]
-class EmbeddedScreenPageRoute
-    extends PageRouteInfo<EmbeddedScreenPageRouteArgs> {
+class EmbeddedScreenPageRoute extends PageRouteInfo<EmbeddedScreenPageRouteArgs> {
   EmbeddedScreenPageRoute({
     required EmbeddedData data,
     List<PageRouteInfo>? children,
@@ -554,8 +544,7 @@ class EmbeddedTabPageRouteArgs {
 
 /// generated route for
 /// [ErrorDetailsScreenPage]
-class ErrorDetailsScreenPageRoute
-    extends PageRouteInfo<ErrorDetailsScreenPageRouteArgs> {
+class ErrorDetailsScreenPageRoute extends PageRouteInfo<ErrorDetailsScreenPageRouteArgs> {
   ErrorDetailsScreenPageRoute({
     required String title,
     required List<ErrorFieldModel> fields,
@@ -596,8 +585,7 @@ class ErrorDetailsScreenPageRouteArgs {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! ErrorDetailsScreenPageRouteArgs) return false;
-    return title == other.title &&
-        const ListEquality().equals(fields, other.fields);
+    return title == other.title && const ListEquality().equals(fields, other.fields);
   }
 
   @override
@@ -740,8 +728,7 @@ class LogRecordsConsoleScreenPageRoute extends PageRouteInfo<void> {
 /// [LoginCoreUrlAssignScreenPage]
 class LoginCoreUrlAssignScreenPageRoute extends PageRouteInfo<void> {
   const LoginCoreUrlAssignScreenPageRoute({List<PageRouteInfo>? children})
-      : super(LoginCoreUrlAssignScreenPageRoute.name,
-            initialChildren: children);
+      : super(LoginCoreUrlAssignScreenPageRoute.name, initialChildren: children);
 
   static const String name = 'LoginCoreUrlAssignScreenPageRoute';
 
@@ -827,8 +814,7 @@ class LoginOtpSigninVerifyScreenPageRoute extends PageRouteInfo<void> {
 /// [LoginPasswordSigninScreenPage]
 class LoginPasswordSigninScreenPageRoute extends PageRouteInfo<void> {
   const LoginPasswordSigninScreenPageRoute({List<PageRouteInfo>? children})
-      : super(LoginPasswordSigninScreenPageRoute.name,
-            initialChildren: children);
+      : super(LoginPasswordSigninScreenPageRoute.name, initialChildren: children);
 
   static const String name = 'LoginPasswordSigninScreenPageRoute';
 
@@ -848,8 +834,7 @@ class LoginRouterPageRoute extends PageRouteInfo<LoginRouterPageRouteArgs> {
     List<PageRouteInfo>? children,
   }) : super(
           LoginRouterPageRoute.name,
-          args:
-              LoginRouterPageRouteArgs(launchEmbeddedData: launchEmbeddedData),
+          args: LoginRouterPageRouteArgs(launchEmbeddedData: launchEmbeddedData),
           initialChildren: children,
         );
 
@@ -889,8 +874,7 @@ class LoginRouterPageRouteArgs {
 
 /// generated route for
 /// [LoginSignupEmbeddedRequestScreenPage]
-class LoginSignupEmbeddedRequestScreenPageRoute
-    extends PageRouteInfo<LoginSignupEmbeddedRequestScreenPageRouteArgs> {
+class LoginSignupEmbeddedRequestScreenPageRoute extends PageRouteInfo<LoginSignupEmbeddedRequestScreenPageRouteArgs> {
   LoginSignupEmbeddedRequestScreenPageRoute({
     required EmbeddedData embeddedData,
     List<PageRouteInfo>? children,
@@ -940,8 +924,7 @@ class LoginSignupEmbeddedRequestScreenPageRouteArgs {
 /// [LoginSignupRequestScreenPage]
 class LoginSignupRequestScreenPageRoute extends PageRouteInfo<void> {
   const LoginSignupRequestScreenPageRoute({List<PageRouteInfo>? children})
-      : super(LoginSignupRequestScreenPageRoute.name,
-            initialChildren: children);
+      : super(LoginSignupRequestScreenPageRoute.name, initialChildren: children);
 
   static const String name = 'LoginSignupRequestScreenPageRoute';
 
@@ -971,24 +954,58 @@ class LoginSignupRouterPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [LoginSignupVerifyScreenPage]
-class LoginSignupVerifyScreenPageRoute extends PageRouteInfo<void> {
-  const LoginSignupVerifyScreenPageRoute({List<PageRouteInfo>? children})
-      : super(LoginSignupVerifyScreenPageRoute.name, initialChildren: children);
+class LoginSignupVerifyScreenPageRoute extends PageRouteInfo<LoginSignupVerifyScreenPageRouteArgs> {
+  LoginSignupVerifyScreenPageRoute({
+    required Set<SafeAreaSide> bodySafeAreaSides,
+    List<PageRouteInfo>? children,
+  }) : super(
+          LoginSignupVerifyScreenPageRoute.name,
+          args: LoginSignupVerifyScreenPageRouteArgs(
+            bodySafeAreaSides: bodySafeAreaSides,
+          ),
+          initialChildren: children,
+        );
 
   static const String name = 'LoginSignupVerifyScreenPageRoute';
 
   static PageInfo page = PageInfo(
     name,
     builder: (data) {
-      return LoginSignupVerifyScreenPage();
+      final args = data.argsAs<LoginSignupVerifyScreenPageRouteArgs>();
+      return LoginSignupVerifyScreenPage(
+        bodySafeAreaSides: args.bodySafeAreaSides,
+      );
     },
   );
 }
 
+class LoginSignupVerifyScreenPageRouteArgs {
+  const LoginSignupVerifyScreenPageRouteArgs({required this.bodySafeAreaSides});
+
+  final Set<SafeAreaSide> bodySafeAreaSides;
+
+  @override
+  String toString() {
+    return 'LoginSignupVerifyScreenPageRouteArgs{bodySafeAreaSides: $bodySafeAreaSides}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! LoginSignupVerifyScreenPageRouteArgs) return false;
+    return const SetEquality().equals(
+      bodySafeAreaSides,
+      other.bodySafeAreaSides,
+    );
+  }
+
+  @override
+  int get hashCode => const SetEquality().hash(bodySafeAreaSides);
+}
+
 /// generated route for
 /// [LoginSwitchScreenPage]
-class LoginSwitchScreenPageRoute
-    extends PageRouteInfo<LoginSwitchScreenPageRouteArgs> {
+class LoginSwitchScreenPageRoute extends PageRouteInfo<LoginSwitchScreenPageRouteArgs> {
   LoginSwitchScreenPageRoute({
     required Set<SafeAreaSide> bodySafeAreaSides,
     List<LoginType>? forceLoginTypes,
@@ -1083,8 +1100,7 @@ class MainScreenPageRoute extends PageRouteInfo<void> {
 /// generated route for
 /// [MainShell]
 class MainShellRoute extends PageRouteInfo<void> {
-  const MainShellRoute({List<PageRouteInfo>? children})
-      : super(MainShellRoute.name, initialChildren: children);
+  const MainShellRoute({List<PageRouteInfo>? children}) : super(MainShellRoute.name, initialChildren: children);
 
   static const String name = 'MainShellRoute';
 
@@ -1130,8 +1146,7 @@ class NetworkScreenPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [NumberCdrsScreenPage]
-class NumberCdrsScreenPageRoute
-    extends PageRouteInfo<NumberCdrsScreenPageRouteArgs> {
+class NumberCdrsScreenPageRoute extends PageRouteInfo<NumberCdrsScreenPageRouteArgs> {
   NumberCdrsScreenPageRoute({
     required String number,
     List<PageRouteInfo>? children,
@@ -1261,8 +1276,7 @@ class RecentsScreenPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [SelfConfigScreenPage]
-class SelfConfigScreenPageRoute
-    extends PageRouteInfo<SelfConfigScreenPageRouteArgs> {
+class SelfConfigScreenPageRoute extends PageRouteInfo<SelfConfigScreenPageRouteArgs> {
   SelfConfigScreenPageRoute({required Uri url, List<PageRouteInfo>? children})
       : super(
           SelfConfigScreenPageRoute.name,
@@ -1336,8 +1350,7 @@ class SettingsScreenPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [SmsConversationScreenPage]
-class SmsConversationScreenPageRoute
-    extends PageRouteInfo<SmsConversationScreenPageRouteArgs> {
+class SmsConversationScreenPageRoute extends PageRouteInfo<SmsConversationScreenPageRouteArgs> {
   SmsConversationScreenPageRoute({
     required String firstNumber,
     required String secondNumber,
@@ -1390,14 +1403,11 @@ class SmsConversationScreenPageRouteArgs {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! SmsConversationScreenPageRouteArgs) return false;
-    return firstNumber == other.firstNumber &&
-        secondNumber == other.secondNumber &&
-        recipientId == other.recipientId;
+    return firstNumber == other.firstNumber && secondNumber == other.secondNumber && recipientId == other.recipientId;
   }
 
   @override
-  int get hashCode =>
-      firstNumber.hashCode ^ secondNumber.hashCode ^ recipientId.hashCode;
+  int get hashCode => firstNumber.hashCode ^ secondNumber.hashCode ^ recipientId.hashCode;
 }
 
 /// generated route for
@@ -1418,8 +1428,7 @@ class SystemNotificationsPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [TermsConditionsScreenPage]
-class TermsConditionsScreenPageRoute
-    extends PageRouteInfo<TermsConditionsScreenPageRouteArgs> {
+class TermsConditionsScreenPageRoute extends PageRouteInfo<TermsConditionsScreenPageRouteArgs> {
   TermsConditionsScreenPageRoute({
     String? initialUriQueryParam,
     List<PageRouteInfo>? children,
@@ -1489,8 +1498,7 @@ class ThemeModeScreenPageRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [UndefinedScreenPage]
-class UndefinedScreenPageRoute
-    extends PageRouteInfo<UndefinedScreenPageRouteArgs> {
+class UndefinedScreenPageRoute extends PageRouteInfo<UndefinedScreenPageRouteArgs> {
   UndefinedScreenPageRoute({
     required UndefinedType undefinedType,
     List<PageRouteInfo>? children,

--- a/lib/features/login/features/login_signup/view/login_signup_router_page.dart
+++ b/lib/features/login/features/login_signup/view/login_signup_router_page.dart
@@ -37,7 +37,12 @@ class LoginSignupRouterPage extends StatelessWidget {
             return [
               if (embedded == null) const LoginSignupRequestScreenPageRoute(),
               if (embedded != null) LoginSignupEmbeddedRequestScreenPageRoute(embeddedData: embedded),
-              if (whenLoginSignupVerifyScreenPageActive(state)) const LoginSignupVerifyScreenPageRoute(),
+
+              // In embedded flow, the webview occupies the full screen, including tabs and logo.
+              // For the next native screen (e.g., OTP verification), a safe area is required to avoid UI overlap.
+              if (whenLoginSignupVerifyScreenPageActive(state))
+                LoginSignupVerifyScreenPageRoute(
+                    bodySafeAreaSides: embedded != null ? SafeAreaSide.values.toSet() : {}),
             ];
           },
           onPopRoute: (route, results) {

--- a/lib/features/login/features/login_signup/view/login_signup_verify_screen.dart
+++ b/lib/features/login/features/login_signup/view/login_signup_verify_screen.dart
@@ -13,7 +13,12 @@ export 'login_signup_verify_screen_style.dart';
 export 'login_signup_verify_screen_styles.dart';
 
 class LoginSignupVerifyScreen extends StatelessWidget {
-  const LoginSignupVerifyScreen({super.key});
+  const LoginSignupVerifyScreen({
+    super.key,
+    required this.bodySafeAreaSides,
+  });
+
+  final Set<SafeAreaSide> bodySafeAreaSides;
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +49,10 @@ class LoginSignupVerifyScreen extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(kInset, kInset / 2, kInset, kInset),
           color: themeData.scaffoldBackgroundColor,
           child: SafeArea(
+            top: bodySafeAreaSides.contains(SafeAreaSide.top),
+            bottom: bodySafeAreaSides.contains(SafeAreaSide.bottom),
+            left: bodySafeAreaSides.contains(SafeAreaSide.left),
+            right: bodySafeAreaSides.contains(SafeAreaSide.right),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [

--- a/lib/features/login/features/login_signup/view/login_signup_verify_screen_page.dart
+++ b/lib/features/login/features/login_signup/view/login_signup_verify_screen_page.dart
@@ -7,11 +7,15 @@ import 'package:webtrit_phone/features/features.dart';
 @RoutePage()
 class LoginSignupVerifyScreenPage extends StatelessWidget {
   // ignore: use_key_in_widget_constructors
-  const LoginSignupVerifyScreenPage();
+  const LoginSignupVerifyScreenPage({
+    required this.bodySafeAreaSides,
+  });
+
+  final Set<SafeAreaSide> bodySafeAreaSides;
 
   @override
   Widget build(BuildContext context) {
-    const widget = LoginSignupVerifyScreen();
+    final widget = LoginSignupVerifyScreen(bodySafeAreaSides: bodySafeAreaSides);
     return widget;
   }
 }

--- a/screenshots/lib/screenshots/login_signup_verify_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_signup_verify_screen_screenshot.dart
@@ -26,7 +26,7 @@ class LoginSignUpVerifyScreenshot extends StatelessWidget {
             SizedBox(height: kInset),
           ],
         ),
-        body: LoginSignupVerifyScreen(),
+        body: LoginSignupVerifyScreen(bodySafeAreaSides: SafeAreaSide.values.toSet()),
         currentLoginType: LoginType.signup,
         supportedLoginTypes: [
           LoginType.otpSignin,


### PR DESCRIPTION
This PR adds configurable bodySafeAreaSides to the LoginSignupVerifyScreenPage to control safe area handling in embedded flows. This allows the component to adapt its safe area behavior based on whether it's running in an embedded context or standalone.

Added a required bodySafeAreaSides parameter to control which sides of the safe area are applied
Updated the routing logic to provide different safe area configurations based on embedded flow state
Modified generated router code to support the new parameter through proper route arguments