### PR TITLE
chore: update Flutter to 3.41.2 and suppress experimental_member_use warnings

### DIFF
--- a/.github/flutter_version.yaml
+++ b/.github/flutter_version.yaml
@@ -1,3 +1,3 @@
 flutter:
-  version: "3.35.7"
+  version: "3.41.2"
   channel: "stable"

--- a/lib/features/settings/features/voicemail/widgets/audio_view.dart
+++ b/lib/features/settings/features/voicemail/widgets/audio_view.dart
@@ -154,6 +154,9 @@ class _AudioViewState extends State<AudioView> with WidgetsBindingObserver {
       return AudioSource.uri(_uri);
     }
 
+    // No stable caching alternative exists in just_audio (0.10.5).
+    // LockCachingAudioSource is the only built-in caching API and has been actively maintained since 2020.
+    // ignore: experimental_member_use
     return LockCachingAudioSource(_uri, headers: _headers, cacheFile: _getCacheFile());
   }
 

--- a/packages/data/app_database/lib/src/migrations/migration_v10.dart
+++ b/packages/data/app_database/lib/src/migrations/migration_v10.dart
@@ -12,6 +12,9 @@ class MigrationV10 extends Migration {
   Future<void> execute(AppDatabase db, Migrator m) async {
     final contactsTable = v10.Contacts(db);
 
+    // No stable alternative exists in drift (2.29.0).
+    // TableMigration is the only high-level API for complex ALTER TABLE operations.
+    // ignore: experimental_member_use
     await m.alterTable(TableMigration(contactsTable, columnTransformer: {}));
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -35,10 +35,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "8.4.1"
   ansicolor:
     dependency: transitive
     description:
@@ -202,10 +202,10 @@ packages:
     dependency: "direct main"
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -346,10 +346,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   dart_webrtc:
     dependency: transitive
     description:
@@ -1077,10 +1077,10 @@ packages:
     dependency: "direct dev"
     description:
       name: l10n_mapper_generator
-      sha256: e8c31c5f2885b2e6e727704e292a512af5da97f1134b87472352e674fca2db47
+      sha256: "2c74194f476ffc6a37b16b2851fe73cbe35b6eec936cb485afa85fc0d974eb8d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -1109,10 +1109,10 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: ef5cd5f907157eb7aa87d1704504b5a6386d2cbff88a3c2b3344477bab323ee9
+      sha256: "4f3d70c34c52cc5034e8cc6f53d35aa3a32fb373b78fb4c29cf45cd1dcf06942"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.5"
   linkify:
     dependency: "direct main"
     description:
@@ -1157,18 +1157,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: "direct main"
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
@@ -1744,26 +1744,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   time:
     dependency: transitive
     description:
@@ -2000,7 +2000,7 @@ packages:
       path: "../webtrit_callkeep/webtrit_callkeep"
       relative: true
     source: path
-    version: "0.3.1+0"
+    version: "0.0.0+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:
@@ -2185,5 +2185,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.10.7 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2186,4 +2186,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.7 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.41.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ app_version: 0.0.0
 
 environment:
   sdk: ^3.8.0
-  flutter: ^3.19.0
+  flutter: ^3.41.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
Both LockCachingAudioSource (just_audio) and TableMigration (drift) are the only available APIs for their respective tasks with no stable alternatives. Added ignore directives with explanatory comments.