### PR TITLE
fix(settings): add optimistic toggle with spinner for register status switch

### DIFF
--- a/lib/features/register_status/cubit/register_status_cubit.dart
+++ b/lib/features/register_status/cubit/register_status_cubit.dart
@@ -8,9 +8,19 @@ import 'package:webtrit_phone/repositories/repositories.dart';
 
 final _logger = Logger('RegisterStatusCubit');
 
+class RegisterStatus {
+  const RegisterStatus({required this.value, this.isUpdating = false});
+
+  final bool value;
+  final bool isUpdating;
+
+  RegisterStatus copyWith({bool? value, bool? isUpdating}) =>
+      RegisterStatus(value: value ?? this.value, isUpdating: isUpdating ?? this.isUpdating);
+}
+
 class RegisterStatusCubit extends Cubit<RegisterStatus> {
   RegisterStatusCubit(this.appRepository, this.registerStatusRepository, {this.handleError})
-    : super(registerStatusRepository.getRegisterStatus()) {
+    : super(RegisterStatus(value: registerStatusRepository.getRegisterStatus())) {
     fetchStatus();
     _connectivitySub = Connectivity().onConnectivityChanged.listen(_handleConnectivity);
   }
@@ -29,7 +39,7 @@ class RegisterStatusCubit extends Cubit<RegisterStatus> {
     try {
       final status = await appRepository.getRegisterStatus();
       registerStatusRepository.setRegisterStatus(status);
-      emit(status);
+      emit(RegisterStatus(value: status));
     } catch (e, s) {
       _logger.warning('Failed to get register status', e, s);
       handleError?.call(e, s);
@@ -37,12 +47,14 @@ class RegisterStatusCubit extends Cubit<RegisterStatus> {
   }
 
   Future<void> setStatus(bool value) async {
+    emit(RegisterStatus(value: value, isUpdating: true));
     try {
       await appRepository.setRegisterStatus(value);
       await registerStatusRepository.setRegisterStatus(value);
-      emit(value);
+      emit(RegisterStatus(value: value, isUpdating: false));
     } catch (e, stackTrace) {
       _logger.warning('_onRegisterStatusChanged', e, stackTrace);
+      emit(RegisterStatus(value: !value, isUpdating: false));
       handleError?.call(e, stackTrace);
     }
   }
@@ -53,5 +65,3 @@ class RegisterStatusCubit extends Cubit<RegisterStatus> {
     return super.close();
   }
 }
-
-typedef RegisterStatus = bool;

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -86,12 +86,16 @@ class SettingsScreen extends StatelessWidget {
                           context.l10n.settings_ListViewTileTitle_registered,
                           style: effectiveStyle?.itemTextStyle,
                         ),
-                        value: registerState,
-                        onChanged: (value) => _onRegisterStatusChanged(context, value),
-                        secondary: Icon(
-                          Icons.account_circle_outlined,
-                          color: effectiveStyle?.userIconColor ?? effectiveStyle?.leadingIconsColor,
-                        ),
+                        value: registerState.value,
+                        onChanged: registerState.isUpdating
+                            ? null
+                            : (value) => _onRegisterStatusChanged(context, value),
+                        secondary: registerState.isUpdating
+                            ? const SizedCircularProgressIndicator(size: 24, strokeWidth: 2)
+                            : Icon(
+                                Icons.account_circle_outlined,
+                                color: effectiveStyle?.userIconColor ?? effectiveStyle?.leadingIconsColor,
+                              ),
                       ),
                     ),
                     if (showSeparators) const ListTileSeparator(),

--- a/screenshots/lib/mocks/mock_register_status_cubit.dart
+++ b/screenshots/lib/mocks/mock_register_status_cubit.dart
@@ -2,16 +2,15 @@ import 'package:bloc_test/bloc_test.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 
-class MockRegisterStatusCubit extends MockCubit<RegisterStatus>
-    implements RegisterStatusCubit {
+class MockRegisterStatusCubit extends MockCubit<RegisterStatus> implements RegisterStatusCubit {
   MockRegisterStatusCubit();
 
-  factory MockRegisterStatusCubit.initial(RegisterStatus initialStatus) {
+  factory MockRegisterStatusCubit.initial(bool initialValue) {
     final mock = MockRegisterStatusCubit();
     whenListen(
       mock,
       const Stream<RegisterStatus>.empty(),
-      initialState: initialStatus,
+      initialState: RegisterStatus(value: initialValue),
     );
     return mock;
   }


### PR DESCRIPTION
Replaces the blocking register status toggle with an optimistic update pattern — the switch flips immediately, shows a spinner, disables during the API call, and reverts on failure.