### PR TITLE
fix: ensure auto-compact mode only triggers for the current active call

### DIFF
--- a/lib/features/call/extensions/active_call_extension.dart
+++ b/lib/features/call/extensions/active_call_extension.dart
@@ -5,15 +5,15 @@ extension ActiveCallListAutoCompact on List<ActiveCall> {
   /// Determines whether UI controls should auto-compact (auto-hide / Compact Mode)
   /// based on the current call state.
   bool get shouldAutoCompact {
-    var hasAnyVideo = false;
+    if (isEmpty) return false;
 
-    for (final c in this) {
-      if (c.wasHungUp) return false;
-      if (c.processingStatus != CallProcessingStatus.connected) return false;
+    // Consider only the foreground active call (the call currently shown to the user).
+    // Keep auto-compact disabled for audio-only foreground calls, even if a call on another line has video.
+    final activeCall = current;
 
-      hasAnyVideo = hasAnyVideo || (c.cameraEnabled && c.remoteVideo);
-    }
+    if (activeCall.wasHungUp) return false;
+    if (activeCall.processingStatus != CallProcessingStatus.connected) return false;
 
-    return hasAnyVideo;
+    return activeCall.cameraEnabled && activeCall.remoteVideo;
   }
 }

--- a/test/mocks/mock_active_call.dart
+++ b/test/mocks/mock_active_call.dart
@@ -8,6 +8,7 @@ class MockActiveCall extends Fake implements ActiveCall {
     this.wasHungUp = false,
     this.cameraEnabled = false,
     this.remoteVideo = false,
+    this.held = false,
   });
 
   @override
@@ -21,4 +22,7 @@ class MockActiveCall extends Fake implements ActiveCall {
 
   @override
   final bool remoteVideo;
+
+  @override
+  final bool held;
 }


### PR DESCRIPTION
This PR fixes the auto-compact mode logic to only consider the current (foreground) active call, rather than checking all active calls. This ensures that when a user has multiple calls (e.g., one on hold and one active), the auto-compact UI behavior is determined solely by the properties of the foreground call.

### Key Changes
- Modified `shouldAutoCompact` getter to check only the current active call instead of iterating through all calls
- Added `held` property to `MockActiveCall` to support testing of multi-call scenarios
- Updated test cases to reflect the new "current call only" logic and added comprehensive multi-call test scenarios