### PR TITLE
feat: update keystores path to applications subdirectory

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ include $(TOOLS_MAKEFILE)
 # Variables
 DART_DEFINE_FILE = --dart-define-from-file=dart_define.json
 CONFIGURATOR = dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart
-KEYSTORES_PATH = --keystores-path=../webtrit_phone_keystores
+KEYSTORES_PATH = --keystores-path=../webtrit_phone_keystores/applications
 
 # ===========================
 #  Paths to Configuration Files


### PR DESCRIPTION
## Summary
- Updated `--keystores-path` in makefile to reflect the new `webtrit_phone_keystores` repo structure where keystore folders were moved into `applications/` subdirectory.

## Test plan
- [x] Run `make configure id=<appId> token=<jwt>` and verify keystores are resolved correctly