### PR TITLE
fix: show contact extension only when available

### DIFF
--- a/lib/features/messaging/features/chat_conversation_builder/view/builder_stages/dialog_contact_selection_view.dart
+++ b/lib/features/messaging/features/chat_conversation_builder/view/builder_stages/dialog_contact_selection_view.dart
@@ -74,7 +74,12 @@ class DialogContactSelectionView extends StatelessWidget {
                     radius: 24,
                   ),
                   title: Text(contact.displayTitle),
-                  subtitle: Text('Ext: ${contact.extension ?? "N/A"}', style: theme.textTheme.bodySmall),
+                  subtitle: contact.extension == null
+                      ? null
+                      : Text(
+                          context.l10n.messaging_ConversationBuilders_contactExtension(contact.extension!),
+                          style: theme.textTheme.bodySmall,
+                        ),
                   onTap: () => builderCubit.onDialogCreateConfirm(contact),
                 ),
               );

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1585,6 +1585,12 @@ abstract class AppLocalizations {
   /// **'Create group'**
   String get messaging_ConversationBuilders_createGroup;
 
+  /// Label for a contact's extension number in the contact list.
+  ///
+  /// In en, this message translates to:
+  /// **'Ext: {extension}'**
+  String messaging_ConversationBuilders_contactExtension(String extension);
+
   /// No description provided for @messaging_ConversationBuilders_externalContacts_heading.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -1193,6 +1193,9 @@ class AppLocalizationsMapper {
           (actual, supportedConstraint) => localizations
               .main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
                   actual, supportedConstraint),
+      'messaging_ConversationBuilders_contactExtension': (extension) =>
+          localizations
+              .messaging_ConversationBuilders_contactExtension(extension),
       'notifications_errorSnackBar_signalingDisconnectWithCodeName':
           (codeName) => localizations
               .notifications_errorSnackBar_signalingDisconnectWithCodeName(

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -859,6 +859,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get messaging_ConversationBuilders_createGroup => 'Create group';
 
   @override
+  String messaging_ConversationBuilders_contactExtension(String extension) {
+    return 'Ext: $extension';
+  }
+
+  @override
   String get messaging_ConversationBuilders_externalContacts_heading =>
       'Cloud PBX contacts';
 

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -880,6 +880,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get messaging_ConversationBuilders_createGroup => 'Crea gruppo';
 
   @override
+  String messaging_ConversationBuilders_contactExtension(String extension) {
+    return 'Int: $extension';
+  }
+
+  @override
   String get messaging_ConversationBuilders_externalContacts_heading =>
       'Contatti Cloud PBX';
 

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -875,6 +875,11 @@ class AppLocalizationsUk extends AppLocalizations {
   String get messaging_ConversationBuilders_createGroup => 'Створити групу';
 
   @override
+  String messaging_ConversationBuilders_contactExtension(String extension) {
+    return 'Внутр: $extension';
+  }
+
+  @override
   String get messaging_ConversationBuilders_externalContacts_heading =>
       'Контакти Хмарної АТС';
 

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -667,6 +667,16 @@
   "@messaging_ConversationBuilders_create": {},
   "messaging_ConversationBuilders_createGroup": "Create group",
   "@messaging_ConversationBuilders_createGroup": {},
+  "messaging_ConversationBuilders_contactExtension": "Ext: {extension}",
+  "@messaging_ConversationBuilders_contactExtension": {
+    "description": "Label for a contact's extension number in the contact list.",
+    "placeholders": {
+      "extension": {
+        "type": "String",
+        "example": "101"
+      }
+    }
+  },
   "messaging_ConversationBuilders_externalContacts_heading": "Cloud PBX contacts",
   "@messaging_ConversationBuilders_externalContacts_heading": {},
   "messaging_ConversationBuilders_invalidNumber_message1": "The contact has an invalid phone number. It should be in the format ",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -667,6 +667,16 @@
   "@messaging_ConversationBuilders_create": {},
   "messaging_ConversationBuilders_createGroup": "Crea gruppo",
   "@messaging_ConversationBuilders_createGroup": {},
+  "messaging_ConversationBuilders_contactExtension": "Int: {extension}",
+  "@messaging_ConversationBuilders_contactExtension": {
+    "description": "Etichetta per il numero di interno di un contatto nell'elenco contatti.",
+    "placeholders": {
+      "extension": {
+        "type": "String",
+        "example": "101"
+      }
+    }
+  },
   "messaging_ConversationBuilders_externalContacts_heading": "Contatti Cloud PBX",
   "@messaging_ConversationBuilders_externalContacts_heading": {},
   "messaging_ConversationBuilders_invalidNumber_message1": "Il tsontact ha un numero di telefono non valido. Dovrebbe essere nel formato ",
@@ -1215,7 +1225,7 @@
   "@settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps": {},
   "settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip": "Rimuovere le linee di mappa RTP statiche per i codec audio (ad es. PCMU, PCMA) dall'SDP, per ridurre la dimensione dell'SDP. Può aiutare con problemi di frammentazione MTU su alcuni endpoint SIP.",
   "@settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip": {},
-  "settings_encoding_Section_extra_sdp_mod_remapTE8": "Rimappare il codice TE_8k a 101", 
+  "settings_encoding_Section_extra_sdp_mod_remapTE8": "Rimappare il codice TE_8k a 101",
   "@settings_encoding_Section_extra_sdp_mod_remapTE8": {},
   "settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip": "Cambiare il tipo di payload TE8 a 101 nell'SDP per una migliore compatibilità con alcuni endpoint SIP.",
   "@settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip": {},

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -667,6 +667,16 @@
   "@messaging_ConversationBuilders_create": {},
   "messaging_ConversationBuilders_createGroup": "Створити групу",
   "@messaging_ConversationBuilders_createGroup": {},
+  "messaging_ConversationBuilders_contactExtension": "Внутр: {extension}",
+  "@messaging_ConversationBuilders_contactExtension": {
+    "description": "Мітка для внутрішнього номера контакту у списку контактів.",
+    "placeholders": {
+      "extension": {
+        "type": "String",
+        "example": "101"
+      }
+    }
+  },
   "messaging_ConversationBuilders_externalContacts_heading": "Контакти Хмарної АТС",
   "@messaging_ConversationBuilders_externalContacts_heading": {},
   "messaging_ConversationBuilders_invalidNumber_message1": "Контакт має недійсний номер телефону. Він має бути у форматі ",
@@ -1215,7 +1225,7 @@
   "@settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps": {},
   "settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip": "Видалити статичні RTP map рядки для аудіо кодеків (наприклад, PCMU, PCMA) з SDP для зменшення розміру SDP. Може допомогти з проблемами фрагментації MTU на деяких SIP клієнтах.",
   "@settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip": {},
-  "settings_encoding_Section_extra_sdp_mod_remapTE8": "Перепризначити код TE_8k на 101", 
+  "settings_encoding_Section_extra_sdp_mod_remapTE8": "Перепризначити код TE_8k на 101",
   "@settings_encoding_Section_extra_sdp_mod_remapTE8": {},
   "settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip": "Змінити тип навантаження TE8 на 101 в SDP для кращої сумісності з деякими SIP клієнтами.",
   "@settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip": {},


### PR DESCRIPTION
This PR adds localized support for displaying contact extension numbers in the messaging conversation builder. The hardcoded "Ext:" label has been replaced with localizable strings, and the logic has been improved to hide the subtitle when no extension is available.

Added localization entries for contact extension labels in English, Italian, and Ukrainian
Updated generated localization files to include the new translation method
Refactored the contact list UI to use localized strings and conditionally display the extension