### PR TITLE
refactor: remove deprecated performSetSpeaker stub from CallBloc

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2701,12 +2701,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   @override
-  @Deprecated('Used performAudioDeviceSet instead')
-  Future<bool> performSetSpeaker(String callId, bool enabled) {
-    return Future.value(true);
-  }
-
-  @override
   Future<bool> performAudioDeviceSet(String callId, CallkeepAudioDevice device) {
     final callDevice = CallAudioDevice.fromCallkeep(device);
     return _perform(_CallPerformEvent.audioDeviceSet(callId, callDevice));


### PR DESCRIPTION
Depends: https://github.com/WebTrit/webtrit_callkeep/pull/127