### PR TITLE
refactor: re-engineer actionpad styling to semantic roles

### DIFF
--- a/lib/features/keypad/widgets/actionpad.dart
+++ b/lib/features/keypad/widgets/actionpad.dart
@@ -57,10 +57,10 @@ class Actionpad extends StatelessWidget {
           Visibility(
             visible: onInitiatedTransferPressed == null,
             child: Transform.scale(
-              scale: .75,
+              scale: localStyle?.secondary?.scale ?? 1.0,
               child: TextButton(
                 onPressed: actionsEnabled ? () {} : null,
-                style: localStyle?.callStart,
+                style: localStyle?.secondary?.style,
                 child: PopupMenuButton(
                   enabled: actionsEnabled,
                   child: Icon(Icons.more_vert, size: iconSize),
@@ -86,34 +86,43 @@ class Actionpad extends StatelessWidget {
           Visibility(
             visible: onInitiatedTransferPressed == null && onVideoCallPressed != null,
             child: Transform.scale(
-              scale: .75,
+              scale: localStyle?.secondary?.scale ?? 1.0,
               child: TextButton(
                 key: actionPadVideoCallKey,
                 onPressed: actionsEnabled ? onVideoCallPressed : null,
-                style: localStyle?.callStart,
+                style: localStyle?.secondary?.style,
                 child: Icon(Icons.videocam, size: iconSize),
               ),
             ),
           ),
         if (onInitiatedTransferPressed != null)
-          TextButton(
-            onPressed: actionsEnabled ? onInitiatedTransferPressed : null,
-            style: localStyle?.callTransfer,
-            child: Icon(Icons.phone_forwarded, size: iconSize),
+          Transform.scale(
+            scale: localStyle?.primary?.scale ?? 1.0,
+            child: TextButton(
+              onPressed: actionsEnabled ? onInitiatedTransferPressed : null,
+              style: localStyle?.primary?.style,
+              child: Icon(Icons.phone_forwarded, size: iconSize),
+            ),
           )
         else
-          TextButton(
-            key: actionPadStartKey,
-            onPressed: actionsEnabled ? onAudioCallPressed : null,
-            style: localStyle?.callStart,
-            child: Icon(Icons.call, size: iconSize),
+          Transform.scale(
+            scale: localStyle?.primary?.scale ?? 1.0,
+            child: TextButton(
+              key: actionPadStartKey,
+              onPressed: actionsEnabled ? onAudioCallPressed : null,
+              style: localStyle?.primary?.style,
+              child: Icon(Icons.call, size: iconSize),
+            ),
           ),
-        TextButton(
-          key: actionPadBackspaceKey,
-          onPressed: actionsEnabled ? onBackspacePressed : null,
-          onLongPress: actionsEnabled ? onBackspaceLongPress : null,
-          style: localStyle?.backspacePressed,
-          child: const Icon(Icons.backspace_outlined),
+        Transform.scale(
+          scale: localStyle?.backspace?.scale ?? 1.0,
+          child: TextButton(
+            key: actionPadBackspaceKey,
+            onPressed: actionsEnabled ? onBackspacePressed : null,
+            onLongPress: actionsEnabled ? onBackspaceLongPress : null,
+            style: localStyle?.backspace?.style,
+            child: const Icon(Icons.backspace_outlined),
+          ),
         ),
       ],
     );

--- a/lib/features/keypad/widgets/actionpad.dart
+++ b/lib/features/keypad/widgets/actionpad.dart
@@ -50,6 +50,7 @@ class Actionpad extends StatelessWidget {
     final optionsAvaliable = onTransferPressed != null || callNumbers.length > 1;
 
     return TextButtonsTable(
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
       minimumSize: Size.square(minimumDimension),
       children: [
         if (optionsAvaliable)

--- a/lib/features/keypad/widgets/actionpad_style.dart
+++ b/lib/features/keypad/widgets/actionpad_style.dart
@@ -2,41 +2,41 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class ActionpadStyle with Diagnosticable {
-  const ActionpadStyle({this.callTransfer, this.callStart, this.backspacePressed});
+  const ActionpadStyle({this.primary, this.secondary, this.backspace});
 
-  final ButtonStyle? callTransfer;
-  final ButtonStyle? callStart;
-  final ButtonStyle? backspacePressed;
+  /// The main action button style (usually center: Audio Call, Transfer Confirm).
+  final ScaleButtonStyle? primary;
 
-  ActionpadStyle copyWith({ButtonStyle? callTransfer, ButtonStyle? callStart, ButtonStyle? backspacePressed}) {
+  /// The secondary action button style (usually left: Video Call, Options Menu).
+  final ScaleButtonStyle? secondary;
+
+  /// The backspace button style (usually right).
+  final ScaleButtonStyle? backspace;
+
+  ActionpadStyle copyWith({ScaleButtonStyle? primary, ScaleButtonStyle? secondary, ScaleButtonStyle? backspace}) {
     return ActionpadStyle(
-      callTransfer: callTransfer ?? this.callTransfer,
-      callStart: callStart ?? this.callStart,
-      backspacePressed: backspacePressed ?? this.backspacePressed,
+      primary: primary ?? this.primary,
+      secondary: secondary ?? this.secondary,
+      backspace: backspace ?? this.backspace,
     );
   }
 
   static ActionpadStyle merge(ActionpadStyle? a, ActionpadStyle? b) {
     if (a == null) return b ?? const ActionpadStyle();
     if (b == null) return a;
-    return ActionpadStyle(
-      callTransfer: _mergeButtonStyles(a.callTransfer, b.callTransfer),
-      callStart: _mergeButtonStyles(a.callStart, b.callStart),
-      backspacePressed: _mergeButtonStyles(a.backspacePressed, b.backspacePressed),
-    );
-  }
 
-  static ButtonStyle? _mergeButtonStyles(ButtonStyle? a, ButtonStyle? b) {
-    if (a == null) return b;
-    if (b == null) return a;
-    return a.merge(b);
+    return ActionpadStyle(
+      primary: ScaleButtonStyle.merge(a.primary, b.primary),
+      secondary: ScaleButtonStyle.merge(a.secondary, b.secondary),
+      backspace: ScaleButtonStyle.merge(a.backspace, b.backspace),
+    );
   }
 
   static ActionpadStyle lerp(ActionpadStyle? a, ActionpadStyle? b, double t) {
     return ActionpadStyle(
-      callTransfer: ButtonStyle.lerp(a?.callTransfer, b?.callTransfer, t),
-      callStart: ButtonStyle.lerp(a?.callStart, b?.callStart, t),
-      backspacePressed: ButtonStyle.lerp(a?.backspacePressed, b?.backspacePressed, t),
+      primary: ScaleButtonStyle.lerp(a?.primary, b?.primary, t),
+      secondary: ScaleButtonStyle.lerp(a?.secondary, b?.secondary, t),
+      backspace: ScaleButtonStyle.lerp(a?.backspace, b?.backspace, t),
     );
   }
 
@@ -44,8 +44,40 @@ class ActionpadStyle with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties
-      ..add(DiagnosticsProperty<ButtonStyle?>('callTransfer', callTransfer))
-      ..add(DiagnosticsProperty<ButtonStyle?>('callStart', callStart))
-      ..add(DiagnosticsProperty<ButtonStyle?>('backspacePressed', backspacePressed));
+      ..add(DiagnosticsProperty<ScaleButtonStyle?>('primary', primary))
+      ..add(DiagnosticsProperty<ScaleButtonStyle?>('secondary', secondary))
+      ..add(DiagnosticsProperty<ScaleButtonStyle?>('backspace', backspace));
+  }
+}
+
+class ScaleButtonStyle with Diagnosticable {
+  const ScaleButtonStyle({this.style, this.scale = 1.0});
+
+  final ButtonStyle? style;
+  final double scale;
+
+  /// Merges two ScaleButtonStyle objects.
+  /// The [style] is merged using ButtonStyle.merge.
+  /// The [scale] from [b] takes precedence over [a] if [b] is not null.
+  static ScaleButtonStyle? merge(ScaleButtonStyle? a, ScaleButtonStyle? b) {
+    if (a == null) return b;
+    if (b == null) return a;
+    return ScaleButtonStyle(style: a.style?.merge(b.style) ?? b.style, scale: b.scale);
+  }
+
+  static ScaleButtonStyle? lerp(ScaleButtonStyle? a, ScaleButtonStyle? b, double t) {
+    if (a == null && b == null) return null;
+    return ScaleButtonStyle(
+      style: ButtonStyle.lerp(a?.style, b?.style, t),
+      scale: Tween<double>(begin: a?.scale ?? 1.0, end: b?.scale ?? 1.0).transform(t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty<ButtonStyle?>('style', style))
+      ..add(DoubleProperty('scale', scale));
   }
 }

--- a/lib/theme/factory/styles/action_pad_style_factory.dart
+++ b/lib/theme/factory/styles/action_pad_style_factory.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 
+import 'package:logging/logging.dart';
+
+import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 
 import '../theme_style_factory.dart';
+
+final _logger = Logger('ActionPadStyleFactory');
 
 class ActionPadStyleFactory implements ThemeStyleFactory<ActionpadStyles> {
   ActionPadStyleFactory(this.colors, this.config, this.defaultFontFamily);
@@ -17,30 +22,22 @@ class ActionPadStyleFactory implements ThemeStyleFactory<ActionpadStyles> {
     const defaultScale = 0.75;
     const callStartScale = 1.0;
 
+    _logger.finePretty('Creating ActionPadStyles, config = $config, defaultFontFamily = $defaultFontFamily');
+
     final filledStyle = TextButton.styleFrom(
       padding: EdgeInsets.zero,
       foregroundColor: colors.onSecondary,
       backgroundColor: colors.secondary,
-      iconColor: colors.surface,
       disabledForegroundColor: colors.onSurface.withValues(alpha: 0.38),
       disabledIconColor: colors.onSurface.withValues(alpha: 0.38),
       disabledBackgroundColor: colors.onSurface.withValues(alpha: 0.12),
-    );
-
-    final backspaceStyle = TextButton.styleFrom(
-      padding: EdgeInsets.zero,
-      foregroundColor: colors.onSurface,
-      backgroundColor: Colors.transparent,
-      iconColor: colors.surface,
-      disabledForegroundColor: colors.onSurface.withValues(alpha: 0.38),
-      disabledIconColor: colors.onSurface.withValues(alpha: 0.38),
     );
 
     return ActionpadStyles(
       primary: ActionpadStyle(
         primary: _resolveStyle(source: config?.callStart, fallback: filledStyle, scale: callStartScale),
         secondary: _resolveStyle(source: config?.callTransfer, fallback: filledStyle, scale: defaultScale),
-        backspace: _resolveStyle(source: config?.backspacePressed, fallback: backspaceStyle, scale: defaultScale),
+        backspace: _resolveStyle(source: config?.backspacePressed, fallback: filledStyle, scale: defaultScale),
       ),
     );
   }
@@ -51,7 +48,27 @@ class ActionPadStyleFactory implements ThemeStyleFactory<ActionpadStyles> {
     ButtonStyleConfig? source,
     bool checkTransparency = true,
   }) {
-    final style = source?.toButtonStyle(defaultFontFamily: defaultFontFamily).merge(fallback) ?? fallback;
+    final sourceStyle = source?.toButtonStyle(defaultFontFamily: defaultFontFamily);
+
+    // If no config provided, strictly use fallback
+    if (sourceStyle == null) {
+      final backgroundColor = fallback.backgroundColor?.resolve({});
+      final isTransparent = checkTransparency && (backgroundColor == null || backgroundColor.a == 0);
+      return ScaleButtonStyle(style: fallback, scale: isTransparent ? 1 : scale);
+    }
+
+    // Force override properties using copyWith to ensure config values take precedence
+    final style = fallback.copyWith(
+      backgroundColor: sourceStyle.backgroundColor,
+      foregroundColor: sourceStyle.foregroundColor,
+      iconColor: sourceStyle.iconColor,
+      overlayColor: sourceStyle.overlayColor,
+      shadowColor: sourceStyle.shadowColor,
+      elevation: sourceStyle.elevation,
+      side: sourceStyle.side,
+      shape: sourceStyle.shape,
+      textStyle: sourceStyle.textStyle,
+    );
 
     final backgroundColor = style.backgroundColor?.resolve({});
     final isTransparent = checkTransparency && (backgroundColor == null || backgroundColor.a == 0);

--- a/lib/theme/factory/styles/action_pad_style_factory.dart
+++ b/lib/theme/factory/styles/action_pad_style_factory.dart
@@ -6,66 +6,56 @@ import 'package:webtrit_phone/theme/theme.dart';
 import '../theme_style_factory.dart';
 
 class ActionPadStyleFactory implements ThemeStyleFactory<ActionpadStyles> {
-  ActionPadStyleFactory(this.colors, this.config);
+  ActionPadStyleFactory(this.colors, this.config, this.defaultFontFamily);
 
   final ColorScheme colors;
   final ActionPadWidgetConfig? config;
+  final String? defaultFontFamily;
 
   @override
   ActionpadStyles create() {
-    const disabledColorOpacity = 0.4;
+    const defaultScale = 0.75;
+    const callStartScale = 1.0;
 
-    final defaultCallDisabledIconColor = colors.surface.withValues(alpha: disabledColorOpacity);
-
-    final callStartForegroundColor = config?.callStart.foregroundColor?.toColor() ?? colors.onTertiary;
-    final callStartBackgroundColor = config?.callStart.backgroundColor?.toColor() ?? colors.tertiary;
-    final callStartIconColor = config?.callStart.iconColor?.toColor() ?? colors.surface;
-    final callStartDisabledIconColor = config?.callStart.disabledIconColor?.toColor() ?? defaultCallDisabledIconColor;
-
-    final callTransferForegroundColor = config?.callTransfer.foregroundColor?.toColor() ?? colors.onSecondary;
-    final callTransferBackgroundColor = config?.callTransfer.backgroundColor?.toColor() ?? colors.secondary;
-    final callTransferIconColor = config?.callTransfer.iconColor?.toColor() ?? colors.surface;
-    final callTransferDisabledIconColor =
-        config?.callTransfer.disabledIconColor?.toColor() ?? defaultCallDisabledIconColor;
-
-    final backspacePressedStyleForegroundColor =
-        config?.backspacePressed.foregroundColor?.toColor() ?? colors.onSecondary;
-    final backspacePressedStyleBackgroundColor = config?.backspacePressed.backgroundColor?.toColor();
-    final backspacePressedStyleIconColor = config?.backspacePressed.iconColor?.toColor() ?? colors.onSurface;
-    final backspacePressedStyleDisabledIconColor =
-        config?.backspacePressed.disabledIconColor?.toColor() ?? colors.surface;
-
-    final callStartStyle = TextButton.styleFrom(
-      foregroundColor: callStartForegroundColor,
-      backgroundColor: callStartBackgroundColor,
-      disabledForegroundColor: colors.onTertiary.withValues(alpha: disabledColorOpacity),
-      iconColor: callStartIconColor,
-      disabledIconColor: callStartDisabledIconColor,
+    final filledStyle = TextButton.styleFrom(
       padding: EdgeInsets.zero,
+      foregroundColor: colors.onSecondary,
+      backgroundColor: colors.secondary,
+      iconColor: colors.surface,
+      disabledForegroundColor: colors.onSurface.withValues(alpha: 0.38),
+      disabledIconColor: colors.onSurface.withValues(alpha: 0.38),
+      disabledBackgroundColor: colors.onSurface.withValues(alpha: 0.12),
     );
 
-    final callTransferStyle = TextButton.styleFrom(
-      foregroundColor: callTransferForegroundColor,
-      backgroundColor: callTransferBackgroundColor,
-      disabledForegroundColor: colors.secondary.withValues(alpha: disabledColorOpacity),
-      iconColor: callTransferIconColor,
-      disabledIconColor: callTransferDisabledIconColor,
+    final backspaceStyle = TextButton.styleFrom(
       padding: EdgeInsets.zero,
-    );
-
-    final backspacePressedStyle = TextButton.styleFrom(
-      foregroundColor: backspacePressedStyleForegroundColor,
-      backgroundColor: backspacePressedStyleBackgroundColor,
-      iconColor: backspacePressedStyleIconColor,
-      disabledIconColor: backspacePressedStyleDisabledIconColor,
+      foregroundColor: colors.onSurface,
+      backgroundColor: Colors.transparent,
+      iconColor: colors.surface,
+      disabledForegroundColor: colors.onSurface.withValues(alpha: 0.38),
+      disabledIconColor: colors.onSurface.withValues(alpha: 0.38),
     );
 
     return ActionpadStyles(
       primary: ActionpadStyle(
-        callStart: callStartStyle,
-        callTransfer: callTransferStyle,
-        backspacePressed: backspacePressedStyle,
+        primary: _resolveStyle(source: config?.callStart, fallback: filledStyle, scale: callStartScale),
+        secondary: _resolveStyle(source: config?.callTransfer, fallback: filledStyle, scale: defaultScale),
+        backspace: _resolveStyle(source: config?.backspacePressed, fallback: backspaceStyle, scale: defaultScale),
       ),
     );
+  }
+
+  ScaleButtonStyle _resolveStyle({
+    required ButtonStyle fallback,
+    required double scale,
+    ButtonStyleConfig? source,
+    bool checkTransparency = true,
+  }) {
+    final style = source?.toButtonStyle(defaultFontFamily: defaultFontFamily).merge(fallback) ?? fallback;
+
+    final backgroundColor = style.backgroundColor?.resolve({});
+    final isTransparent = checkTransparency && (backgroundColor == null || backgroundColor.a == 0);
+
+    return ScaleButtonStyle(style: style, scale: isTransparent ? 1 : scale);
   }
 }

--- a/lib/theme/factory/styles/keypad_screen_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_screen_style_factory.dart
@@ -42,7 +42,7 @@ class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> 
           config: config.keypad,
           textTheme: textTheme,
         ).create().primary,
-        actionpadStyle: ActionPadStyleFactory(colors, config.actionpad).create().primary,
+        actionpadStyle: ActionPadStyleFactory(colors, config.actionpad, defaultFontFamily).create().primary,
       ),
     );
   }

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -57,7 +57,6 @@ class ThemeStyleFactoryProvider {
     final primaryGradientColorsConfig = widgetConfig.decorationConfig.primaryGradientColorsConfig;
     final confirmDialog = widgetConfig.dialog.confirmDialog;
     final snackBar = widgetConfig.dialog.snackBar;
-    final actionPad = widgetConfig.actionPad;
     final callStatuses = widgetConfig.statuses.callStatuses;
     final registrationStatuses = widgetConfig.statuses.registrationStatuses;
     final elevatedButton = widgetConfig.button.primaryElevatedButton;
@@ -71,7 +70,6 @@ class ThemeStyleFactoryProvider {
     final textButtonStyle = TextButtonStyleFactory(colorScheme).create();
 
     // Specific widget styles
-    final actionPadStyleFactory = ActionPadStyleFactory(colorScheme, actionPad);
     final appIconStylesProvider = AppIconStyleFactory(colorScheme, appIconConfig);
     final confirmDialogStylesProvider = ConfirmDialogStyleFactory(colorScheme, textButtonStyle, confirmDialog);
     final inputDecorationStyleFactory = InputDecorationStyleFactory(colorScheme);
@@ -147,7 +145,6 @@ class ThemeStyleFactoryProvider {
       textButtonStyle,
       appIconStylesProvider.create(),
       confirmDialogStylesProvider.create(),
-      actionPadStyleFactory.create(),
       inputDecorationStyleFactory.create(),
       callStatusStyleFactory.create(),
       elevatedButtonStyleFactory.create(),

--- a/lib/widgets/text_buttons_table.dart
+++ b/lib/widgets/text_buttons_table.dart
@@ -13,15 +13,24 @@ class TextButtonsTable extends StatelessWidget {
     this.keyButtonsInTableRowCount = 3,
     this.style,
     required this.children,
+    this.defaultVerticalAlignment = TableCellVerticalAlignment.top,
   }) : assert(children.length % keyButtonsInTableRowCount == 0);
 
+  /// The list of widgets to display as buttons in the table.
   final List<Widget> children;
 
+  /// The minimum size of the buttons in the table.
+  /// This parameter is deprecated, use [style.minimumSize] instead.
   @Deprecated('Use style.minimumSize instead')
   final Size? minimumSize;
 
+  /// The number of buttons to display in each row of the table.
   final int keyButtonsInTableRowCount;
 
+  /// The default vertical alignment of the table cells.
+  final TableCellVerticalAlignment defaultVerticalAlignment;
+
+  /// The style to apply to the text buttons table.
   final TextButtonsTableStyle? style;
 
   @override
@@ -53,7 +62,7 @@ class TextButtonsTable extends StatelessWidget {
           minimumSize: minimumSize ?? merged.minimumSize,
         ).merge(merged.buttonStyle).merge(textButtonThemeData.style),
       ),
-      child: Table(children: tableRows),
+      child: Table(children: tableRows, defaultVerticalAlignment: defaultVerticalAlignment),
     );
   }
 }

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -415,6 +415,29 @@ class KeypadPageConfig with _$KeypadPageConfig implements BasePageConfig {
 
 @freezed
 @JsonSerializable(explicitToJson: true)
+class ActionPadWidgetConfig with _$ActionPadWidgetConfig {
+  const ActionPadWidgetConfig({
+    this.callStart = const ButtonStyleConfig(),
+    this.callTransfer = const ButtonStyleConfig(),
+    this.backspacePressed = const ButtonStyleConfig(),
+  });
+
+  @override
+  final ButtonStyleConfig callStart;
+
+  @override
+  final ButtonStyleConfig callTransfer;
+
+  @override
+  final ButtonStyleConfig backspacePressed;
+
+  factory ActionPadWidgetConfig.fromJson(Map<String, Object?> json) => _$ActionPadWidgetConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$ActionPadWidgetConfigToJson(this);
+}
+
+@freezed
+@JsonSerializable(explicitToJson: true)
 class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
   const SettingsPageConfig({
     this.themeOverride = const ThemeOverrideConfig(),

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -2664,6 +2664,194 @@ case _:
 
 
 /// @nodoc
+mixin _$ActionPadWidgetConfig {
+
+ ButtonStyleConfig get callStart; ButtonStyleConfig get callTransfer; ButtonStyleConfig get backspacePressed;
+/// Create a copy of ActionPadWidgetConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ActionPadWidgetConfigCopyWith<ActionPadWidgetConfig> get copyWith => _$ActionPadWidgetConfigCopyWithImpl<ActionPadWidgetConfig>(this as ActionPadWidgetConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActionPadWidgetConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.callTransfer, callTransfer) || other.callTransfer == callTransfer)&&(identical(other.backspacePressed, backspacePressed) || other.backspacePressed == backspacePressed));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,callStart,callTransfer,backspacePressed);
+
+@override
+String toString() {
+  return 'ActionPadWidgetConfig(callStart: $callStart, callTransfer: $callTransfer, backspacePressed: $backspacePressed)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ActionPadWidgetConfigCopyWith<$Res>  {
+  factory $ActionPadWidgetConfigCopyWith(ActionPadWidgetConfig value, $Res Function(ActionPadWidgetConfig) _then) = _$ActionPadWidgetConfigCopyWithImpl;
+@useResult
+$Res call({
+ ButtonStyleConfig callStart, ButtonStyleConfig callTransfer, ButtonStyleConfig backspacePressed
+});
+
+
+
+
+}
+/// @nodoc
+class _$ActionPadWidgetConfigCopyWithImpl<$Res>
+    implements $ActionPadWidgetConfigCopyWith<$Res> {
+  _$ActionPadWidgetConfigCopyWithImpl(this._self, this._then);
+
+  final ActionPadWidgetConfig _self;
+  final $Res Function(ActionPadWidgetConfig) _then;
+
+/// Create a copy of ActionPadWidgetConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? callTransfer = null,Object? backspacePressed = null,}) {
+  return _then(ActionPadWidgetConfig(
+callStart: null == callStart ? _self.callStart : callStart // ignore: cast_nullable_to_non_nullable
+as ButtonStyleConfig,callTransfer: null == callTransfer ? _self.callTransfer : callTransfer // ignore: cast_nullable_to_non_nullable
+as ButtonStyleConfig,backspacePressed: null == backspacePressed ? _self.backspacePressed : backspacePressed // ignore: cast_nullable_to_non_nullable
+as ButtonStyleConfig,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ActionPadWidgetConfig].
+extension ActionPadWidgetConfigPatterns on ActionPadWidgetConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
 mixin _$SettingsPageConfig {
 
  ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle;

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -454,6 +454,32 @@ Map<String, dynamic> _$KeypadPageConfigToJson(KeypadPageConfig instance) =>
       'themeOverride': instance.themeOverride.toJson(),
     };
 
+ActionPadWidgetConfig _$ActionPadWidgetConfigFromJson(
+  Map<String, dynamic> json,
+) => ActionPadWidgetConfig(
+  callStart: json['callStart'] == null
+      ? const ButtonStyleConfig()
+      : ButtonStyleConfig.fromJson(json['callStart'] as Map<String, dynamic>),
+  callTransfer: json['callTransfer'] == null
+      ? const ButtonStyleConfig()
+      : ButtonStyleConfig.fromJson(
+          json['callTransfer'] as Map<String, dynamic>,
+        ),
+  backspacePressed: json['backspacePressed'] == null
+      ? const ButtonStyleConfig()
+      : ButtonStyleConfig.fromJson(
+          json['backspacePressed'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$ActionPadWidgetConfigToJson(
+  ActionPadWidgetConfig instance,
+) => <String, dynamic>{
+  'callStart': instance.callStart.toJson(),
+  'callTransfer': instance.callTransfer.toJson(),
+  'backspacePressed': instance.backspacePressed.toJson(),
+};
+
 SettingsPageConfig _$SettingsPageConfigFromJson(Map<String, dynamic> json) =>
     SettingsPageConfig(
       themeOverride: json['themeOverride'] == null

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
@@ -21,7 +21,6 @@ class ThemeWidgetConfig with _$ThemeWidgetConfig {
     this.input = const InputWidgetConfig(),
     this.text = const TextWidgetConfig(),
     this.dialog = const DialogWidgetConfig(),
-    this.actionPad = const ActionPadWidgetConfig(),
     this.statuses = const StatusesWidgetConfig(),
     this.decorationConfig = const DecorationConfig(),
   });
@@ -49,9 +48,6 @@ class ThemeWidgetConfig with _$ThemeWidgetConfig {
 
   @override
   final DialogWidgetConfig dialog;
-
-  @override
-  final ActionPadWidgetConfig actionPad;
 
   @override
   final StatusesWidgetConfig statuses;
@@ -573,29 +569,6 @@ class SnackBarWidgetConfig with _$SnackBarWidgetConfig {
   factory SnackBarWidgetConfig.fromJson(Map<String, Object?> json) => _$SnackBarWidgetConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$SnackBarWidgetConfigToJson(this);
-}
-
-@freezed
-@JsonSerializable(explicitToJson: true)
-class ActionPadWidgetConfig with _$ActionPadWidgetConfig {
-  const ActionPadWidgetConfig({
-    this.callStart = const ElevatedButtonWidgetConfig(),
-    this.callTransfer = const ElevatedButtonWidgetConfig(),
-    this.backspacePressed = const ElevatedButtonWidgetConfig(),
-  });
-
-  @override
-  final ElevatedButtonWidgetConfig callStart;
-
-  @override
-  final ElevatedButtonWidgetConfig callTransfer;
-
-  @override
-  final ElevatedButtonWidgetConfig backspacePressed;
-
-  factory ActionPadWidgetConfig.fromJson(Map<String, Object?> json) => _$ActionPadWidgetConfigFromJson(json);
-
-  Map<String, Object?> toJson() => _$ActionPadWidgetConfigToJson(this);
 }
 
 @freezed

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ThemeWidgetConfig {
 
- FontsConfig get fonts; ButtonWidgetConfig get button; GroupWidgetConfig? get group; BarWidgetConfig get bar; ImageAssetsConfig get imageAssets; InputWidgetConfig get input; TextWidgetConfig get text; DialogWidgetConfig get dialog; ActionPadWidgetConfig get actionPad; StatusesWidgetConfig get statuses; DecorationConfig get decorationConfig;
+ FontsConfig get fonts; ButtonWidgetConfig get button; GroupWidgetConfig? get group; BarWidgetConfig get bar; ImageAssetsConfig get imageAssets; InputWidgetConfig get input; TextWidgetConfig get text; DialogWidgetConfig get dialog; StatusesWidgetConfig get statuses; DecorationConfig get decorationConfig;
 /// Create a copy of ThemeWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $ThemeWidgetConfigCopyWith<ThemeWidgetConfig> get copyWith => _$ThemeWidgetConfi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ThemeWidgetConfig&&(identical(other.fonts, fonts) || other.fonts == fonts)&&(identical(other.button, button) || other.button == button)&&(identical(other.group, group) || other.group == group)&&(identical(other.bar, bar) || other.bar == bar)&&(identical(other.imageAssets, imageAssets) || other.imageAssets == imageAssets)&&(identical(other.input, input) || other.input == input)&&(identical(other.text, text) || other.text == text)&&(identical(other.dialog, dialog) || other.dialog == dialog)&&(identical(other.actionPad, actionPad) || other.actionPad == actionPad)&&(identical(other.statuses, statuses) || other.statuses == statuses)&&(identical(other.decorationConfig, decorationConfig) || other.decorationConfig == decorationConfig));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ThemeWidgetConfig&&(identical(other.fonts, fonts) || other.fonts == fonts)&&(identical(other.button, button) || other.button == button)&&(identical(other.group, group) || other.group == group)&&(identical(other.bar, bar) || other.bar == bar)&&(identical(other.imageAssets, imageAssets) || other.imageAssets == imageAssets)&&(identical(other.input, input) || other.input == input)&&(identical(other.text, text) || other.text == text)&&(identical(other.dialog, dialog) || other.dialog == dialog)&&(identical(other.statuses, statuses) || other.statuses == statuses)&&(identical(other.decorationConfig, decorationConfig) || other.decorationConfig == decorationConfig));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,fonts,button,group,bar,imageAssets,input,text,dialog,actionPad,statuses,decorationConfig);
+int get hashCode => Object.hash(runtimeType,fonts,button,group,bar,imageAssets,input,text,dialog,statuses,decorationConfig);
 
 @override
 String toString() {
-  return 'ThemeWidgetConfig(fonts: $fonts, button: $button, group: $group, bar: $bar, imageAssets: $imageAssets, input: $input, text: $text, dialog: $dialog, actionPad: $actionPad, statuses: $statuses, decorationConfig: $decorationConfig)';
+  return 'ThemeWidgetConfig(fonts: $fonts, button: $button, group: $group, bar: $bar, imageAssets: $imageAssets, input: $input, text: $text, dialog: $dialog, statuses: $statuses, decorationConfig: $decorationConfig)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $ThemeWidgetConfigCopyWith<$Res>  {
   factory $ThemeWidgetConfigCopyWith(ThemeWidgetConfig value, $Res Function(ThemeWidgetConfig) _then) = _$ThemeWidgetConfigCopyWithImpl;
 @useResult
 $Res call({
- FontsConfig fonts, ButtonWidgetConfig button, GroupWidgetConfig? group, BarWidgetConfig bar, ImageAssetsConfig imageAssets, InputWidgetConfig input, TextWidgetConfig text, DialogWidgetConfig dialog, ActionPadWidgetConfig actionPad, StatusesWidgetConfig statuses, DecorationConfig decorationConfig
+ FontsConfig fonts, ButtonWidgetConfig button, GroupWidgetConfig? group, BarWidgetConfig bar, ImageAssetsConfig imageAssets, InputWidgetConfig input, TextWidgetConfig text, DialogWidgetConfig dialog, StatusesWidgetConfig statuses, DecorationConfig decorationConfig
 });
 
 
@@ -63,7 +63,7 @@ class _$ThemeWidgetConfigCopyWithImpl<$Res>
 
 /// Create a copy of ThemeWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? fonts = null,Object? button = null,Object? group = freezed,Object? bar = null,Object? imageAssets = null,Object? input = null,Object? text = null,Object? dialog = null,Object? actionPad = null,Object? statuses = null,Object? decorationConfig = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? fonts = null,Object? button = null,Object? group = freezed,Object? bar = null,Object? imageAssets = null,Object? input = null,Object? text = null,Object? dialog = null,Object? statuses = null,Object? decorationConfig = null,}) {
   return _then(ThemeWidgetConfig(
 fonts: null == fonts ? _self.fonts : fonts // ignore: cast_nullable_to_non_nullable
 as FontsConfig,button: null == button ? _self.button : button // ignore: cast_nullable_to_non_nullable
@@ -73,8 +73,7 @@ as BarWidgetConfig,imageAssets: null == imageAssets ? _self.imageAssets : imageA
 as ImageAssetsConfig,input: null == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
 as InputWidgetConfig,text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as TextWidgetConfig,dialog: null == dialog ? _self.dialog : dialog // ignore: cast_nullable_to_non_nullable
-as DialogWidgetConfig,actionPad: null == actionPad ? _self.actionPad : actionPad // ignore: cast_nullable_to_non_nullable
-as ActionPadWidgetConfig,statuses: null == statuses ? _self.statuses : statuses // ignore: cast_nullable_to_non_nullable
+as DialogWidgetConfig,statuses: null == statuses ? _self.statuses : statuses // ignore: cast_nullable_to_non_nullable
 as StatusesWidgetConfig,decorationConfig: null == decorationConfig ? _self.decorationConfig : decorationConfig // ignore: cast_nullable_to_non_nullable
 as DecorationConfig,
   ));
@@ -4226,194 +4225,6 @@ as String,
 
 /// Adds pattern-matching-related methods to [SnackBarWidgetConfig].
 extension SnackBarWidgetConfigPatterns on SnackBarWidgetConfig {
-/// A variant of `map` that fallback to returning `orElse`.
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case final Subclass value:
-///     return ...;
-///   case _:
-///     return orElse();
-/// }
-/// ```
-
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
-final _that = this;
-switch (_that) {
-case _:
-  return orElse();
-
-}
-}
-/// A `switch`-like method, using callbacks.
-///
-/// Callbacks receives the raw object, upcasted.
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case final Subclass value:
-///     return ...;
-///   case final Subclass2 value:
-///     return ...;
-/// }
-/// ```
-
-@optionalTypeArgs TResult map<TResult extends Object?>(){
-final _that = this;
-switch (_that) {
-case _:
-  throw StateError('Unexpected subclass');
-
-}
-}
-/// A variant of `map` that fallback to returning `null`.
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case final Subclass value:
-///     return ...;
-///   case _:
-///     return null;
-/// }
-/// ```
-
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
-final _that = this;
-switch (_that) {
-case _:
-  return null;
-
-}
-}
-/// A variant of `when` that fallback to an `orElse` callback.
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case Subclass(:final field):
-///     return ...;
-///   case _:
-///     return orElse();
-/// }
-/// ```
-
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
-switch (_that) {
-case _:
-  return orElse();
-
-}
-}
-/// A `switch`-like method, using callbacks.
-///
-/// As opposed to `map`, this offers destructuring.
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case Subclass(:final field):
-///     return ...;
-///   case Subclass2(:final field2):
-///     return ...;
-/// }
-/// ```
-
-@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
-switch (_that) {
-case _:
-  throw StateError('Unexpected subclass');
-
-}
-}
-/// A variant of `when` that fallback to returning `null`
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case Subclass(:final field):
-///     return ...;
-///   case _:
-///     return null;
-/// }
-/// ```
-
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
-switch (_that) {
-case _:
-  return null;
-
-}
-}
-
-}
-
-
-/// @nodoc
-mixin _$ActionPadWidgetConfig {
-
- ElevatedButtonWidgetConfig get callStart; ElevatedButtonWidgetConfig get callTransfer; ElevatedButtonWidgetConfig get backspacePressed;
-/// Create a copy of ActionPadWidgetConfig
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$ActionPadWidgetConfigCopyWith<ActionPadWidgetConfig> get copyWith => _$ActionPadWidgetConfigCopyWithImpl<ActionPadWidgetConfig>(this as ActionPadWidgetConfig, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActionPadWidgetConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.callTransfer, callTransfer) || other.callTransfer == callTransfer)&&(identical(other.backspacePressed, backspacePressed) || other.backspacePressed == backspacePressed));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,callStart,callTransfer,backspacePressed);
-
-@override
-String toString() {
-  return 'ActionPadWidgetConfig(callStart: $callStart, callTransfer: $callTransfer, backspacePressed: $backspacePressed)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $ActionPadWidgetConfigCopyWith<$Res>  {
-  factory $ActionPadWidgetConfigCopyWith(ActionPadWidgetConfig value, $Res Function(ActionPadWidgetConfig) _then) = _$ActionPadWidgetConfigCopyWithImpl;
-@useResult
-$Res call({
- ElevatedButtonWidgetConfig callStart, ElevatedButtonWidgetConfig callTransfer, ElevatedButtonWidgetConfig backspacePressed
-});
-
-
-
-
-}
-/// @nodoc
-class _$ActionPadWidgetConfigCopyWithImpl<$Res>
-    implements $ActionPadWidgetConfigCopyWith<$Res> {
-  _$ActionPadWidgetConfigCopyWithImpl(this._self, this._then);
-
-  final ActionPadWidgetConfig _self;
-  final $Res Function(ActionPadWidgetConfig) _then;
-
-/// Create a copy of ActionPadWidgetConfig
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? callTransfer = null,Object? backspacePressed = null,}) {
-  return _then(ActionPadWidgetConfig(
-callStart: null == callStart ? _self.callStart : callStart // ignore: cast_nullable_to_non_nullable
-as ElevatedButtonWidgetConfig,callTransfer: null == callTransfer ? _self.callTransfer : callTransfer // ignore: cast_nullable_to_non_nullable
-as ElevatedButtonWidgetConfig,backspacePressed: null == backspacePressed ? _self.backspacePressed : backspacePressed // ignore: cast_nullable_to_non_nullable
-as ElevatedButtonWidgetConfig,
-  ));
-}
-
-}
-
-
-/// Adds pattern-matching-related methods to [ActionPadWidgetConfig].
-extension ActionPadWidgetConfigPatterns on ActionPadWidgetConfig {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
@@ -33,11 +33,6 @@ ThemeWidgetConfig _$ThemeWidgetConfigFromJson(
   dialog: json['dialog'] == null
       ? const DialogWidgetConfig()
       : DialogWidgetConfig.fromJson(json['dialog'] as Map<String, dynamic>),
-  actionPad: json['actionPad'] == null
-      ? const ActionPadWidgetConfig()
-      : ActionPadWidgetConfig.fromJson(
-          json['actionPad'] as Map<String, dynamic>,
-        ),
   statuses: json['statuses'] == null
       ? const StatusesWidgetConfig()
       : StatusesWidgetConfig.fromJson(json['statuses'] as Map<String, dynamic>),
@@ -58,7 +53,6 @@ Map<String, dynamic> _$ThemeWidgetConfigToJson(ThemeWidgetConfig instance) =>
       'input': instance.input.toJson(),
       'text': instance.text.toJson(),
       'dialog': instance.dialog.toJson(),
-      'actionPad': instance.actionPad.toJson(),
       'statuses': instance.statuses.toJson(),
       'decorationConfig': instance.decorationConfig.toJson(),
     };
@@ -461,34 +455,6 @@ Map<String, dynamic> _$SnackBarWidgetConfigToJson(
   'errorBackgroundColor': instance.errorBackgroundColor,
   'infoBackgroundColor': instance.infoBackgroundColor,
   'warningBackgroundColor': instance.warningBackgroundColor,
-};
-
-ActionPadWidgetConfig _$ActionPadWidgetConfigFromJson(
-  Map<String, dynamic> json,
-) => ActionPadWidgetConfig(
-  callStart: json['callStart'] == null
-      ? const ElevatedButtonWidgetConfig()
-      : ElevatedButtonWidgetConfig.fromJson(
-          json['callStart'] as Map<String, dynamic>,
-        ),
-  callTransfer: json['callTransfer'] == null
-      ? const ElevatedButtonWidgetConfig()
-      : ElevatedButtonWidgetConfig.fromJson(
-          json['callTransfer'] as Map<String, dynamic>,
-        ),
-  backspacePressed: json['backspacePressed'] == null
-      ? const ElevatedButtonWidgetConfig()
-      : ElevatedButtonWidgetConfig.fromJson(
-          json['backspacePressed'] as Map<String, dynamic>,
-        ),
-);
-
-Map<String, dynamic> _$ActionPadWidgetConfigToJson(
-  ActionPadWidgetConfig instance,
-) => <String, dynamic>{
-  'callStart': instance.callStart.toJson(),
-  'callTransfer': instance.callTransfer.toJson(),
-  'backspacePressed': instance.backspacePressed.toJson(),
 };
 
 StatusesWidgetConfig _$StatusesWidgetConfigFromJson(


### PR DESCRIPTION
Refactors Actionpad styling to rely on semantic “roles” (primary/secondary/backspace) and relocates the ActionPad widget config from the widget-theme config to the page-theme config.