### PR TITLE
feat: add LoggerPretty extension with chunking and safe formatting

### DIFF
--- a/lib/extensions/extensions.dart
+++ b/lib/extensions/extensions.dart
@@ -12,6 +12,7 @@ export 'duration.dart';
 export 'feature_access.dart';
 export 'iterable.dart';
 export 'locale.dart';
+export 'logger_extensions.dart';
 export 'main_flavor.dart';
 export 'media_query_metrics_extensions.dart';
 export 'messaging_socket_exception.dart';

--- a/lib/extensions/logger_extensions.dart
+++ b/lib/extensions/logger_extensions.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+extension LoggerPretty on Logger {
+  /// Logs data with info level formatting.
+  void infoPretty(Object? data, {String? tag}) => logPretty(data, tag: tag, level: Level.INFO);
+
+  /// Logs data with fine level formatting.
+  void finePretty(Object? data, {String? tag}) => logPretty(data, tag: tag, level: Level.FINE);
+
+  /// Logs data with warning level formatting.
+  void warningPretty(Object? data, {String? tag}) => logPretty(data, tag: tag, level: Level.WARNING);
+
+  /// Logs formatted data safely by handling large payloads and environment constraints.
+  void logPretty(
+    Object? data, {
+    Level level = Level.INFO,
+    String? tag,
+    int chunkSize = 800,
+    int maxLogLength = 20000,
+    int maxCollectionItems = 50,
+  }) {
+    if (!isLoggable(level) || kReleaseMode) {
+      return;
+    }
+
+    final effectiveTag = tag ?? name;
+    final baseHeader = '[$effectiveTag]';
+
+    try {
+      var formattedString = _formatDataSafe(data, maxCollectionItems);
+
+      if (formattedString.length > maxLogLength) {
+        formattedString = '${formattedString.substring(0, maxLogLength)}\n\n... [Log Truncated: Too Large]';
+      }
+
+      _processLogChunks(formattedString, baseHeader, level, chunkSize);
+    } catch (e) {
+      log(level, '$baseHeader [Log Error]: $e');
+    }
+  }
+
+  String _formatDataSafe(Object? data, int maxItems) {
+    if (data is String && data.startsWith('v=0')) {
+      return data.length > 5000
+          ? '${data.substring(0, 5000)}... (SDP truncated)'
+          : data.replaceAll(RegExp(r'\r?\n'), '\n  ');
+    }
+
+    try {
+      final safeObject = _jsonSafe(data, maxItems);
+      return const JsonEncoder.withIndent('  ').convert(safeObject);
+    } catch (_) {
+      return data.toString();
+    }
+  }
+
+  void _processLogChunks(String message, String header, Level level, int chunkSize) {
+    final totalChunks = (message.length / chunkSize).ceil();
+
+    for (var i = 0; i < totalChunks; i++) {
+      final start = i * chunkSize;
+      final end = math.min(start + chunkSize, message.length);
+      final part = message.substring(start, end);
+      final chunkHeader = totalChunks > 1 ? '$header (${i + 1}/$totalChunks): ' : '$header: ';
+
+      log(level, '$chunkHeader$part');
+    }
+  }
+
+  static Object? _jsonSafe(Object? v, int maxItems) {
+    if (v == null || v is num || v is bool || v is String) {
+      return v;
+    }
+
+    if (v is Iterable) {
+      final list = v.toList();
+      final truncated = list.take(maxItems).map((e) => _jsonSafe(e, maxItems)).toList();
+
+      if (list.length > maxItems) {
+        truncated.add('... (${list.length - maxItems} more items)');
+      }
+      return truncated;
+    }
+
+    if (v is Map) {
+      final entries = v.entries.take(maxItems).map((e) => MapEntry(e.key.toString(), _jsonSafe(e.value, maxItems)));
+      final result = Map.fromEntries(entries);
+
+      if (v.length > maxItems) {
+        result['...'] = '(${v.length - maxItems} more keys)';
+      }
+      return result;
+    }
+
+    return v.toString();
+  }
+}

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -875,6 +875,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// So the answering method [__onCallPerformEventAnswered] will wait until offer and line is assigned
   /// to the [ActiveCall] by logic below, do not change status in that case.
   Future<void> __onCallSignalingEventIncoming(_CallSignalingEventIncoming event, Emitter<CallState> emit) async {
+    _logger.infoPretty(event.jsep?.sdp, tag: '__onCallSignalingEventIncoming');
+
     final video = event.jsep?.hasVideo ?? false;
     final handle = CallkeepHandle.number(event.caller);
     final contactName = await contactNameResolver.resolveWithNumber(handle.value);
@@ -1800,6 +1802,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
       final localDescription = await peerConnection.createOffer({});
       sdpMunger?.apply(localDescription);
+      _logger.infoPretty(localDescription.sdp, tag: '__onCallPerformEventStarted');
 
       // Need to initiate outgoing call before set localDescription to avoid races
       // between [OutgoingCallRequest] and [IceTrickleRequest]s.

--- a/test/extesions/logger_pretty_test.dart
+++ b/test/extesions/logger_pretty_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:logging/logging.dart';
+
+import 'package:webtrit_phone/extensions/extensions.dart';
+
+void main() {
+  late Logger logger;
+  late List<LogRecord> emittedLogs;
+
+  setUp(() {
+    Logger.root.clearListeners();
+    emittedLogs = [];
+    logger = Logger('TestLogger');
+
+    logger.onRecord.listen(emittedLogs.add);
+  });
+
+  group('LoggerPretty Extension Tests', () {
+    test('Should format simple Map as pretty JSON', () {
+      final data = {'id': 1, 'name': 'Test User'};
+
+      logger.infoPretty(data);
+
+      expect(emittedLogs.length, 1);
+      final message = emittedLogs.first.message;
+
+      expect(message, contains('[TestLogger]: {'));
+      expect(message, contains('  "id": 1'));
+      expect(message, contains('  "name": "Test User"'));
+    });
+
+    test('Should handle SDP strings correctly (formatting newlines)', () {
+      const sdpInput = 'v=0\r\no=mozilla...ISMB 12345\r\ns=Session Name\r\nt=0 0';
+
+      logger.infoPretty(sdpInput, tag: 'WebRTC');
+
+      expect(emittedLogs.length, 1);
+      final message = emittedLogs.first.message;
+
+      expect(message, contains('[WebRTC]: v=0'));
+      expect(message, contains('\n  o=mozilla'));
+      expect(message, contains('\n  s=Session Name'));
+    });
+
+    test('Should truncate extremely large lists (Collection Safety)', () {
+      final largeList = List.generate(100, (index) => 'Item $index');
+
+      logger.logPretty(largeList, maxCollectionItems: 10);
+
+      final message = emittedLogs.first.message;
+
+      expect(message, contains('"Item 0"'));
+      expect(message, contains('"Item 9"'));
+      expect(message, isNot(contains('"Item 11"')));
+      expect(message, contains('90 more items'));
+    });
+
+    test('Should truncate extremely large maps (Collection Safety)', () {
+      final largeMap = {for (var i = 0; i < 100; i++) 'key_$i': 'value_$i'};
+
+      logger.logPretty(largeMap, maxCollectionItems: 5);
+
+      final message = emittedLogs.first.message;
+
+      expect(message, contains('key_0'));
+      expect(message, contains('key_4'));
+      expect(message, isNot(contains('key_6')));
+      expect(message, contains('95 more keys'));
+    });
+
+    test('Should split long messages into chunks', () {
+      final longString = List.generate(10, (_) => '0123456789').join();
+
+      logger.logPretty(longString, chunkSize: 40);
+
+      expect(emittedLogs.length, 3);
+      expect(emittedLogs[0].message, contains('(1/3)'));
+      expect(emittedLogs[1].message, contains('(2/3)'));
+      expect(emittedLogs[2].message, contains('(3/3)'));
+    });
+
+    test('Should strictly truncate log message when it exceeds maxLogLength', () {
+      final buffer = StringBuffer();
+      for (var i = 0; i < 50; i++) {
+        buffer.write('Line $i: Lorem ipsum dolor sit amet, consectetur adipiscing elit. ');
+      }
+      final longGeneratedText = buffer.toString();
+
+      logger.logPretty(longGeneratedText, maxLogLength: 150);
+
+      final message = emittedLogs.first.message;
+
+      expect(message, contains('[TestLogger]'));
+      expect(message, contains('[Log Truncated: Too Large'));
+      expect(message, contains('Line 0: Lorem ipsum'));
+      expect(message, isNot(contains('Line 49')));
+      expect(message.length, lessThan(longGeneratedText.length));
+    });
+  });
+}

--- a/test/extesions/logger_pretty_test.dart
+++ b/test/extesions/logger_pretty_test.dart
@@ -97,5 +97,14 @@ void main() {
       expect(message, isNot(contains('Line 49')));
       expect(message.length, lessThan(longGeneratedText.length));
     });
