### PR TITLE
refactor: connectivity check

### DIFF
--- a/dart_define.json
+++ b/dart_define.json
@@ -27,7 +27,7 @@
   "__WEBTRIT_CALL_TRIGGER_MECHANISM_SMS_PREFIX_DESCRIPTION": "SMS prefix used to filter relevant messages for fallback incoming call triggering",
   "WEBTRIT_CALL_TRIGGER_MECHANISM_SMS_REGEX_PATTERN": "https://app\\.webtrit\\.com/call\\?callId=([^&]+)&handle=([^&]+)&displayName=([^&]+)&hasVideo=(true|false)",
   "__WEBTRIT_CALL_TRIGGER_MECHANISM_SMS_REGEX_PATTERN_DESCRIPTION": "ICU-compatible regex pattern to extract callId, handle, displayName and hasVideo from the SMS body",
-  "WEBTRIT_APP_CONNECTIVITY_CHECK_URL": "http://192.168.10.100:4000/api/v1/system-info",
+  "__WEBTRIT_APP_CONNECTIVITY_CHECK_URL": "http://192.168.10.100:4000/api/v1/system-info",
   "__WEBTRIT_APP_CONNECTIVITY_CHECK_URL_DESCRIPTION": "Used to verify internet connectivity via HTTP GET request. Should point to a lightweight, always-available endpoint (e.g. /system-info or /generate_204). Must return 2xx response on success.",
   "WEBTRIT_APP_USER_REPOSITORY_POLLING_INTERVAL_SECONDS": 10,
   "WEBTRIT_APP_SYSTEM_INFO_REPOSITORY_POLLING_INTERVAL_SECONDS": 300,

--- a/lib/environment_config.dart
+++ b/lib/environment_config.dart
@@ -117,12 +117,9 @@ class EnvironmentConfig {
 
   static const CONNECTIVITY_CHECK_URL__NAME = 'WEBTRIT_APP_CONNECTIVITY_CHECK_URL';
 
-  // URL used to check internet connectivity. Defaults to Google (204).
-  // Should return a quick 200/204 response.
-  static const CONNECTIVITY_CHECK_URL = String.fromEnvironment(
-    CONNECTIVITY_CHECK_URL__NAME,
-    defaultValue: 'https://www.google.com/generate_204',
-  );
+  static const CONNECTIVITY_CHECK_URL = bool.hasEnvironment(CONNECTIVITY_CHECK_URL__NAME)
+      ? String.fromEnvironment(CONNECTIVITY_CHECK_URL__NAME)
+      : null;
 
   static const USER_REPOSITORY_POLLING_INTERVAL_SECONDS__NAME = 'WEBTRIT_APP_USER_REPOSITORY_POLLING_INTERVAL_SECONDS';
   static const USER_REPOSITORY_POLLING_INTERVAL_SECONDS = int.fromEnvironment(

--- a/lib/features/embedded/view/embedded_screen_page.dart
+++ b/lib/features/embedded/view/embedded_screen_page.dart
@@ -114,16 +114,22 @@ class EmbeddedScreenPage extends StatelessWidget {
   }
 
   ConnectivityRecoveryStrategy _createConnectivityRecoveryStrategy(BuildContext context, EmbeddedData data) {
-    final executor = context.read<WebtritApiClientFactory>().createHttpRequestExecutor();
+    final customUrl = EnvironmentConfig.CONNECTIVITY_CHECK_URL;
+    final apiFactory = context.read<WebtritApiClientFactory>();
+
+    final connectivityChecker = switch (customUrl) {
+      String url => CustomConnectivityChecker(
+        connectivityCheckUrl: url,
+        createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
+      ),
+      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
+    };
 
     return ConnectivityRecoveryStrategy.create(
       initialUri: data.uri,
       type: data.reconnectStrategy,
       connectivityStream: Connectivity().onConnectivityChanged,
-      connectivityCheckerBuilder: () => DefaultConnectivityChecker(
-        connectivityCheckUrl: EnvironmentConfig.CONNECTIVITY_CHECK_URL,
-        createHttpRequestExecutor: executor,
-      ),
+      connectivityCheckerBuilder: () => connectivityChecker,
     );
   }
 }

--- a/lib/features/login/features/login_signup/view/login_signup_embedded_request_screen_page.dart
+++ b/lib/features/login/features/login_signup/view/login_signup_embedded_request_screen_page.dart
@@ -72,16 +72,22 @@ class LoginSignupEmbeddedRequestScreenPage extends StatelessWidget {
   }
 
   ConnectivityRecoveryStrategy _createConnectivityRecoveryStrategy(BuildContext context, EmbeddedData data) {
-    final executor = context.read<WebtritApiClientFactory>().createHttpRequestExecutor();
+    final customUrl = EnvironmentConfig.CONNECTIVITY_CHECK_URL;
+    final apiFactory = context.read<WebtritApiClientFactory>();
+
+    final connectivityChecker = switch (customUrl) {
+      String url => CustomConnectivityChecker(
+        connectivityCheckUrl: url,
+        createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
+      ),
+      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
+    };
 
     return ConnectivityRecoveryStrategy.create(
       initialUri: data.uri,
       type: data.reconnectStrategy,
       connectivityStream: Connectivity().onConnectivityChanged,
-      connectivityCheckerBuilder: () => DefaultConnectivityChecker(
-        connectivityCheckUrl: EnvironmentConfig.CONNECTIVITY_CHECK_URL,
-        createHttpRequestExecutor: executor,
-      ),
+      connectivityCheckerBuilder: () => connectivityChecker,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -202,14 +202,18 @@ class RootApp extends StatelessWidget {
   }
 
   ConnectivityService _createConnectivityService(BuildContext context) {
-    final executor = context.read<WebtritApiClientFactory>().createHttpRequestExecutor();
+    final customUrl = EnvironmentConfig.CONNECTIVITY_CHECK_URL;
+    final apiFactory = context.read<WebtritApiClientFactory>();
 
-    return ConnectivityServiceImpl(
-      connectivityChecker: DefaultConnectivityChecker(
-        connectivityCheckUrl: EnvironmentConfig.CONNECTIVITY_CHECK_URL,
-        createHttpRequestExecutor: executor,
+    final connectivityChecker = switch (customUrl) {
+      String url => CustomConnectivityChecker(
+        connectivityCheckUrl: url,
+        createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
       ),
-    );
+      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
+    };
+
+    return ConnectivityServiceImpl(connectivityChecker: connectivityChecker);
   }
 
   void _disposeConnectivityService(BuildContext _, ConnectivityService value) {

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -249,6 +249,15 @@ class WebtritApiClient {
     return _httpClientExecute('delete', pathSegments, token, null, options: options);
   }
 
+  Future<bool> healthCheck({RequestOptions options = const RequestOptions()}) async {
+    try {
+      await _httpClientExecuteGet(['health-check'], null, null, requestOptions: options);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<SystemInfo> getSystemInfo({RequestOptions options = const RequestOptions()}) async {
     final responseJson = await _httpClientExecuteGet(['system-info'], null, null, requestOptions: options);
 


### PR DESCRIPTION
Refactor connectivity check to use default webtrit healthcheck api from current saved core if no custom check url specified.