### PR TITLE
feat: Implement dynamic styling for LoginSwitch segmented button

### DIFF
--- a/assets/themes/original.page.dark.config.json
+++ b/assets/themes/original.page.dark.config.json
@@ -85,6 +85,12 @@
             "bottom": 24
           }
         }
+      },
+      "segmentButtonStyle": {
+        "shape": {
+          "type": "rounded",
+          "borderRadius": 4.0
+        }
       }
     },
     "otpSignin": {

--- a/assets/themes/original.page.light.config.json
+++ b/assets/themes/original.page.light.config.json
@@ -77,6 +77,12 @@
             "bottom": 24
           }
         }
+      },
+      "segmentButtonStyle": {
+        "shape": {
+          "type": "rounded",
+          "borderRadius": 4.0
+        }
       }
     },
     "otpSignin": {

--- a/lib/features/login/view/login_switch_screen.dart
+++ b/lib/features/login/view/login_switch_screen.dart
@@ -37,6 +37,7 @@ class LoginSwitchScreen extends StatelessWidget {
           if (header != null) header!,
           if (supportedLoginTypes.length > 1) ...[
             SegmentedButton<LoginType>(
+              style: localStyle?.segmentButtonStyle,
               segments: supportedLoginTypes
                   .map(
                     (loginType) => ButtonSegment(

--- a/lib/features/login/view/login_switch_screen_style.dart
+++ b/lib/features/login/view/login_switch_screen_style.dart
@@ -10,24 +10,28 @@ class LoginSwitchScreenStyle with Diagnosticable {
     this.pictureLogoStyle,
     this.contentThemeOverride,
     this.applyToAppBar,
+    this.segmentButtonStyle,
   });
 
   final SystemUiOverlayStyle? systemUiOverlayStyle;
   final ThemeImageStyle? pictureLogoStyle;
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
+  final ButtonStyle? segmentButtonStyle;
 
   LoginSwitchScreenStyle copyWith({
     SystemUiOverlayStyle? systemUiOverlayStyle,
     ThemeImageStyle? pictureLogoStyle,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
+    ButtonStyle? segmentButtonStyle,
   }) {
     return LoginSwitchScreenStyle(
       systemUiOverlayStyle: systemUiOverlayStyle ?? this.systemUiOverlayStyle,
       pictureLogoStyle: pictureLogoStyle ?? this.pictureLogoStyle,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
+      segmentButtonStyle: segmentButtonStyle ?? this.segmentButtonStyle,
     );
   }
 
@@ -40,6 +44,7 @@ class LoginSwitchScreenStyle with Diagnosticable {
       pictureLogoStyle: ThemeImageStyle.merge(a.pictureLogoStyle, b.pictureLogoStyle),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
+      segmentButtonStyle: a.segmentButtonStyle?.merge(b.segmentButtonStyle) ?? b.segmentButtonStyle,
     );
   }
 
@@ -49,6 +54,7 @@ class LoginSwitchScreenStyle with Diagnosticable {
       pictureLogoStyle: ThemeImageStyle.lerp(a?.pictureLogoStyle, b?.pictureLogoStyle, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
+      segmentButtonStyle: ButtonStyle.lerp(a?.segmentButtonStyle, b?.segmentButtonStyle, t),
     );
   }
 
@@ -59,5 +65,6 @@ class LoginSwitchScreenStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<ThemeImageStyle?>('pictureLogoStyle', pictureLogoStyle));
     properties.add(EnumProperty<ThemeMode?>('contentThemeOverride', contentThemeOverride));
     properties.add(DiagnosticsProperty<bool?>('applyToAppBar', applyToAppBar));
+    properties.add(DiagnosticsProperty<ButtonStyle?>('segmentButtonStyle', segmentButtonStyle));
   }
 }

--- a/lib/theme/extension/button_style_config.dart
+++ b/lib/theme/extension/button_style_config.dart
@@ -1,30 +1,39 @@
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_appearance_theme/models/models.dart';
-
 import 'package:webtrit_phone/theme/extension/extension.dart';
 
 extension ButtonStyleConfigExtension on ButtonStyleConfig {
   ButtonStyle toButtonStyle() {
     return ButtonStyle(
       textStyle: textStyle != null ? WidgetStateProperty.all(textStyle!.toTextStyle()) : null,
-      backgroundColor: backgroundColor != null ? WidgetStateProperty.all(backgroundColor!.toColor()) : null,
-      foregroundColor: foregroundColor != null ? WidgetStateProperty.all(foregroundColor!.toColor()) : null,
+      backgroundColor: _resolveColor(backgroundColor, disabledBackgroundColor),
+      foregroundColor: _resolveColor(foregroundColor, disabledForegroundColor),
       overlayColor: overlayColor != null ? WidgetStateProperty.all(overlayColor!.toColor()) : null,
-      shadowColor: shadowColor != null ? WidgetStateProperty.all(shadowColor!.toColor()) : null,
+      shadowColor: _resolveColor(shadowColor, disabledShadowColor),
       surfaceTintColor: surfaceTintColor != null ? WidgetStateProperty.all(surfaceTintColor!.toColor()) : null,
       elevation: elevation != null ? WidgetStateProperty.all(elevation) : null,
       padding: padding != null ? WidgetStateProperty.all(padding!.toEdgeInsets()) : null,
       minimumSize: minimumSize != null ? WidgetStateProperty.all(minimumSize!.toSize()) : null,
       fixedSize: fixedSize != null ? WidgetStateProperty.all(fixedSize!.toSize()) : null,
       maximumSize: maximumSize != null ? WidgetStateProperty.all(maximumSize!.toSize()) : null,
-      iconColor: iconColor != null ? WidgetStateProperty.all(iconColor!.toColor()) : null,
+      iconColor: _resolveColor(iconColor, disabledIconColor),
       iconSize: iconSize != null ? WidgetStateProperty.all(iconSize) : null,
       side: side != null ? WidgetStateProperty.all(side!.toBorderSide()) : null,
       shape: shape != null ? WidgetStateProperty.all(shape!.toOutlinedBorder()) : null,
       visualDensity: visualDensity?.toVisualDensity(),
       animationDuration: animationDuration != null ? Duration(milliseconds: animationDuration!) : null,
     );
+  }
+
+  WidgetStateProperty<Color?>? _resolveColor(String? normal, String? disabled) {
+    if (normal == null && disabled == null) return null;
+    return WidgetStateProperty.resolveWith((states) {
+      if (states.contains(WidgetState.disabled)) {
+        return disabled?.toColor();
+      }
+      return normal?.toColor();
+    });
   }
 }
 
@@ -38,8 +47,11 @@ extension EdgeInsetsConfigExtension on EdgeInsetsConfig {
 
 extension BorderSideConfigExtension on BorderSideConfig {
   BorderSide toBorderSide() {
+    final resolvedColor = color?.toColor();
+    if (resolvedColor == null) return BorderSide.none;
+
     return BorderSide(
-      color: color?.toColor() ?? const Color(0xFF000000),
+      color: resolvedColor,
       width: width,
       style: style == 'none' ? BorderStyle.none : BorderStyle.solid,
     );

--- a/lib/theme/extension/button_style_config.dart
+++ b/lib/theme/extension/button_style_config.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_appearance_theme/models/models.dart';
+
+import 'package:webtrit_phone/theme/extension/extension.dart';
+
+extension ButtonStyleConfigExtension on ButtonStyleConfig {
+  ButtonStyle toButtonStyle() {
+    return ButtonStyle(
+      textStyle: textStyle != null ? WidgetStateProperty.all(textStyle!.toTextStyle()) : null,
+      backgroundColor: backgroundColor != null ? WidgetStateProperty.all(backgroundColor!.toColor()) : null,
+      foregroundColor: foregroundColor != null ? WidgetStateProperty.all(foregroundColor!.toColor()) : null,
+      overlayColor: overlayColor != null ? WidgetStateProperty.all(overlayColor!.toColor()) : null,
+      shadowColor: shadowColor != null ? WidgetStateProperty.all(shadowColor!.toColor()) : null,
+      surfaceTintColor: surfaceTintColor != null ? WidgetStateProperty.all(surfaceTintColor!.toColor()) : null,
+      elevation: elevation != null ? WidgetStateProperty.all(elevation) : null,
+      padding: padding != null ? WidgetStateProperty.all(padding!.toEdgeInsets()) : null,
+      minimumSize: minimumSize != null ? WidgetStateProperty.all(minimumSize!.toSize()) : null,
+      fixedSize: fixedSize != null ? WidgetStateProperty.all(fixedSize!.toSize()) : null,
+      maximumSize: maximumSize != null ? WidgetStateProperty.all(maximumSize!.toSize()) : null,
+      iconColor: iconColor != null ? WidgetStateProperty.all(iconColor!.toColor()) : null,
+      iconSize: iconSize != null ? WidgetStateProperty.all(iconSize) : null,
+      side: side != null ? WidgetStateProperty.all(side!.toBorderSide()) : null,
+      shape: shape != null ? WidgetStateProperty.all(shape!.toOutlinedBorder()) : null,
+      visualDensity: visualDensity?.toVisualDensity(),
+      animationDuration: animationDuration != null ? Duration(milliseconds: animationDuration!) : null,
+    );
+  }
+}
+
+extension SizeConfigExtension on SizeConfig {
+  Size toSize() => Size(width, height);
+}
+
+extension EdgeInsetsConfigExtension on EdgeInsetsConfig {
+  EdgeInsets toEdgeInsets() => EdgeInsets.only(left: left, top: top, right: right, bottom: bottom);
+}
+
+extension BorderSideConfigExtension on BorderSideConfig {
+  BorderSide toBorderSide() {
+    return BorderSide(
+      color: color?.toColor() ?? const Color(0xFF000000),
+      width: width,
+      style: style == 'none' ? BorderStyle.none : BorderStyle.solid,
+    );
+  }
+}
+
+extension ShapeBorderConfigExtension on ShapeBorderConfig {
+  OutlinedBorder toOutlinedBorder() {
+    switch (type) {
+      case 'rounded':
+        return RoundedRectangleBorder(borderRadius: BorderRadius.circular(borderRadius ?? 0.0));
+      case 'circle':
+        return const CircleBorder();
+      case 'stadium':
+        return const StadiumBorder();
+      case 'beveled':
+        return BeveledRectangleBorder(borderRadius: BorderRadius.circular(borderRadius ?? 0.0));
+      default:
+        return const RoundedRectangleBorder();
+    }
+  }
+}
+
+extension VisualDensityConfigExtension on VisualDensityConfig {
+  VisualDensity toVisualDensity() => VisualDensity(horizontal: horizontal, vertical: vertical);
+}

--- a/lib/theme/extension/extension.dart
+++ b/lib/theme/extension/extension.dart
@@ -1,6 +1,7 @@
 export 'alignment_config_extension.dart';
 export 'box_fit_config_extension.dart';
 export 'brightness.dart';
+export 'button_style_config.dart';
 export 'color_scheme_config.dart';
 export 'custom_color.dart';
 export 'elevated_button_styles.dart';

--- a/lib/theme/factory/styles/elevated_button_style_factory.dart
+++ b/lib/theme/factory/styles/elevated_button_style_factory.dart
@@ -9,38 +9,33 @@ class ElevatedButtonStyleFactory implements ThemeStyleFactory<ElevatedButtonStyl
   ElevatedButtonStyleFactory(this.colors, this.config);
 
   final ColorScheme colors;
-  final ElevatedButtonWidgetConfig? config;
+  final ButtonStyleConfig? config;
 
   @override
   ElevatedButtonStyles create() {
-    final foregroundColor = config?.foregroundColor?.toColor() ?? colors.onPrimary;
-    final backgroundColor = config?.backgroundColor?.toColor() ?? colors.primary;
-    final textStyleColor = config?.textColor?.toColor();
-
     return ElevatedButtonStyles(
       primary: ElevatedButton.styleFrom(
-        foregroundColor: foregroundColor,
-        backgroundColor: backgroundColor,
-        textStyle: TextStyle(color: textStyleColor),
+        foregroundColor: colors.onPrimary,
+        backgroundColor: colors.primary,
         disabledForegroundColor: colors.onPrimaryContainer.withValues(alpha: 0.38),
         disabledBackgroundColor: colors.onPrimaryContainer.withValues(alpha: 0.12),
-      ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+      ).copyWith(elevation: WidgetStateProperty.all(0.0)).merge(config?.toButtonStyle()),
       neutral: ElevatedButton.styleFrom(
         foregroundColor: colors.onSurface,
         backgroundColor: colors.surface,
-      ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+      ).copyWith(elevation: WidgetStateProperty.all(0.0)),
       primaryOnDark: ElevatedButton.styleFrom(
         foregroundColor: colors.onPrimary,
         backgroundColor: colors.primary,
         disabledForegroundColor: colors.onPrimary.withValues(alpha: 0.5),
         disabledBackgroundColor: colors.primary.withValues(alpha: 0.5),
-      ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+      ).copyWith(elevation: WidgetStateProperty.all(0.0)),
       neutralOnDark: ElevatedButton.styleFrom(
         foregroundColor: colors.onSurface,
         backgroundColor: colors.surface,
         disabledForegroundColor: colors.onSurface.withValues(alpha: 0.5),
         disabledBackgroundColor: colors.surface.withValues(alpha: 0.5),
-      ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+      ).copyWith(elevation: WidgetStateProperty.all(0.0)),
     );
   }
 }

--- a/lib/theme/factory/styles/login_switch_screen_style_factory.dart
+++ b/lib/theme/factory/styles/login_switch_screen_style_factory.dart
@@ -21,6 +21,7 @@ class LoginSwitchScreenStyleFactory implements ThemeStyleFactory<LoginSwitchScre
         contentThemeOverride: config?.themeOverride.mode.toThemeMode(),
         applyToAppBar: config?.themeOverride.applyToAppBar,
         pictureLogoStyle: pictureLogoStyle,
+        segmentButtonStyle: config?.segmentButtonStyle?.toButtonStyle(),
       ),
     );
   }

