### PR TITLE
refactor: centralize local contact phone number sanitization in ContactsLocalDataSource

### DIFF
--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -5,7 +5,6 @@ import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/utils/regexes.dart';
 
 import 'local_contacts_repository.dart';
 
@@ -82,8 +81,7 @@ class LocalContactsRepository implements ILocalContactsRepository {
             phones: contact.phones
                 .map(
                   (phone) => LocalContactPhone(
-                    // TODO: maybe store raw and sanitized versions together
-                    number: phone.number.replaceAll(RegExp(numberSanitizeRegex), ''),
+                    number: phone.number,
                     label: phone.label == PhoneLabel.custom ? phone.customLabel : phone.label.name,
                   ),
                 )


### PR DESCRIPTION
This PR refactors phone number sanitization for local device contacts by moving the sanitization logic from `LocalContactsRepository` (where contacts are fetched) to `ContactsLocalDataSource` (where contacts are persisted to the database). This ensures that phone numbers are sanitized consistently at the point of storage rather than at the point of retrieval.

### Key Changes:
- Centralized phone number sanitization in `ContactsLocalDataSource` by adding a `_sanitizeNumber` helper method
- Removed sanitization logic from `LocalContactsRepository`, allowing raw phone numbers to flow through the repository layer
- Added comprehensive test coverage for phone number sanitization with various formats (international, formatted with spaces/dashes/parentheses)