### PR TITLE
fix: show notification when self-managed phone account registration fails

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1253,14 +1253,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
 
     if (callkeepError != null) {
-      emit(state.copyWithPopActiveCall(callId));
-
       if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
         final Uri telLaunchUri = Uri(scheme: 'tel', path: event.handle.value);
         launchUrl(telLaunchUri);
+      } else if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
+        submitNotification(const CallErrorRegisteringSelfManagedPhoneAccountNotification());
       } else {
         _logger.warning('__onCallControlEventStarted callkeepError: $callkeepError');
       }
+      emit(state.copyWithPopActiveCall(callId));
+
       return;
     }
   }

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -188,3 +188,12 @@ final class ActiveLineBlindTransferWarningNotification extends MessageNotificati
     return context.l10n.notifications_errorSnackBar_activeLineBlindTransferWarning;
   }
 }
+
+final class CallErrorRegisteringSelfManagedPhoneAccountNotification extends ErrorNotification {
+  const CallErrorRegisteringSelfManagedPhoneAccountNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.call_errorRegisteringSelfManagedPhoneAccount;
+  }
+}

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -357,6 +357,12 @@ abstract class AppLocalizations {
   /// **'Transfer processing'**
   String get call_description_transferProcessing;
 
+  /// Shown when the app fails to register a self-managed phone account with the system.
+  ///
+  /// In en, this message translates to:
+  /// **'There was a problem registering the self-managed phone account.'**
+  String get call_errorRegisteringSelfManagedPhoneAccount;
+
   /// No description provided for @call_FailureAcknowledgeDialog_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -144,6 +144,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get call_description_transferProcessing => 'Transfer processing';
 
   @override
+  String get call_errorRegisteringSelfManagedPhoneAccount =>
+      'There was a problem registering the self-managed phone account.';
+
+  @override
   String get call_FailureAcknowledgeDialog_title => 'Failure';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -146,6 +146,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get call_description_transferProcessing => 'Elaborazione del trasferimento';
 
   @override
+  String get call_errorRegisteringSelfManagedPhoneAccount =>
+      'Si è verificato un problema durante la registrazione dell\'account telefonico autogestito.';
+
+  @override
   String get call_FailureAcknowledgeDialog_title => 'Guasto';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -145,6 +145,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get call_description_transferProcessing => 'Обробка переадресації';
 
   @override
+  String get call_errorRegisteringSelfManagedPhoneAccount =>
+      'Виникла проблема під час реєстрації самокерованого телефонного облікового запису.';
+
+  @override
   String get call_FailureAcknowledgeDialog_title => 'Помилка';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -92,6 +92,10 @@
   "@call_description_requestToAttendedTransfer": {},
   "call_description_transferProcessing": "Transfer processing",
   "@call_description_transferProcessing": {},
+  "call_errorRegisteringSelfManagedPhoneAccount": "There was a problem registering the self-managed phone account.",
+  "@call_errorRegisteringSelfManagedPhoneAccount": {
+    "description": "Shown when the app fails to register a self-managed phone account with the system."
+  },
   "call_FailureAcknowledgeDialog_title": "Failure",
   "@call_FailureAcknowledgeDialog_title": {},
   "callProcessingStatus_answering": "Answering the call, please hold on…",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -92,6 +92,10 @@
   "@call_description_requestToAttendedTransfer": {},
   "call_description_transferProcessing": "Elaborazione del trasferimento",
   "@call_description_transferProcessing": {},
+  "call_errorRegisteringSelfManagedPhoneAccount": "Si è verificato un problema durante la registrazione dell'account telefonico autogestito.",
+  "@call_errorRegisteringSelfManagedPhoneAccount": {
+    "description": "Shown when the app fails to register a self-managed phone account with the system."
+  },
   "call_FailureAcknowledgeDialog_title": "Guasto",
   "@call_FailureAcknowledgeDialog_title": {},
   "callProcessingStatus_answering": "Rispondendo alla chiamata, attendi prego…",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -92,6 +92,10 @@
   "@call_description_requestToAttendedTransfer": {},
   "call_description_transferProcessing": "Обробка переадресації",
   "@call_description_transferProcessing": {},
+  "call_errorRegisteringSelfManagedPhoneAccount": "Виникла проблема під час реєстрації самокерованого телефонного облікового запису.",
+  "@call_errorRegisteringSelfManagedPhoneAccount": {
+    "description": "Shown when the app fails to register a self-managed phone account with the system."
+  },
   "call_FailureAcknowledgeDialog_title": "Помилка",
   "@call_FailureAcknowledgeDialog_title": {},
   "callProcessingStatus_answering": "Прийняття виклику, будь ласка, зачекайте…",


### PR DESCRIPTION
This PR adds localized error handling for a self-managed phone account registration failure scenario. When the app fails to register a self-managed phone account with the system, users will now see an appropriate error message in their preferred language.

Added new localization strings for Ukrainian, Italian, and English languages
Created a new notification class to display the error message
Updated call handling logic to show the notification when registration fails

Related: https://github.com/WebTrit/webtrit_callkeep/pull/105