### PR TITLE
fix: fixed call handling from recents calls on ios

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -727,7 +727,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       emit(state.copyWith(
         callServiceState: state.callServiceState.copyWith(
           signalingClientStatus: SignalingClientStatus.disconnect,
-          registration: const Registration(status: RegistrationStatus.registering),
           lastSignalingClientDisconnectError: null,
           lastSignalingDisconnectCode: null,
         ),

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -36,6 +36,8 @@ class ThemeStyleFactoryProvider {
     final callStatuses = widgetConfig.statuses.callStatuses;
     final registrationStatuses = widgetConfig.statuses.registrationStatuses;
     final elevatedButton = widgetConfig.button.primaryElevatedButton;
+    // TODO: Remove in future major release after migrating to CallPageActionsConfig
+    // ignore: deprecated_member_use
     final callActions = widgetConfig.group?.callActions;
     final groupTitleListTile = widgetConfig.group?.groupTitleListTile;
     final linkify = widgetConfig.text.linkify;


### PR DESCRIPTION
Fixed call handling when user initiates call from recents list on iOS. Also added TODO label for callActions in theme_style_factory_provider.