### PR TITLE
feat: support metadata for missed call display name in isolate

### DIFF
--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
@@ -85,7 +84,7 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
           event.callId.hashCode,
           // TODO: Add localization
           'Missed Call',
-          getDisplayNameForMissedCall(event, call) ?? 'Unknown',
+          _getDisplayNameForMissedCall(event, call) ?? 'Unknown',
           payload: {'callId': event.callId, 'type': 'missed_call'},
         ),
       );
@@ -94,8 +93,7 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
     }
   }
 
-  @protected
-  String? getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
+  String? _getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
     return call.username;
   }
 
@@ -153,7 +151,7 @@ class PushNotificationIsolateManager extends IsolateManager {
 
   Future<void> launchSignaling(CallkeepIncomingCallMetadata? metadata) async {
     _metadata = metadata;
-    logger.info('Starting background call event service');
+    logger.info('Starting background call event service: $metadata');
     return signalingManager.launch();
   }
 
@@ -175,12 +173,17 @@ class PushNotificationIsolateManager extends IsolateManager {
   }
 
   @override
-  @protected
-  String? getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
+  String? _getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
+    final signalingName = super._getDisplayNameForMissedCall(event, call);
+    if (signalingName?.isNotEmpty == true) {
+      return signalingName;
+    }
+
     if (_metadata?.callId == event.callId && _metadata!.displayName?.isNotEmpty == true) {
       return _metadata!.displayName;
     }
-    return super.getDisplayNameForMissedCall(event, call);
+
+    return signalingName;
   }
 }
 

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -144,7 +144,11 @@ class PushNotificationIsolateManager extends IsolateManager {
     _pushService.setBackgroundServiceDelegate(this);
   }
 
+  /// The service for interacting with the isolate that was launched by an incoming push notification.
   final BackgroundPushNotificationService _pushService;
+
+  /// The metadata of the incoming call.
+  /// This is used to display the caller's name in the missed call notification.
   CallkeepIncomingCallMetadata? _metadata;
 
   Future<void> launchSignaling(CallkeepIncomingCallMetadata? metadata) async {

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
@@ -84,13 +85,18 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
           event.callId.hashCode,
           // TODO: Add localization
           'Missed Call',
-          call.username ?? 'Unknown',
+          getDisplayNameForMissedCall(event, call) ?? 'Unknown',
           payload: {'callId': event.callId, 'type': 'missed_call'},
         ),
       );
     } catch (e) {
       logger.severe('Failed to show missed call notification', e);
     }
+  }
+
+  @protected
+  String? getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
+    return call.username;
   }
 
   // Default behavior: End calls on signaling error.
@@ -139,8 +145,10 @@ class PushNotificationIsolateManager extends IsolateManager {
   }
 
   final BackgroundPushNotificationService _pushService;
+  CallkeepIncomingCallMetadata? _metadata;
 
-  Future<void> launchSignaling() async {
+  Future<void> launchSignaling(CallkeepIncomingCallMetadata? metadata) async {
+    _metadata = metadata;
     logger.info('Starting background call event service');
     return signalingManager.launch();
   }
@@ -160,6 +168,15 @@ class PushNotificationIsolateManager extends IsolateManager {
     if (!(await signalingManager.hasNetworkConnection())) {
       throw Exception('Not connected');
     }
+  }
+
+  @override
+  @protected
+  String? getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
+    if (_metadata?.callId == event.callId && _metadata!.displayName?.isNotEmpty == true) {
+      return _metadata!.displayName;
+    }
+    return super.getDisplayNameForMissedCall(event, call);
   }
 }
 

--- a/lib/features/call/services/services_isolate.dart
+++ b/lib/features/call/services/services_isolate.dart
@@ -91,7 +91,10 @@ final _logger = Logger('BackgroundCallIsolate');
 
 // Called by the Flutter engine when the signaling service is started.
 @pragma('vm:entry-point')
-Future<void> onPushNotificationSyncCallback(CallkeepPushNotificationSyncStatus status) async {
+Future<void> onPushNotificationSyncCallback(
+  CallkeepPushNotificationSyncStatus status,
+  CallkeepIncomingCallMetadata? metadata,
+) async {
   await _initializeCommonDependencies();
   await _initializePushNotificationDependencies();
 
@@ -99,7 +102,7 @@ Future<void> onPushNotificationSyncCallback(CallkeepPushNotificationSyncStatus s
 
   switch (status) {
     case CallkeepPushNotificationSyncStatus.synchronizeCallStatus:
-      await _pushNotificationIsolateManager?.launchSignaling();
+      await _pushNotificationIsolateManager?.launchSignaling(metadata);
     case CallkeepPushNotificationSyncStatus.releaseResources:
       await _disposeCommonDependencies();
   }
@@ -107,7 +110,7 @@ Future<void> onPushNotificationSyncCallback(CallkeepPushNotificationSyncStatus s
 
 // Called by the Flutter engine when the signaling service is triggered.
 @pragma('vm:entry-point')
-Future<void> onSignalingSyncCallback(CallkeepServiceStatus status) async {
+Future<void> onSignalingSyncCallback(CallkeepServiceStatus status, CallkeepIncomingCallMetadata? metadata) async {
   await _initializeCommonDependencies();
   await _initializeSignalingDependencies();
 

--- a/lib/repositories/push_notifications/local_push_repository.dart
+++ b/lib/repositories/push_notifications/local_push_repository.dart
@@ -49,8 +49,8 @@ class LocalPushRepositoryFLNImpl implements LocalPushRepository {
   }
 
   @override
-  Future<void> displayPush(AppLocalPush notification) async {
-    FlutterLocalNotificationsPlugin().show(
+  Future<void> displayPush(AppLocalPush notification) {
+    return FlutterLocalNotificationsPlugin().show(
       notification.id,
       notification.title,
       notification.body,


### PR DESCRIPTION
- Introduce getDisplayNameForMissedCall in IsolateManager to resolve caller names.
- Update PushNotificationIsolateManager to utilize CallkeepIncomingCallMetadata for missed call notifications.
- Pass metadata through onPushNotificationSyncCallback and onSignalingSyncCallback.
- Ensure LocalPushRepository returns the future from the notification plugin.


Depend: https://github.com/WebTrit/webtrit_callkeep/pull/137