### PR TITLE
fix: hide initial online snackbar

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -237,31 +237,31 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final newRegistration = change.nextState.callServiceState.registration;
     final previousRegistration = change.currentState.callServiceState.registration;
 
-    if (newRegistration != previousRegistration) {
+    if (newRegistration != previousRegistration && newRegistration != null) {
       _logger.fine('_onRegistrationChange: $newRegistration to $previousRegistration');
 
-      final newRegistrationStatus = newRegistration?.status;
+      final newRegistrationStatus = newRegistration.status;
       final previousRegistrationStatus = previousRegistration?.status;
 
-      if (newRegistrationStatus?.isRegistered == true && previousRegistrationStatus?.isRegistered != true) {
+      if (previousRegistrationStatus?.isRegistered == false && newRegistrationStatus.isRegistered == true) {
         presenceSettingsRepository.resetLastSettingsSync();
         submitNotification(AppOnlineNotification());
       }
 
-      if (newRegistrationStatus?.isRegistered != true && previousRegistrationStatus?.isRegistered == true) {
+      if (previousRegistrationStatus?.isRegistered == true && newRegistrationStatus.isRegistered == false) {
         submitNotification(AppOfflineNotification());
       }
 
-      if (newRegistrationStatus?.isFailed == true || newRegistrationStatus?.isUnregistered == true) {
+      if (newRegistrationStatus.isFailed == true || newRegistrationStatus.isUnregistered == true) {
         add(const _ResetStateEvent.completeCalls());
       }
 
-      if (newRegistrationStatus?.isFailed == true) {
+      if (newRegistrationStatus.isFailed == true) {
         submitNotification(
           SipRegistrationFailedNotification(
-            knownCode: SignalingRegistrationFailedCode.values.byCode(newRegistration?.code),
-            systemCode: newRegistration?.code,
-            systemReason: newRegistration?.reason,
+            knownCode: SignalingRegistrationFailedCode.values.byCode(newRegistration.code),
+            systemCode: newRegistration.code,
+            systemReason: newRegistration.reason,
           ),
         );
       }


### PR DESCRIPTION
This pull request refines the logic for handling SIP registration state changes in the `CallBloc` class. The updates ensure more robust null-checking and improve the accuracy of state transition detection, which affects how notifications and state resets are triggered.

**Improvements to registration state handling:**

* Added a null-check to ensure `newRegistration` is not null before proceeding with status comparisons, preventing potential runtime errors.
* Refined the logic for detecting transitions between registered and unregistered states by comparing previous and new statuses explicitly, resulting in more accurate triggering of online/offline notifications and state resets.
* Removed unnecessary null-aware operators when accessing `newRegistration.status`, as the null-check is now performed earlier.
* Updated the notification for registration failure to use non-nullable fields from `newRegistration`, improving reliability of failure reporting.