### PR TITLE
fix: conversation screen title align

### DIFF
--- a/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
+++ b/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
@@ -87,6 +87,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
                   child: Container(color: theme.canvasColor.withAlpha(150)),
                 ),
               ),
+              centerTitle: true,
               title: FadeIn(
                 child: Builder(
                   builder: (context) {


### PR DESCRIPTION
This pull request introduces a minor UI adjustment to the chat conversation screen. The app bar's title is now centered, improving the visual alignment of the title in the interface.

- UI enhancement:
  * Centered the app bar title in the `ChatConversationScreen` by setting `centerTitle: true` in `conversation_screen.dart`.