### PR TITLE
chore: upgrade Gradle to 8.13, AGP to 8.13.0, and migrate build scripts to Java 17

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,7 +27,7 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-def projectPropertyDartDefines = [:];
+def projectPropertyDartDefines = [:]
 if (project.hasProperty('dart-defines')) {
     projectPropertyDartDefines += project.property('dart-defines')
             .split(',')
@@ -139,8 +139,8 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     flavorDimensions "deeplinks", "smsReceiver"
@@ -235,7 +235,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -288,6 +288,6 @@ flutter {
 }
 
 dependencies {
-    androidTestUtil "androidx.test:orchestrator:1.5.1"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    androidTestUtil "androidx.test:orchestrator:1.6.1"
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,14 +5,13 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
+rootProject.layout.buildDirectory.set(file("../build"))
+
 subprojects {
-    project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
-    project.evaluationDependsOn(':app')
+    layout.buildDirectory.set(file("${rootProject.layout.buildDirectory.get()}/${name}"))
+    evaluationDependsOn(":app")
 }
 
 tasks.register("clean", Delete) {
-    delete rootProject.buildDir
+    delete(rootProject.layout.buildDirectory)
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,10 +18,10 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.6.1' apply false
-    id "org.jetbrains.kotlin.android" version "2.0.0" apply false
-    id "com.google.gms.google-services" version "4.4.2" apply false
-    id "com.google.firebase.crashlytics" version "2.9.9" apply false
+    id "com.android.application" version '8.13.0' apply false
+    id "org.jetbrains.kotlin.android" version "2.2.21" apply false
+    id "com.google.gms.google-services" version "4.4.4" apply false
+    id "com.google.firebase.crashlytics" version "3.0.6" apply false
 }
 
 include ":app"


### PR DESCRIPTION
This PR updates Android build tools and dependencies to their latest versions, including Gradle, Android Gradle Plugin (AGP), Kotlin, and various Google/Firebase libraries. It also modernizes the Gradle build script syntax by replacing deprecated buildDir properties with the newer layout.buildDirectory API.

- Updated Gradle from 8.7 to 8.13 and AGP from 8.6.1 to 8.13.0
- Upgraded Kotlin from 2.0.0 to 2.2.21 and Java compatibility to VERSION_17
- Modernized build directory configuration syntax