### PR TITLE
chore: add diagnostic logging for recents number mismatch

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2826,11 +2826,25 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   void _addToRecents(ActiveCall activeCall) {
+    final number = activeCall.handle.value;
+    final username = activeCall.displayName;
+
+    _logger.info(
+      '[Recents:store] '
+      'direction=${activeCall.direction.name} '
+      'number=$number '
+      'number.hash=${number.hashCode} '
+      'username=$username '
+      'username.hash=${username?.hashCode} '
+      'numberEqualsUsername=${number == username} '
+      'usernameIsNull=${username == null}',
+    );
+
     NewCall call = (
       direction: activeCall.direction,
-      number: activeCall.handle.value,
+      number: number,
       video: activeCall.video,
-      username: activeCall.displayName,
+      username: username,
       createdTime: activeCall.createdTime,
       acceptedTime: activeCall.acceptedTime,
       hungUpTime: activeCall.hungUpTime,

--- a/lib/repositories/recents/recents_repository.dart
+++ b/lib/repositories/recents/recents_repository.dart
@@ -1,8 +1,12 @@
 import 'dart:async';
 
+import 'package:logging/logging.dart';
+
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/mappers/mappers.dart';
 import 'package:webtrit_phone/models/models.dart';
+
+final _logger = Logger('RecentsRepository');
 
 class RecentsRepository with PresenceInfoDriftMapper, CallLogsDriftMapper, ContactsDriftMapper, RecentsDriftMapper {
   RecentsRepository({required AppDatabase appDatabase}) : _appDatabase = appDatabase;
@@ -10,9 +14,52 @@ class RecentsRepository with PresenceInfoDriftMapper, CallLogsDriftMapper, Conta
   final AppDatabase _appDatabase;
 
   Stream<List<Recent>> watchRecents() {
-    return _appDatabase.recentsDao.watchLastRecents().map(
-      (callLogsExt) => callLogsExt.map(recentFromDrift).toList(growable: false),
-    );
+    return _appDatabase.recentsDao.watchLastRecents().map((callLogsExt) {
+      return callLogsExt
+          .map((data) {
+            final recent = recentFromDrift(data);
+            final entry = recent.callLogEntry;
+            final contact = recent.contact;
+
+            final numberHash = entry.number.hashCode;
+            final usernameHash = entry.username?.hashCode;
+            final contactNameHash = contact?.maybeName?.hashCode;
+            final resolvedNameHash = recent.name.hashCode;
+
+            final nameSource = contact?.maybeName != null
+                ? 'contact.maybeName'
+                : entry.username != null
+                ? 'callLog.username'
+                : 'callLog.number';
+
+            final mismatch = recent.name != entry.number;
+
+            if (mismatch) {
+              _logger.warning(
+                '[Recents:mismatch] '
+                'id=${entry.id} '
+                'direction=${entry.direction.name} '
+                'number=${entry.number} '
+                'number.hash=$numberHash '
+                'username=${entry.username} '
+                'username.hash=$usernameHash '
+                'contactName=${contact?.maybeName} '
+                'contactName.hash=$contactNameHash '
+                'resolvedName=${recent.name} '
+                'resolvedName.hash=$resolvedNameHash '
+                'nameSource=$nameSource '
+                'hasContact=${contact != null} '
+                'contactId=${contact?.id} '
+                'contactSourceType=${contact?.sourceType} '
+                'contactPhonesCount=${contact?.phones.length ?? 0} '
+                'numberEqualsUsername=${entry.number == entry.username}',
+              );
+            }
+
+            return recent;
+          })
+          .toList(growable: false);
+    });
   }
 
   Future<void> deleteByCallId(int id) async {


### PR DESCRIPTION
Add hash-based and raw value logging to trace why recent calls list shows two different phone numbers per entry. Raw values are visible when Logz.io anonymization is disabled, hashes work with it enabled.