### PR TITLE
feat: add call log event lookup and incoming video SDP helper extensions

### DIFF
--- a/lib/extensions/call_line_logs_extension.dart
+++ b/lib/extensions/call_line_logs_extension.dart
@@ -1,0 +1,25 @@
+import 'package:collection/collection.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+
+extension CallLineLogsExtension on Iterable<Line?> {
+  /// Finds the first event of type [T] inside the CallEventLog wrappers.
+  T? findEvent<T extends CallEvent>(String callId) {
+    // Find the correct line
+    final line = firstWhereOrNull((it) => it?.callId == callId);
+    if (line == null) return null;
+
+    // Look through callLogs, find CallEventLogs, and check the inner event type
+    return line.callLogs.whereType<CallEventLog>().map((log) => log.callEvent).whereType<T>().firstOrNull;
+  }
+}
+
+extension IncomingCallVideoExtension on IncomingCallEvent {
+  /// Returns true if the JSEP payload contains a video media description.
+  bool get isVideo {
+    final sdp = jsep?['sdp'] as String?;
+    if (sdp == null) return false;
+
+    // m=video is the standard SDP prefix for video streams
+    return sdp.contains('m=video');
+  }
+}

--- a/lib/extensions/call_line_logs_extension.dart
+++ b/lib/extensions/call_line_logs_extension.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
+// TODO: Add unit tests
 extension CallLineLogsExtension on Iterable<Line?> {
   /// Finds the first event of type [T] inside the CallEventLog wrappers.
   T? findEvent<T extends CallEvent>(String callId) {
@@ -13,6 +14,7 @@ extension CallLineLogsExtension on Iterable<Line?> {
   }
 }
 
+//TODO: Add unit tests
 extension IncomingCallVideoExtension on IncomingCallEvent {
   /// Returns true if the JSEP payload contains a video media description.
   bool get isVideo {

--- a/lib/extensions/extensions.dart
+++ b/lib/extensions/extensions.dart
@@ -2,6 +2,7 @@ export 'agreement.dart';
 export 'app_database.dart';
 export 'audio_player_extension.dart';
 export 'build_context.dart';
+export 'call_line_logs_extension.dart';
 export 'call_status.dart';
 export 'callkeep_handle.dart';
 export 'clock.dart';

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -59,9 +59,9 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
     return signalingManager.dispose();
   }
 
-  void _handleHangupCall(HangupEvent event) async {
+  void _handleHangupCall(HangupEvent event, NewCall call) async {
     try {
-      logger.info('Ending call: ${event.callId}');
+      logger.info('Ending call: ${event.callId} - ${call.number}');
       await endCallOnService(event.callId);
     } catch (e) {
       _handleExceptions(e);


### PR DESCRIPTION
This PR enriches call hangup handling by deriving call log metadata from signaling line events and adds helpers for inspecting call logs and SDP for video. It also wires these helpers into the signaling manager and background isolate to support better logging and diagnostics.

**Changes:**
- Extended `SignalingManager`’s hangup callback to pass a `NewCall`-shaped payload derived from line call logs, including direction, caller identity, video flag, and timestamps.
- Added `CallLineLogsExtension` for looking up typed call events by `callId`, and `IncomingCallVideoExtension` for detecting video media in SDP, exporting them via the central `extensions.dart` barrel.
- Updated `IsolateManager`’s hangup handler to accept the enriched call info and improve logging output.