### PR TITLE
fix: fix splash config generation and add android_12 image support

### DIFF
--- a/makefile
+++ b/makefile
@@ -73,16 +73,17 @@ FLUTTER_NATIVE_SPLASH_CONFIG = $(CONFIGS_PATH)/flutter_native_splash.yaml
 # - Use `SPLASH_COLOR` for a solid background color.
 # - Use `SPLASH_IMAGE` for a custom background image (useful for gradients).
 # - Only one of them should be set at a time.
-SPLASH_COLOR ?= "#123752"
+SPLASH_COLOR ?= \#123752
 
 # Android 12+ splash screen configuration
 #
 # - From Android 12 onwards, splash screens are handled differently.
 # - Visit: https://developer.android.com/guide/topics/ui/splash-screen
-ANDROID_12_SPLASH_COLOR ?= "#123752"
+ANDROID_12_SPLASH_COLOR ?= \#123752
+ANDROID_12_SPLASH_IMAGE ?= tool/assets/native_splash/image.png
 
 # Path to splash screen background image (if used)
-SPLASH_IMAGE ?= "tool/assets/native_splash/image.png"
+SPLASH_IMAGE ?= tool/assets/native_splash/image.png
 
 # ===========================
 #  Localizely Configuration
@@ -158,11 +159,12 @@ generate-launcher-icons:
 
 ## Generate flutter_native_splash.yaml with custom parameters
 generate-native-splash-config:
-	@echo "flutter_native_splash:" > $(FLUTTER_NATIVE_SPLASH_CONFIG)
-	@echo "  color: \"$${SPLASH_COLOR:-$(SPLASH_COLOR)}\"" >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
-	@echo "  image: \"$${SPLASH_IMAGE:-$(SPLASH_IMAGE)}\"" >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
-	@echo "  android_12:" >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
-	@echo "    color: \"$${ANDROID_12_SPLASH_COLOR:-$(ANDROID_12_SPLASH_COLOR)}\"" >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
+	@echo 'flutter_native_splash:' > $(FLUTTER_NATIVE_SPLASH_CONFIG)
+	@echo '  color: "$(SPLASH_COLOR)"' >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
+	@echo '  image: "$(SPLASH_IMAGE)"' >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
+	@echo '  android_12:' >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
+	@echo '    color: "$(ANDROID_12_SPLASH_COLOR)"' >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
+	@echo '    image: "$(ANDROID_12_SPLASH_IMAGE)"' >> $(FLUTTER_NATIVE_SPLASH_CONFIG)
 
 ## Generate native splash screen using external config
 generate-native-splash:


### PR DESCRIPTION
## Summary
- Escape `#` in Makefile color variables to prevent them being interpreted as shell comments
- Replace shell parameter expansion (`${VAR:-default}`) with Make-only variable expansion
- Add `ANDROID_12_SPLASH_IMAGE` variable for a separate Android 12 splash image
- Use single-quoted `echo` commands to avoid shell interpretation issues

## Problem
The `generate-native-splash-config` Makefile target produced incorrect `flutter_native_splash.yaml` because `#` in hex color values (e.g. `#123752`) was treated as a comment delimiter — both by Make (in variable assignments) and by the shell (inside `${VAR:-"#123752"}` expansions). This resulted in empty or wrong color values in the generated config.

Additionally, there was no way to specify a separate image for the Android 12 splash screen, which uses a different display mechanism (circular masked icon).

## Changes
| File | Change |
|---|---|
| `makefile` | Escape `#` as `\#` in variable defaults, remove shell expansion, add `ANDROID_12_SPLASH_IMAGE`, switch to single-quoted echo |

## Test plan
- [ ] Run `make generate-native-splash-config` and verify correct YAML output with `#123752` colors
- [ ] Override variables: `make generate-native-splash-config SPLASH_COLOR=\#FF0000` and verify
- [ ] Run `make generate-native-splash` and confirm splash resources are generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)