### PR TITLE
fix: solve "sticky speaker" issue by localizing audio state

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1479,14 +1479,17 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _CallControlEventBlindTransferInitiated event,
     Emitter<CallState> emit,
   ) async {
-    var newState = state.copyWith(
-      minimized: true,
-      speakerOnBeforeMinimize: state.audioDevice?.type == CallAudioDeviceType.speaker,
-    );
+    final isSpeakerOn = state.audioDevice?.type == CallAudioDeviceType.speaker;
+
+    var newState = state.copyWith(minimized: true);
+
     await __onCallControlEventSetHeld(_CallControlEventSetHeld(event.callId, true), emit);
 
     newState = newState.copyWithMappedActiveCall(event.callId, (activeCall) {
-      return activeCall.copyWith(transfer: const Transfer.blindTransferInitiated());
+      return activeCall.copyWith(
+        transfer: const Transfer.blindTransferInitiated(),
+        speakerOnBeforeMinimize: isSpeakerOn,
+      );
     });
 
     emit(newState);
@@ -1498,9 +1501,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _CallControlEventAttendedTransferInitiated event,
     Emitter<CallState> emit,
   ) async {
-    emit(
-      state.copyWith(minimized: true, speakerOnBeforeMinimize: state.audioDevice?.type == CallAudioDeviceType.speaker),
-    );
+    final isSpeakerOn = state.audioDevice?.type == CallAudioDeviceType.speaker;
+
+    var newState = state.copyWith(minimized: true);
+
+    newState = newState.copyWithMappedActiveCall(event.callId, (activeCall) {
+      return activeCall.copyWith(speakerOnBeforeMinimize: isSpeakerOn);
+    });
+
+    emit(newState);
+
     await __onCallControlEventSetHeld(_CallControlEventSetHeld(event.callId, true), emit);
   }
 
@@ -1543,8 +1553,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         proximityEnabled: state.shouldListenToProximity,
       );
 
