### PR TITLE
revert: revert AudioEngine migration due to broken audio after unhold

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -126,9 +126,9 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - flutter_webrtc (1.2.0):
+  - flutter_webrtc (0.14.0):
     - Flutter
-    - WebRTC-SDK (= 137.7151.04)
+    - WebRTC-SDK (= 125.6422.07)
   - GoogleAdsOnDeviceConversion (3.1.0):
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
@@ -242,7 +242,7 @@ PODS:
     - sqlite3/session
   - url_launcher_ios (0.0.1):
     - Flutter
-  - WebRTC-SDK (137.7151.04)
+  - WebRTC-SDK (125.6422.07)
   - webtrit_callkeep_ios (0.0.1):
     - Flutter
   - webview_flutter_wkwebview (0.0.1):
@@ -402,7 +402,7 @@ SPEC CHECKSUMS:
   flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  flutter_webrtc: c3e21fc0dcd9d8eb246ae4d5256fcbeb2f5ecd22
+  flutter_webrtc: fd0d3bdef8766a0736dbbe2e5b7e85f1f3c52117
   GoogleAdsOnDeviceConversion: e03a386840803ea7eef3fd22a061930142c039c1
   GoogleAppMeasurement: 1e718274b7e015cefd846ac1fcf7820c70dc017d
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
@@ -421,7 +421,7 @@ SPEC CHECKSUMS:
   sqlite3: 73513155ec6979715d3904ef53a8d68892d4032b
   sqlite3_flutter_libs: 83f8e9f5b6554077f1d93119fe20ebaa5f3a9ef1
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  WebRTC-SDK: 40d4f5ba05cadff14e4db5614aec402a633f007e
+  WebRTC-SDK: dff00a3892bc570b6014e046297782084071657e
   webtrit_callkeep_ios: b6e52a357f27f00596927407b1aff2dc5f9c9b14
   webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
   workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -811,11 +811,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "main_ext_rebase_03.11.25"
-      resolved-ref: "58a75451e0e75665ae01845b59ec693fe07d507f"
+      ref: "main_ext_rebase_10.07.25"
+      resolved-ref: fe9fa05462b7526aa3d05e75bd896dfc1b3288d0
       url: "https://github.com/WebTrit/flutter-webrtc.git"
     source: git
-    version: "1.2.0"
+    version: "0.14.2"
   formz:
     dependency: "direct main"
     description:
@@ -1082,14 +1082,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  logger:
-    dependency: transitive
-    description:
-      name: logger
-      sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.2"
   logging:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   flutter_webrtc:
     git:
       url: https://github.com/WebTrit/flutter-webrtc.git
-      ref: main_ext_rebase_03.11.25
+      ref: main_ext_rebase_10.07.25
   formz: ^0.8.0
   freezed_annotation: ^3.1.0
   google_fonts: ^6.3.2


### PR DESCRIPTION
Rollback to commit 98241e1f because commit ad4f320 introduced an iOS-only regression where audio does not resume after SIP hold/unhold. PeerConnection remains connected, but remote RTP stops (`receiving=false`). Pre-migration behavior works correctly.

https://github.com/flutter-webrtc/flutter-webrtc/commit/ad4f320ed6f4ab246a41f9e939cedee5ac025a80