### PR TITLE
fix: local contacts lazy init subscription

### DIFF
--- a/lib/features/contacts/features/contacts_local_tab/bloc/contacts_local_tab_bloc.dart
+++ b/lib/features/contacts/features/contacts_local_tab/bloc/contacts_local_tab_bloc.dart
@@ -29,7 +29,7 @@ class ContactsLocalTabBloc extends Bloc<ContactsLocalTabEvent, ContactsLocalTabS
   Future<void> _onStarted(ContactsLocalTabStarted event, Emitter<ContactsLocalTabState> emit) async {
     final watchContactsForEachFuture = emit.forEach(
       contactsRepository.watchContacts(event.search, ContactSourceType.local),
-      onData: (List<Contact> contacts) => ContactsLocalTabState(
+      onData: (List<Contact> contacts) => state.copyWith(
         status: _mapLocalContactsSyncStateToStatus(localContactsSyncBloc.state),
         contacts: contacts,
         searching: event.search.isNotEmpty,

--- a/lib/features/contacts/features/contacts_local_tab/view/contacts_local_tab.dart
+++ b/lib/features/contacts/features/contacts_local_tab/view/contacts_local_tab.dart
@@ -24,7 +24,7 @@ class _ContactsLocalTabState extends State<ContactsLocalTab> with WidgetsBinding
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    }
+  }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {


### PR DESCRIPTION
This PR refactors the local contacts subscription initialization to use a lazy pattern, improving resource management and moving app lifecycle observation from the bloc layer to the UI layer.

- Moves app lifecycle observation from LocalContactsSyncBloc to ContactsLocalTab widget
- Implements lazy initialization of contacts stream subscription to avoid premature resource allocation
- Changes state creation to use copyWith to preserve existing state values during updates
