### PR TITLE
feat: implement configurable call actions in chat contact info

### DIFF
--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -265,7 +265,10 @@
   "messaging": {
     "sms": {},
     "chats": {
-      "groupChatButtonEnabled": true
+      "groupChatButtonEnabled": true,
+      "contactInfo": {
+        "showVideoButtonAction": false
+      }
     }
   }
 }

--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -267,7 +267,7 @@
     "chats": {
       "groupChatButtonEnabled": true,
       "contactInfo": {
-        "showVideoButtonAction": false
+        "showVideoButtonAction": true
       }
     }
   }

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -366,7 +366,7 @@ abstract final class MessagingMapper {
       coreChatsSupport: coreSupport.supportsChats,
       tabEnabled: tabEnabled,
       groupChatSupport: appConfig.messaging.chats.groupChatButtonEnabled,
-      contactInfoVideoCallSupport: true,
+      contactInfoVideoCallSupport: appConfig.messaging.chats.contactInfo.showVideoButtonAction,
     );
   }
 }

--- a/lib/features/messaging/bloc/messaging_bloc.dart
+++ b/lib/features/messaging/bloc/messaging_bloc.dart
@@ -36,7 +36,7 @@ class MessagingBloc extends Bloc<MessagingEvent, MessagingState> {
     this._smsRepository,
     this._smsOutboxRepository,
     this._submitNotification,
-  ) : super(MessagingState.initial(_client)) {
+  ) : super(MessagingState.initial(_client, _messagingConfig)) {
     on<Connect>(_connect);
     on<Refresh>(_refresh);
     on<Disconnect>(_onDisconnect);

--- a/lib/features/messaging/bloc/messaging_state.dart
+++ b/lib/features/messaging/bloc/messaging_state.dart
@@ -3,18 +3,19 @@ part of 'messaging_bloc.dart';
 enum ConnectionStatus { initial, error, connecting, connected }
 
 class MessagingState with EquatableMixin {
-  const MessagingState._(this.client, this.status, this.error);
+  const MessagingState._(this.client, this.status, this.messagingConfig, this.error);
 
   final PhoenixSocket client;
   final ConnectionStatus status;
+  final MessagingConfig messagingConfig;
   final Exception? error;
 
-  factory MessagingState.initial(PhoenixSocket client) {
-    return MessagingState._(client, ConnectionStatus.initial, null);
+  factory MessagingState.initial(PhoenixSocket client, MessagingConfig messagingConfig) {
+    return MessagingState._(client, ConnectionStatus.initial, messagingConfig, null);
   }
 
-  MessagingState copyWith({ConnectionStatus? status, Exception? error}) {
-    return MessagingState._(client, status ?? this.status, error);
+  MessagingState copyWith({ConnectionStatus? status, MessagingConfig? messagingConfig, Exception? error}) {
+    return MessagingState._(client, status ?? this.status, messagingConfig ?? this.messagingConfig, error);
   }
 
   @override

--- a/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
+++ b/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
@@ -40,7 +40,12 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
           value: conversationCubit,
           child: ClipRRect(
             borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-            child: DialogInfo(userId, state.credentials.participantId!),
+            child: DialogInfo(
+              userId,
+              state.credentials.participantId!,
+              isAudioCallEnabled: true,
+              isVideoCallEnabled: messagingBloc.state.messagingConfig.contactInfoVideoCallSupport,
+            ),
           ),
         ),
       );

--- a/lib/features/messaging/features/chat_conversation/widgets/dialog_info.dart
+++ b/lib/features/messaging/features/chat_conversation/widgets/dialog_info.dart
@@ -4,17 +4,25 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/widgets/widgets.dart' hide ConfirmDialog;
 
 class DialogInfo extends StatefulWidget {
-  const DialogInfo(this.userId, this.participantId, {super.key});
+  const DialogInfo(
+    this.userId,
+    this.participantId, {
+    required this.isAudioCallEnabled,
+    required this.isVideoCallEnabled,
+    super.key,
+  });
 
   final String userId;
   final String participantId;
+  final bool isAudioCallEnabled;
+  final bool isVideoCallEnabled;
 
   @override
   State<DialogInfo> createState() => _DialogInfoState();
@@ -110,31 +118,22 @@ class _DialogInfoState extends State<DialogInfo> {
                           ),
                           const SizedBox(height: 24),
                           if (contact != null && contact.kind == ContactKind.visible) ...[
-                            Divider(),
+                            const Divider(),
                             Expanded(
                               child: ListView(
                                 children: [
                                   for (ContactPhone contactPhone in contact.phones)
                                     ListTile(
+                                      contentPadding: EdgeInsets.zero,
                                       title: Text(contactPhone.number),
                                       trailing: Row(
                                         mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          IconButton(
-                                            splashRadius: 24,
-                                            icon: const Icon(Icons.call),
-                                            onPressed: () => _onCall(contactPhone, contact, false),
-                                          ),
-                                          IconButton(
-                                            splashRadius: 24,
-                                            icon: const Icon(Icons.videocam),
-                                            onPressed: () => _onCall(contactPhone, contact, true),
-                                          ),
-                                        ],
+                                        children: _buildCallActions(contactPhone, contact),
                                       ),
                                     ),
                                   for (ContactEmail contactEmail in contact.emails)
                                     ListTile(
+                                      contentPadding: EdgeInsets.zero,
                                       title: Text(contactEmail.address),
                                       trailing: IconButton(
                                         splashRadius: 24,
@@ -147,7 +146,7 @@ class _DialogInfoState extends State<DialogInfo> {
                             ),
                             const SizedBox(height: 8),
                           ] else
-                            Spacer(),
+                            const Spacer(),
                         ],
                       ),
                     );
@@ -169,5 +168,23 @@ class _DialogInfoState extends State<DialogInfo> {
         return const Center(child: CircularProgressIndicator());
       },
     );
+  }
+
+  /// Returns a list of call action buttons based on provided configuration.
+  List<Widget> _buildCallActions(ContactPhone contactPhone, Contact contact) {
+    return [
+      if (widget.isAudioCallEnabled)
+        IconButton(
+          splashRadius: 24,
+          icon: const Icon(Icons.call),
+          onPressed: () => _onCall(contactPhone, contact, false),
+        ),
+      if (widget.isVideoCallEnabled)
+        IconButton(
+          splashRadius: 24,
+          icon: const Icon(Icons.videocam),
+          onPressed: () => _onCall(contactPhone, contact, true),
+        ),
+    ];
   }
 }

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -612,12 +612,28 @@ class AppConfigSms with _$AppConfigSms {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigChats with _$AppConfigChats {
-  const AppConfigChats({this.groupChatButtonEnabled = true});
+  const AppConfigChats({this.groupChatButtonEnabled = true, this.contactInfo = const ChatContactInfo()});
 
   @override
   final bool groupChatButtonEnabled;
 
+  @override
+  final ChatContactInfo contactInfo;
+
   factory AppConfigChats.fromJson(Map<String, Object?> json) => _$AppConfigChatsFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigChatsToJson(this);
+}
+
+@freezed
+@JsonSerializable(explicitToJson: true)
+class ChatContactInfo with _$ChatContactInfo {
+  const ChatContactInfo({this.showVideoButtonAction = true});
+
+  @override
+  final bool showVideoButtonAction;
+
+  factory ChatContactInfo.fromJson(Map<String, Object?> json) => _$ChatContactInfoFromJson(json);
+
+  Map<String, Object?> toJson() => _$ChatContactInfoToJson(this);
 }

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
@@ -4830,7 +4830,7 @@ case _:
 /// @nodoc
 mixin _$AppConfigChats {
 
- bool get groupChatButtonEnabled;
+ bool get groupChatButtonEnabled; ChatContactInfo get contactInfo;
 /// Create a copy of AppConfigChats
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -4841,16 +4841,16 @@ $AppConfigChatsCopyWith<AppConfigChats> get copyWith => _$AppConfigChatsCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigChats&&(identical(other.groupChatButtonEnabled, groupChatButtonEnabled) || other.groupChatButtonEnabled == groupChatButtonEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigChats&&(identical(other.groupChatButtonEnabled, groupChatButtonEnabled) || other.groupChatButtonEnabled == groupChatButtonEnabled)&&(identical(other.contactInfo, contactInfo) || other.contactInfo == contactInfo));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,groupChatButtonEnabled);
+int get hashCode => Object.hash(runtimeType,groupChatButtonEnabled,contactInfo);
 
 @override
 String toString() {
-  return 'AppConfigChats(groupChatButtonEnabled: $groupChatButtonEnabled)';
+  return 'AppConfigChats(groupChatButtonEnabled: $groupChatButtonEnabled, contactInfo: $contactInfo)';
 }
 
 
@@ -4861,7 +4861,7 @@ abstract mixin class $AppConfigChatsCopyWith<$Res>  {
   factory $AppConfigChatsCopyWith(AppConfigChats value, $Res Function(AppConfigChats) _then) = _$AppConfigChatsCopyWithImpl;
 @useResult
 $Res call({
- bool groupChatButtonEnabled
+ bool groupChatButtonEnabled, ChatContactInfo contactInfo
 });
 
 
@@ -4878,10 +4878,11 @@ class _$AppConfigChatsCopyWithImpl<$Res>
 
 /// Create a copy of AppConfigChats
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? groupChatButtonEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? groupChatButtonEnabled = null,Object? contactInfo = null,}) {
   return _then(AppConfigChats(
 groupChatButtonEnabled: null == groupChatButtonEnabled ? _self.groupChatButtonEnabled : groupChatButtonEnabled // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,contactInfo: null == contactInfo ? _self.contactInfo : contactInfo // ignore: cast_nullable_to_non_nullable
+as ChatContactInfo,
   ));
 }
 
@@ -4890,6 +4891,192 @@ as bool,
 
 /// Adds pattern-matching-related methods to [AppConfigChats].
 extension AppConfigChatsPatterns on AppConfigChats {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$ChatContactInfo {
+
+ bool get showVideoButtonAction;
+/// Create a copy of ChatContactInfo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChatContactInfoCopyWith<ChatContactInfo> get copyWith => _$ChatContactInfoCopyWithImpl<ChatContactInfo>(this as ChatContactInfo, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChatContactInfo&&(identical(other.showVideoButtonAction, showVideoButtonAction) || other.showVideoButtonAction == showVideoButtonAction));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,showVideoButtonAction);
+
+@override
+String toString() {
+  return 'ChatContactInfo(showVideoButtonAction: $showVideoButtonAction)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChatContactInfoCopyWith<$Res>  {
+  factory $ChatContactInfoCopyWith(ChatContactInfo value, $Res Function(ChatContactInfo) _then) = _$ChatContactInfoCopyWithImpl;
+@useResult
+$Res call({
+ bool showVideoButtonAction
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChatContactInfoCopyWithImpl<$Res>
+    implements $ChatContactInfoCopyWith<$Res> {
+  _$ChatContactInfoCopyWithImpl(this._self, this._then);
+
+  final ChatContactInfo _self;
+  final $Res Function(ChatContactInfo) _then;
+
+/// Create a copy of ChatContactInfo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? showVideoButtonAction = null,}) {
+  return _then(ChatContactInfo(
+showVideoButtonAction: null == showVideoButtonAction ? _self.showVideoButtonAction : showVideoButtonAction // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChatContactInfo].
+extension ChatContactInfoPatterns on ChatContactInfo {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
@@ -508,12 +508,26 @@ Map<String, dynamic> _$AppConfigSmsToJson(AppConfigSms instance) =>
 AppConfigChats _$AppConfigChatsFromJson(Map<String, dynamic> json) =>
     AppConfigChats(
       groupChatButtonEnabled: json['groupChatButtonEnabled'] as bool? ?? true,
+      contactInfo: json['contactInfo'] == null
+          ? const ChatContactInfo()
+          : ChatContactInfo.fromJson(
+              json['contactInfo'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$AppConfigChatsToJson(AppConfigChats instance) =>
     <String, dynamic>{
       'groupChatButtonEnabled': instance.groupChatButtonEnabled,
+      'contactInfo': instance.contactInfo.toJson(),
     };
+
+ChatContactInfo _$ChatContactInfoFromJson(Map<String, dynamic> json) =>
+    ChatContactInfo(
+      showVideoButtonAction: json['showVideoButtonAction'] as bool? ?? true,
+    );
+
+Map<String, dynamic> _$ChatContactInfoToJson(ChatContactInfo instance) =>
+    <String, dynamic>{'showVideoButtonAction': instance.showVideoButtonAction};
 
 FavoritesTabScheme _$FavoritesTabSchemeFromJson(Map<String, dynamic> json) =>
     FavoritesTabScheme(

--- a/screenshots/lib/mocks/mock_messaging_bloc.dart
+++ b/screenshots/lib/mocks/mock_messaging_bloc.dart
@@ -3,6 +3,7 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
 
 import 'clients/clients.dart';
 
@@ -10,8 +11,7 @@ class MockSubmitNotification extends Mock {
   void call(Notification notification);
 }
 
-class MockMessagingBloc extends MockBloc<MessagingEvent, MessagingState>
-    implements MessagingBloc {
+class MockMessagingBloc extends MockBloc<MessagingEvent, MessagingState> implements MessagingBloc {
   MockMessagingBloc();
 
   factory MockMessagingBloc.initial() {
@@ -19,8 +19,15 @@ class MockMessagingBloc extends MockBloc<MessagingEvent, MessagingState>
     whenListen(
       mock,
       const Stream<MessagingState>.empty(),
-      initialState: MessagingState.initial(MockPhoenixSocket())
-          .copyWith(status: ConnectionStatus.connected),
+      initialState: MessagingState.initial(
+          MockPhoenixSocket(),
+          MessagingConfig(
+            coreSmsSupport: true,
+            coreChatsSupport: true,
+            tabEnabled: true,
+            groupChatSupport: true,
+            contactInfoVideoCallSupport: true,
+          )).copyWith(status: ConnectionStatus.connected),
     );
     return mock;
   }


### PR DESCRIPTION
This PR adds configurable video call button visibility in chat contact info and refactors `MessagingState` to use freezed for better immutability and code generation.

**Changes:**
- Introduced `ChatContactInfo` configuration class with `showVideoButtonAction` field to control video call button visibility
- Refactored `MessagingState` from a manual Equatable class to a freezed sealed class
- Modified `DialogInfo` widget to accept `isAudioCallEnabled` and `isVideoCallEnabled` parameters and conditionally render call action buttons