### PR TITLE
refactor: make registration nullable, unify events, and allow early outgoing calls

### DIFF
--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -208,16 +208,8 @@ sealed class _CallSignalingEvent extends CallEvent {
     required String? content,
   }) = _CallSignalingEventNotifyUnknown;
 
-  const factory _CallSignalingEvent.registering() = _CallSignalingEventRegistering;
-
-  const factory _CallSignalingEvent.registered() = _CallSignalingEventRegistered;
-
-  const factory _CallSignalingEvent.registrationFailed(int code, String reason) =
-      _CallSignalingEventRegisterationFailed;
-
-  const factory _CallSignalingEvent.unregistering() = _CallSignalingEventUnregistering;
-
-  const factory _CallSignalingEvent.unregistered() = _CallSignalingEventUnregistered;
+  const factory _CallSignalingEvent.registration(RegistrationStatus status, {int? code, String? reason}) =
+      _CallSignalingEventRegistration;
 }
 
 class _CallSignalingEventIncoming extends _CallSignalingEvent {
@@ -459,30 +451,15 @@ class _CallSignalingEventNotifyUnknown extends _CallSignalingEvent {
   List<Object?> get props => [line, callId, notify, subscriptionState, contentType, content];
 }
 
-class _CallSignalingEventRegistering extends _CallSignalingEvent {
-  const _CallSignalingEventRegistering();
-}
+class _CallSignalingEventRegistration extends _CallSignalingEvent {
+  const _CallSignalingEventRegistration(this.status, {this.code, this.reason});
 
-class _CallSignalingEventRegistered extends _CallSignalingEvent {
-  const _CallSignalingEventRegistered();
-}
-
-class _CallSignalingEventRegisterationFailed extends _CallSignalingEvent {
-  const _CallSignalingEventRegisterationFailed(this.code, this.reason);
-
-  final int code;
-  final String reason;
+  final RegistrationStatus status;
+  final int? code;
+  final String? reason;
 
   @override
-  List<Object?> get props => [code, reason];
-}
-
-class _CallSignalingEventUnregistering extends _CallSignalingEvent {
-  const _CallSignalingEventUnregistering();
-}
-
-class _CallSignalingEventUnregistered extends _CallSignalingEvent {
-  const _CallSignalingEventUnregistered();
+  List<Object?> get props => [status, code, reason];
 }
 
 // call push events

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -39,6 +39,12 @@ class CallState with _$CallState {
 
   CallStatus get status => callServiceState.status;
 
+  /// Indicates that the handshake phase has completed and registration status is available.
+  bool get isHandshakeEstablished => callServiceState.registration?.status != null;
+
+  /// Indicates that the signaling connection to the server is successfully established.
+  bool get isSignalingEstablished => callServiceState.signalingClientStatus.isConnect;
+
   int? retrieveIdleLine() {
     for (var line = 0; line < linesCount; line++) {
       if (!activeCalls.any((activeCall) => activeCall.line == line)) {

--- a/lib/models/call/call_service_state.dart
+++ b/lib/models/call/call_service_state.dart
@@ -15,7 +15,7 @@ enum NetworkStatus { changing, available, none }
 class CallServiceState with _$CallServiceState {
   const CallServiceState({
     this.signalingClientStatus = SignalingClientStatus.connecting,
-    this.registration = const Registration(status: RegistrationStatus.registering),
+    this.registration,
     this.networkStatus,
     this.lastSignalingClientConnectError,
     this.lastSignalingClientDisconnectError,
@@ -25,8 +25,18 @@ class CallServiceState with _$CallServiceState {
   @override
   final SignalingClientStatus signalingClientStatus;
 
+  /// Represents the current registration status of the signaling client.
+  ///
+  /// This status is updated based on signaling-related events, such as:
+  /// - `onDisconnect`: triggered when the signaling connection is lost.
+  /// - `_onHandshakeSignalingEventState`: triggered during handshake updates.
+  /// - `RegisteringEvent` / `RegisteredEvent`: indicate ongoing or successful registration.
+  /// - `RegistrationFailedEvent`: indicates registration failure.
+  /// - `UnregisteringEvent` / `UnregisteredEvent`: indicate ongoing or completed unregistration.
+  ///
+  /// The `registration` field reflects the most recent registration state of the signaling client.
   @override
-  final Registration registration;
+  final Registration? registration;
 
   @override
   final NetworkStatus? networkStatus;
@@ -47,13 +57,13 @@ class CallServiceState with _$CallServiceState {
       return CallStatus.connectivityNone;
     } else if (lastSignalingClientConnectError != null) {
       return CallStatus.connectError;
-    } else if (registration.status.isUnregistered) {
+    } else if (registration?.status.isUnregistered == true) {
       return CallStatus.appUnregistered;
-    } else if (registration.status.isFailed) {
+    } else if (registration?.status.isFailed == true) {
       return CallStatus.connectIssue;
     } else if (lastSignalingDisconnectCode != null) {
       return CallStatus.connectIssue;
-    } else if (signalingClientStatus.isConnect && registration.status.isRegistered) {
+    } else if (signalingClientStatus.isConnect && registration?.status.isRegistered == true) {
       return CallStatus.ready;
     } else {
       return CallStatus.inProgress;

--- a/lib/models/call/call_service_state.freezed.dart
+++ b/lib/models/call/call_service_state.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CallServiceState {
 
- SignalingClientStatus get signalingClientStatus; Registration get registration; NetworkStatus? get networkStatus; Object? get lastSignalingClientConnectError; Object? get lastSignalingClientDisconnectError; int? get lastSignalingDisconnectCode;
+ SignalingClientStatus get signalingClientStatus; Registration? get registration; NetworkStatus? get networkStatus; Object? get lastSignalingClientConnectError; Object? get lastSignalingClientDisconnectError; int? get lastSignalingDisconnectCode;
 /// Create a copy of CallServiceState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -45,7 +45,7 @@ abstract mixin class $CallServiceStateCopyWith<$Res>  {
   factory $CallServiceStateCopyWith(CallServiceState value, $Res Function(CallServiceState) _then) = _$CallServiceStateCopyWithImpl;
 @useResult
 $Res call({
- SignalingClientStatus signalingClientStatus, Registration registration, NetworkStatus? networkStatus, Object? lastSignalingClientConnectError, Object? lastSignalingClientDisconnectError, int? lastSignalingDisconnectCode
+ SignalingClientStatus signalingClientStatus, Registration? registration, NetworkStatus? networkStatus, Object? lastSignalingClientConnectError, Object? lastSignalingClientDisconnectError, int? lastSignalingDisconnectCode
 });
 
 
@@ -62,11 +62,11 @@ class _$CallServiceStateCopyWithImpl<$Res>
 
 /// Create a copy of CallServiceState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? signalingClientStatus = null,Object? registration = null,Object? networkStatus = freezed,Object? lastSignalingClientConnectError = freezed,Object? lastSignalingClientDisconnectError = freezed,Object? lastSignalingDisconnectCode = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? signalingClientStatus = null,Object? registration = freezed,Object? networkStatus = freezed,Object? lastSignalingClientConnectError = freezed,Object? lastSignalingClientDisconnectError = freezed,Object? lastSignalingDisconnectCode = freezed,}) {
   return _then(CallServiceState(
 signalingClientStatus: null == signalingClientStatus ? _self.signalingClientStatus : signalingClientStatus // ignore: cast_nullable_to_non_nullable
-as SignalingClientStatus,registration: null == registration ? _self.registration : registration // ignore: cast_nullable_to_non_nullable
-as Registration,networkStatus: freezed == networkStatus ? _self.networkStatus : networkStatus // ignore: cast_nullable_to_non_nullable
+as SignalingClientStatus,registration: freezed == registration ? _self.registration : registration // ignore: cast_nullable_to_non_nullable
+as Registration?,networkStatus: freezed == networkStatus ? _self.networkStatus : networkStatus // ignore: cast_nullable_to_non_nullable
 as NetworkStatus?,lastSignalingClientConnectError: freezed == lastSignalingClientConnectError ? _self.lastSignalingClientConnectError : lastSignalingClientConnectError ,lastSignalingClientDisconnectError: freezed == lastSignalingClientDisconnectError ? _self.lastSignalingClientDisconnectError : lastSignalingClientDisconnectError ,lastSignalingDisconnectCode: freezed == lastSignalingDisconnectCode ? _self.lastSignalingDisconnectCode : lastSignalingDisconnectCode // ignore: cast_nullable_to_non_nullable
 as int?,
   ));


### PR DESCRIPTION
We removed the hard-coded registration defaults in CallServiceState and the manual status pushes in CallBloc. Registration is now nullable until signaling provides the real state. We also unified registration signaling into a single _CallSignalingEvent.registration(status, {code, reason}) and set linesCount default to 1 so an outgoing call can start even before signaling handshake completes (e.g., from phone Recents).

Previously, we manually set registration status in the bloc and kept a default registering state. This could diverge from the actual signaling state while the app hadn’t yet received updates from signaling. As a result, early flows (like starting a call from iOS/Android Recents) could be blocked because the app believed there were no lines or that the account wasn’t registered yet.

Changed:
- Nullable registration: CallServiceState.registration is now Registration?. null means “not received yet”.
- Unified registration events: Replaced multiple _CallSignalingEvent* (registering/registered/failed/unregistering/unregistered) with a single _CallSignalingEvent.registration(RegistrationStatus, {code, reason}).
- Null-safe checks: All places that read registration now use null-aware logic (e.g., registration?.status.isRegistered == true).
- Default lines: CallState.linesCount now defaults to 1, enabling immediate outgoing call allocation before handshake reports the real line count.
- Cleanup: Removed manual defaulting to Registration(status: registering) on disconnect paths; improved comments and docs for registration flow.

Behavior notes
- If registration == null, we treat it as “pending/unknown” rather than “unregistered”.
- When handshake arrives or signaling events fire, registration becomes concrete and transitions fire as before (online/offline notifications, failure handling, etc.).
- Early outgoing calls can be added to state even if handshake hasn’t populated linesCount yet.