### PR TITLE
refactor: migrate system notifications and SIP presence to supported features

### DIFF
--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -485,8 +485,14 @@ abstract final class SystemNotificationsMapper {
     AppConfig appConfig,
     FeatureOverrides featureOverrides,
   ) {
+    final supportedFeature = appConfig.supported.whereType<SupportedSystemNotifications>().firstOrNull;
+
+    // TODO: Migrate client configurations first before fully removing this property.
+    // ignore: deprecated_member_use_from_same_package, deprecated_member_use
+    final baseEnabled = supportedFeature?.enabled ?? appConfig.mainConfig.systemNotificationsEnabled;
+
     // Apply remote overrides
-    final isEnabled = featureOverrides.isSystemNotificationsEnabled ?? appConfig.mainConfig.systemNotificationsEnabled;
+    final isEnabled = featureOverrides.isSystemNotificationsEnabled ?? baseEnabled;
 
     return SystemNotificationsConfig(
       systemNotificationsSupport: isEnabled && coreSupport.supportsSystemNotifications,
@@ -499,8 +505,14 @@ abstract final class SystemNotificationsMapper {
 abstract final class SipPresenceMapper {
   /// Maps [CoreSupport] and [AppConfig] to [SipPresenceConfig].
   static SipPresenceConfig map(CoreSupport coreSupport, AppConfig appConfig, FeatureOverrides featureOverrides) {
+    final supportedFeature = appConfig.supported.whereType<SupportedSipPresence>().firstOrNull;
+
+    // TODO: Migrate client configurations first before fully removing this property.
+    // ignore: deprecated_member_use_from_same_package, deprecated_member_use
+    final baseEnabled = supportedFeature?.enabled ?? appConfig.mainConfig.sipPresenceEnabled;
+
     // Apply remote overrides
-    final isEnabled = featureOverrides.isSipPresenceEnabled ?? appConfig.mainConfig.sipPresenceEnabled;
+    final isEnabled = featureOverrides.isSipPresenceEnabled ?? baseEnabled;
     final coreSupportEnabled = coreSupport.supportsSipPresence;
 
     return SipPresenceConfig(sipPresenceSupport: isEnabled && coreSupportEnabled);

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -178,9 +178,11 @@ class AppConfigMain with _$AppConfigMain {
   final AppConfigBottomMenu bottomMenu;
 
   @override
+  @Deprecated('Use SupportedFeature.systemNotifications instead')
   final bool systemNotificationsEnabled;
 
   @override
+  @Deprecated('Use SupportedFeature.sipPresence instead')
   final bool sipPresenceEnabled;
 
   factory AppConfigMain.fromJson(Map<String, Object?> json) => _$AppConfigMainFromJson(json);

--- a/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.dart
@@ -19,5 +19,9 @@ sealed class SupportedFeature with _$SupportedFeature {
   /// Defaults to 15 seconds.
   const factory SupportedFeature.monitorConfig({@Default(15) int checkIntervalSec}) = SupportedMonitorConfig;
 
+  const factory SupportedFeature.systemNotifications({@Default(true) bool enabled}) = SupportedSystemNotifications;
+
+  const factory SupportedFeature.sipPresence({@Default(false) bool enabled}) = SupportedSipPresence;
+
   factory SupportedFeature.fromJson(Map<String, Object?> json) => _$SupportedFeatureFromJson(json);
 }

--- a/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.freezed.dart
@@ -27,6 +27,14 @@ SupportedFeature _$SupportedFeatureFromJson(
           return SupportedMonitorConfig.fromJson(
             json
           );
+                case 'systemNotifications':
+          return SupportedSystemNotifications.fromJson(
+            json
+          );
+                case 'sipPresence':
+          return SupportedSipPresence.fromJson(
+            json
+          );
         
           default:
             throw CheckedFromJsonException(
@@ -85,13 +93,15 @@ extension SupportedFeaturePatterns on SupportedFeature {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( SupportedThemeMode value)?  themeMode,TResult Function( SupportedVideoCall value)?  videoCall,TResult Function( SupportedMonitorConfig value)?  monitorConfig,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( SupportedThemeMode value)?  themeMode,TResult Function( SupportedVideoCall value)?  videoCall,TResult Function( SupportedMonitorConfig value)?  monitorConfig,TResult Function( SupportedSystemNotifications value)?  systemNotifications,TResult Function( SupportedSipPresence value)?  sipPresence,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case SupportedThemeMode() when themeMode != null:
 return themeMode(_that);case SupportedVideoCall() when videoCall != null:
 return videoCall(_that);case SupportedMonitorConfig() when monitorConfig != null:
-return monitorConfig(_that);case _:
+return monitorConfig(_that);case SupportedSystemNotifications() when systemNotifications != null:
+return systemNotifications(_that);case SupportedSipPresence() when sipPresence != null:
+return sipPresence(_that);case _:
   return orElse();
 
 }
@@ -109,13 +119,15 @@ return monitorConfig(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( SupportedThemeMode value)  themeMode,required TResult Function( SupportedVideoCall value)  videoCall,required TResult Function( SupportedMonitorConfig value)  monitorConfig,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( SupportedThemeMode value)  themeMode,required TResult Function( SupportedVideoCall value)  videoCall,required TResult Function( SupportedMonitorConfig value)  monitorConfig,required TResult Function( SupportedSystemNotifications value)  systemNotifications,required TResult Function( SupportedSipPresence value)  sipPresence,}){
 final _that = this;
 switch (_that) {
 case SupportedThemeMode():
 return themeMode(_that);case SupportedVideoCall():
 return videoCall(_that);case SupportedMonitorConfig():
-return monitorConfig(_that);}
+return monitorConfig(_that);case SupportedSystemNotifications():
+return systemNotifications(_that);case SupportedSipPresence():
+return sipPresence(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -129,13 +141,15 @@ return monitorConfig(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( SupportedThemeMode value)?  themeMode,TResult? Function( SupportedVideoCall value)?  videoCall,TResult? Function( SupportedMonitorConfig value)?  monitorConfig,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( SupportedThemeMode value)?  themeMode,TResult? Function( SupportedVideoCall value)?  videoCall,TResult? Function( SupportedMonitorConfig value)?  monitorConfig,TResult? Function( SupportedSystemNotifications value)?  systemNotifications,TResult? Function( SupportedSipPresence value)?  sipPresence,}){
 final _that = this;
 switch (_that) {
 case SupportedThemeMode() when themeMode != null:
 return themeMode(_that);case SupportedVideoCall() when videoCall != null:
 return videoCall(_that);case SupportedMonitorConfig() when monitorConfig != null:
-return monitorConfig(_that);case _:
+return monitorConfig(_that);case SupportedSystemNotifications() when systemNotifications != null:
+return systemNotifications(_that);case SupportedSipPresence() when sipPresence != null:
+return sipPresence(_that);case _:
   return null;
 
 }
@@ -152,12 +166,14 @@ return monitorConfig(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( ThemeModeConfig mode)?  themeMode,TResult Function( bool enabled)?  videoCall,TResult Function( int checkIntervalSec)?  monitorConfig,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( ThemeModeConfig mode)?  themeMode,TResult Function( bool enabled)?  videoCall,TResult Function( int checkIntervalSec)?  monitorConfig,TResult Function( bool enabled)?  systemNotifications,TResult Function( bool enabled)?  sipPresence,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case SupportedThemeMode() when themeMode != null:
 return themeMode(_that.mode);case SupportedVideoCall() when videoCall != null:
 return videoCall(_that.enabled);case SupportedMonitorConfig() when monitorConfig != null:
-return monitorConfig(_that.checkIntervalSec);case _:
+return monitorConfig(_that.checkIntervalSec);case SupportedSystemNotifications() when systemNotifications != null:
+return systemNotifications(_that.enabled);case SupportedSipPresence() when sipPresence != null:
+return sipPresence(_that.enabled);case _:
   return orElse();
 
 }
@@ -175,12 +191,14 @@ return monitorConfig(_that.checkIntervalSec);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( ThemeModeConfig mode)  themeMode,required TResult Function( bool enabled)  videoCall,required TResult Function( int checkIntervalSec)  monitorConfig,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( ThemeModeConfig mode)  themeMode,required TResult Function( bool enabled)  videoCall,required TResult Function( int checkIntervalSec)  monitorConfig,required TResult Function( bool enabled)  systemNotifications,required TResult Function( bool enabled)  sipPresence,}) {final _that = this;
 switch (_that) {
 case SupportedThemeMode():
 return themeMode(_that.mode);case SupportedVideoCall():
 return videoCall(_that.enabled);case SupportedMonitorConfig():
-return monitorConfig(_that.checkIntervalSec);}
+return monitorConfig(_that.checkIntervalSec);case SupportedSystemNotifications():
+return systemNotifications(_that.enabled);case SupportedSipPresence():
+return sipPresence(_that.enabled);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -194,12 +212,14 @@ return monitorConfig(_that.checkIntervalSec);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( ThemeModeConfig mode)?  themeMode,TResult? Function( bool enabled)?  videoCall,TResult? Function( int checkIntervalSec)?  monitorConfig,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( ThemeModeConfig mode)?  themeMode,TResult? Function( bool enabled)?  videoCall,TResult? Function( int checkIntervalSec)?  monitorConfig,TResult? Function( bool enabled)?  systemNotifications,TResult? Function( bool enabled)?  sipPresence,}) {final _that = this;
 switch (_that) {
 case SupportedThemeMode() when themeMode != null:
 return themeMode(_that.mode);case SupportedVideoCall() when videoCall != null:
 return videoCall(_that.enabled);case SupportedMonitorConfig() when monitorConfig != null:
-return monitorConfig(_that.checkIntervalSec);case _:
+return monitorConfig(_that.checkIntervalSec);case SupportedSystemNotifications() when systemNotifications != null:
+return systemNotifications(_that.enabled);case SupportedSipPresence() when sipPresence != null:
+return sipPresence(_that.enabled);case _:
   return null;
 
 }
@@ -420,6 +440,152 @@ class _$SupportedMonitorConfigCopyWithImpl<$Res>
   return _then(SupportedMonitorConfig(
 checkIntervalSec: null == checkIntervalSec ? _self.checkIntervalSec : checkIntervalSec // ignore: cast_nullable_to_non_nullable
 as int,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SupportedSystemNotifications implements SupportedFeature {
+  const SupportedSystemNotifications({this.enabled = true, final  String? $type}): $type = $type ?? 'systemNotifications';
+  factory SupportedSystemNotifications.fromJson(Map<String, dynamic> json) => _$SupportedSystemNotificationsFromJson(json);
+
+@JsonKey() final  bool enabled;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of SupportedFeature
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SupportedSystemNotificationsCopyWith<SupportedSystemNotifications> get copyWith => _$SupportedSystemNotificationsCopyWithImpl<SupportedSystemNotifications>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SupportedSystemNotificationsToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SupportedSystemNotifications&&(identical(other.enabled, enabled) || other.enabled == enabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,enabled);
+
+@override
+String toString() {
+  return 'SupportedFeature.systemNotifications(enabled: $enabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SupportedSystemNotificationsCopyWith<$Res> implements $SupportedFeatureCopyWith<$Res> {
+  factory $SupportedSystemNotificationsCopyWith(SupportedSystemNotifications value, $Res Function(SupportedSystemNotifications) _then) = _$SupportedSystemNotificationsCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$SupportedSystemNotificationsCopyWithImpl<$Res>
+    implements $SupportedSystemNotificationsCopyWith<$Res> {
+  _$SupportedSystemNotificationsCopyWithImpl(this._self, this._then);
+
+  final SupportedSystemNotifications _self;
+  final $Res Function(SupportedSystemNotifications) _then;
+
+/// Create a copy of SupportedFeature
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? enabled = null,}) {
+  return _then(SupportedSystemNotifications(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SupportedSipPresence implements SupportedFeature {
+  const SupportedSipPresence({this.enabled = false, final  String? $type}): $type = $type ?? 'sipPresence';
+  factory SupportedSipPresence.fromJson(Map<String, dynamic> json) => _$SupportedSipPresenceFromJson(json);
+
+@JsonKey() final  bool enabled;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of SupportedFeature
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SupportedSipPresenceCopyWith<SupportedSipPresence> get copyWith => _$SupportedSipPresenceCopyWithImpl<SupportedSipPresence>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SupportedSipPresenceToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SupportedSipPresence&&(identical(other.enabled, enabled) || other.enabled == enabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,enabled);
+
+@override
+String toString() {
+  return 'SupportedFeature.sipPresence(enabled: $enabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SupportedSipPresenceCopyWith<$Res> implements $SupportedFeatureCopyWith<$Res> {
+  factory $SupportedSipPresenceCopyWith(SupportedSipPresence value, $Res Function(SupportedSipPresence) _then) = _$SupportedSipPresenceCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$SupportedSipPresenceCopyWithImpl<$Res>
+    implements $SupportedSipPresenceCopyWith<$Res> {
+  _$SupportedSipPresenceCopyWithImpl(this._self, this._then);
+
+  final SupportedSipPresence _self;
+  final $Res Function(SupportedSipPresence) _then;
+
+/// Create a copy of SupportedFeature
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? enabled = null,}) {
+  return _then(SupportedSipPresence(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.g.dart
@@ -48,3 +48,25 @@ Map<String, dynamic> _$SupportedMonitorConfigToJson(
   'checkIntervalSec': instance.checkIntervalSec,
   'type': instance.$type,
 };
+
+SupportedSystemNotifications _$SupportedSystemNotificationsFromJson(
+  Map<String, dynamic> json,
+) => SupportedSystemNotifications(
+  enabled: json['enabled'] as bool? ?? true,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$SupportedSystemNotificationsToJson(
+  SupportedSystemNotifications instance,
+) => <String, dynamic>{'enabled': instance.enabled, 'type': instance.$type};
+
+SupportedSipPresence _$SupportedSipPresenceFromJson(
+  Map<String, dynamic> json,
+) => SupportedSipPresence(
+  enabled: json['enabled'] as bool? ?? false,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$SupportedSipPresenceToJson(
+  SupportedSipPresence instance,
+) => <String, dynamic>{'enabled': instance.enabled, 'type': instance.$type};

--- a/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
+++ b/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
@@ -16,6 +16,8 @@ void main() {
       final config = AppConfig.fromJson(json);
 
       // sanity
+      // TODO: Migrate client configurations first before fully removing this property.
+      // ignore: deprecated_member_use_from_same_package, deprecated_member_use
       expect(config.mainConfig.systemNotificationsEnabled, isTrue);
       expect(config.mainConfig.bottomMenu.cacheSelectedTab, isTrue);
 

--- a/test/helpers/feature_access_factories.dart
+++ b/test/helpers/feature_access_factories.dart
@@ -60,7 +60,11 @@ AppConfig createMockAppConfig() {
 
   when(() => main.bottomMenu).thenReturn(bottomMenu);
   when(() => bottomMenu.tabs).thenReturn([BottomMenuTabScheme.keypad(titleL10n: 'Keypad', icon: '0xe1ce')]);
+  // TODO: Migrate client configurations first before fully removing this property.
+  // ignore: deprecated_member_use_from_same_package, deprecated_member_use
   when(() => main.systemNotificationsEnabled).thenReturn(false);
+  // TODO: Migrate client configurations first before fully removing this property.
+  // ignore: deprecated_member_use_from_same_package, deprecated_member_use
   when(() => main.sipPresenceEnabled).thenReturn(false);
 
   when(() => settings.sections).thenReturn([]);


### PR DESCRIPTION
This PR refactors feature configuration by migrating `systemNotifications` and `sipPresence` from legacy flat properties in `AppConfigMain` to the modern `SupportedFeature` union type pattern. This change provides a more structured and consistent approach to feature configuration.