### PR TITLE
fix: collect outbound rtp stats

### DIFF
--- a/lib/features/call/utils/rtp_traffic_monitor.dart
+++ b/lib/features/call/utils/rtp_traffic_monitor.dart
@@ -5,7 +5,9 @@ import 'package:logging/logging.dart';
 
 enum RtpDirection {
   inbound('inbound-rtp'),
-  outbound('outbound-rtp');
+  outbound('outbound-rtp'),
+  remoteInbound('remote-inbound-rtp'),
+  remoteOutbound('remote-outbound-rtp');
 
   const RtpDirection(this.value);
 
@@ -154,6 +156,10 @@ class RtpTrafficMonitor {
       (RtpDirection.inbound, _) => ('bytesReceived', null),
       (RtpDirection.outbound, MediaKind.video) => ('bytesSent', 'framesEncoded'),
       (RtpDirection.outbound, _) => ('bytesSent', null),
+      (RtpDirection.remoteInbound, MediaKind.video) => ('bytesReceived', 'framesDecoded'),
+      (RtpDirection.remoteInbound, _) => ('bytesReceived', null),
+      (RtpDirection.remoteOutbound, MediaKind.video) => ('bytesSent', 'framesEncoded'),
+      (RtpDirection.remoteOutbound, _) => ('bytesSent', null),
     };
 
     final currentBytes = _safeParseNum(report.values[byteKey]);


### PR DESCRIPTION
This pull request extends the RTP traffic monitoring capabilities by adding support for remote inbound and outbound RTP directions. This allows the monitoring logic to handle a more complete set of RTP stream types, which is important for advanced call analytics and debugging.

**RTP Direction Support:**

* Added `remoteInbound` and `remoteOutbound` variants to the `RtpDirection` enum in `rtp_traffic_monitor.dart` to represent remote RTP streams.

**Traffic Monitoring Logic:**

* Updated the `RtpTrafficMonitor` class to handle the new remote RTP directions, including support for video-specific metrics such as `framesDecoded` and `framesEncoded` where applicable.