-      if (state.speakerOnBeforeMinimize == true) {
-        add(CallControlEvent.audioDeviceSet(state.activeCalls.current.callId, state.availableAudioDevices.getSpeaker));
+      final callBeingTransferred = state.retrieveActiveCall(callId);
+
+      if (callBeingTransferred?.speakerOnBeforeMinimize == true) {
+        add(CallControlEvent.audioDeviceSet(callId, state.availableAudioDevices.getSpeaker));
       }
 
       // After request succesfully submitted, transfer flow will continue
@@ -2265,13 +2277,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
       emit(newState);
 
-      await callkeep.reportUpdateCall(
-        state.activeCalls.current.callId,
-        proximityEnabled: state.shouldListenToProximity,
-      );
+      final currentCall = state.activeCalls.current;
 
-      if (state.speakerOnBeforeMinimize == true) {
-        add(CallControlEvent.audioDeviceSet(state.activeCalls.current.callId, state.availableAudioDevices.getSpeaker));
+      await callkeep.reportUpdateCall(currentCall.callId, proximityEnabled: state.shouldListenToProximity);
+
+      if (currentCall.speakerOnBeforeMinimize == true) {
+        add(CallControlEvent.audioDeviceSet(currentCall.callId, state.availableAudioDevices.getSpeaker));
       }
     } else {
       _logger.warning('__onCallScreenEventDidPush: activeCalls is empty');
@@ -2283,16 +2294,18 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _logger.info('__onCallScreenEventDidPop: shouldMinimize: $shouldMinimize');
 
     if (shouldMinimize) {
+      final currentCallId = state.activeCalls.current.callId;
+      final isSpeakerOn = state.audioDevice?.type == CallAudioDeviceType.speaker;
+
       emit(
-        state.copyWith(
-          minimized: true,
-          speakerOnBeforeMinimize: state.audioDevice?.type == CallAudioDeviceType.speaker,
-        ),
+        state
+            .copyWithMappedActiveCall(currentCallId, (call) {
+              return call.copyWith(speakerOnBeforeMinimize: isSpeakerOn);
+            })
+            .copyWith(minimized: true),
       );
-      await callkeep.reportUpdateCall(
-        state.activeCalls.current.callId,
-        proximityEnabled: state.shouldListenToProximity,
-      );
+
+      await callkeep.reportUpdateCall(currentCallId, proximityEnabled: state.shouldListenToProximity);
     }
   }
 

--- a/lib/features/call/bloc/call_bloc.freezed.dart
+++ b/lib/features/call/bloc/call_bloc.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CallState {
 
- CallServiceState get callServiceState; AppLifecycleState? get currentAppLifecycleState; int get linesCount; List<ActiveCall> get activeCalls; bool? get minimized; bool? get speakerOnBeforeMinimize; CallAudioDevice? get audioDevice; List<CallAudioDevice> get availableAudioDevices;
+ CallServiceState get callServiceState; AppLifecycleState? get currentAppLifecycleState; int get linesCount; List<ActiveCall> get activeCalls; bool? get minimized; CallAudioDevice? get audioDevice; List<CallAudioDevice> get availableAudioDevices;
 /// Create a copy of CallState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $CallStateCopyWith<CallState> get copyWith => _$CallStateCopyWithImpl<CallState>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallState&&(identical(other.callServiceState, callServiceState) || other.callServiceState == callServiceState)&&(identical(other.currentAppLifecycleState, currentAppLifecycleState) || other.currentAppLifecycleState == currentAppLifecycleState)&&(identical(other.linesCount, linesCount) || other.linesCount == linesCount)&&const DeepCollectionEquality().equals(other.activeCalls, activeCalls)&&(identical(other.minimized, minimized) || other.minimized == minimized)&&(identical(other.speakerOnBeforeMinimize, speakerOnBeforeMinimize) || other.speakerOnBeforeMinimize == speakerOnBeforeMinimize)&&(identical(other.audioDevice, audioDevice) || other.audioDevice == audioDevice)&&const DeepCollectionEquality().equals(other.availableAudioDevices, availableAudioDevices));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallState&&(identical(other.callServiceState, callServiceState) || other.callServiceState == callServiceState)&&(identical(other.currentAppLifecycleState, currentAppLifecycleState) || other.currentAppLifecycleState == currentAppLifecycleState)&&(identical(other.linesCount, linesCount) || other.linesCount == linesCount)&&const DeepCollectionEquality().equals(other.activeCalls, activeCalls)&&(identical(other.minimized, minimized) || other.minimized == minimized)&&(identical(other.audioDevice, audioDevice) || other.audioDevice == audioDevice)&&const DeepCollectionEquality().equals(other.availableAudioDevices, availableAudioDevices));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,callServiceState,currentAppLifecycleState,linesCount,const DeepCollectionEquality().hash(activeCalls),minimized,speakerOnBeforeMinimize,audioDevice,const DeepCollectionEquality().hash(availableAudioDevices));
+int get hashCode => Object.hash(runtimeType,callServiceState,currentAppLifecycleState,linesCount,const DeepCollectionEquality().hash(activeCalls),minimized,audioDevice,const DeepCollectionEquality().hash(availableAudioDevices));
 
 @override
 String toString() {
-  return 'CallState(callServiceState: $callServiceState, currentAppLifecycleState: $currentAppLifecycleState, linesCount: $linesCount, activeCalls: $activeCalls, minimized: $minimized, speakerOnBeforeMinimize: $speakerOnBeforeMinimize, audioDevice: $audioDevice, availableAudioDevices: $availableAudioDevices)';
+  return 'CallState(callServiceState: $callServiceState, currentAppLifecycleState: $currentAppLifecycleState, linesCount: $linesCount, activeCalls: $activeCalls, minimized: $minimized, audioDevice: $audioDevice, availableAudioDevices: $availableAudioDevices)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $CallStateCopyWith<$Res>  {
   factory $CallStateCopyWith(CallState value, $Res Function(CallState) _then) = _$CallStateCopyWithImpl;
 @useResult
 $Res call({
- CallServiceState callServiceState, AppLifecycleState? currentAppLifecycleState, int linesCount, List<ActiveCall> activeCalls, bool? minimized, bool? speakerOnBeforeMinimize, CallAudioDevice? audioDevice, List<CallAudioDevice> availableAudioDevices
+ CallServiceState callServiceState, AppLifecycleState? currentAppLifecycleState, int linesCount, List<ActiveCall> activeCalls, bool? minimized, CallAudioDevice? audioDevice, List<CallAudioDevice> availableAudioDevices
 });
 
 
@@ -62,14 +62,13 @@ class _$CallStateCopyWithImpl<$Res>
 
 /// Create a copy of CallState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? callServiceState = null,Object? currentAppLifecycleState = freezed,Object? linesCount = null,Object? activeCalls = null,Object? minimized = freezed,Object? speakerOnBeforeMinimize = freezed,Object? audioDevice = freezed,Object? availableAudioDevices = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? callServiceState = null,Object? currentAppLifecycleState = freezed,Object? linesCount = null,Object? activeCalls = null,Object? minimized = freezed,Object? audioDevice = freezed,Object? availableAudioDevices = null,}) {
   return _then(CallState(
 callServiceState: null == callServiceState ? _self.callServiceState : callServiceState // ignore: cast_nullable_to_non_nullable
 as CallServiceState,currentAppLifecycleState: freezed == currentAppLifecycleState ? _self.currentAppLifecycleState : currentAppLifecycleState // ignore: cast_nullable_to_non_nullable
 as AppLifecycleState?,linesCount: null == linesCount ? _self.linesCount : linesCount // ignore: cast_nullable_to_non_nullable
 as int,activeCalls: null == activeCalls ? _self.activeCalls : activeCalls // ignore: cast_nullable_to_non_nullable
 as List<ActiveCall>,minimized: freezed == minimized ? _self.minimized : minimized // ignore: cast_nullable_to_non_nullable
-as bool?,speakerOnBeforeMinimize: freezed == speakerOnBeforeMinimize ? _self.speakerOnBeforeMinimize : speakerOnBeforeMinimize // ignore: cast_nullable_to_non_nullable
 as bool?,audioDevice: freezed == audioDevice ? _self.audioDevice : audioDevice // ignore: cast_nullable_to_non_nullable
 as CallAudioDevice?,availableAudioDevices: null == availableAudioDevices ? _self.availableAudioDevices : availableAudioDevices // ignore: cast_nullable_to_non_nullable
 as List<CallAudioDevice>,
@@ -206,7 +205,7 @@ case _:
 /// @nodoc
 mixin _$ActiveCall {
 
- CallDirection get direction; int? get line; String get callId; CallkeepHandle get handle; DateTime get createdTime; bool get video; CallProcessingStatus get processingStatus; bool? get frontCamera; bool get held; bool get muted; bool get updating; JsepValue? get incomingOffer; String? get displayName; String? get fromReferId; String? get fromReplaces; String? get fromNumber; DateTime? get acceptedTime; DateTime? get hungUpTime; Transfer? get transfer; Object? get failure; MediaStream? get localStream; MediaStream? get remoteStream;
+ CallDirection get direction; int? get line; String get callId; CallkeepHandle get handle; DateTime get createdTime; bool get video; CallProcessingStatus get processingStatus; bool? get frontCamera; bool get held; bool get muted; bool get updating; JsepValue? get incomingOffer; String? get displayName; String? get fromReferId; String? get fromReplaces; String? get fromNumber; DateTime? get acceptedTime; DateTime? get hungUpTime; Transfer? get transfer; Object? get failure; MediaStream? get localStream; MediaStream? get remoteStream; bool? get speakerOnBeforeMinimize;
 /// Create a copy of ActiveCall
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -217,16 +216,16 @@ $ActiveCallCopyWith<ActiveCall> get copyWith => _$ActiveCallCopyWithImpl<ActiveC
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveCall&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.line, line) || other.line == line)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.handle, handle) || other.handle == handle)&&(identical(other.createdTime, createdTime) || other.createdTime == createdTime)&&(identical(other.video, video) || other.video == video)&&(identical(other.processingStatus, processingStatus) || other.processingStatus == processingStatus)&&(identical(other.frontCamera, frontCamera) || other.frontCamera == frontCamera)&&(identical(other.held, held) || other.held == held)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.updating, updating) || other.updating == updating)&&(identical(other.incomingOffer, incomingOffer) || other.incomingOffer == incomingOffer)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.fromReferId, fromReferId) || other.fromReferId == fromReferId)&&(identical(other.fromReplaces, fromReplaces) || other.fromReplaces == fromReplaces)&&(identical(other.fromNumber, fromNumber) || other.fromNumber == fromNumber)&&(identical(other.acceptedTime, acceptedTime) || other.acceptedTime == acceptedTime)&&(identical(other.hungUpTime, hungUpTime) || other.hungUpTime == hungUpTime)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&const DeepCollectionEquality().equals(other.failure, failure)&&(identical(other.localStream, localStream) || other.localStream == localStream)&&(identical(other.remoteStream, remoteStream) || other.remoteStream == remoteStream));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveCall&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.line, line) || other.line == line)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.handle, handle) || other.handle == handle)&&(identical(other.createdTime, createdTime) || other.createdTime == createdTime)&&(identical(other.video, video) || other.video == video)&&(identical(other.processingStatus, processingStatus) || other.processingStatus == processingStatus)&&(identical(other.frontCamera, frontCamera) || other.frontCamera == frontCamera)&&(identical(other.held, held) || other.held == held)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.updating, updating) || other.updating == updating)&&(identical(other.incomingOffer, incomingOffer) || other.incomingOffer == incomingOffer)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.fromReferId, fromReferId) || other.fromReferId == fromReferId)&&(identical(other.fromReplaces, fromReplaces) || other.fromReplaces == fromReplaces)&&(identical(other.fromNumber, fromNumber) || other.fromNumber == fromNumber)&&(identical(other.acceptedTime, acceptedTime) || other.acceptedTime == acceptedTime)&&(identical(other.hungUpTime, hungUpTime) || other.hungUpTime == hungUpTime)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&const DeepCollectionEquality().equals(other.failure, failure)&&(identical(other.localStream, localStream) || other.localStream == localStream)&&(identical(other.remoteStream, remoteStream) || other.remoteStream == remoteStream)&&(identical(other.speakerOnBeforeMinimize, speakerOnBeforeMinimize) || other.speakerOnBeforeMinimize == speakerOnBeforeMinimize));
 }
 
 
 @override
