### PR TITLE
feat: unknown sdp profiles filter

### DIFF
--- a/lib/features/call/utils/sdp_mod_builder.dart
+++ b/lib/features/call/utils/sdp_mod_builder.dart
@@ -303,9 +303,9 @@ class SDPModBuilder {
   ///
   /// For example sdp's from Linksys942 that causes crash on Webrtc 0.12.11:
   /// ```v=0
-  /// o=- 74097 74097 IN IP4 194.9.14.108
+  /// o=- 74097 74097 IN IP4 1.2.3.4
   /// s=-
-  /// c=IN IP4 194.9.14.108
+  /// c=IN IP4 1.2.3.4
   /// t=0 0
   /// m=audio 16442 RTP/AVP 0 8 18 101
   /// a=rtpmap:0 PCMU/8000
@@ -318,9 +318,9 @@ class SDPModBuilder {
   /// ```
   /// or
   /// ```v=0
-  /// o=- 84645 84645 IN IP4 194.9.14.108
+  /// o=- 84645 84645 IN IP4 1.2.3.4
   /// s=-
-  /// c=IN IP4 194.9.14.108
+  /// c=IN IP4 1.2.3.4
   /// t=0 0
   /// m=audio 16444 RTP/AVP 0 8 2 101
   /// a=rtpmap:0 PCMU/8000

--- a/lib/features/call/utils/sdp_mod_builder.dart
+++ b/lib/features/call/utils/sdp_mod_builder.dart
@@ -298,11 +298,11 @@ class SDPModBuilder {
     media['rtcpFb'] = originalRtcpFbs;
   }
 
-  /// Removes incompatible declaration of G729a codec from the SDP.
-  /// that causes Webrtc crash when setting it as remote description.
+  /// Removes unknown rtp profiles declarations from the SDP
+  /// because some of them causes Webrtc crash when setting it as remote description.
   ///
-  /// example sdp from Linksys942 that causes crash on Webrtc 0.12.11:
-  /// v=0
+  /// For example sdp's from Linksys942 that causes crash on Webrtc 0.12.11:
+  /// ```v=0
   /// o=- 74097 74097 IN IP4 194.9.14.108
   /// s=-
   /// c=IN IP4 194.9.14.108
@@ -315,7 +315,23 @@ class SDPModBuilder {
   /// a=fmtp:101 0-15
   /// a=ptime:20
   /// a=sendrecv
-  void removeG729a() {
+  /// ```
+  /// or
+  /// ```v=0
+  /// o=- 84645 84645 IN IP4 194.9.14.108
+  /// s=-
+  /// c=IN IP4 194.9.14.108
+  /// t=0 0
+  /// m=audio 16444 RTP/AVP 0 8 2 101
+  /// a=rtpmap:0 PCMU/8000
+  /// a=rtpmap:8 PCMA/8000
+  /// a=rtpmap:2 G726-32/8000
+  /// a=rtpmap:101 telephone-event/8000
+  /// a=fmtp:101 0-15
+  /// a=ptime:20
+  /// a=sendrecv
+  /// ```
+  void removeUnknownProfiles(RTPCodecKind kind) {
     final media = _getMedia(RTPCodecKind.audio);
     if (media == null) return;
 
@@ -329,15 +345,17 @@ class SDPModBuilder {
     if (media['fmtp'] is List<dynamic>) originalFmtps.addAll(media['fmtp'] as List<dynamic>);
     if (media['rtcpFb'] is List<dynamic>) originalRtcpFbs.addAll(media['rtcpFb'] as List<dynamic>);
 
-    final g729aRtp = originalRtpMaps.firstWhereOrNull((r) => r['codec'].toString().toUpperCase() == 'G729A');
-    if (g729aRtp == null) return;
+    final knownProfilePayloads = RTPCodecProfile.values
+        .where((p) => p.kind == kind)
+        .map((p) => _getProfileId(p))
+        .whereType<int>()
+        .map((id) => id.toString())
+        .toSet();
 
-    final g729aPayload = g729aRtp['payload'];
-
-    final modedPayloads = originalPayloads.where((p) => p != g729aPayload.toString());
-    final modedRtpMaps = originalRtpMaps.where((r) => r['payload'] != g729aPayload);
-    final modedFmtps = originalFmtps.where((f) => f['payload'] != g729aPayload);
-    final modedRtcpFbs = originalRtcpFbs.where((f) => f['payload'] != g729aPayload);
+    final modedPayloads = originalPayloads.where((p) => knownProfilePayloads.contains(p));
+    final modedRtpMaps = originalRtpMaps.where((r) => knownProfilePayloads.contains(r['payload'].toString()));
+    final modedFmtps = originalFmtps.where((f) => knownProfilePayloads.contains(f['payload'].toString()));
+    final modedRtcpFbs = originalRtcpFbs.where((f) => knownProfilePayloads.contains(f['payload'].toString()));
 
     media['payloads'] = modedPayloads.join(' ');
     media['rtp'] = modedRtpMaps.toList();
@@ -404,12 +422,6 @@ class SDPModBuilder {
       {'type': 'AS', 'limit': as},
       {'type': 'TIAS', 'limit': tias},
     ];
-  }
-
-  int parseBandwidthLimit(dynamic value, [int defaultValue = 0]) {
-    if (value is int) return value;
-    if (value is String) return int.tryParse(value) ?? defaultValue;
-    return defaultValue;
   }
 }
 

--- a/lib/features/call/utils/sdp_sanitizer.dart
+++ b/lib/features/call/utils/sdp_sanitizer.dart
@@ -2,6 +2,7 @@ import 'package:logging/logging.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
 import 'package:webtrit_phone/features/call/utils/utils.dart';
+import 'package:webtrit_phone/models/rtp_codec_profile.dart';
 
 final _logger = Logger('SdpSanitizer');
 
@@ -16,7 +17,8 @@ class RemoteSdpSanitizer implements SdpSanitizer {
     if (originalSdp == null) return;
 
     final builder = SDPModBuilder(sdp: originalSdp);
-    builder.removeG729a();
+    builder.removeUnknownProfiles(RTPCodecKind.audio);
+    builder.removeUnknownProfiles(RTPCodecKind.video);
     final sanitizedSdp = builder.sdp;
 
     if (sanitizedSdp != originalSdp) {

--- a/test/features/call/utils/sdp_mod_builder_test.dart
+++ b/test/features/call/utils/sdp_mod_builder_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_phone/features/call/utils/sdp_mod_builder.dart';
+import 'package:webtrit_phone/models/rtp_codec_profile.dart';
+
+void main() {
+  group('SDPModBuilder', () {
+    test('setPtime configures ptime and maxptime', () {
+      final builder = _buildBuilder();
+      builder.setPtime(50, 100);
+
+      final result = builder.sdp;
+      expect(result, contains('a=ptime:50'));
+      expect(result, contains('a=maxptime:100'));
+    });
+
+    test('setPtime clamps both values', () {
+      final builder = _buildBuilder();
+      builder.setPtime(200, 5);
+
+      final result = builder.sdp;
+      expect(result, contains('a=ptime:120'));
+      expect(result, contains('a=maxptime:120'));
+    });
+
+    test('setBitrate configures bandwidth for audio and video', () {
+      final builder = _buildBuilder();
+
+      builder.setBitrate(128, 2000);
+
+      final result = builder.sdp;
+      expect(result, contains('b=AS:154'));
+      expect(result, contains('b=TIAS:128000'));
+      expect(result, contains('b=AS:2400'));
+      expect(result, contains('b=TIAS:2000000'));
+    });
+
+    test('setBitrate clamps both values', () {
+      final builder = _buildBuilder();
+
+      builder.setBitrate(999, 6000);
+
+      final result = builder.sdp;
+      expect(result, contains('b=AS:307'));
+      expect(result, contains('b=TIAS:256000'));
+      expect(result, contains('b=AS:4800'));
+      expect(result, contains('b=TIAS:4000000'));
+    });
+
+    test('setOpusParams overrides fmtp config map', () {
+      final builder = _buildBuilder();
+
+      builder.setOpusParams(16000, 64, true, false);
+
+      final fmtpLine = _line(builder.sdp, 'a=fmtp:111');
+      expect(fmtpLine, contains('stereo=1'));
+      expect(fmtpLine, contains('sprop-stereo=1'));
+      expect(fmtpLine, contains('maxplaybackrate=16000'));
+      expect(fmtpLine, contains('sprop-maxcapturerate=16000'));
+      expect(fmtpLine, contains('maxaveragebitrate=64000'));
+      expect(fmtpLine, contains('usedtx=0'));
+    });
+
+    test('removeProfile drops codec and related RTX entries', () {
+      final builder = _buildBuilder();
+
+      builder.removeProfile(RTPCodecProfile.vp8);
+
+      final result = builder.sdp;
+      final videoLine = _line(result, 'm=video');
+      expect(videoLine, equals('m=video 9 UDP/TLS/RTP/SAVPF 127 103 39 40 200'));
+      expect(result, isNot(contains('a=rtpmap:96 VP8/90000')));
+      expect(result, isNot(contains('a=rtpmap:97 rtx/90000')));
+      expect(result, isNot(contains('a=fmtp:96 ')));
+      expect(result, isNot(contains('a=fmtp:97 ')));
+    });
+
+    test('reorderProfiles prioritizes provided codecs while keeping others', () {
+      final builder = _buildBuilder();
+
+      builder.reorderProfiles([RTPCodecProfile.av1, RTPCodecProfile.vp8], RTPCodecKind.video);
+
+      final result = builder.sdp;
+      final videoLine = _line(result, 'm=video');
+      expect(videoLine, equals('m=video 9 UDP/TLS/RTP/SAVPF 39 40 96 97 127 103 200'));
+      expect(result.indexOf('a=rtpmap:39 AV1/90000'), lessThan(result.indexOf('a=rtpmap:127 H264/90000')));
+      expect(result.indexOf('a=rtpmap:96 VP8/90000'), lessThan(result.indexOf('a=rtpmap:127 H264/90000')));
+    });
+
+    test('removeAudioExtmaps drops ext definitions', () {
+      final builder = _buildBuilder();
+
+      builder.removeAudioExtmaps();
+
+      final result = builder.sdp;
+      expect(result, isNot(contains('a=extmap:1 ')));
+      expect(result, isNot(contains('a=extmap:2 ')));
+    });
+
+    test('removeStaticAudioRtpMaps strips static payload metadata', () {
+      final builder = _buildBuilder();
+
+      builder.removeStaticAudioRtpMaps();
+
+      final result = builder.sdp;
+      for (final removed in ['a=rtpmap:0 ', 'a=rtpmap:8 ', 'a=rtpmap:9 ', 'a=rtpmap:13 ']) {
+        expect(result, isNot(contains(removed)));
+      }
+      expect(result, isNot(contains('a=fmtp:8 ')));
+      expect(result, isNot(contains('a=rtcp-fb:9 ')));
+    });
+
+    test('remapTE8payloadTo101 updates telephone-event entries', () {
+      final builder = _buildBuilder();
+
+      builder.remapTE8payloadTo101();
+
+      final result = builder.sdp;
+      final audioLine = _line(result, 'm=audio');
+      expect(audioLine, equals('m=audio 9 UDP/TLS/RTP/SAVPF 111 63 101 0 8 2 9 13 18'));
+      expect(result, contains('a=rtpmap:101 telephone-event/8000'));
+      expect(result, isNot(contains('a=rtpmap:126 telephone-event/8000')));
+      expect(result, contains('a=fmtp:101 0-15'));
+      expect(result, isNot(contains('a=fmtp:126 0-15')));
+      expect(result, contains('a=rtcp-fb:101 nack'));
+      expect(result, isNot(contains('a=rtcp-fb:126 nack')));
+    });
+
+    test('remove unknown audio profiles', () {
+      final builder = _buildBuilder();
+
+      builder.removeUnknownProfiles(RTPCodecKind.audio);
+
+      final result = builder.sdp;
+      final audioLine = _line(result, 'm=audio');
+      expect(audioLine, equals('m=audio 9 UDP/TLS/RTP/SAVPF 111 63 126 0 8 9 13'));
+      expect(result, isNot(contains('a=rtpmap:18 G729a/8000')));
+      expect(result, isNot(contains('a=rtpmap:2 G726-32/8000')));
+    });
+  });
+}
+
+SDPModBuilder _buildBuilder() => SDPModBuilder(sdp: _baseSdp);
+
+String _line(String sdp, String prefix) {
+  final lines = sdp.split('\r\n');
+  return lines.firstWhere((line) => line.startsWith(prefix), orElse: () => '');
+}
+
+const String _baseSdp =
+    'v=0\r\n'
+    'o=- 0 0 IN IP4 127.0.0.1\r\n'
+    's=-\r\n'
+    't=0 0\r\n'
+    'a=group:BUNDLE 0 1\r\n'
+    'm=audio 9 UDP/TLS/RTP/SAVPF 111 63 126 0 8 2 9 13 18\r\n'
+    'c=IN IP4 0.0.0.0\r\n'
+    'a=mid:0\r\n'
+    'a=sendrecv\r\n'
+    'a=ptime:20\r\n'
+    'a=maxptime:60\r\n'
+    'a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n'
+    'a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n'
+    'a=rtpmap:111 opus/48000/2\r\n'
+    'a=fmtp:111 minptime=10;useinbandfec=1\r\n'
+    'a=rtcp-fb:111 transport-cc\r\n'
+    'a=rtpmap:63 red/48000/2\r\n'
+    'a=fmtp:63 111/111\r\n'
+    'a=rtpmap:126 telephone-event/8000\r\n'
+    'a=fmtp:126 0-15\r\n'
+    'a=rtcp-fb:126 nack\r\n'
+    'a=rtpmap:0 PCMU/8000\r\n'
+    'a=rtpmap:8 PCMA/8000\r\n'
+    'a=fmtp:8 vad=on\r\n'
+    'a=rtpmap:9 G722/8000\r\n'
+    'a=rtcp-fb:9 nack\r\n'
+    'a=rtpmap:13 CN/8000\r\n'
+    'a=rtpmap:18 G729a/8000\r\n'
+    'a=rtpmap:2 G726-32/8000\r\n'
+    'm=video 9 UDP/TLS/RTP/SAVPF 127 103 39 40 96 97 200\r\n'
+    'c=IN IP4 0.0.0.0\r\n'
+    'a=mid:1\r\n'
+    'a=sendrecv\r\n'
+    'a=rtpmap:127 H264/90000\r\n'
+    'a=fmtp:127 packetization-mode=1;profile-level-id=42e01f\r\n'
+    'a=rtcp-fb:127 transport-cc\r\n'
+    'a=rtpmap:103 rtx/90000\r\n'
+    'a=fmtp:103 apt=127\r\n'
+    'a=rtpmap:39 AV1/90000\r\n'
+    'a=fmtp:39 profile=0\r\n'
+    'a=rtcp-fb:39 transport-cc\r\n'
+    'a=rtpmap:40 rtx/90000\r\n'
+    'a=fmtp:40 apt=39\r\n'
+    'a=rtpmap:96 VP8/90000\r\n'
+    'a=fmtp:96 max-fs=12288\r\n'
+    'a=rtcp-fb:96 transport-cc\r\n'
+    'a=rtpmap:97 rtx/90000\r\n'
+    'a=fmtp:97 apt=96\r\n'
+    'a=rtpmap:200 H265/90000\r\n'
+    'a=fmtp:200 profile-id=1\r\n';


### PR DESCRIPTION
This pull request refactors the SDP modification and sanitization logic to more robustly handle unknown RTP profiles, improving compatibility and stability when processing SDP from various devices. It also adds comprehensive unit tests for the `SDPModBuilder` class to ensure correct SDP manipulations. The main changes are as follows:

### SDP Profile Handling Improvements

* Replaces the `removeG729a` method in `SDPModBuilder` with a more general `removeUnknownProfiles` method, which removes any unknown RTP profiles (not just G729a) from the SDP to prevent WebRTC crashes. The method is updated to filter payloads based on known profiles for the given `RTPCodecKind`. [[1]](diffhunk://#diff-da39d94a0dacc629a6c1f5aad0d60e20793e90be078b56ec0d845abd190cf2c8L301-R305) [[2]](diffhunk://#diff-da39d94a0dacc629a6c1f5aad0d60e20793e90be078b56ec0d845abd190cf2c8L318-R334) [[3]](diffhunk://#diff-da39d94a0dacc629a6c1f5aad0d60e20793e90be078b56ec0d845abd190cf2c8L332-R358)
* Updates `RemoteSdpSanitizer` to use `removeUnknownProfiles` for both audio and video streams, ensuring that only supported RTP profiles are kept in sanitized SDPs.
* Removes the now-unused `parseBandwidthLimit` helper function from `SDPModBuilder`.

### Test Coverage

* Adds a new test suite (`sdp_mod_builder_test.dart`) with detailed unit tests for the `SDPModBuilder` class, covering various SDP manipulation scenarios including setting ptime/maxptime, bitrate, Opus parameters, profile removal/reordering, extmap and static rtpmap removal, telephone-event remapping, and the new unknown profile removal logic.
