### PR TITLE
fix: handle session missing exception

### DIFF
--- a/lib/repositories/auth/session_repository.dart
+++ b/lib/repositories/auth/session_repository.dart
@@ -138,9 +138,11 @@ class SessionRepositoryImpl implements SessionRepository {
       _logger.fine('Remote session already revoked or never existed', e, st);
     } on UnauthorizedException catch (e, st) {
       _logger.fine('Remote session already revoked or never existed', e, st);
+    } on SessionMissingException catch (e, st) {
+      _logger.fine('Remote session already revoked', e, st);
     } on RequestFailure catch (e, st) {
-      sessionCleanupWorker?.saveFailedSession(e.url, token: token);
       _logger.warning('Queued token revoke retry', e, st);
+      sessionCleanupWorker?.saveFailedSession(e.url, token: token);
       rethrow;
     } catch (e, st) {
       _logger.severe('Unexpected error during remote revoke', e, st);

--- a/packages/webtrit_api/lib/src/exceptions.dart
+++ b/packages/webtrit_api/lib/src/exceptions.dart
@@ -58,3 +58,16 @@ class UnauthorizedException extends RequestFailure {
         '${code != null ? ', code: $code' : ''})';
   }
 }
+
+class SessionMissingException extends RequestFailure {
+  SessionMissingException({
+    required super.url,
+    required super.requestId,
+    required super.statusCode,
+    super.token,
+    super.error,
+  });
+
+  @override
+  String toString() => 'SessionMissingException(statusCode: $statusCode, requestId: $requestId, url: $url)';
+}

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -148,6 +148,17 @@ class WebtritApiClient {
             _ => ErrorResponse.fromJson(responseDataJson),
           };
 
+          // Handle session_missing specifically
+          if (httpResponse.statusCode == 401 && error?.code == 'session_missing') {
+            throw SessionMissingException(
+              url: tenantUrl,
+              requestId: xRequestId,
+              statusCode: httpResponse.statusCode,
+              token: token,
+              error: error,
+            );
+          }
+
           // Map 422 with code="refresh_token_invalid" to UnauthorizedException.
           // This ensures higher layers can handle expired/invalid sessions in a unified way
           // (e.g., trigger global logout or token refresh).


### PR DESCRIPTION
This PR introduces explicit handling for the backend error session_missing by:
- Adding a new SessionMissingException
- Mapping 401 + code=session_missing to this exception in WebtritApiClient
- Skipping sessionCleanupWorker.saveFailedSession(...) when this exception occurs

When the backend returns session_missing, the session is already revoked or does not exist.
Retrying session cleanup in this case is unnecessary and results in redundant queued retries.
