### PR TITLE
fix: chat builder inherited context

### DIFF
--- a/lib/features/messaging/features/conversations/view/conversations_screen.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen.dart
@@ -17,6 +17,7 @@ enum TabType { chat, sms }
 
 class ConversationsScreen extends StatefulWidget {
   const ConversationsScreen({super.key, this.title});
+
   final Widget? title;
 
   @override


### PR DESCRIPTION
This PR fixes context inheritance issues in the chat and SMS conversation builders by removing useRootNavigator: true from modal bottom sheet calls and simplifying the bottom sheet widget structure.

- Removed useRootNavigator: true parameter to allow proper context inheritance from the parent navigator instead of using the root navigator
- Removed redundant BottomSheet wrapper widgets, as showModalBottomSheet already provides bottom sheet functionality
- Added formatting improvement (blank line after constructor)