### PR TITLE
feat: add support a blurred appbar surface

### DIFF
--- a/lib/features/cdrs/view/recent_cdrs_screen.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen.dart
@@ -72,22 +72,29 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
           ),
         ),
       ),
-      body: TabBarView(
-        controller: _tabController,
-        children: [
-          FullRecentCdrsList(
-            transferEnabled: widget.transferEnabled,
-            videoEnabled: widget.videoEnabled,
-            chatsEnabled: widget.chatsEnabled,
-            smssEnabled: widget.smssEnabled,
+      body: MediaQuery(
+        data: mediaQueryData.copyWith(
+          padding: mediaQueryData.padding.copyWith(
+            top: mediaQueryData.padding.top + kToolbarHeight + kMainAppBarBottomTabHeight,
           ),
-          MissedRecentCdrsList(
-            transferEnabled: widget.transferEnabled,
-            videoEnabled: widget.videoEnabled,
-            chatsEnabled: widget.chatsEnabled,
-            smssEnabled: widget.smssEnabled,
-          ),
-        ],
+        ),
+        child: TabBarView(
+          controller: _tabController,
+          children: [
+            FullRecentCdrsList(
+              transferEnabled: widget.transferEnabled,
+              videoEnabled: widget.videoEnabled,
+              chatsEnabled: widget.chatsEnabled,
+              smssEnabled: widget.smssEnabled,
+            ),
+            MissedRecentCdrsList(
+              transferEnabled: widget.transferEnabled,
+              videoEnabled: widget.videoEnabled,
+              chatsEnabled: widget.chatsEnabled,
+              smssEnabled: widget.smssEnabled,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/cdrs/view/recent_cdrs_screen.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen.dart
@@ -47,9 +47,14 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
     final mediaQueryData = MediaQuery.of(context);
     final l10n = context.l10n;
 
+    final themeData = Theme.of(context);
+
     return Scaffold(
+      extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
+        backgroundColor: themeData.canvasColor.withAlpha(150),
+        flexibleSpace: const BlurredSurface(),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/lib/features/cdrs/view/recent_cdrs_screen.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen.dart
@@ -53,6 +53,7 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
       extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
+        context: context,
         backgroundColor: themeData.canvasColor.withAlpha(150),
         flexibleSpace: const BlurredSurface(),
         bottom: PreferredSize(
@@ -70,7 +71,6 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
             ),
           ),
         ),
-        context: context,
       ),
       body: TabBarView(
         controller: _tabController,

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -7,7 +7,6 @@ import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../../call/call.dart';

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -73,9 +73,6 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final effectiveStyle = widget.style ?? themeData.extension<ContactsScreenStyles>()?.primary;
-    final background = effectiveStyle?.background;
-    final isComplexBackground = background?.isComplex ?? false;
-
     final mediaQueryData = MediaQuery.of(context);
 
     final tabBar = widget.sourceTypes.length <= 1
@@ -127,10 +124,11 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
         background: effectiveStyle?.background,
         contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
         applyToAppBar: effectiveStyle?.applyToAppBar ?? false,
+        extendBodyBehindAppBar: true,
         appBar: MainAppBar(
           title: widget.title,
-          backgroundColor: isComplexBackground ? Colors.transparent : null,
-          elevation: isComplexBackground ? 0 : null,
+          backgroundColor: themeData.canvasColor.withAlpha(150),
+          flexibleSpace: const BlurredSurface(),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -127,6 +127,7 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
         extendBodyBehindAppBar: true,
         appBar: MainAppBar(
           title: widget.title,
+          context: context,
           backgroundColor: themeData.canvasColor.withAlpha(150),
           flexibleSpace: const BlurredSurface(),
           bottom: PreferredSize(
@@ -135,7 +136,6 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
             ),
             child: Column(children: [if (tabBar != null) tabBar, search]),
           ),
-          context: context,
         ),
         body: TabBarView(
           controller: _tabController,

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -136,9 +136,22 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
             child: Column(children: [if (tabBar != null) tabBar, search]),
           ),
         ),
-        body: TabBarView(
-          controller: _tabController,
-          children: [for (final sourceType in widget.sourceTypes) widget.sourceTypeWidgetBuilder(context, sourceType)],
+        body: MediaQuery(
+          data: mediaQueryData.copyWith(
+            padding: mediaQueryData.padding.copyWith(
+              top:
+                  mediaQueryData.padding.top +
+                  kToolbarHeight +
+                  (tabBar != null ? kMainAppBarBottomTabHeight : 0) +
+                  kMainAppBarBottomSearchHeight,
+            ),
+          ),
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              for (final sourceType in widget.sourceTypes) widget.sourceTypeWidgetBuilder(context, sourceType),
+            ],
+          ),
         ),
         bottomNavigationBar: BlocBuilder<CallBloc, CallState>(
           buildWhen: (previous, current) => previous.isBlingTransferInitiated != current.isBlingTransferInitiated,

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -96,18 +96,16 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final effectiveStyle = widget.style ?? themeData.extension<FavoritesScreenStyles>()?.primary;
-    final background = effectiveStyle?.background;
-    final isComplexBackground = background?.isComplex ?? false;
-
     return ThemedScaffold(
       background: effectiveStyle?.background,
       contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
       applyToAppBar: effectiveStyle?.applyToAppBar ?? false,
+      extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: isComplexBackground ? Colors.transparent : null,
-        elevation: isComplexBackground ? 0 : null,
+        backgroundColor: themeData.canvasColor.withAlpha(150),
+        flexibleSpace: const BlurredSurface(),
       ),
       body: BlocBuilder<FavoritesBloc, FavoritesState>(
         builder: (context, state) {

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -13,7 +13,6 @@ import 'package:webtrit_phone/features/messaging/extensions/contact.dart';
 import 'package:webtrit_phone/features/user_info/cubit/user_info_cubit.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/favorite.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../favorites.dart';

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -95,6 +95,9 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final effectiveStyle = widget.style ?? themeData.extension<FavoritesScreenStyles>()?.primary;
+    final mediaQueryData = MediaQuery.of(context);
+    final topPadding = kToolbarHeight + mediaQueryData.padding.top;
+
     return ThemedScaffold(
       background: effectiveStyle?.background,
       contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
@@ -130,6 +133,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                       return BlocBuilder<CallRoutingCubit, CallRoutingState?>(
                         builder: (context, callRoutingState) {
                           return ListView.builder(
+                            padding: EdgeInsets.only(top: topPadding),
                             itemCount: favorites.length,
                             itemBuilder: (context, index) {
                               final favorite = favorites[index];

--- a/lib/features/keypad/view/keypad_screen.dart
+++ b/lib/features/keypad/view/keypad_screen.dart
@@ -22,18 +22,16 @@ class KeypadScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final effectiveStyle = style ?? themeData.extension<KeypadScreenStyles>()?.primary;
-    final background = effectiveStyle?.background;
-    final isComplexBackground = background?.isComplex ?? false;
-
     return ThemedScaffold(
       background: effectiveStyle?.background,
       contentThemeOverride: effectiveStyle?.contentThemeOverride,
       applyToAppBar: effectiveStyle?.applyToAppBar ?? false,
+      extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: title,
         context: context,
-        backgroundColor: isComplexBackground ? Colors.transparent : null,
-        elevation: isComplexBackground ? 0 : null,
+        backgroundColor: themeData.canvasColor.withAlpha(150),
+        flexibleSpace: const BlurredSurface(),
       ),
       body: KeypadView(videoEnabled: videoEnabled, transferEnabled: transferEnabled, style: effectiveStyle),
     );

--- a/lib/features/keypad/view/keypad_screen.dart
+++ b/lib/features/keypad/view/keypad_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/widgets/widgets.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 
 import './keypad_view.dart';
 import 'keypad_screen_style.dart';

--- a/lib/features/messaging/features/conversations/view/conversations_screen.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen.dart
@@ -13,7 +13,6 @@ import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import 'conversations_screen_style.dart';
@@ -178,9 +177,6 @@ class _ConversationsScreenState extends State<ConversationsScreen> with SingleTi
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final effectiveStyle = widget.style ?? themeData.extension<ConversationsScreenStyles>()?.primary;
-    final background = effectiveStyle?.background;
-    final isComplexBackground = background?.isComplex ?? false;
-
     final colorScheme = themeData.colorScheme;
     final mediaQueryData = MediaQuery.of(context);
 
@@ -249,11 +245,12 @@ class _ConversationsScreenState extends State<ConversationsScreen> with SingleTi
         background: effectiveStyle?.background,
         contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
         applyToAppBar: effectiveStyle?.applyToAppBar ?? true,
+        extendBodyBehindAppBar: true,
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          backgroundColor: isComplexBackground ? Colors.transparent : null,
-          elevation: isComplexBackground ? 0 : null,
+          backgroundColor: themeData.canvasColor.withAlpha(150),
+          flexibleSpace: const BlurredSurface(),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -15,7 +15,6 @@ import 'package:webtrit_phone/features/recents/view/recents_screen_styles.dart';
 import 'package:webtrit_phone/features/user_info/cubit/user_info_cubit.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../../call/call.dart';
@@ -125,8 +124,6 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final effectiveStyle = widget.style ?? themeData.extension<RecentsScreenStyles>()?.primary;
-    final background = effectiveStyle?.background;
-    final isComplexBackground = background?.isComplex ?? false;
 
     final mediaQueryData = MediaQuery.of(context);
 
@@ -134,10 +131,11 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
       background: effectiveStyle?.background,
       contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
       applyToAppBar: effectiveStyle?.applyToAppBar ?? false,
+      extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
-        backgroundColor: isComplexBackground ? Colors.transparent : null,
-        elevation: isComplexBackground ? 0 : null,
+        backgroundColor: themeData.canvasColor.withAlpha(150),
+        flexibleSpace: const BlurredSurface(),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -126,6 +126,7 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
     final effectiveStyle = widget.style ?? themeData.extension<RecentsScreenStyles>()?.primary;
 
     final mediaQueryData = MediaQuery.of(context);
+    final topPadding = kToolbarHeight + mediaQueryData.padding.top + kMainAppBarBottomTabHeight;
 
     return ThemedScaffold(
       background: effectiveStyle?.background,
@@ -181,6 +182,7 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
                       return BlocBuilder<CallRoutingCubit, CallRoutingState?>(
                         builder: (context, callRoutingState) {
                           return ListView.builder(
+                            padding: EdgeInsets.only(top: topPadding),
                             itemCount: recentsFiltered.length,
                             itemBuilder: (context, index) {
                               final recent = recentsFiltered[index];

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -134,6 +134,7 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
       extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
+        context: context,
         backgroundColor: themeData.canvasColor.withAlpha(150),
         flexibleSpace: const BlurredSurface(),
         bottom: PreferredSize(
@@ -148,7 +149,6 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
             ),
           ),
         ),
-        context: context,
       ),
       body: BlocBuilder<RecentsBloc, RecentsState>(
         builder: (context, state) {

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -7,7 +7,6 @@ import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 
 import '../bloc/about_bloc.dart';
 import '../widgets/widgets.dart';

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -41,6 +41,9 @@ class _AboutScreenState extends State<AboutScreen> {
     final themeData = Theme.of(context);
     final localStyle = widget.style ?? themeData.extension<AboutScreenStyles>()?.primary;
     final delimiterHeight = themeData.textTheme.titleLarge!.fontSize!;
+    final mediaQuery = MediaQuery.of(context);
+    final topPadding = kToolbarHeight + mediaQuery.padding.top;
+
     return ThemedScaffold(
       background: localStyle?.background,
       extendBodyBehindAppBar: true,
@@ -53,6 +56,7 @@ class _AboutScreenState extends State<AboutScreen> {
         builder: (context, state) {
           return Column(
             children: [
+              SizedBox(height: topPadding),
               Expanded(
                 child: LayoutBuilder(
                   builder: (context, constraints) {

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -42,15 +42,13 @@ class _AboutScreenState extends State<AboutScreen> {
     final themeData = Theme.of(context);
     final localStyle = widget.style ?? themeData.extension<AboutScreenStyles>()?.primary;
     final delimiterHeight = themeData.textTheme.titleLarge!.fontSize!;
-    final background = localStyle?.background;
-    final isComplexBackground = background?.isComplex ?? false;
-
     return ThemedScaffold(
-      background: background,
+      background: localStyle?.background,
+      extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text(context.l10n.settings_ListViewTileTitle_about),
-        backgroundColor: isComplexBackground ? Colors.transparent : null,
-        elevation: isComplexBackground ? 0 : null,
+        backgroundColor: themeData.canvasColor.withAlpha(150),
+        flexibleSpace: const BlurredSurface(),
       ),
       body: BlocBuilder<AboutBloc, AboutState>(
         builder: (context, state) {

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -34,23 +34,20 @@ class SettingsScreen extends StatelessWidget {
     final effectiveStyle = style ?? themeData.extension<SettingsScreenStyles>()?.primary;
 
     final showSeparators = effectiveStyle?.showSeparators ?? true;
-    final background = effectiveStyle?.background;
-    final isComplexBackground = background?.isComplex == true;
 
-    // Calculate top padding to prevent content from going under the AppBar
-    // when using a complex background (which extends body behind app bar).
     final mediaQuery = MediaQuery.of(context);
-    final topPadding = isComplexBackground ? (kToolbarHeight + mediaQuery.padding.top) : 0.0;
+    final topPadding = kToolbarHeight + mediaQuery.padding.top;
 
     return ThemedScaffold(
-      background: background,
+      background: effectiveStyle?.background,
       contentThemeOverride: effectiveStyle?.contentThemeOverride,
       applyToAppBar: effectiveStyle?.applyToAppBar ?? true,
+      extendBodyBehindAppBar: true,
       appBar: AppBar(
         leading: const AutoLeadingButton(),
         title: Text(context.l10n.settings_AppBarTitle_myAccount),
-        backgroundColor: isComplexBackground ? Colors.transparent : null,
-        elevation: isComplexBackground ? 0 : null,
+        backgroundColor: themeData.canvasColor.withAlpha(150),
+        flexibleSpace: const BlurredSurface(),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
@@ -64,7 +61,7 @@ class SettingsScreen extends StatelessWidget {
           return Stack(
             children: [
               SafeArea(
-                top: !isComplexBackground,
+                top: false,
                 bottom: false,
                 child: ListView(
                   padding: (effectiveStyle?.listViewPadding ?? const EdgeInsets.only(top: 16)).add(

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -11,7 +11,6 @@ import 'package:webtrit_phone/features/user_info/user_info.dart';
 import 'package:webtrit_phone/features/session_status/session_status.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 

--- a/lib/features/system_notifications/view/system_notifications_screen.dart
+++ b/lib/features/system_notifications/view/system_notifications_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -59,12 +57,7 @@ class _SystemNotificationsScreenState extends State<SystemNotificationsScreen> {
       appBar: AppBar(
         title: Text(context.l10n.system_notifications_screen_title),
         backgroundColor: theme.canvasColor.withAlpha(150),
-        flexibleSpace: ClipRect(
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-            child: Container(color: theme.canvasColor.withAlpha(150)),
-          ),
-        ),
+        flexibleSpace: const BlurredSurface(),
       ),
       body: BlocBuilder<SystemNotificationsScreenCubit, SystemNotificationScreenState>(
         builder: (context, state) {

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -1,0 +1,23 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class BlurredSurface extends StatelessWidget {
+  const BlurredSurface({super.key, this.color, this.sigmaX = 10, this.sigmaY = 10, this.child});
+
+  final Color? color;
+  final double sigmaX;
+  final double sigmaY;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = this.color ?? Theme.of(context).canvasColor.withAlpha(150);
+    return ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY),
+        child: child ?? Container(color: color),
+      ),
+    );
+  }
+}

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -2,6 +2,11 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+/// A backdrop blur surface intended for use as [AppBar.flexibleSpace].
+///
+/// Applies a [BackdropFilter] with configurable gaussian blur to create
+/// a frosted-glass effect. When used with [Scaffold.extendBodyBehindAppBar],
+/// scrollable content appears blurred beneath the app bar.
 class BlurredSurface extends StatelessWidget {
   const BlurredSurface({super.key, this.color, this.sigmaX = 10, this.sigmaY = 10, this.child});
 

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -19,6 +19,7 @@ class MainAppBar extends AppBar {
     super.bottom,
     required BuildContext context,
     super.backgroundColor,
+    super.flexibleSpace,
     super.elevation,
   }) : super(
          centerTitle: false,

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -3,6 +3,7 @@ export 'ago_ticker.dart';
 export 'agreement_checkbox.dart';
 export 'app_icon.dart';
 export 'back_button.dart';
+export 'blurred_surface.dart';
 export 'circular_progress_template.dart';
 export 'configurable_theme_image.dart';
 export 'confirm_dialog.dart';


### PR DESCRIPTION
This PR introduces a reusable BlurredSurface widget to create a blurred backdrop effect for app bars, replacing scattered inline BackdropFilter implementations across multiple screens. The refactoring standardizes the visual appearance by applying a consistent semi-transparent blurred app bar across all major screens in the application.

