### PR TITLE
fix(call): preserve widget state during auto-compact transition

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -101,211 +101,209 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                   ),
                 AnimatedBuilder(
                   animation: _compactController,
-                  builder: (context, _) => _compactController.compact
-                      ? const SizedBox.expand()
-                      : Positioned.fill(
-                          left: mediaQueryData.padding.left,
-                          right: mediaQueryData.padding.right,
-                          top: mediaQueryData.padding.top,
-                          bottom: mediaQueryData.padding.bottom,
-                          child: Column(
-                            children: [
-                              AppBar(
-                                leading: style?.appBar?.showBackButton == false ? null : const ExtBackButton(),
-                                backgroundColor: style?.appBar?.backgroundColor,
-                                foregroundColor: style?.appBar?.foregroundColor,
-                                primary: style?.appBar?.primary ?? false,
-                                actions: [
-                                  if (activeCalls.shouldAutoCompact)
-                                    CallPopupMenuButton<void>(
-                                      items: _buildPopupMenuItems,
-                                      child: const Icon(Icons.more_vert),
-                                    ),
-                                ],
-                              ),
-                              Expanded(
-                                child: LayoutBuilder(
-                                  builder: (context, constraints) {
-                                    return FittedBox(
-                                      child: ConstrainedBox(
-                                        constraints: BoxConstraints(
-                                          maxWidth: constraints.maxWidth,
-                                          minHeight: constraints.minHeight,
-                                        ),
-                                        child: Column(
-                                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                          children: [
-                                            for (final activeCall in activeCalls)
-                                              CallInfo(
-                                                transfering: activeTransfer is Transfering,
-                                                requestToAttendedTransfer: false,
-                                                inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
-                                                isIncoming: activeCall.isIncoming,
-                                                held: activeCall.held,
-                                                number: activeCall.handle.value,
-                                                username: activeCall.displayName,
-                                                acceptedTime: activeCall.acceptedTime,
-                                                style: style?.callInfo,
-                                                processingStatus: activeCall.processingStatus,
-                                                callStatus: widget.callStatus,
-                                              ),
-                                            if (activeTransfer is AttendedTransferConfirmationRequested)
-                                              CallInfo(
-                                                transfering: false,
-                                                requestToAttendedTransfer: true,
-                                                inviteToAttendedTransfer: false,
-                                                isIncoming: false,
-                                                held: false,
-                                                number: activeCall.handle.value,
-                                                username: activeCall.displayName,
-                                                style: style?.callInfo,
-                                                callStatus: widget.callStatus,
-                                              ),
-                                            CallActions(
-                                              style: style?.actions,
-                                              enableInteractions: widget.callStatus == CallStatus.ready,
-                                              isIncoming: activeCall.isIncoming,
-                                              remoteVideo: activeCall.remoteVideo,
-                                              wasAccepted: activeCall.wasAccepted,
-                                              wasHungUp: activeCall.wasHungUp,
-                                              cameraValue: activeCall.isCameraActive,
-                                              inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
-                                              onCameraChanged: widget.callConfig.isVideoCallEnabled
-                                                  ? (bool value) => _callBloc.add(
-                                                      CallControlEvent.cameraEnabled(activeCall.callId, value),
-                                                    )
-                                                  : null,
-                                              mutedValue: activeCall.muted,
-                                              onMutedChanged: (bool value) =>
-                                                  _callBloc.add(CallControlEvent.setMuted(activeCall.callId, value)),
-                                              audioDevice: widget.audioDevice,
-                                              availableAudioDevices: widget.availableAudioDevices,
-                                              onAudioDeviceChanged: (CallAudioDevice device) {
-                                                _callBloc.add(
-                                                  CallControlEvent.audioDeviceSet(activeCall.callId, device),
-                                                );
-                                              },
-                                              transferableCalls: heldCalls,
-                                              onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
-                                                  ? (!activeCall.wasAccepted || activeTransfer != null
-                                                        ? null
-                                                        : () {
-                                                            _callBloc.add(
-                                                              CallControlEvent.blindTransferInitiated(
-                                                                activeCall.callId,
-                                                              ),
-                                                            );
-                                                          })
-                                                  : null,
-                                              // TODO (Serdun): Simplify complex condition in the widget tree.
-                                              onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
-                                                  ? (!activeCall.wasAccepted || activeTransfer != null
-                                                        ? null
-                                                        : () {
-                                                            _callBloc.add(
-                                                              CallControlEvent.attendedTransferInitiated(
-                                                                activeCall.callId,
-                                                              ),
-                                                            );
-                                                          })
-                                                  : null,
-                                              // TODO (Serdun): Simplify complex condition in the widget tree.
-                                              onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
-                                                  ? (!activeCall.wasAccepted || activeTransfer != null
-                                                        ? null
-                                                        : (ActiveCall referorCall) {
-                                                            _callBloc.add(
-                                                              CallControlEvent.attendedTransferSubmitted(
-                                                                referorCall: referorCall,
-                                                                replaceCall: activeCall,
-                                                              ),
-                                                            );
-                                                          })
-                                                  : null,
-                                              heldValue: activeCall.held,
-                                              onHeldChanged: (bool value) {
-                                                _callBloc.add(CallControlEvent.setHeld(activeCall.callId, value));
-                                              },
-                                              onSwapPressed: activeCalls.length == 2
-                                                  ? () {
-                                                      // TODO maybe introduce particular event with particular callkeep method
-                                                      _callBloc.add(CallControlEvent.setHeld(activeCall.callId, true));
-                                                      for (final otherActiveCall in activeCalls) {
-                                                        if (otherActiveCall.callId != activeCall.callId) {
-                                                          _callBloc.add(
-                                                            CallControlEvent.setHeld(otherActiveCall.callId, false),
-                                                          );
-                                                        }
-                                                      }
-                                                    }
-                                                  : null,
-                                              onHangupPressed: () {
-                                                _callBloc.add(CallControlEvent.ended(activeCall.callId));
-                                              },
-                                              onHangupAndAcceptPressed: activeCalls.length > 1
-                                                  ? () {
-                                                      // TODO maybe introduce particular event with particular callkeep method
-                                                      for (final otherActiveCall in activeCalls) {
-                                                        if (otherActiveCall.callId != activeCall.callId) {
-                                                          _callBloc.add(CallControlEvent.ended(otherActiveCall.callId));
-                                                        }
-                                                      }
-                                                      _callBloc.add(CallControlEvent.answered(activeCall.callId));
-                                                    }
-                                                  : null,
-                                              onHoldAndAcceptPressed: activeCalls.length > 1
-                                                  ? () {
-                                                      // TODO maybe introduce particular event with particular callkeep method
-                                                      for (final otherActiveCall in activeCalls) {
-                                                        if (otherActiveCall.callId != activeCall.callId) {
-                                                          _callBloc.add(
-                                                            CallControlEvent.setHeld(otherActiveCall.callId, true),
-                                                          );
-                                                        }
-                                                      }
-                                                      _callBloc.add(CallControlEvent.answered(activeCall.callId));
-                                                    }
-                                                  : null,
-                                              onAcceptPressed: () {
-                                                _callBloc.add(CallControlEvent.answered(activeCall.callId));
-                                              },
-                                              onApproveTransferPressed:
-                                                  activeTransfer is AttendedTransferConfirmationRequested
-                                                  ? () {
-                                                      _callBloc.add(
-                                                        CallControlEvent.attendedRequestApproved(
-                                                          referId: activeTransfer.referId,
-                                                          referTo: activeTransfer.referTo,
-                                                        ),
-                                                      );
-                                                    }
-                                                  : null,
-                                              onDeclineTransferPressed:
-                                                  activeTransfer is AttendedTransferConfirmationRequested
-                                                  ? () {
-                                                      _callBloc.add(
-                                                        CallControlEvent.attendedRequestDeclined(
-                                                          callId: activeCall.callId,
-                                                          referId: activeTransfer.referId,
-                                                        ),
-                                                      );
-                                                    }
-                                                  : null,
-                                              onKeyPressed: (value) {
-                                                _callBloc.add(CallControlEvent.sentDTMF(activeCall.callId, value));
-                                              },
-                                            ),
-                                          ],
-                                        ),
+                  builder: (context, _) => Positioned.fill(
+                    left: mediaQueryData.padding.left,
+                    right: mediaQueryData.padding.right,
+                    top: mediaQueryData.padding.top,
+                    bottom: mediaQueryData.padding.bottom,
+                    child: AnimatedOpacity(
+                      opacity: _compactController.compact ? 0 : 1,
+                      duration: kThemeAnimationDuration,
+                      child: IgnorePointer(
+                        ignoring: _compactController.compact,
+                        child: Column(
+                          children: [
+                            AppBar(
+                              leading: style?.appBar?.showBackButton == false ? null : const ExtBackButton(),
+                              backgroundColor: style?.appBar?.backgroundColor,
+                              foregroundColor: style?.appBar?.foregroundColor,
+                              primary: style?.appBar?.primary ?? false,
+                              actions: [
+                                if (activeCalls.shouldAutoCompact)
+                                  CallPopupMenuButton<void>(
+                                    items: _buildPopupMenuItems,
+                                    child: const Icon(Icons.more_vert),
+                                  ),
+                              ],
+                            ),
+                            Expanded(
+                              child: LayoutBuilder(
+                                builder: (context, constraints) {
+                                  return FittedBox(
+                                    child: ConstrainedBox(
+                                      constraints: BoxConstraints(
+                                        maxWidth: constraints.maxWidth,
+                                        minHeight: constraints.minHeight,
                                       ),
-                                    );
-                                  },
-                                ),
+                                      child: Column(
+                                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                        children: [
+                                          for (final activeCall in activeCalls)
+                                            CallInfo(
+                                              transfering: activeTransfer is Transfering,
+                                              requestToAttendedTransfer: false,
+                                              inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
+                                              isIncoming: activeCall.isIncoming,
+                                              held: activeCall.held,
+                                              number: activeCall.handle.value,
+                                              username: activeCall.displayName,
+                                              acceptedTime: activeCall.acceptedTime,
+                                              style: style?.callInfo,
+                                              processingStatus: activeCall.processingStatus,
+                                              callStatus: widget.callStatus,
+                                            ),
+                                          if (activeTransfer is AttendedTransferConfirmationRequested)
+                                            CallInfo(
+                                              transfering: false,
+                                              requestToAttendedTransfer: true,
+                                              inviteToAttendedTransfer: false,
+                                              isIncoming: false,
+                                              held: false,
+                                              number: activeCall.handle.value,
+                                              username: activeCall.displayName,
+                                              style: style?.callInfo,
+                                              callStatus: widget.callStatus,
+                                            ),
+                                          CallActions(
+                                            style: style?.actions,
+                                            enableInteractions: widget.callStatus == CallStatus.ready,
+                                            isIncoming: activeCall.isIncoming,
+                                            remoteVideo: activeCall.remoteVideo,
+                                            wasAccepted: activeCall.wasAccepted,
+                                            wasHungUp: activeCall.wasHungUp,
+                                            cameraValue: activeCall.isCameraActive,
+                                            inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
+                                            onCameraChanged: widget.callConfig.isVideoCallEnabled
+                                                ? (bool value) => _callBloc.add(
+                                                    CallControlEvent.cameraEnabled(activeCall.callId, value),
+                                                  )
+                                                : null,
+                                            mutedValue: activeCall.muted,
+                                            onMutedChanged: (bool value) =>
+                                                _callBloc.add(CallControlEvent.setMuted(activeCall.callId, value)),
+                                            audioDevice: widget.audioDevice,
+                                            availableAudioDevices: widget.availableAudioDevices,
+                                            onAudioDeviceChanged: (CallAudioDevice device) {
+                                              _callBloc.add(CallControlEvent.audioDeviceSet(activeCall.callId, device));
+                                            },
+                                            transferableCalls: heldCalls,
+                                            onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
+                                                ? (!activeCall.wasAccepted || activeTransfer != null
+                                                      ? null
+                                                      : () {
+                                                          _callBloc.add(
+                                                            CallControlEvent.blindTransferInitiated(activeCall.callId),
+                                                          );
+                                                        })
+                                                : null,
+                                            // TODO (Serdun): Simplify complex condition in the widget tree.
+                                            onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
+                                                ? (!activeCall.wasAccepted || activeTransfer != null
+                                                      ? null
+                                                      : () {
+                                                          _callBloc.add(
+                                                            CallControlEvent.attendedTransferInitiated(
+                                                              activeCall.callId,
+                                                            ),
+                                                          );
+                                                        })
+                                                : null,
+                                            // TODO (Serdun): Simplify complex condition in the widget tree.
+                                            onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
+                                                ? (!activeCall.wasAccepted || activeTransfer != null
+                                                      ? null
+                                                      : (ActiveCall referorCall) {
+                                                          _callBloc.add(
+                                                            CallControlEvent.attendedTransferSubmitted(
+                                                              referorCall: referorCall,
+                                                              replaceCall: activeCall,
+                                                            ),
+                                                          );
+                                                        })
+                                                : null,
+                                            heldValue: activeCall.held,
+                                            onHeldChanged: (bool value) {
+                                              _callBloc.add(CallControlEvent.setHeld(activeCall.callId, value));
+                                            },
+                                            onSwapPressed: activeCalls.length == 2
+                                                ? () {
+                                                    _callBloc.add(CallControlEvent.setHeld(activeCall.callId, true));
+                                                    for (final otherActiveCall in activeCalls) {
+                                                      if (otherActiveCall.callId != activeCall.callId) {
+                                                        _callBloc.add(
+                                                          CallControlEvent.setHeld(otherActiveCall.callId, false),
+                                                        );
+                                                      }
+                                                    }
+                                                  }
+                                                : null,
+                                            onHangupPressed: () {
+                                              _callBloc.add(CallControlEvent.ended(activeCall.callId));
+                                            },
+                                            onHangupAndAcceptPressed: activeCalls.length > 1
+                                                ? () {
+                                                    for (final otherActiveCall in activeCalls) {
+                                                      if (otherActiveCall.callId != activeCall.callId) {
+                                                        _callBloc.add(CallControlEvent.ended(otherActiveCall.callId));
+                                                      }
+                                                    }
+                                                    _callBloc.add(CallControlEvent.answered(activeCall.callId));
+                                                  }
+                                                : null,
+                                            onHoldAndAcceptPressed: activeCalls.length > 1
+                                                ? () {
+                                                    for (final otherActiveCall in activeCalls) {
+                                                      if (otherActiveCall.callId != activeCall.callId) {
+                                                        _callBloc.add(
+                                                          CallControlEvent.setHeld(otherActiveCall.callId, true),
+                                                        );
+                                                      }
+                                                    }
+                                                    _callBloc.add(CallControlEvent.answered(activeCall.callId));
+                                                  }
+                                                : null,
+                                            onAcceptPressed: () {
+                                              _callBloc.add(CallControlEvent.answered(activeCall.callId));
+                                            },
+                                            onApproveTransferPressed:
+                                                activeTransfer is AttendedTransferConfirmationRequested
+                                                ? () {
+                                                    _callBloc.add(
+                                                      CallControlEvent.attendedRequestApproved(
+                                                        referId: activeTransfer.referId,
+                                                        referTo: activeTransfer.referTo,
+                                                      ),
+                                                    );
+                                                  }
+                                                : null,
+                                            onDeclineTransferPressed:
+                                                activeTransfer is AttendedTransferConfirmationRequested
+                                                ? () {
+                                                    _callBloc.add(
+                                                      CallControlEvent.attendedRequestDeclined(
+                                                        callId: activeCall.callId,
+                                                        referId: activeTransfer.referId,
+                                                      ),
+                                                    );
+                                                  }
+                                                : null,
+                                            onKeyPressed: (value) {
+                                              _callBloc.add(CallControlEvent.sentDTMF(activeCall.callId, value));
+                                            },
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  );
+                                },
                               ),
-                              const SizedBox(height: 20),
-                            ],
-                          ),
+                            ),
+                            const SizedBox(height: 20),
+                          ],
                         ),
+                      ),
+                    ),
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
The `CallActiveScaffold` was using a ternary operator inside `AnimatedBuilder` to switch between `SizedBox.expand()` and the actual UI (`Positioned.fill`).
When `_compactController.compact` became `true`, the entire `CallActions` widget was **physically removed** from the widget tree.

#### **Why it failed for Audio Devices but seemed to work for Transfers:**

* **Audio Device Menu:** The audio selection uses `CallPopupMenuButton` (a wrapper around `PopupMenuButton`). When the menu is open and the "auto-hide" timer fires, the parent `CallActions` is unmounted. When you finally tap on a device, the menu tries to return the value to a callback (`onAudioDeviceChanged`) that no longer exists in a "live" state, or its context has been disposed.
* **Transfers:** Most transfer actions either trigger a navigation event or an immediate Bloc state change that resets the `CompactAutoResetController` or changes the `ActiveCall` state, which often keeps the UI "alive" or replaces it entirely. The audio menu is a more "passive" UI interaction that doesn't inherently notify the compact controller to stop the timer.

#### **Solution**

* **Persistent Tree:** Replaced the ternary operator with a permanent `Positioned.fill`.
* **Visual Toggle:** Used `AnimatedOpacity` to handle the transition. This keeps the `CallActions` widget and its state "alive" in the background even when invisible.
* **Interaction Control:** Added `IgnorePointer` to prevent accidental clicks on invisible buttons while the video is in full-screen mode.

---

### **Changes**

* Modified `CallActiveScaffold` to keep `CallActions` in the widget tree.
* Added `kThemeAnimationDuration` for a smooth fade-in/out effect.
* Ensured all callbacks remain valid during UI transitions.
