### PR TITLE
fix: evaluate feature flag dynamically in FeatureGuard

### DIFF
--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -227,7 +227,7 @@ class AppRouter extends RootStackRouter {
                   path: 'voicemail',
                   guards: [
                     FeatureGuard(
-                      isAllowed: _featureChecker.isEnabled(FeatureFlag.voicemail),
+                      shouldAllow: () => _featureChecker.isEnabled(FeatureFlag.voicemail),
                       onDenied: UndefinedScreenPageRoute(undefinedType: UndefinedType.stackScreenNotSupported),
                     ),
                   ],
@@ -378,14 +378,14 @@ Object _onNavigationLoggerMessage(String callbackName, NavigationResolver resolv
 }
 
 class FeatureGuard implements AutoRouteGuard {
-  FeatureGuard({required this.isAllowed, this.onDenied});
+  FeatureGuard({required this.shouldAllow, this.onDenied});
 
-  final bool isAllowed;
+  final bool Function() shouldAllow;
   final PageRouteInfo? onDenied;
 
   @override
   void onNavigation(NavigationResolver resolver, StackRouter router) {
-    if (isAllowed) {
+    if (shouldAllow()) {
       resolver.next(true);
     } else {
       resolver.next(false);


### PR DESCRIPTION
This PR fixes an issue where feature-based navigation guards were evaluated only once during AppRouter initialization, causing stale feature-flag values to be used during navigation.

Previously, FeatureGuard accepted a boolean (isAllowed) which captured a snapshot of the feature state at router build time. If feature configuration (e.g. voicemail availability) was updated later, navigation guards still relied on the outdated value