### PR TITLE
chore: remove unused PendingCall subscription cleanup

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -78,7 +78,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final OnDiagnosticReportRequested onDiagnosticReportRequested;
 
   StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
-  StreamSubscription<PendingCall>? _pendingCallHandlerSubscription;
 
   late final SignalingClientFactory _signalingClientFactory;
   WebtritSignalingClient? _signalingClient;
@@ -158,8 +157,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     navigator.mediaDevices.ondevicechange = null;
 
     await _connectivityChangedSubscription?.cancel();
-
-    await _pendingCallHandlerSubscription?.cancel();
 
     _signalingClientReconnectTimer?.cancel();
 


### PR DESCRIPTION
This PR removes dead code from the CallBloc class by eliminating an unused `StreamSubscription<PendingCall>` field and its associated cleanup call. The subscription was declared but never initialized or used anywhere in the codebase.

**Changes:**
- Removed unused `_pendingCallHandlerSubscription` field declaration
- Removed corresponding unused subscription cancellation in the `close()` method