### PR TITLE
fix(signaling): add null safety guards to JSON event parsing (WT-599)

### DIFF
--- a/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
@@ -64,14 +64,16 @@ class DialogNotifyEvent extends NotifyEvent with EquatableMixin {
     return DialogNotifyEvent(
       transaction: json['transaction'],
       line: json['line'],
-      callId: json['call_id'],
+      callId: json['call_id'] as String? ?? '',
       notify: json['notify'],
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
           : null,
-      userActiveCalls: (json['user_active_calls'] as List)
-          .map((e) => UserActiveCall.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      userActiveCalls:
+          (json['user_active_calls'] as List?)
+              ?.map((e) => UserActiveCall.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
   }
 
@@ -112,18 +114,27 @@ class UserActiveCall extends Equatable {
 
   factory UserActiveCall.fromJson(Map<String, dynamic> json) {
     return UserActiveCall(
-      id: json['id'],
+      id: json['id'] as String? ?? '',
       state: UserActiveCallState.values.firstWhere(
         (e) => e.name == json['state'],
         orElse: () => UserActiveCallState.unknown,
       ),
-      callId: json['call_id'],
-      direction: UserActiveCallDirection.values.byName(json['direction']),
-      localTag: json['local_tag'],
+      callId: json['call_id'] as String? ?? '',
+      direction: _parseDirection(json['direction']),
+      localTag: json['local_tag'] as String? ?? '',
       remoteTag: json['remote_tag'],
-      remoteNumber: json['remote_number'],
+      remoteNumber: json['remote_number'] as String? ?? '',
       remoteDisplayName: json['remote_display_name'],
     );
+  }
+
+  static UserActiveCallDirection _parseDirection(dynamic value) {
+    if (value == null) return UserActiveCallDirection.initiator;
+    try {
+      return UserActiveCallDirection.values.byName(value);
+    } catch (_) {
+      return UserActiveCallDirection.initiator;
+    }
   }
 
   @override
@@ -155,15 +166,14 @@ class PresenceNotifyEvent extends NotifyEvent with EquatableMixin {
     return PresenceNotifyEvent(
       transaction: json['transaction'],
       line: json['line'],
-      callId: json['call_id'],
+      callId: json['call_id'] as String? ?? '',
       notify: json['notify'],
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
           : null,
-      number: json['number'],
-      presenceInfo: (json['presence_info'] as List<dynamic>)
-          .map((item) => SignalingPresenceInfo.fromJson(item))
-          .toList(),
+      number: json['number'] as String? ?? '',
+      presenceInfo:
+          (json['presence_info'] as List<dynamic>?)?.map((item) => SignalingPresenceInfo.fromJson(item)).toList() ?? [],
     );
   }
 
@@ -200,14 +210,14 @@ class SignalingPresenceInfo extends Equatable {
   @override
   factory SignalingPresenceInfo.fromJson(Map<String, dynamic> json) {
     return SignalingPresenceInfo(
-      id: json['id'],
-      available: json['available'],
-      note: json['note'],
+      id: json['id'] as String? ?? '',
+      available: json['available'] as bool? ?? false,
+      note: json['note'] as String? ?? '',
       statusIcon: json['status_icon'],
       device: json['device'],
       timeOffsetMin: json['time_offset_min'],
       timestamp: json['timestamp'],
-      activities: (json['activities'] as List<dynamic>).map((e) => e as String).toList(),
+      activities: (json['activities'] as List<dynamic>?)?.whereType<String>().toList() ?? [],
     );
   }
 
@@ -238,7 +248,7 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
 
   @override
   factory ReferNotifyEvent.fromJson(Map<String, dynamic> json) {
-    final contentStr = json['content'] as String;
+    final contentStr = json['content'] as String?;
     final state = switch (contentStr) {
       String s when s.startsWith('SIP/2.0 100') => ReferNotifyState.trying,
       String s when s.contains('200 OK') => ReferNotifyState.ok,
@@ -248,7 +258,7 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
     return ReferNotifyEvent(
       transaction: json['transaction'],
       line: json['line'],
-      callId: json['call_id'],
+      callId: json['call_id'] as String? ?? '',
       notify: json['notify'],
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
@@ -286,7 +296,7 @@ class UnknownNotifyEvent extends NotifyEvent with EquatableMixin {
     return UnknownNotifyEvent(
       transaction: json['transaction'],
       line: json['line'],
-      callId: json['call_id'],
+      callId: json['call_id'] as String? ?? '',
       notify: json['notify'],
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])

--- a/packages/webtrit_signaling/lib/src/events/line/ice_media_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_media_event.dart
@@ -28,9 +28,18 @@ class IceMediaEvent extends LineEvent {
     return IceMediaEvent(
       transaction: json['transaction'],
       line: json['line'],
-      mid: json['mid'],
-      type: IceMediaType.values.byName(json['type']),
-      receiving: json['receiving'],
+      mid: json['mid'] as String? ?? '',
+      type: _parseMediaType(json['type']),
+      receiving: json['receiving'] as bool? ?? false,
     );
+  }
+
+  static IceMediaType _parseMediaType(dynamic value) {
+    if (value == null) return IceMediaType.audio;
+    try {
+      return IceMediaType.values.byName(value);
+    } catch (_) {
+      return IceMediaType.audio;
+    }
   }
 }

--- a/packages/webtrit_signaling/lib/src/events/line/ice_slowlink_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_slowlink_event.dart
@@ -29,11 +29,20 @@ class IceSlowLinkEvent extends LineEvent {
 
     return IceSlowLinkEvent(
       transaction: json['transaction'],
-      mid: json['mid'],
+      mid: json['mid'] as String? ?? '',
       line: json['line'],
-      media: IceMediaType.values.byName(json['media']),
-      uplink: json['uplink'],
-      lost: json['lost'],
+      media: _parseMediaType(json['media']),
+      uplink: json['uplink'] as bool? ?? false,
+      lost: json['lost'] as int? ?? 0,
     );
+  }
+
+  static IceMediaType _parseMediaType(dynamic value) {
+    if (value == null) return IceMediaType.audio;
+    try {
+      return IceMediaType.values.byName(value);
+    } catch (_) {
+      return IceMediaType.audio;
+    }
   }
 }

--- a/packages/webtrit_signaling/lib/src/events/line/ice_trickle_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_trickle_event.dart
@@ -16,8 +16,8 @@ class IceTrickleEvent extends LineEvent {
       throw ArgumentError.value(eventTypeValue, Event.typeKey, 'Not equal $typeValue');
     }
 
-    final candidateJson = json['candidate'] as Map<String, dynamic>;
-    if (candidateJson['completed'] == true) {
+    final candidateJson = json['candidate'] as Map<String, dynamic>?;
+    if (candidateJson == null || candidateJson['completed'] == true) {
       return IceTrickleEvent(transaction: json['transaction'], line: json['line'], candidate: null);
     } else {
       return IceTrickleEvent(transaction: json['transaction'], line: json['line'], candidate: candidateJson);

--- a/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
+++ b/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
@@ -109,17 +109,17 @@ class StateHandshake extends Handshake {
       throw ArgumentError.value(handshakeTypeValue, Handshake.typeKey, 'Not equal $typeValue');
     }
 
-    final keepaliveInterval = Duration(milliseconds: json['keepalive_interval'] as int);
+    final keepaliveInterval = Duration(milliseconds: json['keepalive_interval'] as int? ?? 30000);
 
-    final timestamp = json['timestamp'] as int;
+    final timestamp = json['timestamp'] as int? ?? 0;
 
     final registrationMessage = json['registration'];
     final registration = Registration(
-      status: RegistrationStatus.values.byName(registrationMessage['status']),
-      code: registrationMessage['code'],
-      reason: registrationMessage['reason'],
+      status: _parseRegistrationStatus(registrationMessage?['status']),
+      code: registrationMessage?['code'],
+      reason: registrationMessage?['reason'],
     );
-    final linesJson = json['lines'] as List<dynamic>;
+    final linesJson = json['lines'] as List<dynamic>? ?? <dynamic>[];
     final lines = linesJson
         .asMap()
         .entries
@@ -139,9 +139,9 @@ class StateHandshake extends Handshake {
             return null;
           }
 
-          final callLogs = (lineJson['call_logs'] as List<dynamic>)
+          final callLogs = (lineJson['call_logs'] as List<dynamic>? ?? <dynamic>[])
               .map<CallLog>((callLogJson) {
-                final timestamp = callLogJson[0] as int;
+                final timestamp = callLogJson[0] as int? ?? 0;
                 final requestOrResponseOrEventJson = callLogJson[1];
                 requestOrResponseOrEventJson['line'] = lineIndex; // inject line to apply universal fromJson methods
                 requestOrResponseOrEventJson['call_id'] = callId; // inject call_id to apply universal fromJson methods
@@ -177,7 +177,9 @@ class StateHandshake extends Handshake {
     final contactsPresenceInfoJson = json['presence_contacts_info'] as Map<String, dynamic>?;
     final contactsPresenceInfo =
         contactsPresenceInfoJson?.map((key, value) {
-          final presenceInfoList = (value as List<dynamic>).map((e) => SignalingPresenceInfo.fromJson(e)).toList();
+          final presenceInfoList =
+              (value as List<dynamic>?)?.map((e) => SignalingPresenceInfo.fromJson(e)).toList() ??
+              <SignalingPresenceInfo>[];
           return MapEntry(key, presenceInfoList);
         }) ??
         <String, List<SignalingPresenceInfo>>{};
@@ -187,9 +189,9 @@ class StateHandshake extends Handshake {
     if (guestLineJson != null) {
       final callId = guestLineJson['call_id'] as String?;
       if (callId != null) {
-        final callLogs = (guestLineJson['call_logs'] as List<dynamic>)
+        final callLogs = (guestLineJson['call_logs'] as List<dynamic>? ?? <dynamic>[])
             .map<CallLog>((callLogJson) {
-              final timestamp = callLogJson[0] as int;
+              final timestamp = callLogJson[0] as int? ?? 0;
               final requestOrResponseOrEventJson = callLogJson[1];
               requestOrResponseOrEventJson['line'] = null; // inject line to apply universal fromJson methods
               requestOrResponseOrEventJson['call_id'] = callId; // inject call_id to apply universal fromJson methods
@@ -225,5 +227,14 @@ class StateHandshake extends Handshake {
       contactsPresenceInfo: contactsPresenceInfo,
       guestLine: guestLine,
     );
+  }
+
+  static RegistrationStatus _parseRegistrationStatus(dynamic value) {
+    if (value == null) return RegistrationStatus.unregistered;
+    try {
+      return RegistrationStatus.values.byName(value);
+    } catch (_) {
+      return RegistrationStatus.unregistered;
+    }
   }
 }


### PR DESCRIPTION
## Description
Prevent `_TypeError` crashes (`'Null'` is not a subtype of `'String'`) in signaling event deserialization when the server sends malformed or incomplete JSON messages. This addresses the critical incident pattern with 337 occurrences across PortaPhone, Signal Connect, Vox OmniOne, and Call Home.

## Crash Prevention Summary
| Severity | Count | Scope |
| :--- | :--- | :--- |
| **CRITICAL** | 8 | Confirmed crash sources (`call_id`, `user_active_calls`, etc.) |
| **HIGH** | 11 | Preventive guards for identical deserialization patterns |
| **MEDIUM** | 1 | Edge cases |

## Key Changes
* **Safe Primitives:** Added `as Type? ?? default` fallbacks for `String`, `int`, and `bool` fields (e.g., `call_id`, `remote_number`, `keepalive_interval`).
* **Safe Collections:** Replaced unsafe `as List` casts with `as List<dynamic>? ?? []`. Implemented `.whereType<T>()` to prevent internal element cast crashes.
* **Safe Enums:** Replaced direct `Enum.values.byName()` with `try-catch` wrappers to provide safe default values for `null` or unknown server strings.
* **Safe Objects:** Added null checks for nested Maps before accessing keys (e.g., `candidate` in `IceTrickleEvent`).

**Branch:** `fix/signaling-null-safety-guards` | **Commit:** `b5e66657`