### PR TITLE
fix: audio device button interaction and visual selection state

### DIFF
--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -419,7 +419,10 @@ class _CallActionsState extends State<CallActions> {
                 onSelected: onAudioDeviceChanged,
                 child: IgnorePointer(
                   child: TextButton(
-                    onPressed: null,
+                    /// Use an empty callback instead of null to prevent the button from
+                    /// entering the 'disabled' state, which would override the custom
+                    /// style with default disabled theme colors.
+                    onPressed: () {},
                     style: widget.style?.speaker,
                     child: Icon(switch (audioDevice?.type) {
                       CallAudioDeviceType.speaker => Icons.volume_up,

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -185,7 +185,8 @@ class _CallActionsState extends State<CallActions> {
     final actionPadIconSize = themeData.textTheme.headlineMedium!.fontSize;
     final popupMenuIconSize = themeData.textTheme.bodyLarge!.fontSize;
 
-    // final style = CallScreenActionsStyle.merge(widget.style, Theme.of(context).extension<CallActionsStyles>()?.primary);
+    // States
+    final isAudioSelected = audioDevice?.type != CallAudioDeviceType.earpiece;
 
     // Keypad
     final foregroundColor =
@@ -423,6 +424,7 @@ class _CallActionsState extends State<CallActions> {
                     /// entering the 'disabled' state, which would override the custom
                     /// style with default disabled theme colors.
                     onPressed: () {},
+                    statesController: _speakerStatesController..update(WidgetState.selected, isAudioSelected),
                     style: widget.style?.speaker,
                     child: Icon(switch (audioDevice?.type) {
                       CallAudioDeviceType.speaker => Icons.volume_up,


### PR DESCRIPTION
This PR addresses two issues related to the audio device selection button in the call screen:

1. **Visual Interaction:** Fixed an issue where the button appeared visually "disabled" (greyed out) because `onPressed` was set to `null`.
2. **State Consistency:** Fixed the lack of visual highlighting when multiple audio devices were available (popup menu mode).