### PR TITLE
fix: prevent keepalive write-after-close and harden transaction lifecycle

### DIFF
--- a/packages/webtrit_signaling/lib/src/exceptions.dart
+++ b/packages/webtrit_signaling/lib/src/exceptions.dart
@@ -52,6 +52,15 @@ class WebtritSignalingTransactionTimeoutException extends WebtritSignalingTransa
   const WebtritSignalingTransactionTimeoutException(super.id, super.transactionId);
 }
 
+class WebtritSignalingBadStateException extends WebtritSignalingException {
+  const WebtritSignalingBadStateException(super.id, this.error);
+
+  final StateError error;
+
+  @override
+  String toString() => '${super.toString()}, stateError: $error';
+}
+
 class WebtritSignalingKeepaliveTransactionTimeoutException extends WebtritSignalingTransactionTimeoutException {
   const WebtritSignalingKeepaliveTransactionTimeoutException(super.id, super.transactionId);
 }

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -248,9 +248,9 @@ class WebtritSignalingClient {
       requestJson['transaction'] = transaction.id;
     }
 
-    _addMessage(requestJson);
-
     try {
+      _addMessage(requestJson);
+
       final responseJson = await transaction.future;
       if (transaction.isIdGenerate) {
         responseJson.remove('transaction');

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -309,6 +309,7 @@ class WebtritSignalingClient {
       final elapsed = await _executeKeepaliveTransaction(defaultExecuteTransactionTimeoutDuration);
       _logger.finest('handshake keepalive latency: $elapsed');
 
+      // Stop the keepalive loop if the socket was closed between send and response.
       if (_wsc.closeCode == null) {
         _startKeepaliveTimer();
       }

--- a/packages/webtrit_signaling/pubspec.yaml
+++ b/packages/webtrit_signaling/pubspec.yaml
@@ -19,3 +19,5 @@ dependencies:
 dev_dependencies:
   lints: ^6.0.0
   test: ^1.26.3
+  mocktail: ^1.0.4
+  fake_async: ^1.3.1

--- a/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
+++ b/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+
+class MockWebSocketChannel extends Mock implements WebSocketChannel {}
+
+class MockWebSocketSink extends Mock implements WebSocketSink {}
+
+void main() {
+  group('WebtritSignalingClient Keepalive Race Condition', () {
+    late MockWebSocketChannel mockChannel;
+    late MockWebSocketSink mockSink;
+    late StreamController<dynamic> streamController;
+    late WebtritSignalingClient client;
+
+    setUp(() {
+      mockChannel = MockWebSocketChannel();
+      mockSink = MockWebSocketSink();
+      streamController = StreamController<dynamic>();
+
+      when(() => mockChannel.sink).thenReturn(mockSink);
+      when(() => mockChannel.stream).thenAnswer((_) => streamController.stream);
+      when(() => mockChannel.closeCode).thenReturn(null);
+      when(() => mockSink.close(any(), any())).thenAnswer((_) => Future.value());
+    });
+
+    tearDown(() {
+      streamController.close();
+    });
+
+    test('should gracefully terminate keepalive loop without error when timer fires on a closed socket', () {
+      fakeAsync((async) {
+        client = WebtritSignalingClient.inner(mockChannel);
+
+        var errorReported = false;
+        Object? reportedError;
+
+        client.listen(
+          onStateHandshake: (_) {},
+          onEvent: (_) {},
+          onError: (e, s) {
+            errorReported = true;
+            reportedError = e;
+          },
+          onDisconnect: (_, _) {},
+        );
+
+        var isPhysicalSocketClosed = false;
+
+        // Throws StateError to simulate writing to a closed sink.
+        when(() => mockSink.add(any())).thenAnswer((invocation) {
+          if (isPhysicalSocketClosed) {
+            throw StateError('Bad state: Cannot add event after closing.');
+          }
+        });
+
+        // Initiates the Keepalive timer (100ms interval).
+        final handshakeData = jsonEncode({
+          'handshake': 'state',
+          'timestamp': 1705322000000,
+          'keepalive_interval': 100,
+          'registration': {'status': 'registered'},
+          'lines': [],
+          'user_active_calls': [],
+          'presence_contacts_info': {},
+          'guest_line': null,
+        });
+
+        streamController.add(handshakeData);
+        async.flushMicrotasks();
+
+        // Simulates a physical connection drop without explicit client disconnection.
+        // The client remains unaware of the transport failure, allowing the timer to persist.
+        isPhysicalSocketClosed = true;
+
+        // Advances time to trigger the Keepalive timer (100ms + buffer).
+        async.elapse(const Duration(milliseconds: 200));
+
+        // Confirms the write was attempted (validating the race condition logic executed).
+        verify(() => mockSink.add(any())).called(greaterThan(0));
+
+        // Ensures the internal exception was handled silently and not reported.
+        expect(errorReported, isFalse, reason: 'Race condition caused an exception to leak to onError: $reportedError');
+      });
+    });
+  });
+}

--- a/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
+++ b/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
@@ -12,31 +12,44 @@ class MockWebSocketChannel extends Mock implements WebSocketChannel {}
 
 class MockWebSocketSink extends Mock implements WebSocketSink {}
 
+/// Helper to create a valid handshake state JSON string.
+String _handshakeJson({int keepaliveInterval = 100}) {
+  return jsonEncode({
+    'handshake': 'state',
+    'timestamp': 1705322000000,
+    'keepalive_interval': keepaliveInterval,
+    'registration': {'status': 'registered'},
+    'lines': [],
+    'user_active_calls': [],
+    'presence_contacts_info': {},
+    'guest_line': null,
+  });
+}
+
 void main() {
-  group('WebtritSignalingClient Keepalive Race Condition', () {
-    late MockWebSocketChannel mockChannel;
-    late MockWebSocketSink mockSink;
-    late StreamController<dynamic> streamController;
-    late WebtritSignalingClient client;
+  late MockWebSocketChannel mockChannel;
+  late MockWebSocketSink mockSink;
+  late StreamController<dynamic> streamController;
 
-    setUp(() {
-      mockChannel = MockWebSocketChannel();
-      mockSink = MockWebSocketSink();
-      streamController = StreamController<dynamic>();
+  setUp(() {
+    mockChannel = MockWebSocketChannel();
+    mockSink = MockWebSocketSink();
+    streamController = StreamController<dynamic>();
 
-      when(() => mockChannel.sink).thenReturn(mockSink);
-      when(() => mockChannel.stream).thenAnswer((_) => streamController.stream);
-      when(() => mockChannel.closeCode).thenReturn(null);
-      when(() => mockSink.close(any(), any())).thenAnswer((_) => Future.value());
-    });
+    when(() => mockChannel.sink).thenReturn(mockSink);
+    when(() => mockChannel.stream).thenAnswer((_) => streamController.stream);
+    when(() => mockChannel.closeCode).thenReturn(null);
+    when(() => mockSink.close(any(), any())).thenAnswer((_) => Future.value());
+  });
 
-    tearDown(() {
-      streamController.close();
-    });
+  tearDown(() {
+    streamController.close();
+  });
 
-    test('should gracefully terminate keepalive loop without error when timer fires on a closed socket', () {
+  group('Keepalive race condition', () {
+    test('should gracefully stop keepalive loop when timer fires on a closed socket', () {
       fakeAsync((async) {
-        client = WebtritSignalingClient.inner(mockChannel);
+        final client = WebtritSignalingClient.inner(mockChannel);
 
         var errorReported = false;
         Object? reportedError;
@@ -53,41 +66,128 @@ void main() {
 
         var isPhysicalSocketClosed = false;
 
-        // Throws StateError to simulate writing to a closed sink.
-        when(() => mockSink.add(any())).thenAnswer((invocation) {
+        when(() => mockSink.add(any())).thenAnswer((_) {
           if (isPhysicalSocketClosed) {
-            throw StateError('Bad state: Cannot add event after closing.');
+            throw StateError('Cannot add event after closing.');
           }
         });
 
-        // Initiates the Keepalive timer (100ms interval).
-        final handshakeData = jsonEncode({
-          'handshake': 'state',
-          'timestamp': 1705322000000,
-          'keepalive_interval': 100,
-          'registration': {'status': 'registered'},
-          'lines': [],
-          'user_active_calls': [],
-          'presence_contacts_info': {},
-          'guest_line': null,
-        });
-
-        streamController.add(handshakeData);
+        streamController.add(_handshakeJson());
         async.flushMicrotasks();
 
-        // Simulates a physical connection drop without explicit client disconnection.
-        // The client remains unaware of the transport failure, allowing the timer to persist.
+        // Simulate physical connection drop.
         isPhysicalSocketClosed = true;
 
-        // Advances time to trigger the Keepalive timer (100ms + buffer).
+        // Advance past the keepalive interval.
         async.elapse(const Duration(milliseconds: 200));
 
-        // Confirms the write was attempted (validating the race condition logic executed).
         verify(() => mockSink.add(any())).called(greaterThan(0));
-
-        // Ensures the internal exception was handled silently and not reported.
-        expect(errorReported, isFalse, reason: 'Race condition caused an exception to leak to onError: $reportedError');
+        expect(errorReported, isFalse, reason: 'Race condition leaked to onError: $reportedError');
       });
+    });
+
+    test('should not restart keepalive timer when closeCode is set after successful keepalive', () {
+      fakeAsync((async) {
+        final client = WebtritSignalingClient.inner(mockChannel);
+
+        String? capturedTransactionId;
+        var keepaliveRequestCount = 0;
+
+        // Capture the transaction ID from outgoing keepalive requests.
+        when(() => mockSink.add(any())).thenAnswer((invocation) {
+          final data = invocation.positionalArguments[0] as String;
+          final json = jsonDecode(data) as Map<String, dynamic>;
+          if (json['handshake'] == 'keepalive') {
+            capturedTransactionId = json['transaction'] as String?;
+            keepaliveRequestCount++;
+          }
+        });
+
+        client.listen(onStateHandshake: (_) {}, onEvent: (_) {}, onError: (_, _) {}, onDisconnect: (_, _) {});
+
+        // Start keepalive timer via handshake (100ms interval).
+        streamController.add(_handshakeJson());
+        async.flushMicrotasks();
+
+        // First keepalive fires.
+        async.elapse(const Duration(milliseconds: 110));
+        async.flushMicrotasks();
+        expect(keepaliveRequestCount, equals(1));
+
+        // Respond to first keepalive with matching transaction ID.
+        streamController.add(jsonEncode({'handshake': 'keepalive', 'transaction': capturedTransactionId}));
+        async.flushMicrotasks();
+
+        // Simulate socket closed before next keepalive.
+        when(() => mockChannel.closeCode).thenReturn(1000);
+
+        // Wait well beyond second keepalive interval — timer should not restart.
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+
+        // Only one keepalive request should have been sent.
+        expect(keepaliveRequestCount, equals(1));
+      });
+    });
+  });
+
+  group('Transaction cleanup on send failure', () {
+    test('should throw WebtritSignalingBadStateException when sink.add throws StateError', () async {
+      final client = WebtritSignalingClient.inner(mockChannel);
+
+      client.listen(onStateHandshake: (_) {}, onEvent: (_) {}, onError: (_, _) {}, onDisconnect: (_, _) {});
+
+      // Initialize client with handshake.
+      streamController.add(_handshakeJson());
+      await Future.delayed(Duration.zero);
+
+      // Any sink.add throws StateError (socket broken).
+      when(() => mockSink.add(any())).thenThrow(StateError('Cannot add event after closing.'));
+
+      final request = HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id');
+
+      await expectLater(() => client.execute(request), throwsA(isA<WebtritSignalingBadStateException>()));
+    });
+
+    test('should throw WebtritSignalingBadStateException when closeCode is already set', () async {
+      final client = WebtritSignalingClient.inner(mockChannel);
+
+      client.listen(onStateHandshake: (_) {}, onEvent: (_) {}, onError: (_, _) {}, onDisconnect: (_, _) {});
+
+      // Initialize client with handshake.
+      streamController.add(_handshakeJson());
+      await Future.delayed(Duration.zero);
+
+      // Socket already closed.
+      when(() => mockChannel.closeCode).thenReturn(1000);
+
+      final request = HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id');
+
+      await expectLater(() => client.execute(request), throwsA(isA<WebtritSignalingBadStateException>()));
+    });
+
+    test('should not call sink.add when closeCode is detected before write', () async {
+      final client = WebtritSignalingClient.inner(mockChannel);
+
+      client.listen(onStateHandshake: (_) {}, onEvent: (_) {}, onError: (_, _) {}, onDisconnect: (_, _) {});
+
+      // Initialize client with handshake.
+      streamController.add(_handshakeJson());
+      await Future.delayed(Duration.zero);
+
+      // closeCode set — socket already closed.
+      when(() => mockChannel.closeCode).thenReturn(1000);
+
+      final request = HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id');
+
+      try {
+        await client.execute(request);
+      } on WebtritSignalingBadStateException {
+        // Expected.
+      }
+
+      // sink.add should NOT have been called — pre-check caught it.
+      verifyNever(() => mockSink.add(any()));
     });
   });
 }

--- a/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
+++ b/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
@@ -42,8 +42,8 @@ void main() {
     when(() => mockSink.close(any(), any())).thenAnswer((_) => Future.value());
   });
 
-  tearDown(() {
-    streamController.close();
+  tearDown(() async {
+    await streamController.close();
   });
 
   group('Keepalive race condition', () {
@@ -81,7 +81,7 @@ void main() {
         // Advance past the keepalive interval.
         async.elapse(const Duration(milliseconds: 200));
 
-        verify(() => mockSink.add(any())).called(greaterThan(0));
+        verify(() => mockSink.add(any())).called(1);
         expect(errorReported, isFalse, reason: 'Race condition leaked to onError: $reportedError');
       });
     });
@@ -116,10 +116,10 @@ void main() {
 
         // Respond to first keepalive with matching transaction ID.
         streamController.add(jsonEncode({'handshake': 'keepalive', 'transaction': capturedTransactionId}));
-        async.flushMicrotasks();
 
-        // Simulate socket closed before next keepalive.
+        // Set closeCode BEFORE flushing so _onKeepalive sees it when it resumes.
         when(() => mockChannel.closeCode).thenReturn(1000);
+        async.flushMicrotasks();
 
         // Wait well beyond second keepalive interval — timer should not restart.
         async.elapse(const Duration(milliseconds: 500));
@@ -127,6 +127,11 @@ void main() {
 
         // Only one keepalive request should have been sent.
         expect(keepaliveRequestCount, equals(1));
+
+        // Verify closeCode was checked exactly twice: once in _addData (before write),
+        // once in _onKeepalive (after response, as the 'no restart' guard).
+        // If the timer restarted, closeCode would be accessed a third time.
+        verify(() => mockChannel.closeCode).called(2);
       });
     });
   });


### PR DESCRIPTION
## Problem

Race condition between WebSocket keepalive timer and socket close event in Dart's event loop. When the connection drops, both events are queued — if the timer fires before `onDone`, it writes to a dead socket, causing an unhandled `StateError` that propagates to `_RawReceivePort._handleMessage` (337 crashes, Feb 21–28).

```
 Event loop queue:
 ┌─────────────────┐   ┌─────────────────┐
 │ keepalive timer  │   │ socket onDone   │
 │ (fires first)    │──▶│ (arrives later) │
 └────────┬────────┘   └────────┬────────┘
          │                     │
    sink.add() on               stops timer,
    dead socket                 runs disconnect
          │
    StateError ──▶ _onError ──▶ endCallsOnService()
                                ↑ all active calls killed
```

## Fix

### 1. Pre-check `closeCode` before write (`_addData`)
Skip the write if the socket is already known to be closed. Wrap `StateError` into typed `WebtritSignalingBadStateException`.

### 2. Graceful keepalive stop (`_onKeepalive`)
- Catch `WebtritSignalingBadStateException` → silently exit the loop (no `_onError`)
- Check `closeCode` after successful keepalive → don't restart timer if socket closed mid-transaction

### 3. Transaction cleanup on send failure (`_executeTransaction`)
Moved `_addMessage` inside try-catch so the transaction is removed from the map if the write fails. Previously it leaked — stayed in `_transactions` forever with no response coming.

## Why silent return is safe

Reconnection is triggered by `Connectivity().onConnectivityChanged`, not by `_onError` or `_onDisconnect`. Suppressing the error only prevents unnecessary call termination — it does not block reconnection.

## Tests

5 tests covering both scenarios:

**Keepalive race condition** (fakeAsync)
- Timer fires on closed socket → graceful stop, `onError` not called
- `closeCode` set after successful keepalive → timer not restarted

**Transaction cleanup on send failure** (async)
- `sink.add` throws `StateError` → `WebtritSignalingBadStateException`
- `closeCode` already set → `WebtritSignalingBadStateException`
- `closeCode` detected before write → `sink.add` never called