### PR TITLE
fix: emit state update when toggling existing video track

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1414,6 +1414,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final currentVideoTrack = localStream.getVideoTracks().firstOrNull;
     if (currentVideoTrack != null) {
       currentVideoTrack.enabled = event.enabled;
+      emit(state.copyWithMappedActiveCall(event.callId, (call) => call.copyWith(video: event.enabled)));
       return;
     }
 


### PR DESCRIPTION
Previously, when toggling the camera on an active call with an existing video track, the track's enabled state was modified, but the BLoC did not emit the updated state. This caused the UI button to become desynchronized from the actual camera state (e.g., camera turns off, but button stays active).

This commit adds the missing emit call to ensure the activeCall.video property is updated in the state, triggering the necessary UI rebuilds.