### PR TITLE
fix: prevent forcing speakerphone when headphones are connected on iOS

### DIFF
--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -15,17 +15,15 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   final AudioConstraintsBuilder? audioConstraintsBuilder;
   final VideoConstraintsBuilder? videoConstraintsBuilder;
 
+  /// Requests access to the user's media input devices (camera and/or microphone).
+  ///
+  /// For more information on constraints structure, see:
+  /// https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
   @override
   Future<MediaStream> build({required bool video, bool? frontCamera}) async {
     final Map<String, dynamic> mediaConstraints = {
-      'audio': {'mandatory': audioConstraintsBuilder?.build() ?? {}},
-      'video': video
-          ? {
-              'mandatory': videoConstraintsBuilder?.build() ?? {},
-              if (frontCamera != null) 'facingMode': frontCamera ? 'user' : 'environment',
-              'optional': [],
-            }
-          : false,
+      'audio': _buildAudioConstraints(),
+      'video': video ? _buildVideoConstraintsMap(frontCamera: frontCamera) : false,
     };
 
     try {
@@ -35,13 +33,34 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
         await Helper.setAppleAudioConfiguration(
           AppleAudioConfiguration(appleAudioMode: video ? AppleAudioMode.videoChat : AppleAudioMode.voiceChat),
         );
-        await Helper.setSpeakerphoneOn(video);
+
+        // REMOVED: await Helper.setSpeakerphoneOn(video);
+        // Reason: Calling this forcibly overrides the audio route, causing sound
+        // to play via speaker even when headphones are connected on iOS.
+        // AppleAudioConfiguration handles the default routing correctly.
       }
 
       return localStream;
     } catch (e) {
       throw UserMediaError(e.toString());
     }
+  }
+
+  /// Constructs the map structure for audio constraints.
+  Map<String, dynamic> _buildAudioConstraints() {
+    return {'mandatory': audioConstraintsBuilder?.build() ?? <String, String>{}};
+  }
+
+  /// Constructs the video constraints map.
+  ///
+  /// This method is only called when video is enabled.
+  /// Returns a strictly typed [Map<String, dynamic>].
+  Map<String, dynamic> _buildVideoConstraintsMap({bool? frontCamera}) {
+    return <String, dynamic>{
+      'mandatory': videoConstraintsBuilder?.build() ?? <String, String>{},
+      if (frontCamera != null) 'facingMode': frontCamera ? 'user' : 'environment',
+      'optional': <dynamic>[],
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
This PR refactors `DefaultUserMediaBuilder` to improve code readability and type safety by extracting constraint logic into private methods. Crucially, it resolves an issue on iOS where audio was forcibly routed to the speaker during video calls, ignoring connected headphones.

**Problem:**
Previously, `await Helper.setSpeakerphoneOn(video)` was called unconditionally on mobile platforms. On iOS, this method aggressively overrides the audio route, forcing sound through the loudspeaker even when headphones (Bluetooth or wired) are connected.

**Solution:**
* Removed `await Helper.setSpeakerphoneOn(video)`.
* Retained `Helper.setAppleAudioConfiguration(...)` for iOS.

**Result:**
By relying solely on `AppleAudioConfiguration` with `AppleAudioMode.videoChat`, iOS now correctly prioritizes the audio route:
1. **Headphones connected:** Audio routes to headphones.
2. **No headphones:** Audio defaults to the speaker (standard Video Chat behavior).

## Testing Results

Based on device testing matrix:

| Platform | Scenario | Previous Behavior | New Behavior (Fix) |
| :--- | :--- | :--- | :--- |
| **iOS** | Video Call + Headphones | ❌ **Audio forced to Speaker** | ✅ **Audio stays in Headphones** |
| **iOS** | Video Call (No Headphones) | ✅ Speaker Auto-on | ✅ Speaker Auto-on |
| **Android** | Video Call | Speaker toggle manual | No regression (Speaker toggle manual) |