-int get hashCode => Object.hashAll([runtimeType,direction,line,callId,handle,createdTime,video,processingStatus,frontCamera,held,muted,updating,incomingOffer,displayName,fromReferId,fromReplaces,fromNumber,acceptedTime,hungUpTime,transfer,const DeepCollectionEquality().hash(failure),localStream,remoteStream]);
+int get hashCode => Object.hashAll([runtimeType,direction,line,callId,handle,createdTime,video,processingStatus,frontCamera,held,muted,updating,incomingOffer,displayName,fromReferId,fromReplaces,fromNumber,acceptedTime,hungUpTime,transfer,const DeepCollectionEquality().hash(failure),localStream,remoteStream,speakerOnBeforeMinimize]);
 
 @override
 String toString() {
-  return 'ActiveCall(direction: $direction, line: $line, callId: $callId, handle: $handle, createdTime: $createdTime, video: $video, processingStatus: $processingStatus, frontCamera: $frontCamera, held: $held, muted: $muted, updating: $updating, incomingOffer: $incomingOffer, displayName: $displayName, fromReferId: $fromReferId, fromReplaces: $fromReplaces, fromNumber: $fromNumber, acceptedTime: $acceptedTime, hungUpTime: $hungUpTime, transfer: $transfer, failure: $failure, localStream: $localStream, remoteStream: $remoteStream)';
+  return 'ActiveCall(direction: $direction, line: $line, callId: $callId, handle: $handle, createdTime: $createdTime, video: $video, processingStatus: $processingStatus, frontCamera: $frontCamera, held: $held, muted: $muted, updating: $updating, incomingOffer: $incomingOffer, displayName: $displayName, fromReferId: $fromReferId, fromReplaces: $fromReplaces, fromNumber: $fromNumber, acceptedTime: $acceptedTime, hungUpTime: $hungUpTime, transfer: $transfer, failure: $failure, localStream: $localStream, remoteStream: $remoteStream, speakerOnBeforeMinimize: $speakerOnBeforeMinimize)';
 }
 
 
