### PR TITLE
fix: prioritize config color for avatar initials

### DIFF
--- a/lib/theme/factory/styles/leading_avatar_style_factory.dart
+++ b/lib/theme/factory/styles/leading_avatar_style_factory.dart
@@ -18,7 +18,9 @@ class LeadingAvatarStyleFactory implements ThemeStyleFactory<LeadingAvatarStyles
       primary: LeadingAvatarStyle(
         backgroundColor: _bgColor(),
         radius: config?.radius,
-        initialsTextStyle: config?.initialsTextStyle?.toTextStyle().copyWith(color: colors.onSecondaryContainer),
+        initialsTextStyle: config?.initialsTextStyle?.toTextStyle().copyWith(
+          color: config?.initialsTextStyle?.color?.toColor() ?? colors.onSecondaryContainer,
+        ),
         placeholderIcon: null,
         loadingOverlay: _mapLoading(config?.loading),
         smartIndicator: _mapSmart(config?.smartIndicator),


### PR DESCRIPTION
Previously, the LeadingAvatarStyleFactory forcibly overrode the text color with `onSecondaryContainer`, ignoring the value from the configuration.

This change ensures the configuration color is used if provided, falling back to the theme default only when necessary.