### PR TITLE
fix: enable dynamic theme context fallback for Keypad and TextFields

### DIFF
--- a/lib/theme/extension/text_field_config.dart
+++ b/lib/theme/extension/text_field_config.dart
@@ -5,8 +5,13 @@ import 'package:webtrit_phone/theme/extension/extension.dart';
 import 'package:webtrit_phone/theme/styles/styles.dart';
 
 extension TextFieldConfigToStyle on TextFieldConfig {
-  TextFieldStyle toStyle({required ColorScheme colors, required ThemeData theme, TextFieldStyle? base}) {
-    final baseTextStyle = base?.textStyle ?? theme.textTheme.bodyLarge ?? const TextStyle();
+  /// Converts this configuration to a [TextFieldStyle], optionally merging with a [base] style.
+  ///
+  /// The [theme] parameter determines the text color strategy:
+  /// - If provided, the text style explicitly uses [colors.onSurface].
+  /// - If null, the color remains undefined to allow inheritance from the active context.
+  TextFieldStyle toStyle({required ColorScheme colors, ThemeData? theme, TextFieldStyle? base}) {
+    final baseTextStyle = base?.textStyle ?? theme?.textTheme.bodyLarge ?? const TextStyle();
 
     final configTextStyle = style?.toTextStyle(
       defaultFontSize: baseTextStyle.fontSize,
@@ -17,7 +22,7 @@ extension TextFieldConfigToStyle on TextFieldConfig {
 
     final styleFromConfig = TextFieldStyle(
       decoration: decoration?.toInputDecoration(colors: colors, baseStyle: effectiveTextStyle),
-      textStyle: effectiveTextStyle.copyWith(color: colors.onSurface),
+      textStyle: theme != null ? effectiveTextStyle.copyWith(color: colors.onSurface) : effectiveTextStyle,
       textAlign: _mapTextAlign(textAlign),
       showCursor: showCursor,
       keyboardType: _mapKeyboardType(keyboardType),

--- a/lib/theme/factory/styles/keypad_screen_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_screen_style_factory.dart
@@ -22,7 +22,6 @@ class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> 
 
   @override
   KeypadScreenStyles create() {
-    final themeData = ThemeData(colorScheme: colors);
     final backgroundStyle = config.background?.toStyle();
 
     return KeypadScreenStyles(
@@ -30,10 +29,9 @@ class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> 
         background: backgroundStyle,
         contentThemeOverride: config.themeOverride.mode.toContentThemeOverride(),
         applyToAppBar: config.themeOverride.applyToAppBar,
-        inputField: config.textField?.toStyle(colors: colors, theme: themeData),
+        inputField: config.textField?.toStyle(colors: colors),
         contactNameField: config.contactName?.toStyle(
           colors: colors,
-          theme: themeData,
           base: const TextFieldStyle(textAlign: TextAlign.center, showCursor: false, keyboardType: TextInputType.none),
         ),
         keypadStyle: KeypadStyleFactory(colors, config: config.keypad, textTheme: textTheme).create().primary,

--- a/lib/theme/factory/styles/keypad_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_style_factory.dart
@@ -36,36 +36,26 @@ class KeypadStyleFactory implements ThemeStyleFactory<KeypadStyles> {
     // Number defaults (headlineLarge)
     final defaultNumberFontSize = textTheme.headlineLarge?.fontSize ?? 32.0;
     final defaultNumberFontWeight = textTheme.headlineLarge?.fontWeight ?? FontWeight.w400;
-    final defaultNumberColor = textTheme.headlineLarge?.color ?? colors.onSurface;
 
     // Subtext defaults(bodyMedium)
     final defaultSubFontSize = textTheme.bodyMedium?.fontSize ?? 14.0;
     final defaultSubFontWeight = textTheme.bodyMedium?.fontWeight ?? FontWeight.w400;
-    final defaultSubColor = (textTheme.bodyMedium?.color ?? colors.onSurface).withValues(alpha: 0.6);
 
     return KeypadStyles(
       primary: KeypadStyle(
         keyStyle: KeypadKeyStyle(
           textStyle:
-              config?.textStyle
-                  ?.toTextStyle(defaultFontSize: defaultNumberFontSize, defaultFontWeight: defaultNumberFontWeight)
-                  .copyWith(color: defaultNumberColor) ??
-              TextStyle(
-                fontSize: defaultNumberFontSize,
-                fontWeight: defaultNumberFontWeight,
-                color: defaultNumberColor,
-                height: 1.125,
-              ),
+              config?.textStyle?.toTextStyle(
+                defaultFontSize: defaultNumberFontSize,
+                defaultFontWeight: defaultNumberFontWeight,
+              ) ??
+              TextStyle(fontSize: defaultNumberFontSize, fontWeight: defaultNumberFontWeight, height: 1.125),
           subtextStyle:
-              config?.subtextStyle
-                  ?.toTextStyle(defaultFontSize: defaultSubFontSize, defaultFontWeight: defaultSubFontWeight)
-                  .copyWith(color: defaultSubColor) ??
-              TextStyle(
-                fontSize: defaultSubFontSize,
-                fontWeight: defaultSubFontWeight,
-                color: defaultSubColor,
-                height: 1.428,
-              ),
+              config?.subtextStyle?.toTextStyle(
+                defaultFontSize: defaultSubFontSize,
+                defaultFontWeight: defaultSubFontWeight,
+              ) ??
+              TextStyle(fontSize: defaultSubFontSize, fontWeight: defaultSubFontWeight, height: 1.428),
         ),
       ),
     );


### PR DESCRIPTION
Refactored KeypadStyleFactory and TextFieldConfig to stop hardcoding global theme colors during initialization. By making the theme parameter optional and removing default color assignments, styles now return null for colors when not explicitly configured. This allows the UI to correctly inherit text colors from the active BuildContext (e.g., when using ThemedScaffold overrides).