### PR TITLE
refactor: make FeatureAccess reactive to SystemInfo changes via StreamProvider

### DIFF
--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -27,19 +27,38 @@ class AppRouter extends RootStackRouter {
   AppRouter(
     this._appBloc,
     this._appPermissions,
-    this._launchEmbeddedData,
-    this._bottomMenuFeature,
-    this._featureChecker,
-    this._initialTabResolver,
-  );
+    EmbeddedData? launchEmbeddedData,
+    BottomMenuConfig bottomMenuFeature,
+    InitialTabResolver initialTabResolver,
+    FeatureChecker featureChecker,
+  ) {
+    _launchEmbeddedData = launchEmbeddedData;
+    _bottomMenuFeature = bottomMenuFeature;
+    _initialTabResolver = initialTabResolver;
+    _featureChecker = featureChecker;
+  }
 
   final AppBloc _appBloc;
   final AppPermissions _appPermissions;
-  final FeatureChecker _featureChecker;
-  final InitialTabResolver _initialTabResolver;
 
-  final EmbeddedData? _launchEmbeddedData;
-  final BottomMenuConfig _bottomMenuFeature;
+  late EmbeddedData? _launchEmbeddedData;
+  late BottomMenuConfig _bottomMenuFeature;
+
+  late InitialTabResolver _initialTabResolver;
+  late FeatureChecker _featureChecker;
+
+  /// Updates dependencies dynamically without recreating the router
+  void updateConfiguration(
+    EmbeddedData? launchEmbeddedData,
+    BottomMenuConfig bottomMenuFeature,
+    InitialTabResolver initialTabResolver,
+    FeatureChecker featureChecker,
+  ) {
+    _launchEmbeddedData = launchEmbeddedData;
+    _bottomMenuFeature = bottomMenuFeature;
+    _initialTabResolver = initialTabResolver;
+    _featureChecker = featureChecker;
+  }
 
   Session get session => _appBloc.state.session;
 

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -172,7 +172,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
         ),
         RepositoryProvider<VoicemailRepository>(
           create: (context) {
-            final isVoicemailsEnabled = featureAccess.settingsConfig.isVoicemailsEnabled;
+            final isVoicemailsEnabled = featureAccess.settingsConfig.voicemailsEnabled;
 
             if (isVoicemailsEnabled) {
               return VoicemailRepositoryImpl(
@@ -573,7 +573,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// This method centralizes the polling configuration, so changes in polling logic or intervals
   /// can be made here without touching the [Provider] or [PollingService] setup.
   List<PollingRegistration> _pollingRegistrations(BuildContext context) {
-    final isVoicemailsEnabled = context.read<FeatureAccess>().settingsConfig.isVoicemailsEnabled;
+    final isVoicemailsEnabled = context.read<FeatureAccess>().settingsConfig.voicemailsEnabled;
 
     return [
       PollingRegistration(
@@ -609,7 +609,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// This method centralizes the connectivity recovery configuration, so changes in
   /// registration logic can be made here without touching the [Provider] or service setup.
   List<ConnectivityRecoveryRegistration> _connectivityRecoveryRegistrations(BuildContext context) {
-    final isVoicemailsEnabled = context.read<FeatureAccess>().settingsConfig.isVoicemailsEnabled;
+    final isVoicemailsEnabled = context.read<FeatureAccess>().settingsConfig.voicemailsEnabled;
 
     return [if (isVoicemailsEnabled) ConnectivityRecoveryRegistration.refreshable(context.read<VoicemailRepository>())];
   }

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -52,7 +52,7 @@ class _AppState extends State<App> {
       featureAccess.loginConfig.launchLoginPage,
       featureAccess.bottomMenuConfig,
       initialTabResolver,
-      featureAccess.toChecker(),
+      featureAccess.checker,
     );
   }
 
@@ -71,7 +71,7 @@ class _AppState extends State<App> {
       featureAccess.loginConfig.launchLoginPage,
       featureAccess.bottomMenuConfig,
       initialTabResolver,
-      featureAccess.toChecker(),
+      featureAccess.checker,
     );
   }
 

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -60,7 +60,7 @@ class _AppState extends State<App> {
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final featureAccess = context.read<FeatureAccess>();
+    final featureAccess = context.watch<FeatureAccess>();
 
     final initialTabResolver = BottomMenuInitialTabResolver(
       config: featureAccess.bottomMenuConfig,

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -51,8 +51,27 @@ class _AppState extends State<App> {
       context.read<AppPermissions>(),
       featureAccess.loginConfig.launchLoginPage,
       featureAccess.bottomMenuConfig,
-      featureAccess.toChecker(),
       initialTabResolver,
+      featureAccess.toChecker(),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final featureAccess = context.read<FeatureAccess>();
+
+    final initialTabResolver = BottomMenuInitialTabResolver(
+      config: featureAccess.bottomMenuConfig,
+      repository: context.read<ActiveMainFlavorRepository>(),
+    );
+
+    appRouter.updateConfiguration(
+      featureAccess.loginConfig.launchLoginPage,
+      featureAccess.bottomMenuConfig,
+      initialTabResolver,
+      featureAccess.toChecker(),
     );
   }
 

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -78,13 +78,13 @@ Future<InstanceRegistry> bootstrap() async {
     appBundleId: packageInfo.packageName,
   );
 
-  // Logic / Features
-  final coreSupport = CoreSupportImpl(() => systemInfoLocalDatasource.getSystemInfo());
-  final featureAccess = FeatureAccess.init(
+  // Initialize the immutable feature configuration snapshot.
+  // This instance serves as the `initialData` for the `StreamProvider`, ensuring the UI
+  // has valid feature flags immediately during the first frame, before the SystemInfo stream emits.
+  final featureAccess = FeatureAccess.create(
     appThemes.appConfig,
     appThemes.embeddedResources,
-    activeMainFlavorRepository,
-    coreSupport,
+    systemInfoLocalDatasource.getSystemInfo(),
   );
 
   // Utilities - Capturing instances that were previously just `await Class.init()`
@@ -133,7 +133,6 @@ Future<InstanceRegistry> bootstrap() async {
   registry.register<ContactsAgreementStatusRepository>(contactsAgreementStatusRepository);
 
   // Logic & Features
-  registry.register<CoreSupport>(coreSupport);
   registry.register<FeatureAccess>(featureAccess);
   registry.register<AppMetadataProvider>(appLabels);
   registry.register<AppPermissions>(appPermissions);

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -8,7 +8,6 @@ import 'package:logging/logging.dart';
 import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
@@ -72,13 +71,13 @@ class FeatureAccess extends Equatable {
   final SystemNotificationsConfig systemNotificationsConfig;
   final SipPresenceConfig sipPresenceConfig;
 
-  static FeatureAccess init(
+  static FeatureAccess create(
     AppConfig appConfig,
     List<EmbeddedResource> embeddedResources,
-    ActiveMainFlavorRepository activeMainFlavorRepository,
-    CoreSupport coreSupport,
+    WebtritSystemInfo? systemInfo,
   ) {
     try {
+      final coreSupportSnapshot = CoreSupportImpl(() => systemInfo);
       // Initialize basic features
       final embeddedConfig = EmbeddedMapper.map(embeddedResources);
 
@@ -88,12 +87,12 @@ class FeatureAccess extends Equatable {
 
       final loginConfig = LoginMapper.map(appConfig, embeddedConfig.embeddedResources);
       final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig);
-      final settingsConfig = SettingsMapper.map(appConfig, embeddedResources, coreSupport, termsConfig);
+      final settingsConfig = SettingsMapper.map(appConfig, embeddedResources, coreSupportSnapshot, termsConfig);
       final callConfig = CallMapper.map(appConfig);
-      final messagingConfig = MessagingMapper.map(appConfig, coreSupport);
+      final messagingConfig = MessagingMapper.map(appConfig, coreSupportSnapshot);
       final contactsConfig = ContactsMapper.map(appConfig);
-      final systemNotificationsConfig = SystemNotificationsMapper.map(coreSupport, appConfig);
-      final sipPresenceConfig = SipPresenceMapper.map(coreSupport, appConfig);
+      final systemNotificationsConfig = SystemNotificationsMapper.map(coreSupportSnapshot, appConfig);
+      final sipPresenceConfig = SipPresenceMapper.map(coreSupportSnapshot, appConfig);
 
       return FeatureAccess._(
         embeddedConfig,

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -248,6 +248,7 @@ abstract final class SettingsMapper {
     TermsConfig termsConfig,
   ) {
     final settingSections = <SettingsSection>[];
+    bool hasVoicemail = false;
 
     for (final section in appConfig.settingsConfig.sections.where((s) => s.enabled)) {
       final items = <SettingItem>[];
@@ -257,6 +258,10 @@ abstract final class SettingsMapper {
 
         if (!_isFeatureSupportedByPlatform(flavor)) continue;
         if (!_isFeatureSupportedByCore(flavor, coreSupport)) continue;
+
+        if (flavor == SettingsFlavor.voicemail) {
+          hasVoicemail = true;
+        }
 
         final settingItem = SettingItem(
           titleL10n: item.titleL10n,
@@ -274,7 +279,7 @@ abstract final class SettingsMapper {
       }
     }
 
-    return SettingsConfig(sections: List.unmodifiable(settingSections));
+    return SettingsConfig(voicemailsEnabled: hasVoicemail, sections: List.unmodifiable(settingSections));
   }
 
   // TODO (Serdun): Move platform-specific configuration to a separate config file.

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -502,25 +502,21 @@ abstract final class ContactsMapper {
   }
 }
 
-/// Provides a centralized way to check whether specific [FeatureFlag]s are enabled.
-///
-/// The [FeatureChecker] itself does not contain the logic for determining
-/// if a feature is enabled or disabled. Instead, it relies on the injected
-/// [FeatureResolver] function to evaluate the state of a given [FeatureFlag].
-///
-/// This allows feature availability logic to be configured and maintained
-/// in one place (e.g., [FeatureAccess]), while consumers of [FeatureChecker]
-/// only need to call [isEnabled] to check if a feature should be accessible.
 class FeatureChecker {
-  /// Creates a new [FeatureChecker] with the given [_resolver].
-  ///
-  /// The [_resolver] is a function that maps a [FeatureFlag] to `true`
-  /// (enabled) or `false` (disabled).
-  FeatureChecker(this._resolver);
+  const FeatureChecker(this._access);
 
-  /// A resolver function that determines whether a [FeatureFlag] is enabled.
-  final FeatureResolver _resolver;
+  final FeatureAccess _access;
 
   /// Returns `true` if the given [feature] is enabled, otherwise `false`.
-  bool isEnabled(FeatureFlag feature) => _resolver(feature);
+  bool isEnabled(FeatureFlag feature) {
+    final isEnabled = _resolve(feature);
+    _logger.fine('Feature flag resolution: $feature = $isEnabled');
+    return isEnabled;
+  }
+
+  bool _resolve(FeatureFlag feature) {
+    return switch (feature) {
+      FeatureFlag.voicemail => _access.settingsConfig.voicemailsEnabled,
+    };
+  }
 }

--- a/lib/extensions/feature_access.dart
+++ b/lib/extensions/feature_access.dart
@@ -1,8 +1,6 @@
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
 
-typedef FeatureResolver = bool Function(FeatureFlag);
-
 extension FeatureAccessResolver on FeatureAccess {
   FeatureChecker get checker => FeatureChecker(this);
 

--- a/lib/extensions/feature_access.dart
+++ b/lib/extensions/feature_access.dart
@@ -4,15 +4,7 @@ import 'package:webtrit_phone/models/models.dart';
 typedef FeatureResolver = bool Function(FeatureFlag);
 
 extension FeatureAccessResolver on FeatureAccess {
-  FeatureResolver _toResolver() {
-    final map = <FeatureFlag, bool Function()>{FeatureFlag.voicemail: () => settingsConfig.voicemailsEnabled};
-
-    return (FeatureFlag key) => map[key]?.call() ?? false;
-  }
-
-  FeatureChecker toChecker() {
-    return FeatureChecker(_toResolver());
-  }
+  FeatureChecker get checker => FeatureChecker(this);
 
   List<Permission> get excludedPermissions {
     final sourceTypes = bottomMenuConfig.getTabEnabled<ContactsBottomMenuTab>()?.contactSourceTypes;

--- a/lib/extensions/feature_access.dart
+++ b/lib/extensions/feature_access.dart
@@ -5,7 +5,7 @@ typedef FeatureResolver = bool Function(FeatureFlag);
 
 extension FeatureAccessResolver on FeatureAccess {
   FeatureResolver _toResolver() {
-    final map = <FeatureFlag, bool Function()>{FeatureFlag.voicemail: () => settingsConfig.isVoicemailsEnabled};
+    final map = <FeatureFlag, bool Function()>{FeatureFlag.voicemail: () => settingsConfig.voicemailsEnabled};
 
     return (FeatureFlag key) => map[key]?.call() ?? false;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,7 +71,22 @@ class RootApp extends StatelessWidget {
         Provider<PackageInfo>(create: (_) => instanceRegistry.get()),
         Provider<DeviceInfo>(create: (_) => instanceRegistry.get()),
         Provider<AppPreferences>(create: (_) => instanceRegistry.get()),
-        Provider<FeatureAccess>(create: (_) => instanceRegistry.get()),
+
+        /// Provides reactive [FeatureAccess] configuration that updates with system info changes.
+        ///
+        /// Uses pre-calculated bootstrap data for immediate rendering and regenerates
+        /// immutable snapshots whenever [SystemInfoRepository.infoStream] emits.
+        StreamProvider<FeatureAccess>(
+          initialData: instanceRegistry.get<FeatureAccess>(),
+          create: (context) => instanceRegistry.get<SystemInfoRepository>().infoStream.map(
+            (newSystemInfo) => FeatureAccess.create(
+              instanceRegistry.get<AppThemes>().appConfig,
+              instanceRegistry.get<AppThemes>().embeddedResources,
+              newSystemInfo,
+            ),
+          ),
+          updateShouldNotify: (previous, next) => true,
+        ),
         Provider<SecureStorage>(create: (_) => instanceRegistry.get()),
         Provider<AppPermissions>(create: (_) => instanceRegistry.get()),
         Provider<AppLogger>(create: (_) => instanceRegistry.get()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,8 @@ void main() {
   );
 }
 
+final _logger = Logger('RootApp');
+
 class RootApp extends StatelessWidget {
   const RootApp({super.key, required this.instanceRegistry, required this.baseLogFilePath});
 
@@ -78,14 +80,15 @@ class RootApp extends StatelessWidget {
         /// immutable snapshots whenever [SystemInfoRepository.infoStream] emits.
         StreamProvider<FeatureAccess>(
           initialData: instanceRegistry.get<FeatureAccess>(),
-          create: (context) => instanceRegistry.get<SystemInfoRepository>().infoStream.map(
-            (newSystemInfo) => FeatureAccess.create(
+          create: (context) => instanceRegistry.get<SystemInfoRepository>().infoStream.map((newSystemInfo) {
+            _logger.info('Emitting FeatureAccess from system info: $newSystemInfo');
+            return FeatureAccess.create(
               instanceRegistry.get<AppThemes>().appConfig,
               instanceRegistry.get<AppThemes>().embeddedResources,
               newSystemInfo,
-            ),
-          ),
-          updateShouldNotify: (previous, next) => true,
+            );
+          }),
+          updateShouldNotify: (previous, next) => previous != next,
         ),
         Provider<SecureStorage>(create: (_) => instanceRegistry.get()),
         Provider<AppPermissions>(create: (_) => instanceRegistry.get()),

--- a/lib/models/feature_access/settings_config.dart
+++ b/lib/models/feature_access/settings_config.dart
@@ -1,12 +1,11 @@
 import 'package:equatable/equatable.dart';
 
-import '../settings_flavor.dart';
-
 import 'settings_feature.dart';
 
 /// Configuration for the app settings screen, organized into sections and items.
 class SettingsConfig extends Equatable {
-  SettingsConfig({required List<SettingsSection> sections}) : _sections = List.unmodifiable(sections);
+  SettingsConfig({required this.voicemailsEnabled, required List<SettingsSection> sections})
+    : _sections = List.unmodifiable(sections);
 
   final List<SettingsSection> _sections;
 
@@ -14,10 +13,8 @@ class SettingsConfig extends Equatable {
   List<SettingsSection> get sections => List.unmodifiable(_sections);
 
   /// Check if the voicemail setting is available in any section.
-  bool get isVoicemailsEnabled {
-    return _sections.any((section) => section.items.any((item) => item.flavor == SettingsFlavor.voicemail));
-  }
+  final bool voicemailsEnabled;
 
   @override
-  List<Object?> get props => [_sections];
+  List<Object?> get props => [_sections, voicemailsEnabled];
 }

--- a/screenshots/lib/bootstrap.dart
+++ b/screenshots/lib/bootstrap.dart
@@ -10,7 +10,6 @@ import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
-import 'package:webtrit_phone/utils/utils.dart';
 
 import 'package:screenshots/mocks/mocks.dart';
 
@@ -21,12 +20,9 @@ Future<AppContext> bootstrap() async {
   final packageInfo = await PackageInfoFactory.init();
   final deviceInfo = await DeviceInfoFactory.init();
   final secureStorage = await SecureStorageImpl.init();
-  final appPreferences = await AppPreferencesImpl.init();
   final appInfo = await AppInfo.init(SharedPreferencesAppIdProvider());
 
-  final activeMainFlavorRepository = ActiveMainFlavorRepositoryPrefsImpl(appPreferences);
   final systemInfoLocalRepository = SystemInfoLocalRepositoryPrefsImpl(secureStorage);
-  final coreSupport = CoreSupportImpl(() => systemInfoLocalRepository.getSystemInfo());
 
   final mockAppMetadataProvider = await DefaultAppMetadataProvider.init(
     packageInfo,
@@ -35,11 +31,10 @@ Future<AppContext> bootstrap() async {
     secureStorage,
   );
 
-  final featureAccess = FeatureAccess.init(
+  final featureAccess = FeatureAccess.create(
     appThemes.appConfig,
     appThemes.embeddedResources,
-    activeMainFlavorRepository,
-    coreSupport,
+    systemInfoLocalRepository.getSystemInfo(),
   );
 
   final appBloc = MockAppBloc.allScreen(


### PR DESCRIPTION
This refactor makes `FeatureAccess` configuration reactive to `SystemInfo` updates by rebuilding it from a stream instead of relying on a single, static snapshot obtained at bootstrap time.

**Changes:**
- Replace `FeatureAccess.init` with `FeatureAccess.create`, which builds feature configs from `AppConfig`, embedded resources, and a `WebtritSystemInfo` snapshot, and internalizes `CoreSupportImpl` construction.
- Wire `FeatureAccess` into the DI graph via a `StreamProvider<FeatureAccess>` driven by `SystemInfoRepository.infoStream`, using the bootstrap-created `FeatureAccess` as `initialData`.
- Update both runtime and screenshots bootstraps to construct the initial `FeatureAccess` snapshot from the local `SystemInfo` datasource instead of an injected `CoreSupport`.