### PR TITLE
refactor: use semantic naming (portrait/auto) and optimize utils

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -100,7 +100,7 @@ class _AppState extends State<App> {
       providers: [
         BlocProvider<OrientationsBloc>(
           lazy: false,
-          create: (context) => OrientationsBloc()..add(const OrientationsChanged(PreferredOrientation.regular)),
+          create: (context) => OrientationsBloc()..add(const OrientationsChanged(PreferredOrientation.portrait)),
         ),
         BlocProvider<NotificationsBloc>(create: (context) => NotificationsBloc()),
         BlocProvider<AppBloc>.value(value: appBloc),

--- a/lib/features/call/view/call_shell.dart
+++ b/lib/features/call/view/call_shell.dart
@@ -95,9 +95,9 @@ class _CallShellState extends State<CallShell> {
   void _updateOrientations(BuildContext context, CallDisplay display) {
     final orientationsBloc = context.read<OrientationsBloc>();
     if (display == CallDisplay.screen) {
-      orientationsBloc.add(const OrientationsChanged(PreferredOrientation.call));
+      orientationsBloc.add(const OrientationsChanged(PreferredOrientation.auto));
     } else {
-      orientationsBloc.add(const OrientationsChanged(PreferredOrientation.regular));
+      orientationsBloc.add(const OrientationsChanged(PreferredOrientation.portrait));
     }
   }
 

--- a/lib/features/orientations/bloc/orientations_bloc.dart
+++ b/lib/features/orientations/bloc/orientations_bloc.dart
@@ -22,11 +22,11 @@ class OrientationsBloc extends Bloc<OrientationsEvent, OrientationsState> {
     if (state.lastOrientation == event.orientation) return;
 
     switch (event.orientation) {
-      case PreferredOrientation.regular:
-        await setRegularPreferredOrientations();
+      case PreferredOrientation.portrait:
+        await setPortraitPreferredOrientations();
         break;
-      case PreferredOrientation.call:
-        await setCallPreferredOrientations();
+      case PreferredOrientation.auto:
+        await setAllPreferredOrientations();
         break;
     }
 

--- a/lib/features/orientations/models/preferred_orientation.dart
+++ b/lib/features/orientations/models/preferred_orientation.dart
@@ -1,1 +1,1 @@
-enum PreferredOrientation { regular, call }
+enum PreferredOrientation { portrait, auto }

--- a/lib/utils/orientations.dart
+++ b/lib/utils/orientations.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/services.dart';
 
-Future<void> setRegularPreferredOrientations() {
+Future<void> setPortraitPreferredOrientations() {
   return SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
 }
 
-Future<void> setCallPreferredOrientations() {
+Future<void> setAllPreferredOrientations() {
   return SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,

--- a/lib/utils/orientations.dart
+++ b/lib/utils/orientations.dart
@@ -1,14 +1,20 @@
 import 'package:flutter/services.dart';
 
+/// All supported device orientations.
+const _allOrientations = [
+  DeviceOrientation.portraitUp,
+  DeviceOrientation.portraitDown,
+  DeviceOrientation.landscapeLeft,
+  DeviceOrientation.landscapeRight,
+];
+
+/// Portrait-only orientations.
+const _portraitOrientations = [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown];
+
 Future<void> setPortraitPreferredOrientations() {
-  return SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+  return SystemChrome.setPreferredOrientations(_portraitOrientations);
 }
 
 Future<void> setAllPreferredOrientations() {
-  return SystemChrome.setPreferredOrientations([
-    DeviceOrientation.portraitUp,
-    DeviceOrientation.portraitDown,
-    DeviceOrientation.landscapeLeft,
-    DeviceOrientation.landscapeRight,
-  ]);
+  return SystemChrome.setPreferredOrientations(_allOrientations);
 }


### PR DESCRIPTION
This PR refactors the `PreferredOrientation` enum by renaming its values from `regular/call` to `portrait/auto` to better reflect their intended behavior. The `portrait` value restricts orientation to portrait mode only, while the `auto` value allows all orientations (portrait and landscape).

**Changes:**
- Renamed enum values in `PreferredOrientation` from `regular/call` to `portrait/auto`
- Updated all references to use the new enum value names across the codebase