### PR TITLE
fix: external contacts sync kind overwrite

### DIFF
--- a/lib/repositories/contacts/contacts_local_data_source.dart
+++ b/lib/repositories/contacts/contacts_local_data_source.dart
@@ -42,6 +42,7 @@ class ContactsLocalDataSourceImpl implements ContactsLocalDataSource {
 
       final syncedExternalContactsIds = await _appDatabase.contactsDao.getContactsSourceIds(
         ContactSourceTypeEnum.external,
+        kind: ContactKind.visible,
       );
 
       // Use `safeSourceId` because that is the value persisted in the database.
@@ -57,7 +58,9 @@ class ContactsLocalDataSourceImpl implements ContactsLocalDataSource {
         );
       }
 
-      await Future.wait(contacts.map((externalContact) => _upsertContactInternal(externalContact)));
+      await Future.wait(
+        contacts.map((externalContact) => _upsertContactInternal(externalContact, kind: ContactKind.visible)),
+      );
     });
   }
 

--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -219,10 +219,13 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
     return getAllContacts(null, kind: ContactKind.service);
   }
 
-  Future<Set<String>> getContactsSourceIds(ContactSourceTypeEnum sourceType) async {
+  Future<Set<String>> getContactsSourceIds(ContactSourceTypeEnum sourceType, {ContactKind? kind}) async {
     final query = selectOnly(contactsTable);
     query.addColumns([contactsTable.id, contactsTable.sourceId, contactsTable.sourceType]);
     query.where(contactsTable.sourceType.equals(sourceType.index));
+    if (kind != null) {
+      query.where(contactsTable.kind.equals(kind.index));
+    }
 
     final rows = await query.get();
     return rows.map((row) => row.read(contactsTable.sourceId)).nonNulls.toSet();


### PR DESCRIPTION
Fixes case when external contact fetched by ui before global contact list firstly synced and kind of such contact remains to "service" forever