### PR TITLE
fix: prevent duplicate outgoing calls using hybrid event transformer

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -130,7 +130,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     on<_HandshakeSignalingEventState>(_onHandshakeSignalingEventState, transformer: sequential());
     on<_CallSignalingEvent>(_onCallSignalingEvent, transformer: sequential());
     on<_CallPushEventIncoming>(_onCallPushEventIncoming, transformer: sequential());
-    on<CallControlEvent>(_onCallControlEvent, transformer: sequential());
+    on<CallControlEvent>(_onCallControlEvent, transformer: droppable());
     on<_CallPerformEvent>(_onCallPerformEvent, transformer: sequential());
     on<_PeerConnectionEvent>(_onPeerConnectionEvent, transformer: sequential());
     on<CallScreenEvent>(_onCallScreenEvent, transformer: sequential());

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -13,6 +13,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:async/async.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
@@ -130,7 +131,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     on<_HandshakeSignalingEventState>(_onHandshakeSignalingEventState, transformer: sequential());
     on<_CallSignalingEvent>(_onCallSignalingEvent, transformer: sequential());
     on<_CallPushEventIncoming>(_onCallPushEventIncoming, transformer: sequential());
-    on<CallControlEvent>(_onCallControlEvent, transformer: droppable());
+    on<CallControlEvent>(
+      _onCallControlEvent,
+      transformer: (events, mapper) => StreamGroup.merge([
+        droppable<CallControlEvent>().call(events.where((e) => e is _CallControlEventStarted), mapper),
+        sequential<CallControlEvent>().call(events.where((e) => e is! _CallControlEventStarted), mapper),
+      ]),
+    );
     on<_CallPerformEvent>(_onCallPerformEvent, transformer: sequential());
     on<_PeerConnectionEvent>(_onPeerConnectionEvent, transformer: sequential());
     on<CallScreenEvent>(_onCallScreenEvent, transformer: sequential());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,7 +71,7 @@ packages:
     source: hosted
     version: "2.7.0"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,6 +93,7 @@ dependencies:
   icon_decoration: ^2.1.0
   emoji_picker_flutter: ^4.3.0
   mask_text_input_formatter: ^2.9.0
+  async: ^2.13.0
 
   webtrit_api:
     path: ./packages/webtrit_api


### PR DESCRIPTION
This PR fixes an issue where duplicate outgoing calls could be initiated by implementing a hybrid event transformer that applies different processing strategies to different types of call control events.

Changes:

- Added async package dependency (v2.13.0) to enable StreamGroup.merge functionality
- Modified the CallControlEvent handler to use a hybrid transformer that applies droppable behavior to _CallControlEventStarted events while maintaining sequential processing for other event types
