### PR TITLE
fix(theme): propagate defaultFontFamily to theme factories

### DIFF
--- a/lib/theme/extension/button_style_config.dart
+++ b/lib/theme/extension/button_style_config.dart
@@ -4,9 +4,11 @@ import 'package:webtrit_appearance_theme/models/models.dart';
 import 'package:webtrit_phone/theme/extension/extension.dart';
 
 extension ButtonStyleConfigExtension on ButtonStyleConfig {
-  ButtonStyle toButtonStyle() {
+  ButtonStyle toButtonStyle({required String? defaultFontFamily}) {
     return ButtonStyle(
-      textStyle: textStyle != null ? WidgetStateProperty.all(textStyle!.toTextStyle()) : null,
+      textStyle: textStyle != null
+          ? WidgetStateProperty.all(textStyle!.toTextStyle(defaultFontFamily: defaultFontFamily))
+          : null,
       backgroundColor: _resolveColor(backgroundColor, disabledBackgroundColor),
       foregroundColor: _resolveColor(foregroundColor, disabledForegroundColor),
       overlayColor: overlayColor != null ? WidgetStateProperty.all(overlayColor!.toColor()) : null,

--- a/lib/theme/extension/input_decoration.dart
+++ b/lib/theme/extension/input_decoration.dart
@@ -22,7 +22,11 @@ extension InputDecorationConfigExtension on InputDecorationConfig {
   ///
   /// Requires a [ColorScheme] to resolve default colors and an optional
   /// [baseStyle] to be used as a foundation for text styles.
-  InputDecoration toInputDecoration({required ColorScheme colors, TextStyle? baseStyle}) {
+  InputDecoration toInputDecoration({
+    required ColorScheme colors,
+    required String? defaultFontFamily,
+    TextStyle? baseStyle,
+  }) {
     // Map specific border configurations for different states
     final mappedBorder = _mapBorder(border, colors);
     final mappedEnabledBorder = _mapBorder(enabledBorder, colors);
@@ -50,27 +54,32 @@ extension InputDecorationConfigExtension on InputDecorationConfig {
     // the default Flutter theme styles.
 
     final hintStyleResult = hintStyle != null
-        ? _resolveStyle(hintStyle, baseStyle: baseStyle, color: onSurface50)
+        ? _resolveStyle(hintStyle, defaultFontFamily: defaultFontFamily, baseStyle: baseStyle, color: onSurface50)
         : null;
 
     final prefixStyleResult = prefixStyle != null
-        ? _resolveStyle(prefixStyle, baseStyle: baseStyle, color: onSurface)
+        ? _resolveStyle(prefixStyle, defaultFontFamily: defaultFontFamily, baseStyle: baseStyle, color: onSurface)
         : null;
 
     final labelStyleResult = labelStyle != null
-        ? _resolveStyle(labelStyle, baseStyle: baseStyle, color: onSurface)
+        ? _resolveStyle(labelStyle, defaultFontFamily: defaultFontFamily, baseStyle: baseStyle, color: onSurface)
         : null;
 
     final suffixStyleResult = suffixStyle != null
-        ? _resolveStyle(suffixStyle, baseStyle: baseStyle, color: onSurface)
+        ? _resolveStyle(suffixStyle, defaultFontFamily: defaultFontFamily, baseStyle: baseStyle, color: onSurface)
         : null;
 
     final helperStyleResult = helperStyle != null
-        ? _resolveStyle(helperStyle, baseStyle: smallBaseStyle, color: onSurfaceVariant)
+        ? _resolveStyle(
+            helperStyle,
+            defaultFontFamily: defaultFontFamily,
+            baseStyle: smallBaseStyle,
+            color: onSurfaceVariant,
+          )
         : null;
 
     final errorStyleResult = errorStyle != null
-        ? _resolveStyle(errorStyle, baseStyle: smallBaseStyle, color: errorColor)
+        ? _resolveStyle(errorStyle, defaultFontFamily: defaultFontFamily, baseStyle: smallBaseStyle, color: errorColor)
         : null;
 
     return InputDecoration(
@@ -99,10 +108,15 @@ extension InputDecorationConfigExtension on InputDecorationConfig {
   }
 
   /// Helper to merge a [TextStyleConfig] with a [baseStyle] and apply a specific [color].
-  TextStyle _resolveStyle(TextStyleConfig? config, {TextStyle? baseStyle, Color? color}) {
+  TextStyle _resolveStyle(
+    TextStyleConfig? config, {
+    required String? defaultFontFamily,
+    TextStyle? baseStyle,
+    Color? color,
+  }) {
     final base = baseStyle ?? const TextStyle();
 
-    final custom = config?.toTextStyle();
+    final custom = config?.toTextStyle(defaultFontFamily: defaultFontFamily);
     final mergedStyle = custom != null ? base.merge(custom) : base;
 
     return mergedStyle.copyWith(color: color);

--- a/lib/theme/extension/text_field_config.dart
+++ b/lib/theme/extension/text_field_config.dart
@@ -10,10 +10,16 @@ extension TextFieldConfigToStyle on TextFieldConfig {
   /// The [theme] parameter determines the text color strategy:
   /// - If provided, the text style explicitly uses [colors.onSurface].
   /// - If null, the color remains undefined to allow inheritance from the active context.
-  TextFieldStyle toStyle({required ColorScheme colors, ThemeData? theme, TextFieldStyle? base}) {
+  TextFieldStyle toStyle({
+    required ColorScheme colors,
+    required String? defaultFontFamily,
+    ThemeData? theme,
+    TextFieldStyle? base,
+  }) {
     final baseTextStyle = base?.textStyle ?? theme?.textTheme.bodyLarge ?? const TextStyle();
 
     final configTextStyle = style?.toTextStyle(
+      defaultFontFamily: defaultFontFamily,
       defaultFontSize: baseTextStyle.fontSize,
       defaultFontWeight: baseTextStyle.fontWeight,
     );
@@ -21,7 +27,11 @@ extension TextFieldConfigToStyle on TextFieldConfig {
     final effectiveTextStyle = baseTextStyle.merge(configTextStyle);
 
     final styleFromConfig = TextFieldStyle(
-      decoration: decoration?.toInputDecoration(colors: colors, baseStyle: effectiveTextStyle),
+      decoration: decoration?.toInputDecoration(
+        colors: colors,
+        defaultFontFamily: defaultFontFamily,
+        baseStyle: effectiveTextStyle,
+      ),
       textStyle: theme != null ? effectiveTextStyle.copyWith(color: colors.onSurface) : effectiveTextStyle,
       textAlign: _mapTextAlign(textAlign),
       showCursor: showCursor,

--- a/lib/theme/extension/text_style_config.dart
+++ b/lib/theme/extension/text_style_config.dart
@@ -5,7 +5,7 @@ import 'package:webtrit_phone/theme/extension/extension.dart';
 
 extension TextStyleConfigExtension on TextStyleConfig {
   TextStyle toTextStyle({
-    String? defaultFontFamily,
+    required String? defaultFontFamily,
     double? defaultFontSize,
     FontWeight? defaultFontWeight,
     FontStyle defaultFontStyle = FontStyle.normal,

--- a/lib/theme/factory/styles/call_screen_style_factory.dart
+++ b/lib/theme/factory/styles/call_screen_style_factory.dart
@@ -15,10 +15,11 @@ const double kDisabledOpacity = 0.40;
 final _logger = Logger('CallScreenStyleFactory');
 
 class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
-  CallScreenStyleFactory(this.colors, this.pageConfig, this.legacyCallActionsConfig);
+  CallScreenStyleFactory(this.colors, this.pageConfig, this.legacyCallActionsConfig, this.defaultFontFamily);
 
   final ColorScheme colors;
   final CallPageConfig? pageConfig;
+  final String? defaultFontFamily;
 
   // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
   // ignore: deprecated_member_use
@@ -54,10 +55,10 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
       return null;
     }
 
-    final userInfoTextStyle = cfg.usernameTextStyle?.toTextStyle();
-    final numberTextStyle = cfg.numberTextStyle?.toTextStyle();
-    final callStatusTextStyle = cfg.callStatusTextStyle?.toTextStyle();
-    final processingStatusTextStyle = cfg.processingStatusTextStyle?.toTextStyle();
+    final userInfoTextStyle = cfg.usernameTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
+    final numberTextStyle = cfg.numberTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
+    final callStatusTextStyle = cfg.callStatusTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
+    final processingStatusTextStyle = cfg.processingStatusTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
 
     return CallInfoStyle(
       userInfo: _mergeWithDefaultTextStyle(

--- a/lib/theme/factory/styles/elevated_button_style_factory.dart
+++ b/lib/theme/factory/styles/elevated_button_style_factory.dart
@@ -6,20 +6,24 @@ import '../../models/models.dart';
 import '../theme_style_factory.dart';
 
 class ElevatedButtonStyleFactory implements ThemeStyleFactory<ElevatedButtonStyles> {
-  ElevatedButtonStyleFactory(this.colors, this.config);
+  ElevatedButtonStyleFactory(this.colors, this.config, this.defaultFontFamily);
 
   final ColorScheme colors;
   final ButtonStyleConfig? config;
+  final String? defaultFontFamily;
 
   @override
   ElevatedButtonStyles create() {
     return ElevatedButtonStyles(
-      primary: ElevatedButton.styleFrom(
-        foregroundColor: colors.onPrimary,
-        backgroundColor: colors.primary,
-        disabledForegroundColor: colors.onPrimaryContainer.withValues(alpha: 0.38),
-        disabledBackgroundColor: colors.onPrimaryContainer.withValues(alpha: 0.12),
-      ).copyWith(elevation: WidgetStateProperty.all(0.0)).merge(config?.toButtonStyle()),
+      primary:
+          ElevatedButton.styleFrom(
+                foregroundColor: colors.onPrimary,
+                backgroundColor: colors.primary,
+                disabledForegroundColor: colors.onPrimaryContainer.withValues(alpha: 0.38),
+                disabledBackgroundColor: colors.onPrimaryContainer.withValues(alpha: 0.12),
+              )
+              .copyWith(elevation: WidgetStateProperty.all(0.0))
+              .merge(config?.toButtonStyle(defaultFontFamily: defaultFontFamily)),
       neutral: ElevatedButton.styleFrom(
         foregroundColor: colors.onSurface,
         backgroundColor: colors.surface,

--- a/lib/theme/factory/styles/group_title_list_styles.dart
+++ b/lib/theme/factory/styles/group_title_list_styles.dart
@@ -5,16 +5,17 @@ import 'package:webtrit_phone/theme/theme.dart';
 import '../theme_style_factory.dart';
 
 class GroupTitleListStyleFactory implements ThemeStyleFactory<GroupTitleListStyles> {
-  GroupTitleListStyleFactory(this.colors, this.config);
+  GroupTitleListStyleFactory(this.colors, this.config, this.defaultFontFamily);
 
   final ColorScheme colors;
   final GroupTitleListTileWidgetConfig? config;
+  final String? defaultFontFamily;
 
   @override
   GroupTitleListStyles create() {
     final backgroundColor = config?.backgroundColor?.toColor() ?? colors.surface;
 
-    final textStyle = config?.textStyle?.toTextStyle();
+    final textStyle = config?.textStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
 
     return GroupTitleListStyles(
       primary: GroupTitleListStyle(textStyle: textStyle, background: backgroundColor),

--- a/lib/theme/factory/styles/keypad_screen_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_screen_style_factory.dart
@@ -14,11 +14,12 @@ import 'action_pad_style_factory.dart';
 import 'keypad_style_factory.dart';
 
 class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> {
-  KeypadScreenStyleFactory(this.colors, {required this.config, required this.textTheme});
+  KeypadScreenStyleFactory(this.colors, this.defaultFontFamily, {required this.config, required this.textTheme});
 
   final ColorScheme colors;
   final KeypadPageConfig config;
   final TextTheme textTheme;
+  final String? defaultFontFamily;
 
   @override
   KeypadScreenStyles create() {
@@ -29,12 +30,18 @@ class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> 
         background: backgroundStyle,
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
-        inputField: config.textField?.toStyle(colors: colors),
+        inputField: config.textField?.toStyle(colors: colors, defaultFontFamily: defaultFontFamily),
         contactNameField: config.contactName?.toStyle(
           colors: colors,
+          defaultFontFamily: defaultFontFamily,
           base: const TextFieldStyle(textAlign: TextAlign.center, showCursor: false, keyboardType: TextInputType.none),
         ),
-        keypadStyle: KeypadStyleFactory(colors, config: config.keypad, textTheme: textTheme).create().primary,
+        keypadStyle: KeypadStyleFactory(
+          colors,
+          defaultFontFamily,
+          config: config.keypad,
+          textTheme: textTheme,
+        ).create().primary,
         actionpadStyle: ActionPadStyleFactory(colors, config.actionpad).create().primary,
       ),
     );

--- a/lib/theme/factory/styles/keypad_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_style_factory.dart
@@ -25,11 +25,12 @@ import '../theme_style_factory.dart';
 /// inside widgets (e.g. `merge(theme.textTheme.headlineLarge)`),
 /// so that the final computed sizes are always respected.
 class KeypadStyleFactory implements ThemeStyleFactory<KeypadStyles> {
-  KeypadStyleFactory(this.colors, {required this.config, required this.textTheme});
+  KeypadStyleFactory(this.colors, this.defaultFontFamily, {required this.config, required this.textTheme});
 
   final ColorScheme colors;
   final KeypadStyleConfig? config;
   final TextTheme textTheme;
+  final String? defaultFontFamily;
 
   @override
   KeypadStyles create() {
@@ -46,12 +47,14 @@ class KeypadStyleFactory implements ThemeStyleFactory<KeypadStyles> {
         keyStyle: KeypadKeyStyle(
           textStyle:
               config?.textStyle?.toTextStyle(
+                defaultFontFamily: defaultFontFamily,
                 defaultFontSize: defaultNumberFontSize,
                 defaultFontWeight: defaultNumberFontWeight,
               ) ??
               TextStyle(fontSize: defaultNumberFontSize, fontWeight: defaultNumberFontWeight, height: 1.125),
           subtextStyle:
               config?.subtextStyle?.toTextStyle(
+                defaultFontFamily: defaultFontFamily,
                 defaultFontSize: defaultSubFontSize,
                 defaultFontWeight: defaultSubFontWeight,
               ) ??

--- a/lib/theme/factory/styles/leading_avatar_style_factory.dart
+++ b/lib/theme/factory/styles/leading_avatar_style_factory.dart
@@ -7,10 +7,11 @@ import 'package:webtrit_phone/theme/styles/styles.dart';
 import '../theme_style_factory.dart';
 
 class LeadingAvatarStyleFactory implements ThemeStyleFactory<LeadingAvatarStyles> {
-  LeadingAvatarStyleFactory(this.colors, this.config);
+  LeadingAvatarStyleFactory(this.colors, this.config, this.defaultFontFamily);
 
   final ColorScheme colors;
   final LeadingAvatarStyleConfig? config;
+  final String? defaultFontFamily;
 
   @override
   LeadingAvatarStyles create() {
@@ -18,9 +19,9 @@ class LeadingAvatarStyleFactory implements ThemeStyleFactory<LeadingAvatarStyles
       primary: LeadingAvatarStyle(
         backgroundColor: _bgColor(),
         radius: config?.radius,
-        initialsTextStyle: config?.initialsTextStyle?.toTextStyle().copyWith(
-          color: config?.initialsTextStyle?.color?.toColor() ?? colors.onSecondaryContainer,
-        ),
+        initialsTextStyle: config?.initialsTextStyle
+            ?.toTextStyle(defaultFontFamily: defaultFontFamily)
+            .copyWith(color: config?.initialsTextStyle?.color?.toColor() ?? colors.onSecondaryContainer),
         placeholderIcon: null,
         loadingOverlay: _mapLoading(config?.loading),
         smartIndicator: _mapSmart(config?.smartIndicator),

--- a/lib/theme/factory/styles/leading_avatar_style_factory.dart
+++ b/lib/theme/factory/styles/leading_avatar_style_factory.dart
@@ -19,9 +19,7 @@ class LeadingAvatarStyleFactory implements ThemeStyleFactory<LeadingAvatarStyles
       primary: LeadingAvatarStyle(
         backgroundColor: _bgColor(),
         radius: config?.radius,
-        initialsTextStyle: config?.initialsTextStyle
-            ?.toTextStyle(defaultFontFamily: defaultFontFamily)
-            .copyWith(color: config?.initialsTextStyle?.color?.toColor() ?? colors.onSecondaryContainer),
+        initialsTextStyle: _mapInitialsTextStyle(config?.initialsTextStyle),
         placeholderIcon: null,
         loadingOverlay: _mapLoading(config?.loading),
         smartIndicator: _mapSmart(config?.smartIndicator),
@@ -29,6 +27,14 @@ class LeadingAvatarStyleFactory implements ThemeStyleFactory<LeadingAvatarStyles
         presenceBadge: _mapPresence(config?.presenceBadge),
       ),
     );
+  }
+
+  TextStyle? _mapInitialsTextStyle(TextStyleConfig? config) {
+    if (config == null) return null;
+
+    return config
+        .toTextStyle(defaultFontFamily: defaultFontFamily)
+        .copyWith(color: config.color?.toColor() ?? colors.onSecondaryContainer);
   }
 
   Color _bgColor() => config?.backgroundColor?.toColor() ?? colors.secondaryContainer;

--- a/lib/theme/factory/styles/login_otp_signin_page_style_factory.dart
+++ b/lib/theme/factory/styles/login_otp_signin_page_style_factory.dart
@@ -6,11 +6,12 @@ import 'package:webtrit_phone/theme/theme.dart';
 import '../theme_style_factory.dart';
 
 class LoginOtpSigninPageStyleFactory implements ThemeStyleFactory<LoginOtpSigninPageStyles> {
-  LoginOtpSigninPageStyleFactory(this.colors, {required this.config, required this.textTheme});
+  LoginOtpSigninPageStyleFactory(this.colors, this.defaultFontFamily, {required this.config, required this.textTheme});
 
   final ColorScheme colors;
   final LoginOtpSigninPageConfig? config;
   final TextTheme textTheme;
+  final String? defaultFontFamily;
 
   @override
   LoginOtpSigninPageStyles create() {
@@ -27,7 +28,12 @@ class LoginOtpSigninPageStyleFactory implements ThemeStyleFactory<LoginOtpSignin
       ),
     );
 
-    final inputRef = config?.refTextField?.toStyle(colors: colors, theme: themeData, base: baseTextFieldStyle);
+    final inputRef = config?.refTextField?.toStyle(
+      colors: colors,
+      defaultFontFamily: defaultFontFamily,
+      theme: themeData,
+      base: baseTextFieldStyle,
+    );
 
     return LoginOtpSigninPageStyles(primary: LoginOtpSigninPageStyle(refInput: inputRef));
   }

--- a/lib/theme/factory/styles/login_password_signin_page_style_factory.dart
+++ b/lib/theme/factory/styles/login_password_signin_page_style_factory.dart
@@ -6,11 +6,17 @@ import 'package:webtrit_phone/theme/theme.dart';
 import '../theme_style_factory.dart';
 
 class LoginPasswordSigninPageStyleFactory implements ThemeStyleFactory<LoginPasswordSigninPageStyles> {
-  LoginPasswordSigninPageStyleFactory(this.colors, {required this.config, required this.textTheme});
+  LoginPasswordSigninPageStyleFactory(
+    this.colors,
+    this.defaultFontFamily, {
+    required this.config,
+    required this.textTheme,
+  });
 
   final ColorScheme colors;
   final LoginPasswordSigninPageConfig? config;
   final TextTheme textTheme;
+  final String? defaultFontFamily;
 
   @override
   LoginPasswordSigninPageStyles create() {
@@ -30,8 +36,18 @@ class LoginPasswordSigninPageStyleFactory implements ThemeStyleFactory<LoginPass
 
     return LoginPasswordSigninPageStyles(
       primary: LoginPasswordSigninPageStyle(
-        refInput: config?.refTextField?.toStyle(colors: colors, theme: themeData, base: baseTextFieldStyle),
-        passwordInput: config?.passwordTextField?.toStyle(colors: colors, theme: themeData, base: baseTextFieldStyle),
+        refInput: config?.refTextField?.toStyle(
+          colors: colors,
+          defaultFontFamily: defaultFontFamily,
+          theme: themeData,
+          base: baseTextFieldStyle,
+        ),
+        passwordInput: config?.passwordTextField?.toStyle(
+          colors: colors,
+          defaultFontFamily: defaultFontFamily,
+          theme: themeData,
+          base: baseTextFieldStyle,
+        ),
       ),
     );
   }

--- a/lib/theme/factory/styles/login_switch_screen_style_factory.dart
+++ b/lib/theme/factory/styles/login_switch_screen_style_factory.dart
@@ -7,10 +7,11 @@ import '../theme_style_factory.dart';
 import 'theme_image_style.dart';
 
 class LoginSwitchScreenStyleFactory implements ThemeStyleFactory<LoginSwitchScreenStyles> {
-  LoginSwitchScreenStyleFactory(this.config, this.colors);
+  LoginSwitchScreenStyleFactory(this.config, this.colors, this.defaultFontFamily);
 
   final LoginSwitchPageConfig? config;
   final ColorScheme colors;
+  final String? defaultFontFamily;
 
   @override
   LoginSwitchScreenStyles create() {
@@ -21,7 +22,7 @@ class LoginSwitchScreenStyleFactory implements ThemeStyleFactory<LoginSwitchScre
         contentThemeOverride: config?.themeOverride.mode.toThemeMode(),
         applyToAppBar: config?.themeOverride.applyToAppBar,
         pictureLogoStyle: pictureLogoStyle,
-        segmentButtonStyle: config?.segmentButtonStyle?.toButtonStyle(),
+        segmentButtonStyle: config?.segmentButtonStyle?.toButtonStyle(defaultFontFamily: defaultFontFamily),
       ),
     );
   }

--- a/lib/theme/factory/styles/settings_screen_style_factory.dart
+++ b/lib/theme/factory/styles/settings_screen_style_factory.dart
@@ -10,19 +10,24 @@ import '../theme_style_factory.dart';
 import 'group_title_list_styles.dart';
 
 class SettingsScreenStyleFactory implements ThemeStyleFactory<SettingsScreenStyles> {
-  SettingsScreenStyleFactory(this.colors, this.config);
+  SettingsScreenStyleFactory(this.colors, this.config, this.defaultFontFamily);
 
   final ColorScheme colors;
   final SettingsPageConfig? config;
+  final String? defaultFontFamily;
 
   @override
   SettingsScreenStyles create() {
     final leadingIconsColor = config?.leadingIconsColor?.toColor();
     final logoutIconColor = config?.logoutIconColor?.toColor();
     final userIconColor = config?.userIconColor?.toColor();
-    final itemTextStyle = config?.itemTextStyle?.toTextStyle();
+    final itemTextStyle = config?.itemTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
     final backgroundStyle = config?.background?.toStyle();
-    final groupTitleListStyle = GroupTitleListStyleFactory(colors, config?.groupTitleListTile).create().primary;
+    final groupTitleListStyle = GroupTitleListStyleFactory(
+      colors,
+      config?.groupTitleListTile,
+      defaultFontFamily,
+    ).create().primary;
 
     // Resolve theme override values safely
     final contentThemeOverride = config?.themeOverride.mode.toThemeMode();

--- a/lib/theme/factory/theme_data/app_bar_theme_data_factory.dart
+++ b/lib/theme/factory/theme_data/app_bar_theme_data_factory.dart
@@ -5,9 +5,10 @@ import 'package:webtrit_phone/theme/theme.dart';
 import '../theme_style_factory.dart';
 
 class AppBarThemeDataFactory implements ThemeStyleFactory<AppBarTheme> {
-  const AppBarThemeDataFactory(this.config);
+  const AppBarThemeDataFactory(this.config, this.defaultFontFamily);
 
   final AppBarConfig config;
+  final String? defaultFontFamily;
 
   @override
   AppBarTheme create() {
@@ -24,8 +25,8 @@ class AppBarThemeDataFactory implements ThemeStyleFactory<AppBarTheme> {
       centerTitle: config.centerTitle,
       iconTheme: config.iconTheme?.toIconThemeData(),
       actionsIconTheme: config.actionsIconTheme?.toIconThemeData(),
-      titleTextStyle: config.titleTextStyle?.toTextStyle(),
-      toolbarTextStyle: config.toolbarTextStyle?.toTextStyle(),
+      titleTextStyle: config.titleTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+      toolbarTextStyle: config.toolbarTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
       systemOverlayStyle: config.systemOverlayStyle?.toSystemUiOverlayStyle(),
     );
   }

--- a/lib/theme/factory/theme_data/tab_bar_theme_data_factory.dart
+++ b/lib/theme/factory/theme_data/tab_bar_theme_data_factory.dart
@@ -5,10 +5,11 @@ import 'package:webtrit_phone/theme/theme.dart';
 import '../theme_style_factory.dart';
 
 class TabBarThemeDataFactory implements ThemeStyleFactory<TabBarThemeData> {
-  const TabBarThemeDataFactory(this.colors, this.config);
+  const TabBarThemeDataFactory(this.colors, this.config, this.defaultFontFamily);
 
   final ColorScheme colors;
   final TabBarConfig config;
+  final String? defaultFontFamily;
 
   @override
   TabBarThemeData create() {
@@ -25,8 +26,8 @@ class TabBarThemeDataFactory implements ThemeStyleFactory<TabBarThemeData> {
       indicator: _createIndicator(config),
       dividerHeight: config.dividerHeight,
       labelPadding: config.labelPadding?.toEdgeInsets(),
-      labelStyle: config.labelStyle?.toTextStyle(),
-      unselectedLabelStyle: config.unselectedLabelStyle?.toTextStyle(),
+      labelStyle: config.labelStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+      unselectedLabelStyle: config.unselectedLabelStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
       indicatorSize: config.indicatorSize?.toTabBarIndicatorSize,
       tabAlignment: config.tabAlignment?.toTabAlignment,
       indicatorAnimation: config.indicatorAnimation?.toTabIndicatorAnimation,

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+
+import 'package:logging/logging.dart';
+
 import 'package:webtrit_phone/theme/factory/styles/conversations_screen_style_factory.dart';
 import 'package:webtrit_phone/theme/factory/styles/embedded_screen_style_factory.dart';
 import 'package:webtrit_phone/theme/factory/styles/favorites_screen_style_factory.dart';
@@ -9,21 +12,39 @@ import '../models/models.dart';
 
 import 'theme_data/theme_data.dart';
 
-// TODO(Serdun): Decompose correctly common widget styles configurations from t;he page styles configurations
+final _logger = Logger('ThemeStyleFactoryProvider');
+
+// TODO(Serdun): Decompose correctly common widget styles configurations from the page styles configurations
 class ThemeStyleFactoryProvider {
   ThemeStyleFactoryProvider({
     required this.colorScheme,
     required this.widgetConfig,
     required this.pageConfig,
     required this.seedThemeData,
-  });
+  }) {
+    defaultTextTheme = TextThemeDataFactory(colorScheme, widgetConfig.fonts, seedThemeData).create();
+  }
 
+  /// The color scheme used as a basis for all themed components.
   final ColorScheme colorScheme;
+
+  /// Configuration for common widget styles across the application.
   final ThemeWidgetConfig widgetConfig;
+
+  /// Configuration for page-specific styles.
   final ThemePageConfig pageConfig;
+
+  /// The seed theme data used to inherit base styles.
   final ThemeData seedThemeData;
 
+  /// The default text theme derived from the color scheme and widget configuration.
+  late final TextTheme defaultTextTheme;
+
   List<ThemeExtension> createThemeExtensions() {
+    final defaultFontFamily = defaultTextTheme.bodyMedium?.fontFamily;
+
+    _logger.info('Default font family: $defaultFontFamily');
+
     // Page schema
     final loginPageScheme = pageConfig.login;
     final callPageScheme = pageConfig.dialing;
@@ -55,7 +76,7 @@ class ThemeStyleFactoryProvider {
     final confirmDialogStylesProvider = ConfirmDialogStyleFactory(colorScheme, textButtonStyle, confirmDialog);
     final inputDecorationStyleFactory = InputDecorationStyleFactory(colorScheme);
     final callStatusStyleFactory = CallStatusStyleFactory(colorScheme, callStatuses);
-    final elevatedButtonStyleFactory = ElevatedButtonStyleFactory(colorScheme, elevatedButton);
+    final elevatedButtonStyleFactory = ElevatedButtonStyleFactory(colorScheme, elevatedButton, defaultFontFamily);
     final textButtonStyleFactory = TextButtonStyleFactory(colorScheme);
     // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
     // ignore: deprecated_member_use_from_same_package
@@ -64,24 +85,31 @@ class ThemeStyleFactoryProvider {
     final outlinedButtonStyleFactory = OutlinedButtonStyleFactory(colorScheme);
     final registrationStatusStyleFactory = RegisteredStatusStyleFactory(colorScheme, registrationStatuses);
     final snackBarStyleFactory = SnackBarStyleFactory(colorScheme, snackBar);
-    final groupTitleListStyleFactory = GroupTitleListStyleFactory(colorScheme, groupTitleListTile);
+    final groupTitleListStyleFactory = GroupTitleListStyleFactory(colorScheme, groupTitleListTile, defaultFontFamily);
     final gradientsStyleFactory = GradientsStyleFactory(primaryGradientColorsConfig);
 
     final loginModeSelectStyleFactory = LoginModeSelectScreenStyleFactory(loginPageScheme.modeSelect, colorScheme);
     final leadingAvatarStyleFactory = LeadingAvatarStyleFactory(
       colorScheme,
       widgetConfig.imageAssets.leadingAvatarStyle,
+      defaultFontFamily,
     );
-    final keypadStyleFactory = KeypadStyleFactory(colorScheme, config: null, textTheme: createTextTheme());
+    final keypadStyleFactory = KeypadStyleFactory(
+      colorScheme,
+      defaultFontFamily,
+      config: null,
+      textTheme: defaultTextTheme,
+    );
     final embeddedRequestErrorDialogFactory = EmbeddedRequestErrorDialogFactory(imageAssetsConfig);
 
     // Screen-specific styles
     final aboutScreenStyleFactory = AboutScreenStyleFactory(pageConfig.about);
-    final callScreenStyleFactory = CallScreenStyleFactory(colorScheme, callPageScheme, callActions);
+    final callScreenStyleFactory = CallScreenStyleFactory(colorScheme, callPageScheme, callActions, defaultFontFamily);
     final keypadScreenStyleFactory = KeypadScreenStyleFactory(
       colorScheme,
+      defaultFontFamily,
       config: pageConfig.keypad,
-      textTheme: createTextTheme(),
+      textTheme: defaultTextTheme,
     );
     final loginOtpSigninVerifyScreenStyleFactory = LoginOtpSigninVerifyScreenStyleFactory(
       colorScheme,
@@ -91,18 +119,24 @@ class ThemeStyleFactoryProvider {
       colorScheme,
       loginPageScheme.signupVerify,
     );
-    final loginSwitchScreenStyleFactory = LoginSwitchScreenStyleFactory(loginPageScheme.switchPage, colorScheme);
+    final loginSwitchScreenStyleFactory = LoginSwitchScreenStyleFactory(
+      loginPageScheme.switchPage,
+      colorScheme,
+      defaultFontFamily,
+    );
     final loginOtpSigninPageStyleFactory = LoginOtpSigninPageStyleFactory(
       colorScheme,
+      defaultFontFamily,
       config: loginPageScheme.otpSignin,
-      textTheme: createTextTheme(),
+      textTheme: defaultTextTheme,
     );
     final loginPasswordSigninPageStyleFactory = LoginPasswordSigninPageStyleFactory(
       colorScheme,
+      defaultFontFamily,
       config: loginPageScheme.passwordSignin,
-      textTheme: createTextTheme(),
+      textTheme: defaultTextTheme,
     );
-    final settingsScreenStyleFactory = SettingsScreenStyleFactory(colorScheme, pageConfig.settings);
+    final settingsScreenStyleFactory = SettingsScreenStyleFactory(colorScheme, pageConfig.settings, defaultFontFamily);
     final contactsScreenStyleFactory = ContactsScreenStyleFactory(colorScheme, pageConfig.contacts);
     final recentsScreenStyleFactory = RecentsScreenStyleFactory(colorScheme, pageConfig.recents);
     final favoritesScreenStyleFactory = FavoritesScreenStyleFactory(colorScheme, pageConfig.favorites);
@@ -174,11 +208,15 @@ class ThemeStyleFactoryProvider {
   }
 
   TabBarThemeData createTabBarTheme() {
-    return TabBarThemeDataFactory(colorScheme, widgetConfig.bar.tabBarConfig).create();
+    return TabBarThemeDataFactory(
+      colorScheme,
+      widgetConfig.bar.tabBarConfig,
+      defaultTextTheme.bodyMedium?.fontFamily,
+    ).create();
   }
 
   AppBarTheme createAppBarTheme() {
-    return AppBarThemeDataFactory(widgetConfig.bar.appBarConfig).create();
+    return AppBarThemeDataFactory(widgetConfig.bar.appBarConfig, defaultTextTheme.bodyMedium?.fontFamily).create();
   }
 
   InputDecorationTheme createInputDecorationTheme() {
@@ -187,10 +225,6 @@ class ThemeStyleFactoryProvider {
 
   TextSelectionThemeData createTextSelectionThemeData() {
     return TextSelectionThemeDataFactory(colorScheme, widgetConfig.text.selection).create();
-  }
-
-  TextTheme createTextTheme() {
-    return TextThemeDataFactory(colorScheme, widgetConfig.fonts, seedThemeData).create();
   }
 
   ProgressIndicatorThemeData createProgressIndicatorThemeData() {

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -43,7 +43,7 @@ class ThemeStyleFactoryProvider {
   List<ThemeExtension> createThemeExtensions() {
     final defaultFontFamily = defaultTextTheme.bodyMedium?.fontFamily;
 
-    _logger.info('Default font family: $defaultFontFamily');
+    _logger.finer('Default font family: $defaultFontFamily');
 
     // Page schema
     final loginPageScheme = pageConfig.login;

--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -105,7 +105,7 @@ class ThemeProvider extends InheritedWidget {
       seedThemeData: seedThemeData,
     );
 
-    return ThemeData.from(colorScheme: colorScheme, textTheme: style.createTextTheme(), useMaterial3: true).copyWith(
+    return ThemeData.from(colorScheme: colorScheme, textTheme: style.defaultTextTheme, useMaterial3: true).copyWith(
       primaryColorLight: colorScheme.secondaryContainer,
       primaryColorDark: colorScheme.onSecondaryContainer,
       scaffoldBackgroundColor: colorScheme.surfaceBright,


### PR DESCRIPTION
This PR propagates a `defaultFontFamily` derived from the app’s base `TextTheme` through theme factories and config-to-style conversion extensions to ensure consistent font rendering across custom component styles.

**Changes:**
- Introduces a cached `defaultTextTheme` in `ThemeStyleFactoryProvider` and uses it when building `ThemeData`.
- Extends multiple style factories and config-to-style extension methods to accept/apply `defaultFontFamily`.
- Updates `AppBarTheme`/`TabBarTheme` factories and button/text-field related conversions to pass the default font family through.