### PR TITLE
chore: suppress experimental_member_use warnings with justification comments

### DIFF
--- a/lib/features/settings/features/voicemail/widgets/audio_view.dart
+++ b/lib/features/settings/features/voicemail/widgets/audio_view.dart
@@ -154,6 +154,9 @@ class _AudioViewState extends State<AudioView> with WidgetsBindingObserver {
       return AudioSource.uri(_uri);
     }
 
+    // No stable caching alternative exists in just_audio (0.10.5).
+    // LockCachingAudioSource is the only built-in caching API and has been actively maintained since 2020.
+    // ignore: experimental_member_use
     return LockCachingAudioSource(_uri, headers: _headers, cacheFile: _getCacheFile());
   }
 

--- a/packages/data/app_database/lib/src/migrations/migration_v10.dart
+++ b/packages/data/app_database/lib/src/migrations/migration_v10.dart
@@ -12,6 +12,9 @@ class MigrationV10 extends Migration {
   Future<void> execute(AppDatabase db, Migrator m) async {
     final contactsTable = v10.Contacts(db);
 
+    // No stable alternative exists in drift (2.29.0).
+    // TableMigration is the only high-level API for complex ALTER TABLE operations.
+    // ignore: experimental_member_use
     await m.alterTable(TableMigration(contactsTable, columnTransformer: {}));
   }
 }


### PR DESCRIPTION
Both LockCachingAudioSource (just_audio) and TableMigration (drift) are the only available APIs for their respective tasks with no stable alternatives. Added ignore directives with explanatory comments.