### PR TITLE
refactor: rename isolate manager callbacks/services for clarity and unify error logging

### DIFF
--- a/lib/features/call/services/services_isolate.dart
+++ b/lib/features/call/services/services_isolate.dart
@@ -97,7 +97,7 @@ Future<void> onPushNotificationSyncCallback(CallkeepPushNotificationSyncStatus s
 
   switch (status) {
     case CallkeepPushNotificationSyncStatus.synchronizeCallStatus:
-      await _pushNotificationIsolateManager?.sync();
+      await _pushNotificationIsolateManager?.launchSignaling();
     case CallkeepPushNotificationSyncStatus.releaseResources:
       await _disposeCommonDependencies();
   }
@@ -111,7 +111,7 @@ Future<void> onSignalingSyncCallback(CallkeepServiceStatus status) async {
 
   _logger.info('onSignalingSyncCallback: $status');
 
-  await _signalingForegroundIsolateManager?.sync(status);
+  await _signalingForegroundIsolateManager?.handleLifecycleStatus(status);
   // TODO: Implement a deterministic cleanup path for common dependencies (DB, storages, logger)
   // for the signaling isolate. Unlike the push-notification flow, this callback currently has
   // no explicit "releaseResources" event, so we need a reliable trigger (or idle-timeout) to


### PR DESCRIPTION
This PR refactors the isolate manager code to improve naming clarity and consistency. It renames callback methods to follow the `_on*` pattern, renames service fields to be more descriptive, updates public method names to better reflect their purpose, and simplifies error logging by removing an unnecessary wrapper function.

**Changes:**
- Renamed callback methods from `_handle*` to `_on*` prefix for consistency with Dart conventions
- Renamed service fields from generic `_callkeep` to specific `_pushService` and `_signalingService` for clarity
- Renamed `sync()` to `launchSignaling()` and `sync(status)` to `handleLifecycleStatus(status)` for better semantic meaning
- Unified error logging by removing `_handleExceptions()` wrapper and using direct `logger.severe()` calls