+
+    test('Should handle null data safely', () {
+      logger.infoPretty(null);
+
+      expect(emittedLogs.length, 1);
+      final message = emittedLogs.first.message;
+
+      expect(message, contains('[TestLogger]: null'));
+    });
   });
 }


### PR DESCRIPTION
This PR introduces `LoggerPretty` to fix unreadable WebRTC logs and **solve the console line character limit issue** (e.g., Android Logcat truncates lines >4KB).

**Problem & Solution**

* **The Problem:** Long logs (like SDP offers or large JSONs) get silently truncated by the OS console, making debugging impossible.
* **The Solution:** Implemented a **chunking mechanism** that splits large messages into numbered parts `(1/3)`, `(2/3)`... preserving the log tag for filtering.

**Key Changes**

* **Bypass Line Limits:** Automatically splits logs >800 chars (configurable) into sequential chunks.
* **SDP Formatting:** Detects `v=0` and formats WebRTC blobs with proper indentation.
* **Safety Guardrails:** Added `maxLogLength` and `maxCollectionItems` to prevent UI jank or OOM on massive datasets.

**Preview**

> Notice the `(1/2)` chunking indicator and formatted SDP:

```text
I/flutter ( 337): 2026-01-26 17:08:16.645269 INFO CallBloc - [__onCallPerformEventStarted] (1/2): v=0
I/flutter ( 337):    o=- 80762302957955848 2 IN IP4 127.0.0.1
I/flutter ( 337):    s=-
...
I/flutter ( 337): 2026-01-26 17:08:16.645503 INFO CallBloc - [__onCallPerformEventStarted] (2/2): riments/rtp-hdrext/abs-send-time
I/flutter ( 337):    a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01

```