--- a/packages/webtrit_appearance_theme/lib/models/common/button_style_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/button_style_config.dart
@@ -63,6 +63,18 @@ class ButtonStyleConfig with _$ButtonStyleConfig {
 
     /// The duration of animated changes in milliseconds.
     this.animationDuration,
+
+    /// The button's background fill color in hex format when the button is disabled.
+    this.disabledBackgroundColor,
+
+    /// The color for the button's text/icon descendants in hex format when the button is disabled.
+    this.disabledForegroundColor,
+
+    /// The icon's color in hex format when the button is disabled.
+    this.disabledIconColor,
+
+    /// The shadow color in hex format when the button is disabled.
+    this.disabledShadowColor,
   });
 
   /// The style for a button's text descendants.
@@ -76,6 +88,22 @@ class ButtonStyleConfig with _$ButtonStyleConfig {
   /// The color for the button's text/icon descendants in hex format.
   @override
   final String? foregroundColor;
+
+  /// The button's background fill color in hex format when the button is disabled.
+  @override
+  final String? disabledBackgroundColor;
+
+  /// The color for the button's text/icon descendants in hex format when the button is disabled.
+  @override
+  final String? disabledForegroundColor;
+
+  /// The icon's color in hex format when the button is disabled.
+  @override
+  final String? disabledIconColor;
+
+  /// The shadow color in hex format when the button is disabled.
+  @override
+  final String? disabledShadowColor;
 
   /// The highlight color for states (focused, hovered, pressed) in hex format.
   @override

--- a/packages/webtrit_appearance_theme/lib/models/common/button_style_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/button_style_config.dart
@@ -1,0 +1,139 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'geometry_config.dart';
+import 'text_style_config.dart';
+
+part 'button_style_config.freezed.dart';
+
+part 'button_style_config.g.dart';
+
+/// Represents a configurable button style used for UI theming.
+/// Maps to Flutter's [ButtonStyle].
+@freezed
+@JsonSerializable(explicitToJson: true)
+class ButtonStyleConfig with _$ButtonStyleConfig {
+  const ButtonStyleConfig({
+    /// The style for a button's text descendants.
+    this.textStyle,
+
+    /// The button's background fill color in hex format.
+    this.backgroundColor,
+
+    /// The color for the button's text/icon descendants in hex format.
+    this.foregroundColor,
+
+    /// The highlight color for states (focused, hovered, pressed) in hex format.
+    this.overlayColor,
+
+    /// The shadow color in hex format.
+    this.shadowColor,
+
+    /// The surface tint color in hex format.
+    this.surfaceTintColor,
+
+    /// The elevation of the button.
+    this.elevation,
+
+    /// The padding between the button's boundary and its child.
+    this.padding,
+
+    /// The minimum size of the button.
+    this.minimumSize,
+
+    /// The fixed size of the button.
+    this.fixedSize,
+
+    /// The maximum size of the button.
+    this.maximumSize,
+
+    /// The icon's color in hex format.
+    this.iconColor,
+
+    /// The icon's size.
+    this.iconSize,
+
+    /// The color and weight of the button's outline.
+    this.side,
+
+    /// The shape of the button (e.g., rounded corners).
+    this.shape,
+
+    /// Defines how compact the button's layout will be.
+    this.visualDensity,
+
+    /// The duration of animated changes in milliseconds.
+    this.animationDuration,
+  });
+
+  /// The style for a button's text descendants.
+  @override
+  final TextStyleConfig? textStyle;
+
+  /// The button's background fill color in hex format.
+  @override
+  final String? backgroundColor;
+
+  /// The color for the button's text/icon descendants in hex format.
+  @override
+  final String? foregroundColor;
+
+  /// The highlight color for states (focused, hovered, pressed) in hex format.
+  @override
+  final String? overlayColor;
+
+  /// The shadow color in hex format.
+  @override
+  final String? shadowColor;
+
+  /// The surface tint color in hex format.
+  @override
+  final String? surfaceTintColor;
+
+  /// The elevation of the button.
+  @override
+  final double? elevation;
+
+  /// The padding between the button's boundary and its child.
+  @override
+  final EdgeInsetsConfig? padding;
+
+  /// The minimum size of the button.
+  @override
+  final SizeConfig? minimumSize;
+
+  /// The fixed size of the button.
+  @override
+  final SizeConfig? fixedSize;
+
+  /// The maximum size of the button.
+  @override
+  final SizeConfig? maximumSize;
+
+  /// The icon's color in hex format.
+  @override
+  final String? iconColor;
+
+  /// The icon's size.
+  @override
+  final double? iconSize;
+
+  /// The color and weight of the button's outline.
+  @override
+  final BorderSideConfig? side;
+
+  /// The shape of the button (e.g., rounded corners).
+  @override
+  final ShapeBorderConfig? shape;
+
+  /// Defines how compact the button's layout will be.
+  @override
+  final VisualDensityConfig? visualDensity;
+
+  /// The duration of animated changes in milliseconds.
+  @override
+  final int? animationDuration;
+
+  factory ButtonStyleConfig.fromJson(Map<String, Object?> json) => _$ButtonStyleConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$ButtonStyleConfigToJson(this);
+}

--- a/packages/webtrit_appearance_theme/lib/models/common/button_style_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/button_style_config.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ButtonStyleConfig {
 
- TextStyleConfig? get textStyle; String? get backgroundColor; String? get foregroundColor; String? get overlayColor; String? get shadowColor; String? get surfaceTintColor; double? get elevation; EdgeInsetsConfig? get padding; SizeConfig? get minimumSize; SizeConfig? get fixedSize; SizeConfig? get maximumSize; String? get iconColor; double? get iconSize; BorderSideConfig? get side; ShapeBorderConfig? get shape; VisualDensityConfig? get visualDensity; int? get animationDuration;
+ TextStyleConfig? get textStyle; String? get backgroundColor; String? get foregroundColor; String? get disabledBackgroundColor; String? get disabledForegroundColor; String? get disabledIconColor; String? get disabledShadowColor; String? get overlayColor; String? get shadowColor; String? get surfaceTintColor; double? get elevation; EdgeInsetsConfig? get padding; SizeConfig? get minimumSize; SizeConfig? get fixedSize; SizeConfig? get maximumSize; String? get iconColor; double? get iconSize; BorderSideConfig? get side; ShapeBorderConfig? get shape; VisualDensityConfig? get visualDensity; int? get animationDuration;
 /// Create a copy of ButtonStyleConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $ButtonStyleConfigCopyWith<ButtonStyleConfig> get copyWith => _$ButtonStyleConfi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ButtonStyleConfig&&(identical(other.textStyle, textStyle) || other.textStyle == textStyle)&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.foregroundColor, foregroundColor) || other.foregroundColor == foregroundColor)&&(identical(other.overlayColor, overlayColor) || other.overlayColor == overlayColor)&&(identical(other.shadowColor, shadowColor) || other.shadowColor == shadowColor)&&(identical(other.surfaceTintColor, surfaceTintColor) || other.surfaceTintColor == surfaceTintColor)&&(identical(other.elevation, elevation) || other.elevation == elevation)&&(identical(other.padding, padding) || other.padding == padding)&&(identical(other.minimumSize, minimumSize) || other.minimumSize == minimumSize)&&(identical(other.fixedSize, fixedSize) || other.fixedSize == fixedSize)&&(identical(other.maximumSize, maximumSize) || other.maximumSize == maximumSize)&&(identical(other.iconColor, iconColor) || other.iconColor == iconColor)&&(identical(other.iconSize, iconSize) || other.iconSize == iconSize)&&(identical(other.side, side) || other.side == side)&&(identical(other.shape, shape) || other.shape == shape)&&(identical(other.visualDensity, visualDensity) || other.visualDensity == visualDensity)&&(identical(other.animationDuration, animationDuration) || other.animationDuration == animationDuration));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ButtonStyleConfig&&(identical(other.textStyle, textStyle) || other.textStyle == textStyle)&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.foregroundColor, foregroundColor) || other.foregroundColor == foregroundColor)&&(identical(other.disabledBackgroundColor, disabledBackgroundColor) || other.disabledBackgroundColor == disabledBackgroundColor)&&(identical(other.disabledForegroundColor, disabledForegroundColor) || other.disabledForegroundColor == disabledForegroundColor)&&(identical(other.disabledIconColor, disabledIconColor) || other.disabledIconColor == disabledIconColor)&&(identical(other.disabledShadowColor, disabledShadowColor) || other.disabledShadowColor == disabledShadowColor)&&(identical(other.overlayColor, overlayColor) || other.overlayColor == overlayColor)&&(identical(other.shadowColor, shadowColor) || other.shadowColor == shadowColor)&&(identical(other.surfaceTintColor, surfaceTintColor) || other.surfaceTintColor == surfaceTintColor)&&(identical(other.elevation, elevation) || other.elevation == elevation)&&(identical(other.padding, padding) || other.padding == padding)&&(identical(other.minimumSize, minimumSize) || other.minimumSize == minimumSize)&&(identical(other.fixedSize, fixedSize) || other.fixedSize == fixedSize)&&(identical(other.maximumSize, maximumSize) || other.maximumSize == maximumSize)&&(identical(other.iconColor, iconColor) || other.iconColor == iconColor)&&(identical(other.iconSize, iconSize) || other.iconSize == iconSize)&&(identical(other.side, side) || other.side == side)&&(identical(other.shape, shape) || other.shape == shape)&&(identical(other.visualDensity, visualDensity) || other.visualDensity == visualDensity)&&(identical(other.animationDuration, animationDuration) || other.animationDuration == animationDuration));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,textStyle,backgroundColor,foregroundColor,overlayColor,shadowColor,surfaceTintColor,elevation,padding,minimumSize,fixedSize,maximumSize,iconColor,iconSize,side,shape,visualDensity,animationDuration);
+int get hashCode => Object.hashAll([runtimeType,textStyle,backgroundColor,foregroundColor,disabledBackgroundColor,disabledForegroundColor,disabledIconColor,disabledShadowColor,overlayColor,shadowColor,surfaceTintColor,elevation,padding,minimumSize,fixedSize,maximumSize,iconColor,iconSize,side,shape,visualDensity,animationDuration]);
 
 @override
 String toString() {
-  return 'ButtonStyleConfig(textStyle: $textStyle, backgroundColor: $backgroundColor, foregroundColor: $foregroundColor, overlayColor: $overlayColor, shadowColor: $shadowColor, surfaceTintColor: $surfaceTintColor, elevation: $elevation, padding: $padding, minimumSize: $minimumSize, fixedSize: $fixedSize, maximumSize: $maximumSize, iconColor: $iconColor, iconSize: $iconSize, side: $side, shape: $shape, visualDensity: $visualDensity, animationDuration: $animationDuration)';
+  return 'ButtonStyleConfig(textStyle: $textStyle, backgroundColor: $backgroundColor, foregroundColor: $foregroundColor, disabledBackgroundColor: $disabledBackgroundColor, disabledForegroundColor: $disabledForegroundColor, disabledIconColor: $disabledIconColor, disabledShadowColor: $disabledShadowColor, overlayColor: $overlayColor, shadowColor: $shadowColor, surfaceTintColor: $surfaceTintColor, elevation: $elevation, padding: $padding, minimumSize: $minimumSize, fixedSize: $fixedSize, maximumSize: $maximumSize, iconColor: $iconColor, iconSize: $iconSize, side: $side, shape: $shape, visualDensity: $visualDensity, animationDuration: $animationDuration)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $ButtonStyleConfigCopyWith<$Res>  {
   factory $ButtonStyleConfigCopyWith(ButtonStyleConfig value, $Res Function(ButtonStyleConfig) _then) = _$ButtonStyleConfigCopyWithImpl;
 @useResult
 $Res call({
- TextStyleConfig? textStyle, String? backgroundColor, String? foregroundColor, String? overlayColor, String? shadowColor, String? surfaceTintColor, double? elevation, EdgeInsetsConfig? padding, SizeConfig? minimumSize, SizeConfig? fixedSize, SizeConfig? maximumSize, String? iconColor, double? iconSize, BorderSideConfig? side, ShapeBorderConfig? shape, VisualDensityConfig? visualDensity, int? animationDuration
+ TextStyleConfig? textStyle, String? backgroundColor, String? foregroundColor, String? overlayColor, String? shadowColor, String? surfaceTintColor, double? elevation, EdgeInsetsConfig? padding, SizeConfig? minimumSize, SizeConfig? fixedSize, SizeConfig? maximumSize, String? iconColor, double? iconSize, BorderSideConfig? side, ShapeBorderConfig? shape, VisualDensityConfig? visualDensity, int? animationDuration, String? disabledBackgroundColor, String? disabledForegroundColor, String? disabledIconColor, String? disabledShadowColor
 });
 
 
@@ -63,7 +63,7 @@ class _$ButtonStyleConfigCopyWithImpl<$Res>
 
 /// Create a copy of ButtonStyleConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? textStyle = freezed,Object? backgroundColor = freezed,Object? foregroundColor = freezed,Object? overlayColor = freezed,Object? shadowColor = freezed,Object? surfaceTintColor = freezed,Object? elevation = freezed,Object? padding = freezed,Object? minimumSize = freezed,Object? fixedSize = freezed,Object? maximumSize = freezed,Object? iconColor = freezed,Object? iconSize = freezed,Object? side = freezed,Object? shape = freezed,Object? visualDensity = freezed,Object? animationDuration = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? textStyle = freezed,Object? backgroundColor = freezed,Object? foregroundColor = freezed,Object? overlayColor = freezed,Object? shadowColor = freezed,Object? surfaceTintColor = freezed,Object? elevation = freezed,Object? padding = freezed,Object? minimumSize = freezed,Object? fixedSize = freezed,Object? maximumSize = freezed,Object? iconColor = freezed,Object? iconSize = freezed,Object? side = freezed,Object? shape = freezed,Object? visualDensity = freezed,Object? animationDuration = freezed,Object? disabledBackgroundColor = freezed,Object? disabledForegroundColor = freezed,Object? disabledIconColor = freezed,Object? disabledShadowColor = freezed,}) {
   return _then(ButtonStyleConfig(
 textStyle: freezed == textStyle ? _self.textStyle : textStyle // ignore: cast_nullable_to_non_nullable
 as TextStyleConfig?,backgroundColor: freezed == backgroundColor ? _self.backgroundColor : backgroundColor // ignore: cast_nullable_to_non_nullable
@@ -82,7 +82,11 @@ as double?,side: freezed == side ? _self.side : side // ignore: cast_nullable_to
 as BorderSideConfig?,shape: freezed == shape ? _self.shape : shape // ignore: cast_nullable_to_non_nullable
 as ShapeBorderConfig?,visualDensity: freezed == visualDensity ? _self.visualDensity : visualDensity // ignore: cast_nullable_to_non_nullable
 as VisualDensityConfig?,animationDuration: freezed == animationDuration ? _self.animationDuration : animationDuration // ignore: cast_nullable_to_non_nullable
-as int?,
+as int?,disabledBackgroundColor: freezed == disabledBackgroundColor ? _self.disabledBackgroundColor : disabledBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,disabledForegroundColor: freezed == disabledForegroundColor ? _self.disabledForegroundColor : disabledForegroundColor // ignore: cast_nullable_to_non_nullable
+as String?,disabledIconColor: freezed == disabledIconColor ? _self.disabledIconColor : disabledIconColor // ignore: cast_nullable_to_non_nullable
+as String?,disabledShadowColor: freezed == disabledShadowColor ? _self.disabledShadowColor : disabledShadowColor // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/common/button_style_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/button_style_config.freezed.dart
@@ -1,0 +1,216 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'button_style_config.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ButtonStyleConfig {
+
+ TextStyleConfig? get textStyle; String? get backgroundColor; String? get foregroundColor; String? get overlayColor; String? get shadowColor; String? get surfaceTintColor; double? get elevation; EdgeInsetsConfig? get padding; SizeConfig? get minimumSize; SizeConfig? get fixedSize; SizeConfig? get maximumSize; String? get iconColor; double? get iconSize; BorderSideConfig? get side; ShapeBorderConfig? get shape; VisualDensityConfig? get visualDensity; int? get animationDuration;
+/// Create a copy of ButtonStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ButtonStyleConfigCopyWith<ButtonStyleConfig> get copyWith => _$ButtonStyleConfigCopyWithImpl<ButtonStyleConfig>(this as ButtonStyleConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ButtonStyleConfig&&(identical(other.textStyle, textStyle) || other.textStyle == textStyle)&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.foregroundColor, foregroundColor) || other.foregroundColor == foregroundColor)&&(identical(other.overlayColor, overlayColor) || other.overlayColor == overlayColor)&&(identical(other.shadowColor, shadowColor) || other.shadowColor == shadowColor)&&(identical(other.surfaceTintColor, surfaceTintColor) || other.surfaceTintColor == surfaceTintColor)&&(identical(other.elevation, elevation) || other.elevation == elevation)&&(identical(other.padding, padding) || other.padding == padding)&&(identical(other.minimumSize, minimumSize) || other.minimumSize == minimumSize)&&(identical(other.fixedSize, fixedSize) || other.fixedSize == fixedSize)&&(identical(other.maximumSize, maximumSize) || other.maximumSize == maximumSize)&&(identical(other.iconColor, iconColor) || other.iconColor == iconColor)&&(identical(other.iconSize, iconSize) || other.iconSize == iconSize)&&(identical(other.side, side) || other.side == side)&&(identical(other.shape, shape) || other.shape == shape)&&(identical(other.visualDensity, visualDensity) || other.visualDensity == visualDensity)&&(identical(other.animationDuration, animationDuration) || other.animationDuration == animationDuration));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,textStyle,backgroundColor,foregroundColor,overlayColor,shadowColor,surfaceTintColor,elevation,padding,minimumSize,fixedSize,maximumSize,iconColor,iconSize,side,shape,visualDensity,animationDuration);
+
+@override
+String toString() {
+  return 'ButtonStyleConfig(textStyle: $textStyle, backgroundColor: $backgroundColor, foregroundColor: $foregroundColor, overlayColor: $overlayColor, shadowColor: $shadowColor, surfaceTintColor: $surfaceTintColor, elevation: $elevation, padding: $padding, minimumSize: $minimumSize, fixedSize: $fixedSize, maximumSize: $maximumSize, iconColor: $iconColor, iconSize: $iconSize, side: $side, shape: $shape, visualDensity: $visualDensity, animationDuration: $animationDuration)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ButtonStyleConfigCopyWith<$Res>  {
+  factory $ButtonStyleConfigCopyWith(ButtonStyleConfig value, $Res Function(ButtonStyleConfig) _then) = _$ButtonStyleConfigCopyWithImpl;
+@useResult
+$Res call({
+ TextStyleConfig? textStyle, String? backgroundColor, String? foregroundColor, String? overlayColor, String? shadowColor, String? surfaceTintColor, double? elevation, EdgeInsetsConfig? padding, SizeConfig? minimumSize, SizeConfig? fixedSize, SizeConfig? maximumSize, String? iconColor, double? iconSize, BorderSideConfig? side, ShapeBorderConfig? shape, VisualDensityConfig? visualDensity, int? animationDuration
+});
+
+
+
+
+}
+/// @nodoc
+class _$ButtonStyleConfigCopyWithImpl<$Res>
+    implements $ButtonStyleConfigCopyWith<$Res> {
+  _$ButtonStyleConfigCopyWithImpl(this._self, this._then);
+
+  final ButtonStyleConfig _self;
+  final $Res Function(ButtonStyleConfig) _then;
+
+/// Create a copy of ButtonStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? textStyle = freezed,Object? backgroundColor = freezed,Object? foregroundColor = freezed,Object? overlayColor = freezed,Object? shadowColor = freezed,Object? surfaceTintColor = freezed,Object? elevation = freezed,Object? padding = freezed,Object? minimumSize = freezed,Object? fixedSize = freezed,Object? maximumSize = freezed,Object? iconColor = freezed,Object? iconSize = freezed,Object? side = freezed,Object? shape = freezed,Object? visualDensity = freezed,Object? animationDuration = freezed,}) {
+  return _then(ButtonStyleConfig(
+textStyle: freezed == textStyle ? _self.textStyle : textStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,backgroundColor: freezed == backgroundColor ? _self.backgroundColor : backgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,foregroundColor: freezed == foregroundColor ? _self.foregroundColor : foregroundColor // ignore: cast_nullable_to_non_nullable
+as String?,overlayColor: freezed == overlayColor ? _self.overlayColor : overlayColor // ignore: cast_nullable_to_non_nullable
+as String?,shadowColor: freezed == shadowColor ? _self.shadowColor : shadowColor // ignore: cast_nullable_to_non_nullable
+as String?,surfaceTintColor: freezed == surfaceTintColor ? _self.surfaceTintColor : surfaceTintColor // ignore: cast_nullable_to_non_nullable
+as String?,elevation: freezed == elevation ? _self.elevation : elevation // ignore: cast_nullable_to_non_nullable
+as double?,padding: freezed == padding ? _self.padding : padding // ignore: cast_nullable_to_non_nullable
+as EdgeInsetsConfig?,minimumSize: freezed == minimumSize ? _self.minimumSize : minimumSize // ignore: cast_nullable_to_non_nullable
+as SizeConfig?,fixedSize: freezed == fixedSize ? _self.fixedSize : fixedSize // ignore: cast_nullable_to_non_nullable
+as SizeConfig?,maximumSize: freezed == maximumSize ? _self.maximumSize : maximumSize // ignore: cast_nullable_to_non_nullable
+as SizeConfig?,iconColor: freezed == iconColor ? _self.iconColor : iconColor // ignore: cast_nullable_to_non_nullable
+as String?,iconSize: freezed == iconSize ? _self.iconSize : iconSize // ignore: cast_nullable_to_non_nullable
+as double?,side: freezed == side ? _self.side : side // ignore: cast_nullable_to_non_nullable
+as BorderSideConfig?,shape: freezed == shape ? _self.shape : shape // ignore: cast_nullable_to_non_nullable
+as ShapeBorderConfig?,visualDensity: freezed == visualDensity ? _self.visualDensity : visualDensity // ignore: cast_nullable_to_non_nullable
+as VisualDensityConfig?,animationDuration: freezed == animationDuration ? _self.animationDuration : animationDuration // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ButtonStyleConfig].
+extension ButtonStyleConfigPatterns on ButtonStyleConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+// dart format on

--- a/packages/webtrit_appearance_theme/lib/models/common/button_style_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/button_style_config.g.dart
@@ -43,6 +43,10 @@ ButtonStyleConfig _$ButtonStyleConfigFromJson(Map<String, dynamic> json) =>
               json['visualDensity'] as Map<String, dynamic>,
             ),
       animationDuration: (json['animationDuration'] as num?)?.toInt(),
+      disabledBackgroundColor: json['disabledBackgroundColor'] as String?,
+      disabledForegroundColor: json['disabledForegroundColor'] as String?,
+      disabledIconColor: json['disabledIconColor'] as String?,
+      disabledShadowColor: json['disabledShadowColor'] as String?,
     );
 
 Map<String, dynamic> _$ButtonStyleConfigToJson(ButtonStyleConfig instance) =>
@@ -50,6 +54,10 @@ Map<String, dynamic> _$ButtonStyleConfigToJson(ButtonStyleConfig instance) =>
       'textStyle': instance.textStyle?.toJson(),
       'backgroundColor': instance.backgroundColor,
       'foregroundColor': instance.foregroundColor,
+      'disabledBackgroundColor': instance.disabledBackgroundColor,
+      'disabledForegroundColor': instance.disabledForegroundColor,
+      'disabledIconColor': instance.disabledIconColor,
+      'disabledShadowColor': instance.disabledShadowColor,
       'overlayColor': instance.overlayColor,
       'shadowColor': instance.shadowColor,
       'surfaceTintColor': instance.surfaceTintColor,

--- a/packages/webtrit_appearance_theme/lib/models/common/button_style_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/button_style_config.g.dart
@@ -1,0 +1,67 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'button_style_config.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ButtonStyleConfig _$ButtonStyleConfigFromJson(Map<String, dynamic> json) =>
+    ButtonStyleConfig(
+      textStyle: json['textStyle'] == null
+          ? null
+          : TextStyleConfig.fromJson(json['textStyle'] as Map<String, dynamic>),
+      backgroundColor: json['backgroundColor'] as String?,
+      foregroundColor: json['foregroundColor'] as String?,
+      overlayColor: json['overlayColor'] as String?,
+      shadowColor: json['shadowColor'] as String?,
+      surfaceTintColor: json['surfaceTintColor'] as String?,
+      elevation: (json['elevation'] as num?)?.toDouble(),
+      padding: json['padding'] == null
+          ? null
+          : EdgeInsetsConfig.fromJson(json['padding'] as Map<String, dynamic>),
+      minimumSize: json['minimumSize'] == null
+          ? null
+          : SizeConfig.fromJson(json['minimumSize'] as Map<String, dynamic>),
+      fixedSize: json['fixedSize'] == null
+          ? null
+          : SizeConfig.fromJson(json['fixedSize'] as Map<String, dynamic>),
+      maximumSize: json['maximumSize'] == null
+          ? null
+          : SizeConfig.fromJson(json['maximumSize'] as Map<String, dynamic>),
+      iconColor: json['iconColor'] as String?,
+      iconSize: (json['iconSize'] as num?)?.toDouble(),
+      side: json['side'] == null
+          ? null
+          : BorderSideConfig.fromJson(json['side'] as Map<String, dynamic>),
+      shape: json['shape'] == null
+          ? null
+          : ShapeBorderConfig.fromJson(json['shape'] as Map<String, dynamic>),
+      visualDensity: json['visualDensity'] == null
+          ? null
+          : VisualDensityConfig.fromJson(
+              json['visualDensity'] as Map<String, dynamic>,
+            ),
+      animationDuration: (json['animationDuration'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$ButtonStyleConfigToJson(ButtonStyleConfig instance) =>
+    <String, dynamic>{
+      'textStyle': instance.textStyle?.toJson(),
+      'backgroundColor': instance.backgroundColor,
+      'foregroundColor': instance.foregroundColor,
+      'overlayColor': instance.overlayColor,
+      'shadowColor': instance.shadowColor,
+      'surfaceTintColor': instance.surfaceTintColor,
+      'elevation': instance.elevation,
+      'padding': instance.padding?.toJson(),
+      'minimumSize': instance.minimumSize?.toJson(),
+      'fixedSize': instance.fixedSize?.toJson(),
+      'maximumSize': instance.maximumSize?.toJson(),
+      'iconColor': instance.iconColor,
+      'iconSize': instance.iconSize,
+      'side': instance.side?.toJson(),
+      'shape': instance.shape?.toJson(),
+      'visualDensity': instance.visualDensity?.toJson(),
+      'animationDuration': instance.animationDuration,
+    };

--- a/packages/webtrit_appearance_theme/lib/models/common/common.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/common.dart
@@ -1,4 +1,6 @@
 export 'border_config.dart';
+export 'button_style_config.dart';
+export 'geometry_config.dart';
 export 'icon_data_config.dart';
 export 'icon_theme_data_config.dart';
 export 'input_decoration_config.dart';

--- a/packages/webtrit_appearance_theme/lib/models/common/geometry_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/geometry_config.dart
@@ -1,0 +1,110 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'geometry_config.freezed.dart';
+
+part 'geometry_config.g.dart';
+
+/// Represents a 2D size.
+@freezed
+@JsonSerializable()
+class SizeConfig with _$SizeConfig {
+  const SizeConfig({required this.width, required this.height});
+
+  @override
+  final double width;
+
+  @override
+  final double height;
+
+  factory SizeConfig.fromJson(Map<String, Object?> json) => _$SizeConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$SizeConfigToJson(this);
+}
+
+/// Represents immutable set of offsets in each of the four cardinal directions.
+@freezed
+@JsonSerializable()
+class EdgeInsetsConfig with _$EdgeInsetsConfig {
+  const EdgeInsetsConfig({this.left = 0.0, this.top = 0.0, this.right = 0.0, this.bottom = 0.0});
+
+  @override
+  final double left;
+  @override
+  final double top;
+  @override
+  final double right;
+  @override
+  final double bottom;
+
+  factory EdgeInsetsConfig.fromJson(Map<String, Object?> json) => _$EdgeInsetsConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$EdgeInsetsConfigToJson(this);
+
+  /// Helper factory for symmetric padding.
+  factory EdgeInsetsConfig.symmetric({double vertical = 0.0, double horizontal = 0.0}) {
+    return EdgeInsetsConfig(left: horizontal, top: vertical, right: horizontal, bottom: vertical);
+  }
+
+  /// Helper factory for all-sides padding.
+  factory EdgeInsetsConfig.all(double value) {
+    return EdgeInsetsConfig(left: value, top: value, right: value, bottom: value);
+  }
+}
+
+/// Represents a border side configuration.
+@freezed
+@JsonSerializable()
+class BorderSideConfig with _$BorderSideConfig {
+  const BorderSideConfig({this.color, this.width = 1.0, this.style = 'solid'});
+
+  /// Color in hex format.
+  @override
+  final String? color;
+
+  @override
+  final double width;
+
+  /// Border style (e.g., 'solid', 'none').
+  @override
+  final String style;
+
+  factory BorderSideConfig.fromJson(Map<String, Object?> json) => _$BorderSideConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$BorderSideConfigToJson(this);
+}
+
+/// Represents the shape of the button (e.g., RoundedRectangleBorder, CircleBorder).
+@freezed
+@JsonSerializable()
+class ShapeBorderConfig with _$ShapeBorderConfig {
+  const ShapeBorderConfig({this.type = 'rounded', this.borderRadius});
+
+  /// The type of shape. Common values: 'rounded', 'circle', 'stadium', 'beveled'.
+  @override
+  final String type;
+
+  /// The border radius value (for rounded/beveled shapes).
+  @override
+  final double? borderRadius;
+
+  factory ShapeBorderConfig.fromJson(Map<String, Object?> json) => _$ShapeBorderConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$ShapeBorderConfigToJson(this);
+}
+
+/// Represents visual density (compactness).
+@freezed
+@JsonSerializable()
+class VisualDensityConfig with _$VisualDensityConfig {
+  const VisualDensityConfig({this.horizontal = 0.0, this.vertical = 0.0});
+
+  @override
+  final double horizontal;
+
+  @override
+  final double vertical;
+
+  factory VisualDensityConfig.fromJson(Map<String, Object?> json) => _$VisualDensityConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$VisualDensityConfigToJson(this);
+}

--- a/packages/webtrit_appearance_theme/lib/models/common/geometry_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/geometry_config.freezed.dart
@@ -1,0 +1,952 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'geometry_config.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SizeConfig {
+
+ double get width; double get height;
+/// Create a copy of SizeConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SizeConfigCopyWith<SizeConfig> get copyWith => _$SizeConfigCopyWithImpl<SizeConfig>(this as SizeConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SizeConfig&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,width,height);
+
+@override
+String toString() {
+  return 'SizeConfig(width: $width, height: $height)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SizeConfigCopyWith<$Res>  {
+  factory $SizeConfigCopyWith(SizeConfig value, $Res Function(SizeConfig) _then) = _$SizeConfigCopyWithImpl;
+@useResult
+$Res call({
+ double width, double height
+});
+
+
+
+
+}
+/// @nodoc
+class _$SizeConfigCopyWithImpl<$Res>
+    implements $SizeConfigCopyWith<$Res> {
+  _$SizeConfigCopyWithImpl(this._self, this._then);
+
+  final SizeConfig _self;
+  final $Res Function(SizeConfig) _then;
+
+/// Create a copy of SizeConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? width = null,Object? height = null,}) {
+  return _then(SizeConfig(
+width: null == width ? _self.width : width // ignore: cast_nullable_to_non_nullable
+as double,height: null == height ? _self.height : height // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SizeConfig].
+extension SizeConfigPatterns on SizeConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$EdgeInsetsConfig {
+
+ double get left; double get top; double get right; double get bottom;
+/// Create a copy of EdgeInsetsConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EdgeInsetsConfigCopyWith<EdgeInsetsConfig> get copyWith => _$EdgeInsetsConfigCopyWithImpl<EdgeInsetsConfig>(this as EdgeInsetsConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EdgeInsetsConfig&&(identical(other.left, left) || other.left == left)&&(identical(other.top, top) || other.top == top)&&(identical(other.right, right) || other.right == right)&&(identical(other.bottom, bottom) || other.bottom == bottom));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,left,top,right,bottom);
+
+@override
+String toString() {
+  return 'EdgeInsetsConfig(left: $left, top: $top, right: $right, bottom: $bottom)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EdgeInsetsConfigCopyWith<$Res>  {
+  factory $EdgeInsetsConfigCopyWith(EdgeInsetsConfig value, $Res Function(EdgeInsetsConfig) _then) = _$EdgeInsetsConfigCopyWithImpl;
+@useResult
+$Res call({
+ double left, double top, double right, double bottom
+});
+
+
+
+
+}
+/// @nodoc
+class _$EdgeInsetsConfigCopyWithImpl<$Res>
+    implements $EdgeInsetsConfigCopyWith<$Res> {
+  _$EdgeInsetsConfigCopyWithImpl(this._self, this._then);
+
+  final EdgeInsetsConfig _self;
+  final $Res Function(EdgeInsetsConfig) _then;
+
+/// Create a copy of EdgeInsetsConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? left = null,Object? top = null,Object? right = null,Object? bottom = null,}) {
+  return _then(EdgeInsetsConfig(
+left: null == left ? _self.left : left // ignore: cast_nullable_to_non_nullable
+as double,top: null == top ? _self.top : top // ignore: cast_nullable_to_non_nullable
+as double,right: null == right ? _self.right : right // ignore: cast_nullable_to_non_nullable
+as double,bottom: null == bottom ? _self.bottom : bottom // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EdgeInsetsConfig].
+extension EdgeInsetsConfigPatterns on EdgeInsetsConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$BorderSideConfig {
+
+ String? get color; double get width; String get style;
+/// Create a copy of BorderSideConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BorderSideConfigCopyWith<BorderSideConfig> get copyWith => _$BorderSideConfigCopyWithImpl<BorderSideConfig>(this as BorderSideConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BorderSideConfig&&(identical(other.color, color) || other.color == color)&&(identical(other.width, width) || other.width == width)&&(identical(other.style, style) || other.style == style));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,color,width,style);
+
+@override
+String toString() {
+  return 'BorderSideConfig(color: $color, width: $width, style: $style)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BorderSideConfigCopyWith<$Res>  {
+  factory $BorderSideConfigCopyWith(BorderSideConfig value, $Res Function(BorderSideConfig) _then) = _$BorderSideConfigCopyWithImpl;
+@useResult
+$Res call({
+ String? color, double width, String style
+});
+
+
+
+
+}
+/// @nodoc
+class _$BorderSideConfigCopyWithImpl<$Res>
+    implements $BorderSideConfigCopyWith<$Res> {
+  _$BorderSideConfigCopyWithImpl(this._self, this._then);
+
+  final BorderSideConfig _self;
+  final $Res Function(BorderSideConfig) _then;
+
+/// Create a copy of BorderSideConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? color = freezed,Object? width = null,Object? style = null,}) {
+  return _then(BorderSideConfig(
+color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String?,width: null == width ? _self.width : width // ignore: cast_nullable_to_non_nullable
+as double,style: null == style ? _self.style : style // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BorderSideConfig].
+extension BorderSideConfigPatterns on BorderSideConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$ShapeBorderConfig {
+
+ String get type; double? get borderRadius;
+/// Create a copy of ShapeBorderConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ShapeBorderConfigCopyWith<ShapeBorderConfig> get copyWith => _$ShapeBorderConfigCopyWithImpl<ShapeBorderConfig>(this as ShapeBorderConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ShapeBorderConfig&&(identical(other.type, type) || other.type == type)&&(identical(other.borderRadius, borderRadius) || other.borderRadius == borderRadius));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,borderRadius);
+
+@override
+String toString() {
+  return 'ShapeBorderConfig(type: $type, borderRadius: $borderRadius)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ShapeBorderConfigCopyWith<$Res>  {
+  factory $ShapeBorderConfigCopyWith(ShapeBorderConfig value, $Res Function(ShapeBorderConfig) _then) = _$ShapeBorderConfigCopyWithImpl;
+@useResult
+$Res call({
+ String type, double? borderRadius
+});
+
+
+
+
+}
+/// @nodoc
+class _$ShapeBorderConfigCopyWithImpl<$Res>
+    implements $ShapeBorderConfigCopyWith<$Res> {
+  _$ShapeBorderConfigCopyWithImpl(this._self, this._then);
+
+  final ShapeBorderConfig _self;
+  final $Res Function(ShapeBorderConfig) _then;
+
+/// Create a copy of ShapeBorderConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? borderRadius = freezed,}) {
+  return _then(ShapeBorderConfig(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,borderRadius: freezed == borderRadius ? _self.borderRadius : borderRadius // ignore: cast_nullable_to_non_nullable
+as double?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ShapeBorderConfig].
+extension ShapeBorderConfigPatterns on ShapeBorderConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$VisualDensityConfig {
+
+ double get horizontal; double get vertical;
+/// Create a copy of VisualDensityConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VisualDensityConfigCopyWith<VisualDensityConfig> get copyWith => _$VisualDensityConfigCopyWithImpl<VisualDensityConfig>(this as VisualDensityConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VisualDensityConfig&&(identical(other.horizontal, horizontal) || other.horizontal == horizontal)&&(identical(other.vertical, vertical) || other.vertical == vertical));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,horizontal,vertical);
+
+@override
+String toString() {
+  return 'VisualDensityConfig(horizontal: $horizontal, vertical: $vertical)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VisualDensityConfigCopyWith<$Res>  {
+  factory $VisualDensityConfigCopyWith(VisualDensityConfig value, $Res Function(VisualDensityConfig) _then) = _$VisualDensityConfigCopyWithImpl;
+@useResult
+$Res call({
+ double horizontal, double vertical
+});
+
+
+
+
+}
+/// @nodoc
+class _$VisualDensityConfigCopyWithImpl<$Res>
+    implements $VisualDensityConfigCopyWith<$Res> {
+  _$VisualDensityConfigCopyWithImpl(this._self, this._then);
+
+  final VisualDensityConfig _self;
+  final $Res Function(VisualDensityConfig) _then;
+
+/// Create a copy of VisualDensityConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? horizontal = null,Object? vertical = null,}) {
+  return _then(VisualDensityConfig(
+horizontal: null == horizontal ? _self.horizontal : horizontal // ignore: cast_nullable_to_non_nullable
+as double,vertical: null == vertical ? _self.vertical : vertical // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [VisualDensityConfig].
+extension VisualDensityConfigPatterns on VisualDensityConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+// dart format on

--- a/packages/webtrit_appearance_theme/lib/models/common/geometry_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/geometry_config.g.dart
@@ -1,0 +1,70 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'geometry_config.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SizeConfig _$SizeConfigFromJson(Map<String, dynamic> json) => SizeConfig(
+  width: (json['width'] as num).toDouble(),
+  height: (json['height'] as num).toDouble(),
+);
+
+Map<String, dynamic> _$SizeConfigToJson(SizeConfig instance) =>
+    <String, dynamic>{'width': instance.width, 'height': instance.height};
+
+EdgeInsetsConfig _$EdgeInsetsConfigFromJson(Map<String, dynamic> json) =>
+    EdgeInsetsConfig(
+      left: (json['left'] as num?)?.toDouble() ?? 0.0,
+      top: (json['top'] as num?)?.toDouble() ?? 0.0,
+      right: (json['right'] as num?)?.toDouble() ?? 0.0,
+      bottom: (json['bottom'] as num?)?.toDouble() ?? 0.0,
+    );
+
+Map<String, dynamic> _$EdgeInsetsConfigToJson(EdgeInsetsConfig instance) =>
+    <String, dynamic>{
+      'left': instance.left,
+      'top': instance.top,
+      'right': instance.right,
+      'bottom': instance.bottom,
+    };
+
+BorderSideConfig _$BorderSideConfigFromJson(Map<String, dynamic> json) =>
+    BorderSideConfig(
+      color: json['color'] as String?,
+      width: (json['width'] as num?)?.toDouble() ?? 1.0,
+      style: json['style'] as String? ?? 'solid',
+    );
+
+Map<String, dynamic> _$BorderSideConfigToJson(BorderSideConfig instance) =>
+    <String, dynamic>{
+      'color': instance.color,
+      'width': instance.width,
+      'style': instance.style,
+    };
+
+ShapeBorderConfig _$ShapeBorderConfigFromJson(Map<String, dynamic> json) =>
+    ShapeBorderConfig(
+      type: json['type'] as String? ?? 'rounded',
+      borderRadius: (json['borderRadius'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$ShapeBorderConfigToJson(ShapeBorderConfig instance) =>
+    <String, dynamic>{
+      'type': instance.type,
+      'borderRadius': instance.borderRadius,
+    };
+
+VisualDensityConfig _$VisualDensityConfigFromJson(Map<String, dynamic> json) =>
+    VisualDensityConfig(
+      horizontal: (json['horizontal'] as num?)?.toDouble() ?? 0.0,
+      vertical: (json['vertical'] as num?)?.toDouble() ?? 0.0,
+    );
+
+Map<String, dynamic> _$VisualDensityConfigToJson(
+  VisualDensityConfig instance,
+) => <String, dynamic>{
+  'horizontal': instance.horizontal,
+  'vertical': instance.vertical,
+};

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -223,9 +223,13 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
 @freezed
 @JsonSerializable(explicitToJson: true)
 class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConfig {
-  const LoginSwitchPageConfig({this.mainLogo, this.background, this.themeOverride = const ThemeOverrideConfig()});
+  const LoginSwitchPageConfig({
+    this.mainLogo,
+    this.background,
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.segmentButtonStyle,
+  });
 
-  /// Configuration to force override the theme mode.
   @override
   final ThemeOverrideConfig themeOverride;
 
@@ -234,6 +238,9 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
 
   @override
   final PageBackground? background;
+
+  @override
+  final ButtonStyleConfig? segmentButtonStyle;
 
   factory LoginSwitchPageConfig.fromJson(Map<String, Object?> json) => _$LoginSwitchPageConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -1524,7 +1524,7 @@ case _:
 /// @nodoc
 mixin _$LoginSwitchPageConfig {
 
- ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background; ButtonStyleConfig? get segmentButtonStyle;
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1535,16 +1535,16 @@ $LoginSwitchPageConfigCopyWith<LoginSwitchPageConfig> get copyWith => _$LoginSwi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background)&&(identical(other.segmentButtonStyle, segmentButtonStyle) || other.segmentButtonStyle == segmentButtonStyle));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background,segmentButtonStyle);
 
 @override
 String toString() {
-  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background)';
+  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background, segmentButtonStyle: $segmentButtonStyle)';
 }
 
 
@@ -1555,7 +1555,7 @@ abstract mixin class $LoginSwitchPageConfigCopyWith<$Res>  {
   factory $LoginSwitchPageConfigCopyWith(LoginSwitchPageConfig value, $Res Function(LoginSwitchPageConfig) _then) = _$LoginSwitchPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride
+ ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride, ButtonStyleConfig? segmentButtonStyle
 });
 
 
@@ -1572,12 +1572,13 @@ class _$LoginSwitchPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,Object? segmentButtonStyle = freezed,}) {
   return _then(LoginSwitchPageConfig(
 mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo // ignore: cast_nullable_to_non_nullable
 as ImageSource?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
-as ThemeOverrideConfig,
+as ThemeOverrideConfig,segmentButtonStyle: freezed == segmentButtonStyle ? _self.segmentButtonStyle : segmentButtonStyle // ignore: cast_nullable_to_non_nullable
+as ButtonStyleConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -247,6 +247,11 @@ LoginSwitchPageConfig _$LoginSwitchPageConfigFromJson(
       : ThemeOverrideConfig.fromJson(
           json['themeOverride'] as Map<String, dynamic>,
         ),
+  segmentButtonStyle: json['segmentButtonStyle'] == null
+      ? null
+      : ButtonStyleConfig.fromJson(
+          json['segmentButtonStyle'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$LoginSwitchPageConfigToJson(
@@ -255,6 +260,7 @@ Map<String, dynamic> _$LoginSwitchPageConfigToJson(
   'themeOverride': instance.themeOverride.toJson(),
   'mainLogo': instance.mainLogo?.toJson(),
   'background': instance.background?.toJson(),
+  'segmentButtonStyle': instance.segmentButtonStyle?.toJson(),
 };
 
 AboutPageConfig _$AboutPageConfigFromJson(Map<String, dynamic> json) =>

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
@@ -80,10 +80,10 @@ class FontsConfig with _$FontsConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class ButtonWidgetConfig with _$ButtonWidgetConfig {
-  const ButtonWidgetConfig({this.primaryElevatedButton = const ElevatedButtonWidgetConfig()});
+  const ButtonWidgetConfig({this.primaryElevatedButton});
 
   @override
-  final ElevatedButtonWidgetConfig primaryElevatedButton;
+  final ButtonStyleConfig? primaryElevatedButton;
 
   factory ButtonWidgetConfig.fromJson(Map<String, Object?> json) => _$ButtonWidgetConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
@@ -397,7 +397,7 @@ case _:
 /// @nodoc
 mixin _$ButtonWidgetConfig {
 
- ElevatedButtonWidgetConfig get primaryElevatedButton;
+ ButtonStyleConfig? get primaryElevatedButton;
 /// Create a copy of ButtonWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -428,7 +428,7 @@ abstract mixin class $ButtonWidgetConfigCopyWith<$Res>  {
   factory $ButtonWidgetConfigCopyWith(ButtonWidgetConfig value, $Res Function(ButtonWidgetConfig) _then) = _$ButtonWidgetConfigCopyWithImpl;
 @useResult
 $Res call({
- ElevatedButtonWidgetConfig primaryElevatedButton
+ ButtonStyleConfig? primaryElevatedButton
 });
 
 
@@ -445,10 +445,10 @@ class _$ButtonWidgetConfigCopyWithImpl<$Res>
 
 /// Create a copy of ButtonWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? primaryElevatedButton = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? primaryElevatedButton = freezed,}) {
   return _then(ButtonWidgetConfig(
-primaryElevatedButton: null == primaryElevatedButton ? _self.primaryElevatedButton : primaryElevatedButton // ignore: cast_nullable_to_non_nullable
-as ElevatedButtonWidgetConfig,
+primaryElevatedButton: freezed == primaryElevatedButton ? _self.primaryElevatedButton : primaryElevatedButton // ignore: cast_nullable_to_non_nullable
+as ButtonStyleConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
@@ -72,15 +72,15 @@ Map<String, dynamic> _$FontsConfigToJson(FontsConfig instance) =>
 ButtonWidgetConfig _$ButtonWidgetConfigFromJson(Map<String, dynamic> json) =>
     ButtonWidgetConfig(
       primaryElevatedButton: json['primaryElevatedButton'] == null
-          ? const ElevatedButtonWidgetConfig()
-          : ElevatedButtonWidgetConfig.fromJson(
+          ? null
+          : ButtonStyleConfig.fromJson(
               json['primaryElevatedButton'] as Map<String, dynamic>,
             ),
     );
 
 Map<String, dynamic> _$ButtonWidgetConfigToJson(ButtonWidgetConfig instance) =>
     <String, dynamic>{
-      'primaryElevatedButton': instance.primaryElevatedButton.toJson(),
+      'primaryElevatedButton': instance.primaryElevatedButton?.toJson(),
     };
 
 ElevatedButtonWidgetConfig _$ElevatedButtonWidgetConfigFromJson(


### PR DESCRIPTION
Adds theme-configurable styling for the `LoginSwitch` screen’s `SegmentedButton` by introducing a serializable `ButtonStyleConfig` (and supporting geometry models) in the `webtrit_appearance_theme` package, then wiring that style through the app theme/style factories into the login UI.