### PR TITLE
refactor: make configs equatable for reliable state comparison

### DIFF
--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 
 import 'package:logging/logging.dart';
@@ -46,8 +47,8 @@ final Logger _logger = Logger('FeatureAccess');
 ///
 /// 6. **TermsFeature**: Configures access to privacy policy and terms resources. It retrieves the privacy policy URL
 ///    from embedded resources and assigns it to the appropriate settings item when needed.
-class FeatureAccess {
-  FeatureAccess._(
+class FeatureAccess extends Equatable {
+  const FeatureAccess._(
     this.embeddedConfig,
     this.loginConfig,
     this.bottomMenuConfig,
@@ -111,6 +112,20 @@ class FeatureAccess {
       rethrow;
     }
   }
+
+  @override
+  List<Object?> get props => [
+    embeddedConfig,
+    loginConfig,
+    bottomMenuConfig,
+    settingsConfig,
+    callConfig,
+    messagingConfig,
+    contactsConfig,
+    termsConfig,
+    systemNotificationsConfig,
+    sipPresenceConfig,
+  ];
 }
 
 /// Mapper responsible for constructing [LoginConfig] from application configuration.

--- a/lib/models/call/call_trigger_config.dart
+++ b/lib/models/call/call_trigger_config.dart
@@ -1,5 +1,7 @@
+import 'package:equatable/equatable.dart';
+
 /// Configuration that defines how incoming calls can be triggered.
-class CallTriggerConfig {
+class CallTriggerConfig extends Equatable {
   const CallTriggerConfig({
     this.primaryTrigger = IncomingCallTriggerType.pushNotification,
     this.availableTriggers = IncomingCallTriggerType.values,
@@ -14,6 +16,9 @@ class CallTriggerConfig {
 
   /// Configuration for SMS-based fallback triggering.
   final SmsFallbackTriggerConfig smsFallback;
+
+  @override
+  List<Object?> get props => [primaryTrigger, availableTriggers, smsFallback];
 }
 
 /// Represents different mechanisms for receiving incoming calls.
@@ -26,7 +31,7 @@ enum IncomingCallTriggerType {
 }
 
 /// Configuration related to SMS-based fallback triggering.
-class SmsFallbackTriggerConfig {
+class SmsFallbackTriggerConfig extends Equatable {
   const SmsFallbackTriggerConfig({this.enabled = false, this.available = false});
 
   /// Whether the SMS fallback mechanism is currently enabled by the user or system.
@@ -34,4 +39,7 @@ class SmsFallbackTriggerConfig {
 
   /// Whether the SMS fallback option should be available to the user in the UI.
   final bool available;
+
+  @override
+  List<Object?> get props => [enabled, available];
 }

--- a/lib/models/embedded/embedded_data.dart
+++ b/lib/models/embedded/embedded_data.dart
@@ -1,3 +1,5 @@
+import 'package:equatable/equatable.dart';
+
 import 'embedded_payload_data.dart';
 
 /// Defines the strategy for handling reconnections in an embedded resource context.
@@ -15,8 +17,8 @@ enum ReconnectStrategy {
   hardReload,
 }
 
-class EmbeddedData {
-  EmbeddedData({
+class EmbeddedData extends Equatable {
+  const EmbeddedData({
     required this.id,
     required this.uri,
     required this.reconnectStrategy,
@@ -46,4 +48,7 @@ class EmbeddedData {
 
   /// Attributes
   final Map<String, dynamic> attributes;
+
+  @override
+  List<Object?> get props => [id, uri, payload, enableConsoleLogCapture, reconnectStrategy, titleL10n, attributes];
 }

--- a/lib/models/embedded/embedded_data.dart
+++ b/lib/models/embedded/embedded_data.dart
@@ -18,15 +18,16 @@ enum ReconnectStrategy {
 }
 
 class EmbeddedData extends Equatable {
-  const EmbeddedData({
+  EmbeddedData({
     required this.id,
     required this.uri,
     required this.reconnectStrategy,
     this.titleL10n,
-    this.payload = const [],
+    List<EmbeddedPayloadData> payload = const [],
     this.enableConsoleLogCapture = false,
-    this.attributes = const {},
-  });
+    Map<String, dynamic> attributes = const {},
+  }) : _payload = List.unmodifiable(payload),
+       _attributes = Map.unmodifiable(attributes);
 
   /// The URI representing either a local asset file path or a remote URL.
   final String id;
@@ -34,8 +35,10 @@ class EmbeddedData extends Equatable {
   /// The unique identifier for the embedded resource, used to link it with other features or components.
   final Uri uri;
 
+  final List<EmbeddedPayloadData> _payload;
+
   /// The list of payload data to be passed to the embedded resource.
-  final List<EmbeddedPayloadData> payload;
+  List<EmbeddedPayloadData> get payload => _payload;
 
   /// The flag to enable capturing `console.*` logs from inside the WebView.
   final bool enableConsoleLogCapture;
@@ -46,9 +49,11 @@ class EmbeddedData extends Equatable {
   /// The key to use to look up the localized title.
   final String? titleL10n;
 
+  final Map<String, dynamic> _attributes;
+
   /// Attributes
-  final Map<String, dynamic> attributes;
+  Map<String, dynamic> get attributes => _attributes;
 
   @override
-  List<Object?> get props => [id, uri, payload, enableConsoleLogCapture, reconnectStrategy, titleL10n, attributes];
+  List<Object?> get props => [id, uri, _payload, enableConsoleLogCapture, reconnectStrategy, titleL10n, _attributes];
 }

--- a/lib/models/feature_access/bottom_menu_config.dart
+++ b/lib/models/feature_access/bottom_menu_config.dart
@@ -1,3 +1,5 @@
+import 'package:equatable/equatable.dart';
+
 import 'package:webtrit_phone/extensions/extensions.dart';
 
 import '../main_flavor.dart';
@@ -5,7 +7,7 @@ import '../main_flavor.dart';
 import 'bottom_menu_feature.dart';
 
 /// Static configuration for the bottom navigation menu.
-class BottomMenuConfig {
+class BottomMenuConfig extends Equatable {
   const BottomMenuConfig({required List<BottomMenuTab> tabs}) : _tabs = tabs;
 
   final List<BottomMenuTab> _tabs;
@@ -33,4 +35,7 @@ class BottomMenuConfig {
         _tabs.firstWhereOrNull((tab) => tab.initial) ??
         _tabs.first;
   }
+
+  @override
+  List<Object?> get props => [_tabs];
 }

--- a/lib/models/feature_access/bottom_menu_feature.dart
+++ b/lib/models/feature_access/bottom_menu_feature.dart
@@ -98,14 +98,14 @@ final class RecentsBottomMenuTab extends BottomMenuTab {
 }
 
 final class ContactsBottomMenuTab extends BottomMenuTab {
-  const ContactsBottomMenuTab({
-    required this.contactSourceTypes,
+  ContactsBottomMenuTab({
+    required List<ContactSourceType> contactSourceTypes,
     required super.enabled,
     required super.initial,
     required super.titleL10n,
     required super.icon,
     super.data,
-  });
+  }) : contactSourceTypes = List.unmodifiable(contactSourceTypes);
 
   final List<ContactSourceType> contactSourceTypes;
 

--- a/lib/models/feature_access/bottom_menu_feature.dart
+++ b/lib/models/feature_access/bottom_menu_feature.dart
@@ -1,10 +1,12 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:equatable/equatable.dart';
 
 import '../contact_source_type.dart';
-import '../main_flavor.dart';
 import '../embedded/embedded.dart';
+import '../main_flavor.dart';
 
-sealed class BottomMenuTab {
+sealed class BottomMenuTab extends Equatable {
   const BottomMenuTab({
     required this.enabled,
     required this.initial,
@@ -29,18 +31,7 @@ sealed class BottomMenuTab {
   };
 
   @override
-  bool operator ==(Object other) =>
-      other.runtimeType == runtimeType &&
-      other is BottomMenuTab &&
-      other.enabled == enabled &&
-      other.initial == initial &&
-      other.flavor == flavor &&
-      other.titleL10n == titleL10n &&
-      other.icon == icon &&
-      other.data == data;
-
-  @override
-  int get hashCode => Object.hash(enabled, initial, flavor, titleL10n, icon, data);
+  List<Object?> get props => [enabled, initial, titleL10n, icon, data, flavor];
 }
 
 final class FavoritesBottomMenuTab extends BottomMenuTab {
@@ -101,6 +92,9 @@ final class RecentsBottomMenuTab extends BottomMenuTab {
 
   @override
   String get routePath => '${super.routePath}${useCdrs ? '/$cdrsSegment' : ''}';
+
+  @override
+  List<Object?> get props => [...super.props, useCdrs];
 }
 
 final class ContactsBottomMenuTab extends BottomMenuTab {
@@ -117,6 +111,9 @@ final class ContactsBottomMenuTab extends BottomMenuTab {
 
   @override
   MainFlavor get flavor => MainFlavor.contacts;
+
+  @override
+  List<Object?> get props => [...super.props, contactSourceTypes];
 }
 
 final class EmbeddedBottomMenuTab extends BottomMenuTab {
@@ -136,4 +133,7 @@ final class EmbeddedBottomMenuTab extends BottomMenuTab {
 
   @override
   ({String flavor, String? embeddedId}) get pathParts => (flavor: MainFlavor.embedded.name, embeddedId: id);
+
+  @override
+  List<Object?> get props => [...super.props, id];
 }

--- a/lib/models/feature_access/call_config.dart
+++ b/lib/models/feature_access/call_config.dart
@@ -1,11 +1,12 @@
+import 'package:equatable/equatable.dart';
+
 import '../call/call_trigger_config.dart';
 import '../peer_connection_settings.dart';
-
 import 'encoding_config.dart';
 
 /// Configuration for call-related features, including encoding,
 /// transfer capabilities, and PeerConnection settings.
-class CallConfig {
+class CallConfig extends Equatable {
   const CallConfig({
     required this.capabilities,
     required this.encoding,
@@ -18,13 +19,10 @@ class CallConfig {
   final PeerConnectionSettings peerConnection;
 
   /// Configuration for how incoming calls are triggered.
-  ///
-  /// This controls which triggering mechanisms are available and which one is currently active.
-  /// It also defines fallback behavior via SMS if supported.
-  ///
-  /// Note: This setting affects **UI-level visibility and selection** of triggering methods,
-  /// not the underlying signaling implementation.
   final CallTriggerConfig triggerConfig;
+
+  @override
+  List<Object?> get props => [capabilities, encoding, peerConnection, triggerConfig];
 }
 
 /// UI-level configuration for call features.
@@ -34,7 +32,7 @@ class CallConfig {
 ///
 /// Note: Incoming video calls or feature negotiation (e.g., via SDP) are not affected.
 /// To apply restrictions on protocol level, integrate with `SDPMunger` or similar logic.
-class CallCapabilitiesConfig {
+class CallCapabilitiesConfig extends Equatable {
   const CallCapabilitiesConfig({
     this.isVideoCallEnabled = true,
     this.isAudioToVideoSwitchEnabled = true,
@@ -61,4 +59,12 @@ class CallCapabilitiesConfig {
   ///
   /// If `true`, the user can talk to the recipient before transferring the call.
   final bool isAttendedTransferEnabled;
+
+  @override
+  List<Object?> get props => [
+    isVideoCallEnabled,
+    isAudioToVideoSwitchEnabled,
+    isBlindTransferEnabled,
+    isAttendedTransferEnabled,
+  ];
 }

--- a/lib/models/feature_access/contact_details_config.dart
+++ b/lib/models/feature_access/contact_details_config.dart
@@ -1,13 +1,19 @@
-class ContactDetailsConfig {
-  final Set<ContactAction> appBarActions;
-  final Set<ContactAction> phoneTileActions;
-  final Set<ContactAction> emailTileActions;
+import 'package:equatable/equatable.dart';
 
+/// Configuration for the contact details screen, defining available actions for different UI elements.
+class ContactDetailsConfig extends Equatable {
   const ContactDetailsConfig({
     this.appBarActions = const {},
     this.phoneTileActions = const {},
     this.emailTileActions = const {},
   });
+
+  final Set<ContactAction> appBarActions;
+  final Set<ContactAction> phoneTileActions;
+  final Set<ContactAction> emailTileActions;
+
+  @override
+  List<Object?> get props => [appBarActions, phoneTileActions, emailTileActions];
 }
 
 enum ContactAction { chat, voiceCall, videoCall, sms, transfer, callLog, favorite, sendEmail }

--- a/lib/models/feature_access/contact_details_config.dart
+++ b/lib/models/feature_access/contact_details_config.dart
@@ -2,18 +2,31 @@ import 'package:equatable/equatable.dart';
 
 /// Configuration for the contact details screen, defining available actions for different UI elements.
 class ContactDetailsConfig extends Equatable {
-  const ContactDetailsConfig({
-    this.appBarActions = const {},
-    this.phoneTileActions = const {},
-    this.emailTileActions = const {},
-  });
+  ContactDetailsConfig({
+    Set<ContactAction> appBarActions = const {},
+    Set<ContactAction> phoneTileActions = const {},
+    Set<ContactAction> emailTileActions = const {},
+  }) : _appBarActions = Set.unmodifiable(appBarActions),
+       _phoneTileActions = Set.unmodifiable(phoneTileActions),
+       _emailTileActions = Set.unmodifiable(emailTileActions);
 
-  final Set<ContactAction> appBarActions;
-  final Set<ContactAction> phoneTileActions;
-  final Set<ContactAction> emailTileActions;
+  final Set<ContactAction> _appBarActions;
+
+  /// Actions to be displayed in the app bar.
+  Set<ContactAction> get appBarActions => _appBarActions;
+
+  final Set<ContactAction> _phoneTileActions;
+
+  /// Actions to be displayed in the phone number tile.
+  Set<ContactAction> get phoneTileActions => _phoneTileActions;
+
+  final Set<ContactAction> _emailTileActions;
+
+  /// Actions to be displayed in the email address tile.
+  Set<ContactAction> get emailTileActions => _emailTileActions;
 
   @override
-  List<Object?> get props => [appBarActions, phoneTileActions, emailTileActions];
+  List<Object?> get props => [_appBarActions, _phoneTileActions, _emailTileActions];
 }
 
 enum ContactAction { chat, voiceCall, videoCall, sms, transfer, callLog, favorite, sendEmail }

--- a/lib/models/feature_access/contacts_config.dart
+++ b/lib/models/feature_access/contacts_config.dart
@@ -1,9 +1,14 @@
+import 'package:equatable/equatable.dart';
+
 import 'contact_details_config.dart';
 
 /// Configuration for contact-related features, such as actions available on the contact details screen.
-class ContactsConfig {
+class ContactsConfig extends Equatable {
   const ContactsConfig({required this.detailsConfig});
 
   /// The configuration for the contact details screen.
   final ContactDetailsConfig detailsConfig;
+
+  @override
+  List<Object?> get props => [detailsConfig];
 }

--- a/lib/models/feature_access/embedded_config.dart
+++ b/lib/models/feature_access/embedded_config.dart
@@ -1,8 +1,13 @@
+import 'package:equatable/equatable.dart';
+
 import '../embedded/embedded_data.dart';
 
 /// Container for processed embedded resources data.
-class EmbeddedConfig {
+class EmbeddedConfig extends Equatable {
   const EmbeddedConfig(this.embeddedResources);
 
   final List<EmbeddedData> embeddedResources;
+
+  @override
+  List<Object?> get props => [embeddedResources];
 }

--- a/lib/models/feature_access/embedded_config.dart
+++ b/lib/models/feature_access/embedded_config.dart
@@ -4,7 +4,7 @@ import '../embedded/embedded_data.dart';
 
 /// Container for processed embedded resources data.
 class EmbeddedConfig extends Equatable {
-  const EmbeddedConfig(this.embeddedResources);
+  EmbeddedConfig(List<EmbeddedData> embeddedResources) : embeddedResources = List.unmodifiable(embeddedResources);
 
   final List<EmbeddedData> embeddedResources;
 

--- a/lib/models/feature_access/encoding_config.dart
+++ b/lib/models/feature_access/encoding_config.dart
@@ -1,4 +1,6 @@
-class EncodingConfig {
+import 'package:equatable/equatable.dart';
+
+class EncodingConfig extends Equatable {
   const EncodingConfig({
     required this.bypassConfig,
     required this.configurationAllowed,
@@ -8,9 +10,12 @@ class EncodingConfig {
   final bool bypassConfig;
   final bool configurationAllowed;
   final DefaultPresetOverride defaultPresetOverride;
+
+  @override
+  List<Object?> get props => [bypassConfig, configurationAllowed, defaultPresetOverride];
 }
 
-class DefaultPresetOverride {
+class DefaultPresetOverride extends Equatable {
   const DefaultPresetOverride({
     required this.audioBitrate,
     required this.videoBitrate,
@@ -36,4 +41,19 @@ class DefaultPresetOverride {
   final bool? removeExtmaps;
   final bool? removeStaticAudioRtpMaps;
   final bool? remapTE8payloadTo101;
+
+  @override
+  List<Object?> get props => [
+    audioBitrate,
+    videoBitrate,
+    ptime,
+    maxptime,
+    opusSamplingRate,
+    opusBitrate,
+    opusStereo,
+    opusDtx,
+    removeExtmaps,
+    removeStaticAudioRtpMaps,
+    remapTE8payloadTo101,
+  ];
 }

--- a/lib/models/feature_access/login_config.dart
+++ b/lib/models/feature_access/login_config.dart
@@ -5,21 +5,29 @@ import 'login_mode_action.dart';
 
 /// Configuration for the login feature, defining UI titles and available login actions.
 class LoginConfig extends Equatable {
-  const LoginConfig({required this.actions, required this.titleL10n, this.launchLoginPage});
+  LoginConfig({required List<LoginModeAction> actions, required this.titleL10n, required this.launchLoginPage})
+    : _actions = List.unmodifiable(actions);
 
+  /// The key to use to look up the localized title.
   final String? titleL10n;
-  final List<LoginModeAction> actions;
+
+  final List<LoginModeAction> _actions;
+
+  /// Returns all available login actions.
+  List<LoginModeAction> get actions => _actions;
+
+  /// The embedded page to launch for login.
   final EmbeddedData? launchLoginPage;
 
   /// Returns only the actions that represent embedded login configurations.
-  List<LoginEmbeddedModeButton> get embeddedConfigurations => actions.whereType<LoginEmbeddedModeButton>().toList();
+  List<LoginEmbeddedModeButton> get embeddedConfigurations => _actions.whereType<LoginEmbeddedModeButton>().toList();
 
   /// Whether there are any embedded login pages available.
   bool get hasEmbeddedPage => embeddedConfigurations.isNotEmpty;
 
   /// Returns all available login actions.
-  List<LoginModeAction> get launchButtons => actions.toList();
+  List<LoginModeAction> get launchButtons => _actions.toList();
 
   @override
-  List<Object?> get props => [titleL10n, actions, launchLoginPage];
+  List<Object?> get props => [titleL10n, _actions, launchLoginPage];
 }

--- a/lib/models/feature_access/login_config.dart
+++ b/lib/models/feature_access/login_config.dart
@@ -1,10 +1,11 @@
-import '../embedded/embedded_data.dart';
+import 'package:equatable/equatable.dart';
 
+import '../embedded/embedded_data.dart';
 import 'login_mode_action.dart';
 
 /// Configuration for the login feature, defining UI titles and available login actions.
-class LoginConfig {
-  const LoginConfig({required this.titleL10n, required this.actions, required this.launchLoginPage});
+class LoginConfig extends Equatable {
+  const LoginConfig({required this.actions, required this.titleL10n, this.launchLoginPage});
 
   final String? titleL10n;
   final List<LoginModeAction> actions;
@@ -18,4 +19,7 @@ class LoginConfig {
 
   /// Returns all available login actions.
   List<LoginModeAction> get launchButtons => actions.toList();
+
+  @override
+  List<Object?> get props => [titleL10n, actions, launchLoginPage];
 }

--- a/lib/models/feature_access/login_mode_action.dart
+++ b/lib/models/feature_access/login_mode_action.dart
@@ -1,12 +1,17 @@
+import 'package:equatable/equatable.dart';
+
 import '../embedded/embedded.dart';
 import '../login_flavor.dart';
 
-sealed class LoginModeAction {
+sealed class LoginModeAction extends Equatable {
   const LoginModeAction();
 
   String get titleL10n;
 
   LoginFlavor get flavor;
+
+  @override
+  List<Object?> get props => [titleL10n, flavor];
 }
 
 final class LoginDefaultModeAction extends LoginModeAction {
@@ -29,4 +34,7 @@ final class LoginEmbeddedModeButton extends LoginModeAction {
   final LoginFlavor flavor;
 
   final EmbeddedData customLoginFeature;
+
+  @override
+  List<Object?> get props => [...super.props, customLoginFeature];
 }

--- a/lib/models/feature_access/messaging_config.dart
+++ b/lib/models/feature_access/messaging_config.dart
@@ -1,5 +1,7 @@
+import 'package:equatable/equatable.dart';
+
 /// Represents the calculated feature flags for the messaging module.
-class MessagingConfig {
+class MessagingConfig extends Equatable {
   const MessagingConfig({
     required this.coreSmsSupport,
     required this.coreChatsSupport,
@@ -25,4 +27,13 @@ class MessagingConfig {
   /// Check if the internal messaging feature is enabled and supported by remote system.
   /// This is used to determine if internal messaging UI components should be displayed or hidden.
   bool get chatsPresent => coreChatsSupport && tabEnabled;
+
+  @override
+  List<Object?> get props => [
+    coreSmsSupport,
+    coreChatsSupport,
+    tabEnabled,
+    groupChatSupport,
+    contactInfoVideoCallSupport,
+  ];
 }

--- a/lib/models/feature_access/settings_config.dart
+++ b/lib/models/feature_access/settings_config.dart
@@ -1,9 +1,11 @@
-import 'package:webtrit_phone/models/feature_access/settings_feature.dart';
+import 'package:equatable/equatable.dart';
 
 import '../settings_flavor.dart';
 
+import 'settings_feature.dart';
+
 /// Configuration for the app settings screen, organized into sections and items.
-class SettingsConfig {
+class SettingsConfig extends Equatable {
   const SettingsConfig({required List<SettingsSection> sections}) : _sections = sections;
 
   final List<SettingsSection> _sections;
@@ -15,4 +17,7 @@ class SettingsConfig {
   bool get isVoicemailsEnabled {
     return _sections.any((section) => section.items.any((item) => item.flavor == SettingsFlavor.voicemail));
   }
+
+  @override
+  List<Object?> get props => [_sections, isVoicemailsEnabled];
 }

--- a/lib/models/feature_access/settings_config.dart
+++ b/lib/models/feature_access/settings_config.dart
@@ -6,7 +6,7 @@ import 'settings_feature.dart';
 
 /// Configuration for the app settings screen, organized into sections and items.
 class SettingsConfig extends Equatable {
-  const SettingsConfig({required List<SettingsSection> sections}) : _sections = sections;
+  SettingsConfig({required List<SettingsSection> sections}) : _sections = List.unmodifiable(sections);
 
   final List<SettingsSection> _sections;
 
@@ -19,5 +19,5 @@ class SettingsConfig extends Equatable {
   }
 
   @override
-  List<Object?> get props => [_sections, isVoicemailsEnabled];
+  List<Object?> get props => [_sections];
 }

--- a/lib/models/feature_access/settings_feature.dart
+++ b/lib/models/feature_access/settings_feature.dart
@@ -5,7 +5,7 @@ import '../embedded/embedded.dart';
 import '../settings_flavor.dart';
 
 class SettingsSection extends Equatable {
-  const SettingsSection({required this.titleL10n, required this.items});
+  SettingsSection({required this.titleL10n, required List<SettingItem> items}) : items = List.unmodifiable(items);
 
   final String titleL10n;
   final List<SettingItem> items;

--- a/lib/models/feature_access/settings_feature.dart
+++ b/lib/models/feature_access/settings_feature.dart
@@ -1,21 +1,28 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/widgets.dart';
 
-import '../settings_flavor.dart';
 import '../embedded/embedded.dart';
+import '../settings_flavor.dart';
 
-class SettingsSection {
-  SettingsSection({required this.titleL10n, required this.items});
+class SettingsSection extends Equatable {
+  const SettingsSection({required this.titleL10n, required this.items});
 
   final String titleL10n;
   final List<SettingItem> items;
+
+  @override
+  List<Object?> get props => [titleL10n, items];
 }
 
-class SettingItem {
-  SettingItem({required this.titleL10n, required this.icon, required this.flavor, this.data, this.iconColor});
+class SettingItem extends Equatable {
+  const SettingItem({required this.titleL10n, required this.icon, required this.flavor, this.data, this.iconColor});
 
   final String titleL10n;
   final IconData icon;
   final Color? iconColor;
   final SettingsFlavor flavor;
   final EmbeddedData? data;
+
+  @override
+  List<Object?> get props => [titleL10n, icon, iconColor, flavor, data];
 }

--- a/lib/models/feature_access/sip_presence_config.dart
+++ b/lib/models/feature_access/sip_presence_config.dart
@@ -1,7 +1,12 @@
+import 'package:equatable/equatable.dart';
+
 /// Configuration for the SIP presence feature.
-class SipPresenceConfig {
+class SipPresenceConfig extends Equatable {
   const SipPresenceConfig({required this.sipPresenceSupport});
 
   /// Whether the SIP presence feature is enabled and supported by the remote system.
   final bool sipPresenceSupport;
+
+  @override
+  List<Object?> get props => [sipPresenceSupport];
 }

--- a/lib/models/feature_access/system_notifications_config.dart
+++ b/lib/models/feature_access/system_notifications_config.dart
@@ -1,5 +1,7 @@
+import 'package:equatable/equatable.dart';
+
 /// Configuration for the system notifications feature, including push support.
-class SystemNotificationsConfig {
+class SystemNotificationsConfig extends Equatable {
   const SystemNotificationsConfig({
     required this.systemNotificationsSupport,
     required this.systemNotificationsPushSupport,
@@ -10,4 +12,7 @@ class SystemNotificationsConfig {
 
   /// Whether the system notifications push feature is enabled and supported by the remote system.
   final bool systemNotificationsPushSupport;
+
+  @override
+  List<Object?> get props => [systemNotificationsSupport, systemNotificationsPushSupport];
 }

--- a/lib/models/feature_access/terms_config.dart
+++ b/lib/models/feature_access/terms_config.dart
@@ -1,8 +1,13 @@
+import 'package:equatable/equatable.dart';
+
 import '../embedded/embedded_data.dart';
 
 /// Represents the configuration of the terms and privacy policy feature in the app.
-class TermsConfig {
+class TermsConfig extends Equatable {
   const TermsConfig(this.configData);
 
   final EmbeddedData configData;
+
+  @override
+  List<Object?> get props => [configData];
 }

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -83,7 +83,7 @@ class MainScreenScreenshot extends StatelessWidget {
         icon: Icons.history,
         useCdrs: false,
       ),
-      const ContactsBottomMenuTab(
+      ContactsBottomMenuTab(
         enabled: true,
         initial: false,
         titleL10n: 'main_BottomNavigationBarItemLabel_contacts',


### PR DESCRIPTION
Refactors feature-access configuration models to use `Equatable` so app state comparisons can be value-based and more reliable.

**Changes:**
- Converted multiple feature-access config/data classes to `Equatable` and defined `props`.
- Replaced manual `==`/`hashCode` on `BottomMenuTab` with Equatable-based equality (including subclass-specific props).
- Updated `FeatureAccess` to be `Equatable` for holistic feature-state comparisons.