@@ -237,7 +236,7 @@ abstract mixin class $ActiveCallCopyWith<$Res>  {
   factory $ActiveCallCopyWith(ActiveCall value, $Res Function(ActiveCall) _then) = _$ActiveCallCopyWithImpl;
 @useResult
 $Res call({
- CallDirection direction, int? line, String callId, CallkeepHandle handle, DateTime createdTime, bool video, CallProcessingStatus processingStatus, bool? frontCamera, bool held, bool muted, bool updating, JsepValue? incomingOffer, String? displayName, String? fromReferId, String? fromReplaces, String? fromNumber, DateTime? acceptedTime, DateTime? hungUpTime, Transfer? transfer, Object? failure, MediaStream? localStream, MediaStream? remoteStream
+ CallDirection direction, int? line, String callId, CallkeepHandle handle, DateTime createdTime, bool video, CallProcessingStatus processingStatus, bool? frontCamera, bool held, bool muted, bool updating, JsepValue? incomingOffer, String? displayName, String? fromReferId, String? fromReplaces, String? fromNumber, DateTime? acceptedTime, DateTime? hungUpTime, Transfer? transfer, Object? failure, MediaStream? localStream, MediaStream? remoteStream, bool? speakerOnBeforeMinimize
 });
 
 
@@ -254,7 +253,7 @@ class _$ActiveCallCopyWithImpl<$Res>
 
 /// Create a copy of ActiveCall
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? direction = null,Object? line = freezed,Object? callId = null,Object? handle = null,Object? createdTime = null,Object? video = null,Object? processingStatus = null,Object? frontCamera = freezed,Object? held = null,Object? muted = null,Object? updating = null,Object? incomingOffer = freezed,Object? displayName = freezed,Object? fromReferId = freezed,Object? fromReplaces = freezed,Object? fromNumber = freezed,Object? acceptedTime = freezed,Object? hungUpTime = freezed,Object? transfer = freezed,Object? failure = freezed,Object? localStream = freezed,Object? remoteStream = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? direction = null,Object? line = freezed,Object? callId = null,Object? handle = null,Object? createdTime = null,Object? video = null,Object? processingStatus = null,Object? frontCamera = freezed,Object? held = null,Object? muted = null,Object? updating = null,Object? incomingOffer = freezed,Object? displayName = freezed,Object? fromReferId = freezed,Object? fromReplaces = freezed,Object? fromNumber = freezed,Object? acceptedTime = freezed,Object? hungUpTime = freezed,Object? transfer = freezed,Object? failure = freezed,Object? localStream = freezed,Object? remoteStream = freezed,Object? speakerOnBeforeMinimize = freezed,}) {
   return _then(ActiveCall(
 direction: null == direction ? _self.direction : direction // ignore: cast_nullable_to_non_nullable
 as CallDirection,line: freezed == line ? _self.line : line // ignore: cast_nullable_to_non_nullable
@@ -277,7 +276,8 @@ as DateTime?,hungUpTime: freezed == hungUpTime ? _self.hungUpTime : hungUpTime /
 as DateTime?,transfer: freezed == transfer ? _self.transfer : transfer // ignore: cast_nullable_to_non_nullable
 as Transfer?,failure: freezed == failure ? _self.failure : failure ,localStream: freezed == localStream ? _self.localStream : localStream // ignore: cast_nullable_to_non_nullable
 as MediaStream?,remoteStream: freezed == remoteStream ? _self.remoteStream : remoteStream // ignore: cast_nullable_to_non_nullable
-as MediaStream?,
+as MediaStream?,speakerOnBeforeMinimize: freezed == speakerOnBeforeMinimize ? _self.speakerOnBeforeMinimize : speakerOnBeforeMinimize // ignore: cast_nullable_to_non_nullable
+as bool?,
   ));
 }
 

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -8,7 +8,6 @@ class CallState with _$CallState {
     this.linesCount = 0,
     this.activeCalls = const [],
     this.minimized,
-    this.speakerOnBeforeMinimize,
     this.audioDevice,
     this.availableAudioDevices = const [],
   });
