### PR TITLE
feat: add EmptyVoicemailRepository as fallback when voicemail feature is disabled

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -156,11 +156,17 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
         ),
         RepositoryProvider<VoicemailRepository>(
           create: (context) {
-            return VoicemailRepositoryImpl(
-              webtritApiClient: context.read<WebtritApiClient>(),
-              token: context.read<AppBloc>().state.session.token!,
-              appDatabase: context.read<AppDatabase>(),
-            );
+            final isVoicemailsEnabled = context.read<FeatureAccess>().settingsFeature.isVoicemailsEnabled;
+
+            if (isVoicemailsEnabled) {
+              return VoicemailRepositoryImpl(
+                webtritApiClient: context.read<WebtritApiClient>(),
+                token: context.read<AppBloc>().state.session.token!,
+                appDatabase: context.read<AppDatabase>(),
+              );
+            } else {
+              return const EmptyVoicemailRepository();
+            }
           },
         ),
         RepositoryProvider<AppRepository>(

--- a/lib/repositories/voicemail/voicemail_repository.dart
+++ b/lib/repositories/voicemail/voicemail_repository.dart
@@ -307,3 +307,38 @@ class VoicemailRepositoryImpl
     return fetchVoicemails();
   }
 }
+
+/// A no-op implementation of [VoicemailRepository] used when voicemail functionality
+/// is disabled or not available.
+///
+/// All methods in this repository perform no actions and return default or
+/// empty values (e.g., `Future.value()`, `Stream.value(0)`, `Stream.value(const [])`).
+///
+/// This serves as a placeholder to prevent errors when other parts of the application
+/// attempt to interact with the [VoicemailRepository] interface, even if the feature
+/// is not enabled.
+
+class EmptyVoicemailRepository implements VoicemailRepository {
+  const EmptyVoicemailRepository();
+
+  @override
+  Future<void> fetchVoicemails({String? localeCode}) => Future.value();
+
+  @override
+  Future<void> removeVoicemail(String messageId, {String? localeCode}) => Future.value();
+
+  @override
+  Future<void> removeAllVoicemails() => Future.value();
+
+  @override
+  Future<void> updateVoicemailSeenStatus(String messageId, bool seen, {String? localeCode}) => Future.value();
+
+  @override
+  Stream<int> watchUnreadVoicemailsCount() => Stream.value(0);
+
+  @override
+  Stream<List<Voicemail>> watchVoicemails() => Stream.value(const []);
+
+  @override
+  Future<void> refresh() => Future.value();
+}


### PR DESCRIPTION
This PR introduces conditional voicemail repository initialization based on feature flags.
When voicemail functionality is disabled, the app now uses a lightweight EmptyVoicemailRepository (no-op implementation) instead of the full repository to prevent unnecessary initialization.

**Main Fix**
- Resolved an issue causing the app to freeze when opening Settings on iOS due to unguarded voicemail initialization.

**Changes**
- Added EmptyVoicemailRepository class as a no-op fallback implementation.
- Updated main_shell.dart to conditionally instantiate VoicemailRepository only when the voicemail feature is enabled.
- Prevents voicemail resources from being initialized when the feature is turned off, improving startup stability and performance.