### PR TITLE
fix: remove unused import in messaging_shell.dart

### DIFF
--- a/lib/features/messaging/widgets/messaging_shell.dart
+++ b/lib/features/messaging/widgets/messaging_shell.dart
@@ -4,7 +4,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/app/router/app_router.dart';
-import 'package:webtrit_phone/blocs/app/app_bloc.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';


### PR DESCRIPTION
## Summary
- Remove unused import of `app_bloc.dart` in `messaging_shell.dart` to fix the `unused_import` warning

## Test plan
- [x] Build passes without warnings for this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)