@@ -27,9 +26,6 @@ class CallState with _$CallState {
 
   @override
   final bool? minimized;
-
-  @override
-  final bool? speakerOnBeforeMinimize;
 
   @override
   final CallAudioDevice? audioDevice;
@@ -149,6 +145,7 @@ class ActiveCall with _$ActiveCall implements CallEntry {
     this.failure,
     this.localStream,
     this.remoteStream,
+    this.speakerOnBeforeMinimize,
   });
 
   @override
@@ -216,6 +213,9 @@ class ActiveCall with _$ActiveCall implements CallEntry {
 
   @override
   final MediaStream? remoteStream;
+
+  @override
+  final bool? speakerOnBeforeMinimize;
 
   @override
   bool get isIncoming => direction == CallDirection.incoming;


### PR DESCRIPTION
Moved `speakerOnBeforeMinimize` from global `CallState` to `ActiveCall` model to ensure audio preferences are call-specific and properly disposed of when a call ends.

- Fixes a bug where a new audio call would erroneously start on speakerphone if a previous call (or transfer session) had speaker enabled.
- Updated `CallBloc` to preserve and restore speaker state using the specific `ActiveCall` instance during minimization, transfers, and screen transitions.
- Cleaned up `CallState` to prevent stale audio state leakage between unrelated call sessions.