### PR TITLE
fix: harden Firebase background message handling and error reporting

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -228,16 +228,16 @@ Future<void> _initFirebaseMessaging() async {
 
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  final logger = Logger('_firebaseMessagingBackgroundHandler');
+
   runZonedGuarded(
-    () => _handleBackgroundMessage(message),
-    (error, stack) => Logger('_firebaseMessagingBackgroundHandler').severe('Unhandled background error', error, stack),
+    () => _handleBackgroundMessage(message, logger),
+    (error, stack) => logger.severe('Unhandled background error', error, stack),
   );
 }
 
 /// Core logic for processing background messages.
-Future<void> _handleBackgroundMessage(RemoteMessage message) async {
-  final logger = Logger('_firebaseMessagingBackgroundHandler');
-
+Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) async {
   // Cache remote configuration
   final remoteCacheConfigService = await DefaultRemoteCacheConfigService.init();
 

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -228,6 +228,14 @@ Future<void> _initFirebaseMessaging() async {
 
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  runZonedGuarded(
+    () => _handleBackgroundMessage(message),
+    (error, stack) => Logger('_firebaseMessagingBackgroundHandler').severe('Unhandled background error', error, stack),
+  );
+}
+
+/// Core logic for processing background messages.
+Future<void> _handleBackgroundMessage(RemoteMessage message) async {
   final logger = Logger('_firebaseMessagingBackgroundHandler');
 
   // Cache remote configuration


### PR DESCRIPTION
## Pull request overview

This PR hardens the Firebase Cloud Messaging background handler by adding structured error handling, improving error reporting to Firebase Crashlytics, and refactoring database access logic to handle known SQLite concurrency issues gracefully.

Key changes:
- Wraps background message processing in `runZonedGuarded` to catch unhandled errors and report them to Firebase Crashlytics
- Extracts contact resolution logic into a separate function with fallback handling for database lock errors
- Renames `_initFirebase` to `_initFirebaseApp` for clarity