### PR TITLE
fix: change CallControlEvent transformer to droppable

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -130,7 +130,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     on<_HandshakeSignalingEventState>(_onHandshakeSignalingEventState, transformer: sequential());
     on<_CallSignalingEvent>(_onCallSignalingEvent, transformer: sequential());
     on<_CallPushEventIncoming>(_onCallPushEventIncoming, transformer: sequential());
-    on<CallControlEvent>(_onCallControlEvent, transformer: sequential());
+    on<CallControlEvent>(_onCallControlEvent, transformer: droppable());
     on<_CallPerformEvent>(_onCallPerformEvent, transformer: sequential());
     on<_PeerConnectionEvent>(_onPeerConnectionEvent, transformer: sequential());
     on<CallScreenEvent>(_onCallScreenEvent, transformer: sequential());


### PR DESCRIPTION
UI interactions with call controls (Hold, Mute) are intended to be immediate and singular. Changing the transformer from sequential to droppable ensures that rapid or accidental double-taps do not create a queue of events.
No Duplicate Native Requests: Prevents sending multiple "start call" intents to the native side if the user taps the button twice during a slight lag.