### PR TITLE
feat: add getAll() to repository and DAO for unfiltered call log fetch

### DIFF
--- a/lib/repositories/call_logs/call_logs_repository.dart
+++ b/lib/repositories/call_logs/call_logs_repository.dart
@@ -32,6 +32,15 @@ class CallLogsRepository with CallLogsDriftMapper {
   Future<void> deleteById(int id) async {
     await _appDatabase.callLogsDao.deleteCallLog(id);
   }
+
+  /// Retrieves all call log entries from the database without any filtering.
+  ///
+  /// This method is primarily used for testing verification (e.g., checking total row counts)
+  /// or scenarios where a complete history dump is required.
+  Future<List<CallLogEntry>> getAll() async {
+    final data = await _appDatabase.callLogsDao.getAllCallLogs();
+    return data.map(callLogEntryFromDrift).toList();
+  }
 }
 
 typedef NewCall = ({

--- a/packages/data/app_database/lib/src/daos/call_logs_dao.dart
+++ b/packages/data/app_database/lib/src/daos/call_logs_dao.dart
@@ -33,4 +33,9 @@ class CallLogsDao extends DatabaseAccessor<AppDatabase> with _$CallLogsDaoMixin 
   Future deleteCallLog(int id) {
     return (delete(callLogsTable)..where((t) => t.id.equals(id))).go();
   }
+
+  /// Returns all call logs stored in the database.
+  Future<List<CallLogData>> getAllCallLogs() {
+    return select(callLogsTable).get();
+  }
 }


### PR DESCRIPTION
## Pull request overview

This PR adds a `getAll()` method to retrieve all call log entries without any filtering, primarily intended for testing verification and scenarios requiring complete history dumps.

**Key Changes:**

* Added `getAllCallLogs()` method to the `CallLogsDao` class for unfiltered database queries
* Added `getAll()` method to the `CallLogsRepository` class with comprehensive documentation explaining its purpose and use cases
