### PR TITLE
refactor: add isDebug flag to WebtritApiClient and improve request logging

### DIFF
--- a/lib/utils/webtrit_api_client_factory.dart
+++ b/lib/utils/webtrit_api_client_factory.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:ssl_certificates/ssl_certificates.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
@@ -32,6 +34,7 @@ class WebtritApiClientFactory {
       actualTenantId,
       connectionTimeout: kApiClientConnectionTimeout,
       certs: trustedCertificates,
+      isDebug: kDebugMode,
     );
 
     _cachedClient = newClient;

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -43,20 +43,28 @@ class WebtritApiClient {
     String tenantId, {
     Duration? connectionTimeout,
     TrustedCertificates certs = TrustedCertificates.empty,
+    bool isDebug = false,
   }) : this.inner(
          baseUrl,
          tenantId,
          httpClient: createHttpClient(connectionTimeout: connectionTimeout, certs: certs),
+         isDebug: isDebug,
        );
 
   @visibleForTesting
-  WebtritApiClient.inner(Uri baseUrl, String tenantId, {required http.Client httpClient, Logger? logger})
-    : _httpClient = httpClient,
-      _logger = Logger('WebtritApiClient'),
-      tenantUrl = buildTenantUrl(baseUrl, tenantId);
+  WebtritApiClient.inner(
+    Uri baseUrl,
+    String tenantId, {
+    required http.Client httpClient,
+    Logger? logger,
+    this.isDebug = false,
+  }) : _httpClient = httpClient,
+       _logger = Logger('WebtritApiClient'),
+       tenantUrl = buildTenantUrl(baseUrl, tenantId);
 
   final Uri tenantUrl;
   final http.Client _httpClient;
+  final bool isDebug;
 
   void close() {
     _httpClient.close();
@@ -108,7 +116,11 @@ class WebtritApiClient {
 
         if (requestData != null) httpRequest.body = requestData;
 
-        _logger.info(' ${method.toUpperCase()} request($requestAttempt) to $url with requestId: $xRequestId');
+        _logger.info(
+          ' ${method.toUpperCase()} request($requestAttempt) to $url with requestId: $xRequestId'
+          '${isDebug ? ' headers: ${jsonEncode(httpRequest.headers)}' : ''}'
+          '${isDebug && requestData != null ? ', request body: $requestData' : ''}',
+        );
 
         final httpResponse = await http.Response.fromStream(await _httpClient.send(httpRequest));
 


### PR DESCRIPTION
This PR adds an `isDebug` flag to `WebtritApiClient` to enhance request logging with headers and request bodies during development. The flag is automatically enabled in debug mode through the factory.

Key changes:
- Added `isDebug` parameter to `WebtritApiClient` constructors
- Enhanced request logging to conditionally include headers and request body when debug is enabled
- Factory now passes `kDebugMode` to automatically enable debug logging in development builds

### Reviewed changes

| File | Description |
| ---- | ----------- |
| packages/webtrit_api/lib/src/webtrit_api_client.dart | Adds `isDebug` field and parameter to constructors; enhances request logging with conditional headers and body output |
| lib/utils/webtrit_api_client_factory.dart | Imports Flutter foundation and passes `kDebugMode` to enable debug logging in development builds |