### PR TITLE
feat: add text style background decoration support

### DIFF
--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -422,9 +422,21 @@ or
   "letterSpacing": 0.0,
   "fontFeatures": [
     "tabularFigures"
-  ]
+  ],
+  "backgroundColor": "#33000000",
+  "backgroundBorderRadius": 4.0,
+  "backgroundPadding": {
+    "left": 4,
+    "top": 2,
+    "right": 4,
+    "bottom": 2
+  }
 }
 ```
+
+- `backgroundColor` — background fill behind the text (hex).
+- `backgroundBorderRadius` — corner radius for the background decoration.
+- `backgroundPadding` — padding around text when background is applied (`left`, `top`, `right`, `bottom`).
 
 ### Text field (`TextFieldConfig` shape)
 

--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -84,6 +84,14 @@ Top-level keys inside `login`:
       "mainLogo": {
         "asset": "assets/branding/logo.png"
       },
+      "greetingTextStyle": {
+        "color": "#FFFFFFFF",
+        "fontSize": 24,
+        "fontWeight": { "weight": 600 },
+        "backgroundColor": "#CC123752",
+        "backgroundBorderRadius": 8.0,
+        "backgroundPadding": { "left": 16, "top": 8, "right": 16, "bottom": 8 }
+      },
       "buttonLoginStyleType": "primary",
       "buttonSignupStyleType": "primary"
     }
@@ -95,6 +103,7 @@ Top-level keys inside `login`:
 
 - `systemUiOverlayStyle` — status/navigation bar colors & icon brightness
 - `mainLogo` — image descriptor for the primary logo
+- `greetingTextStyle` — text style for the greeting/onboarding text (see [TextStyleConfig](#text-style-textstyleconfig-shape)); when `backgroundColor` is combined with `backgroundBorderRadius` or `backgroundPadding`, a rounded decorated background is rendered behind the text
 - `buttonLoginStyleType`, `buttonSignupStyleType` — enum style presets
 
 ---

--- a/lib/features/login/view/login_mode_select_screen.dart
+++ b/lib/features/login/view/login_mode_select_screen.dart
@@ -31,7 +31,8 @@ class LoginModeSelectScreen extends StatelessWidget {
 
     final localStyle = style ?? loginPageStyles?.primary;
 
-    final titleStyle = themeData.textTheme.displayMedium?.merge(localStyle?.onboardingTextStyle);
+    final onboardingStyle = localStyle?.onboardingTextStyle;
+    final titleStyle = themeData.textTheme.displayMedium?.merge(onboardingStyle?.textStyle);
     final dividerHeight = (titleStyle?.fontSize ?? 0) / 3;
 
     return BlocBuilder<LoginCubit, LoginState>(
@@ -77,7 +78,11 @@ class LoginModeSelectScreen extends StatelessWidget {
                       ConfigurableThemeImage(style: localStyle?.pictureLogoStyle),
                       if (appGreetingL10n != null) ...[
                         SizedBox(height: dividerHeight),
-                        Text(context.parseL10n(appGreetingL10n!), style: titleStyle, textAlign: TextAlign.center),
+                        ExtendedText(
+                          context.parseL10n(appGreetingL10n!),
+                          extendedStyle: onboardingStyle?.copyWith(textStyle: titleStyle),
+                          textAlign: TextAlign.center,
+                        ),
                       ],
                     ],
                   ),

--- a/lib/features/login/view/login_mode_select_screen_style.dart
+++ b/lib/features/login/view/login_mode_select_screen_style.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/extended_text_style.dart';
 
 class LoginModeSelectScreenStyle with Diagnosticable {
   const LoginModeSelectScreenStyle({
@@ -19,7 +20,7 @@ class LoginModeSelectScreenStyle with Diagnosticable {
   final ElevatedButtonStyleType? signUpTypeButton;
   final SystemUiOverlayStyle? systemUiOverlayStyle;
   final ThemeImageStyle? pictureLogoStyle;
-  final TextStyle? onboardingTextStyle;
+  final ExtendedTextStyle? onboardingTextStyle;
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
@@ -28,7 +29,7 @@ class LoginModeSelectScreenStyle with Diagnosticable {
     ElevatedButtonStyleType? signUpTypeButton,
     SystemUiOverlayStyle? systemUiOverlayStyle,
     ThemeImageStyle? pictureLogoStyle,
-    TextStyle? onboardingTextStyle,
+    ExtendedTextStyle? onboardingTextStyle,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
   }) {
@@ -52,7 +53,7 @@ class LoginModeSelectScreenStyle with Diagnosticable {
       signUpTypeButton: b.signUpTypeButton ?? a.signUpTypeButton,
       systemUiOverlayStyle: b.systemUiOverlayStyle ?? a.systemUiOverlayStyle,
       pictureLogoStyle: ThemeImageStyle.merge(a.pictureLogoStyle, b.pictureLogoStyle),
-      onboardingTextStyle: b.onboardingTextStyle ?? a.onboardingTextStyle,
+      onboardingTextStyle: ExtendedTextStyle.merge(a.onboardingTextStyle, b.onboardingTextStyle),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -64,7 +65,7 @@ class LoginModeSelectScreenStyle with Diagnosticable {
       signUpTypeButton: LerpTools.lerpButtonStyleType(a?.signUpTypeButton, b?.signUpTypeButton, t),
       systemUiOverlayStyle: b?.systemUiOverlayStyle ?? a?.systemUiOverlayStyle,
       pictureLogoStyle: ThemeImageStyle.lerp(a?.pictureLogoStyle, b?.pictureLogoStyle, t),
-      onboardingTextStyle: TextStyle.lerp(a?.onboardingTextStyle, b?.onboardingTextStyle, t),
+      onboardingTextStyle: ExtendedTextStyle.lerp(a?.onboardingTextStyle, b?.onboardingTextStyle, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );
@@ -77,7 +78,7 @@ class LoginModeSelectScreenStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<ElevatedButtonStyleType?>('signUpTypeButton', signUpTypeButton));
     properties.add(DiagnosticsProperty<SystemUiOverlayStyle?>('systemUiOverlayStyle', systemUiOverlayStyle));
     properties.add(DiagnosticsProperty<ThemeImageStyle?>('pictureLogoStyle', pictureLogoStyle));
-    properties.add(DiagnosticsProperty<TextStyle?>('onboardingTextStyle', onboardingTextStyle));
+    properties.add(DiagnosticsProperty<ExtendedTextStyle?>('onboardingTextStyle', onboardingTextStyle));
     properties.add(EnumProperty<ThemeMode?>('contentThemeOverride', contentThemeOverride));
     properties.add(DiagnosticsProperty<bool?>('applyToAppBar', applyToAppBar));
   }

--- a/lib/theme/extension/text_style_config.dart
+++ b/lib/theme/extension/text_style_config.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:webtrit_appearance_theme/models/common/common.dart';
 import 'package:webtrit_phone/theme/extension/extension.dart';
+import 'package:webtrit_phone/widgets/extended_text_style.dart';
 
 extension TextStyleConfigExtension on TextStyleConfig {
   TextStyle toTextStyle({
@@ -26,6 +27,18 @@ extension TextStyleConfigExtension on TextStyleConfig {
       height: height ?? defaultHeight,
       decoration: _resolveTextDecoration(decoration) ?? defaultDecoration,
       backgroundColor: backgroundColor?.toColor() ?? defaultBackgroundColor,
+    );
+  }
+
+  ExtendedTextDecoration? toExtendedTextDecoration() {
+    final bgColor = backgroundColor?.toColor();
+    if (bgColor == null) return null;
+    if (backgroundBorderRadius == null && backgroundPadding == null) return null;
+
+    return ExtendedTextDecoration(
+      color: bgColor,
+      borderRadius: backgroundBorderRadius != null ? BorderRadius.circular(backgroundBorderRadius!) : null,
+      padding: backgroundPadding?.toEdgeInsets(),
     );
   }
 

--- a/lib/theme/factory/styles/login_mode_select_screen_style_factory.dart
+++ b/lib/theme/factory/styles/login_mode_select_screen_style_factory.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/extended_text_style.dart';
 
 import '../theme_style_factory.dart';
 import 'theme_image_style.dart';
@@ -16,6 +17,16 @@ class LoginModeSelectScreenStyleFactory implements ThemeStyleFactory<LoginModeSe
   @override
   LoginModeSelectScreenStyles create() {
     final pictureLogoStyle = ThemeImageStyleFactory(source: config?.mainLogo).create();
+    final backgroundDecoration = config?.greetingTextStyle?.toExtendedTextDecoration();
+
+    var textStyle = TextStyle(
+      color: colors.onPrimary,
+      fontWeight: FontWeight.w600,
+    ).merge(config?.greetingTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily));
+
+    if (backgroundDecoration != null) {
+      textStyle = textStyle.copyWith(backgroundColor: null);
+    }
 
     return LoginModeSelectScreenStyles(
       primary: LoginModeSelectScreenStyle(
@@ -23,10 +34,7 @@ class LoginModeSelectScreenStyleFactory implements ThemeStyleFactory<LoginModeSe
         applyToAppBar: config?.themeOverride.applyToAppBar,
         systemUiOverlayStyle: config?.systemUiOverlayStyle?.toSystemUiOverlayStyle(),
         pictureLogoStyle: pictureLogoStyle,
-        onboardingTextStyle: TextStyle(
-          color: colors.onPrimary,
-          fontWeight: FontWeight.w600,
-        ).merge(config?.greetingTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily)),
+        onboardingTextStyle: ExtendedTextStyle(textStyle: textStyle, decoration: backgroundDecoration),
         signInTypeButton: config?.buttonSignupStyleType,
         signUpTypeButton: config?.buttonLoginStyleType,
       ),

--- a/lib/theme/factory/styles/login_mode_select_screen_style_factory.dart
+++ b/lib/theme/factory/styles/login_mode_select_screen_style_factory.dart
@@ -7,10 +7,11 @@ import '../theme_style_factory.dart';
 import 'theme_image_style.dart';
 
 class LoginModeSelectScreenStyleFactory implements ThemeStyleFactory<LoginModeSelectScreenStyles> {
-  LoginModeSelectScreenStyleFactory(this.config, this.colors);
+  LoginModeSelectScreenStyleFactory(this.config, this.colors, this.defaultFontFamily);
 
   final LoginModeSelectPageConfig? config;
   final ColorScheme colors;
+  final String? defaultFontFamily;
 
   @override
   LoginModeSelectScreenStyles create() {
@@ -22,7 +23,10 @@ class LoginModeSelectScreenStyleFactory implements ThemeStyleFactory<LoginModeSe
         applyToAppBar: config?.themeOverride.applyToAppBar,
         systemUiOverlayStyle: config?.systemUiOverlayStyle?.toSystemUiOverlayStyle(),
         pictureLogoStyle: pictureLogoStyle,
-        onboardingTextStyle: TextStyle(color: colors.onPrimary, fontWeight: FontWeight.w600),
+        onboardingTextStyle: TextStyle(
+          color: colors.onPrimary,
+          fontWeight: FontWeight.w600,
+        ).merge(config?.greetingTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily)),
         signInTypeButton: config?.buttonSignupStyleType,
         signUpTypeButton: config?.buttonLoginStyleType,
       ),

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -86,7 +86,11 @@ class ThemeStyleFactoryProvider {
     final groupTitleListStyleFactory = GroupTitleListStyleFactory(colorScheme, groupTitleListTile, defaultFontFamily);
     final gradientsStyleFactory = GradientsStyleFactory(primaryGradientColorsConfig);
 
-    final loginModeSelectStyleFactory = LoginModeSelectScreenStyleFactory(loginPageScheme.modeSelect, colorScheme);
+    final loginModeSelectStyleFactory = LoginModeSelectScreenStyleFactory(
+      loginPageScheme.modeSelect,
+      colorScheme,
+      defaultFontFamily,
+    );
     final leadingAvatarStyleFactory = LeadingAvatarStyleFactory(
       colorScheme,
       widgetConfig.imageAssets.leadingAvatarStyle,

--- a/lib/widgets/extended_text.dart
+++ b/lib/widgets/extended_text.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+export 'extended_text_style.dart';
+
+import 'package:webtrit_phone/widgets/extended_text_style.dart';
+
+class ExtendedText extends StatelessWidget {
+  const ExtendedText(this.data, {super.key, this.extendedStyle, this.textAlign});
+
+  final String data;
+  final ExtendedTextStyle? extendedStyle;
+  final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(data, style: extendedStyle?.textStyle, textAlign: textAlign);
+
+    final decoration = extendedStyle?.decoration;
+    if (decoration == null) return text;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(color: decoration.color, borderRadius: decoration.borderRadius),
+      child: Padding(padding: decoration.padding ?? EdgeInsets.zero, child: text),
+    );
+  }
+}

--- a/lib/widgets/extended_text_style.dart
+++ b/lib/widgets/extended_text_style.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class ExtendedTextDecoration {
+  const ExtendedTextDecoration({required this.color, this.borderRadius, this.padding});
+
+  final Color color;
+  final BorderRadius? borderRadius;
+  final EdgeInsets? padding;
+
+  ExtendedTextDecoration copyWith({Color? color, BorderRadius? borderRadius, EdgeInsets? padding}) {
+    return ExtendedTextDecoration(
+      color: color ?? this.color,
+      borderRadius: borderRadius ?? this.borderRadius,
+      padding: padding ?? this.padding,
+    );
+  }
+
+  static ExtendedTextDecoration? lerp(ExtendedTextDecoration? a, ExtendedTextDecoration? b, double t) {
+    if (a == null && b == null) return null;
+    if (a == null) return b;
+    if (b == null) return a;
+    return ExtendedTextDecoration(
+      color: Color.lerp(a.color, b.color, t)!,
+      borderRadius: BorderRadius.lerp(a.borderRadius, b.borderRadius, t),
+      padding: EdgeInsets.lerp(a.padding, b.padding, t),
+    );
+  }
+}
+
+class ExtendedTextStyle with Diagnosticable {
+  const ExtendedTextStyle({this.textStyle, this.decoration});
+
+  final TextStyle? textStyle;
+  final ExtendedTextDecoration? decoration;
+
+  ExtendedTextStyle copyWith({TextStyle? textStyle, ExtendedTextDecoration? decoration}) {
+    return ExtendedTextStyle(textStyle: textStyle ?? this.textStyle, decoration: decoration ?? this.decoration);
+  }
+
+  static ExtendedTextStyle merge(ExtendedTextStyle? a, ExtendedTextStyle? b) {
+    if (a == null) return b ?? const ExtendedTextStyle();
+    if (b == null) return a;
+    return ExtendedTextStyle(textStyle: b.textStyle ?? a.textStyle, decoration: b.decoration ?? a.decoration);
+  }
+
+  static ExtendedTextStyle lerp(ExtendedTextStyle? a, ExtendedTextStyle? b, double t) {
+    return ExtendedTextStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      decoration: ExtendedTextDecoration.lerp(a?.decoration, b?.decoration, t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle?>('textStyle', textStyle));
+    properties.add(DiagnosticsProperty<ExtendedTextDecoration?>('decoration', decoration));
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -11,6 +11,7 @@ export 'contact_info_builder.dart';
 export 'copy_to_clipboard.dart';
 export 'diagnostic_report_dialog.dart';
 export 'embedded_request_error.dart';
+export 'extended_text.dart';
 export 'extended_text_form_field.dart';
 export 'fade_id.dart';
 export 'history_autocomplete_field.dart';

--- a/packages/webtrit_appearance_theme/lib/models/common/text_style_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/text_style_config.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'padding_config.dart';
+
 part 'text_style_config.freezed.dart';
 
 part 'text_style_config.g.dart';
@@ -39,6 +41,12 @@ class TextStyleConfig with _$TextStyleConfig {
 
     /// Background color for the text in hex format.
     this.backgroundColor,
+
+    /// Border radius for background decoration.
+    this.backgroundBorderRadius,
+
+    /// Padding around text when background is applied.
+    this.backgroundPadding,
   });
 
   /// The name of the font family to use (e.g., "Roboto").
@@ -80,6 +88,14 @@ class TextStyleConfig with _$TextStyleConfig {
   /// Background color for the text in hex format.
   @override
   final String? backgroundColor;
+
+  /// Border radius for background decoration.
+  @override
+  final double? backgroundBorderRadius;
+
+  /// Padding around text when background is applied.
+  @override
+  final PaddingConfig? backgroundPadding;
 
   factory TextStyleConfig.fromJson(Map<String, Object?> json) => _$TextStyleConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/common/text_style_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/text_style_config.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$TextStyleConfig {
 
- String? get fontFamily; double? get fontSize; FontWeightConfig? get fontWeight; FontStyleConfig? get fontStyle; String? get color; double? get letterSpacing; double? get wordSpacing; double? get height; TextDecorationConfig? get decoration; String? get backgroundColor;
+ String? get fontFamily; double? get fontSize; FontWeightConfig? get fontWeight; FontStyleConfig? get fontStyle; String? get color; double? get letterSpacing; double? get wordSpacing; double? get height; TextDecorationConfig? get decoration; String? get backgroundColor; double? get backgroundBorderRadius; PaddingConfig? get backgroundPadding;
 /// Create a copy of TextStyleConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $TextStyleConfigCopyWith<TextStyleConfig> get copyWith => _$TextStyleConfigCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TextStyleConfig&&(identical(other.fontFamily, fontFamily) || other.fontFamily == fontFamily)&&(identical(other.fontSize, fontSize) || other.fontSize == fontSize)&&(identical(other.fontWeight, fontWeight) || other.fontWeight == fontWeight)&&(identical(other.fontStyle, fontStyle) || other.fontStyle == fontStyle)&&(identical(other.color, color) || other.color == color)&&(identical(other.letterSpacing, letterSpacing) || other.letterSpacing == letterSpacing)&&(identical(other.wordSpacing, wordSpacing) || other.wordSpacing == wordSpacing)&&(identical(other.height, height) || other.height == height)&&(identical(other.decoration, decoration) || other.decoration == decoration)&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TextStyleConfig&&(identical(other.fontFamily, fontFamily) || other.fontFamily == fontFamily)&&(identical(other.fontSize, fontSize) || other.fontSize == fontSize)&&(identical(other.fontWeight, fontWeight) || other.fontWeight == fontWeight)&&(identical(other.fontStyle, fontStyle) || other.fontStyle == fontStyle)&&(identical(other.color, color) || other.color == color)&&(identical(other.letterSpacing, letterSpacing) || other.letterSpacing == letterSpacing)&&(identical(other.wordSpacing, wordSpacing) || other.wordSpacing == wordSpacing)&&(identical(other.height, height) || other.height == height)&&(identical(other.decoration, decoration) || other.decoration == decoration)&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.backgroundBorderRadius, backgroundBorderRadius) || other.backgroundBorderRadius == backgroundBorderRadius)&&(identical(other.backgroundPadding, backgroundPadding) || other.backgroundPadding == backgroundPadding));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,fontFamily,fontSize,fontWeight,fontStyle,color,letterSpacing,wordSpacing,height,decoration,backgroundColor);
+int get hashCode => Object.hash(runtimeType,fontFamily,fontSize,fontWeight,fontStyle,color,letterSpacing,wordSpacing,height,decoration,backgroundColor,backgroundBorderRadius,backgroundPadding);
 
 @override
 String toString() {
-  return 'TextStyleConfig(fontFamily: $fontFamily, fontSize: $fontSize, fontWeight: $fontWeight, fontStyle: $fontStyle, color: $color, letterSpacing: $letterSpacing, wordSpacing: $wordSpacing, height: $height, decoration: $decoration, backgroundColor: $backgroundColor)';
+  return 'TextStyleConfig(fontFamily: $fontFamily, fontSize: $fontSize, fontWeight: $fontWeight, fontStyle: $fontStyle, color: $color, letterSpacing: $letterSpacing, wordSpacing: $wordSpacing, height: $height, decoration: $decoration, backgroundColor: $backgroundColor, backgroundBorderRadius: $backgroundBorderRadius, backgroundPadding: $backgroundPadding)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $TextStyleConfigCopyWith<$Res>  {
   factory $TextStyleConfigCopyWith(TextStyleConfig value, $Res Function(TextStyleConfig) _then) = _$TextStyleConfigCopyWithImpl;
 @useResult
 $Res call({
- String? fontFamily, double? fontSize, FontWeightConfig? fontWeight, FontStyleConfig? fontStyle, String? color, double? letterSpacing, double? wordSpacing, double? height, TextDecorationConfig? decoration, String? backgroundColor
+ String? fontFamily, double? fontSize, FontWeightConfig? fontWeight, FontStyleConfig? fontStyle, String? color, double? letterSpacing, double? wordSpacing, double? height, TextDecorationConfig? decoration, String? backgroundColor, double? backgroundBorderRadius, PaddingConfig? backgroundPadding
 });
 
 
@@ -63,7 +63,7 @@ class _$TextStyleConfigCopyWithImpl<$Res>
 
 /// Create a copy of TextStyleConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? fontFamily = freezed,Object? fontSize = freezed,Object? fontWeight = freezed,Object? fontStyle = freezed,Object? color = freezed,Object? letterSpacing = freezed,Object? wordSpacing = freezed,Object? height = freezed,Object? decoration = freezed,Object? backgroundColor = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? fontFamily = freezed,Object? fontSize = freezed,Object? fontWeight = freezed,Object? fontStyle = freezed,Object? color = freezed,Object? letterSpacing = freezed,Object? wordSpacing = freezed,Object? height = freezed,Object? decoration = freezed,Object? backgroundColor = freezed,Object? backgroundBorderRadius = freezed,Object? backgroundPadding = freezed,}) {
   return _then(TextStyleConfig(
 fontFamily: freezed == fontFamily ? _self.fontFamily : fontFamily // ignore: cast_nullable_to_non_nullable
 as String?,fontSize: freezed == fontSize ? _self.fontSize : fontSize // ignore: cast_nullable_to_non_nullable
@@ -75,7 +75,9 @@ as double?,wordSpacing: freezed == wordSpacing ? _self.wordSpacing : wordSpacing
 as double?,height: freezed == height ? _self.height : height // ignore: cast_nullable_to_non_nullable
 as double?,decoration: freezed == decoration ? _self.decoration : decoration // ignore: cast_nullable_to_non_nullable
 as TextDecorationConfig?,backgroundColor: freezed == backgroundColor ? _self.backgroundColor : backgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,backgroundBorderRadius: freezed == backgroundBorderRadius ? _self.backgroundBorderRadius : backgroundBorderRadius // ignore: cast_nullable_to_non_nullable
+as double?,backgroundPadding: freezed == backgroundPadding ? _self.backgroundPadding : backgroundPadding // ignore: cast_nullable_to_non_nullable
+as PaddingConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/common/text_style_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/text_style_config.g.dart
@@ -6,29 +6,34 @@ part of 'text_style_config.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-TextStyleConfig _$TextStyleConfigFromJson(Map<String, dynamic> json) =>
-    TextStyleConfig(
-      fontFamily: json['fontFamily'] as String?,
-      fontSize: (json['fontSize'] as num?)?.toDouble(),
-      fontWeight: json['fontWeight'] == null
-          ? null
-          : FontWeightConfig.fromJson(
-              json['fontWeight'] as Map<String, dynamic>,
-            ),
-      fontStyle: json['fontStyle'] == null
-          ? null
-          : FontStyleConfig.fromJson(json['fontStyle'] as Map<String, dynamic>),
-      color: json['color'] as String?,
-      letterSpacing: (json['letterSpacing'] as num?)?.toDouble(),
-      wordSpacing: (json['wordSpacing'] as num?)?.toDouble(),
-      height: (json['height'] as num?)?.toDouble(),
-      decoration: json['decoration'] == null
-          ? null
-          : TextDecorationConfig.fromJson(
-              json['decoration'] as Map<String, dynamic>,
-            ),
-      backgroundColor: json['backgroundColor'] as String?,
-    );
+TextStyleConfig _$TextStyleConfigFromJson(
+  Map<String, dynamic> json,
+) => TextStyleConfig(
+  fontFamily: json['fontFamily'] as String?,
+  fontSize: (json['fontSize'] as num?)?.toDouble(),
+  fontWeight: json['fontWeight'] == null
+      ? null
+      : FontWeightConfig.fromJson(json['fontWeight'] as Map<String, dynamic>),
+  fontStyle: json['fontStyle'] == null
+      ? null
+      : FontStyleConfig.fromJson(json['fontStyle'] as Map<String, dynamic>),
+  color: json['color'] as String?,
+  letterSpacing: (json['letterSpacing'] as num?)?.toDouble(),
+  wordSpacing: (json['wordSpacing'] as num?)?.toDouble(),
+  height: (json['height'] as num?)?.toDouble(),
+  decoration: json['decoration'] == null
+      ? null
+      : TextDecorationConfig.fromJson(
+          json['decoration'] as Map<String, dynamic>,
+        ),
+  backgroundColor: json['backgroundColor'] as String?,
+  backgroundBorderRadius: (json['backgroundBorderRadius'] as num?)?.toDouble(),
+  backgroundPadding: json['backgroundPadding'] == null
+      ? null
+      : PaddingConfig.fromJson(
+          json['backgroundPadding'] as Map<String, dynamic>,
+        ),
+);
 
 Map<String, dynamic> _$TextStyleConfigToJson(TextStyleConfig instance) =>
     <String, dynamic>{
@@ -42,6 +47,8 @@ Map<String, dynamic> _$TextStyleConfigToJson(TextStyleConfig instance) =>
       'height': instance.height,
       'decoration': instance.decoration?.toJson(),
       'backgroundColor': instance.backgroundColor,
+      'backgroundBorderRadius': instance.backgroundBorderRadius,
+      'backgroundPadding': instance.backgroundPadding?.toJson(),
     };
 
 FontWeightConfig _$FontWeightConfigFromJson(Map<String, dynamic> json) =>

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -195,6 +195,7 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
     this.buttonLoginStyleType = ElevatedButtonStyleType.primary,
     this.buttonSignupStyleType = ElevatedButtonStyleType.primary,
     this.background,
+    this.greetingTextStyle,
   });
 
   @override
@@ -214,6 +215,9 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
 
   @override
   final PageBackground? background;
+
+  @override
+  final TextStyleConfig? greetingTextStyle;
 
   factory LoginModeSelectPageConfig.fromJson(Map<String, Object?> json) => _$LoginModeSelectPageConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -1333,7 +1333,7 @@ case _:
 /// @nodoc
 mixin _$LoginModeSelectPageConfig {
 
- ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background; TextStyleConfig? get greetingTextStyle;
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1344,16 +1344,16 @@ $LoginModeSelectPageConfigCopyWith<LoginModeSelectPageConfig> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background)&&(identical(other.greetingTextStyle, greetingTextStyle) || other.greetingTextStyle == greetingTextStyle));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background,greetingTextStyle);
 
 @override
 String toString() {
-  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background)';
+  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background, greetingTextStyle: $greetingTextStyle)';
 }
 
 
@@ -1364,7 +1364,7 @@ abstract mixin class $LoginModeSelectPageConfigCopyWith<$Res>  {
   factory $LoginModeSelectPageConfigCopyWith(LoginModeSelectPageConfig value, $Res Function(LoginModeSelectPageConfig) _then) = _$LoginModeSelectPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background
+ ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background, TextStyleConfig? greetingTextStyle
 });
 
 
@@ -1381,7 +1381,7 @@ class _$LoginModeSelectPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,Object? greetingTextStyle = freezed,}) {
   return _then(LoginModeSelectPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
@@ -1389,7 +1389,8 @@ as OverlayStyleModel?,mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo 
 as ImageSource?,buttonLoginStyleType: null == buttonLoginStyleType ? _self.buttonLoginStyleType : buttonLoginStyleType // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonStyleType,buttonSignupStyleType: null == buttonSignupStyleType ? _self.buttonSignupStyleType : buttonSignupStyleType // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonStyleType,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,greetingTextStyle: freezed == greetingTextStyle ? _self.greetingTextStyle : greetingTextStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -211,6 +211,11 @@ LoginModeSelectPageConfig _$LoginModeSelectPageConfigFromJson(
   background: json['background'] == null
       ? null
       : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+  greetingTextStyle: json['greetingTextStyle'] == null
+      ? null
+      : TextStyleConfig.fromJson(
+          json['greetingTextStyle'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$LoginModeSelectPageConfigToJson(
@@ -224,6 +229,7 @@ Map<String, dynamic> _$LoginModeSelectPageConfigToJson(
   'buttonSignupStyleType':
       _$ElevatedButtonStyleTypeEnumMap[instance.buttonSignupStyleType]!,
   'background': instance.background?.toJson(),
+  'greetingTextStyle': instance.greetingTextStyle?.toJson(),
 };
 
 const _$ElevatedButtonStyleTypeEnumMap = {

--- a/test/widgets/extended_text_test.dart
+++ b/test/widgets/extended_text_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/widgets/widgets.dart';
+
+void main() {
+  Widget wrapWithMaterial(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  testWidgets('renders plain Text when extendedStyle is null', (tester) async {
+    await tester.pumpWidget(wrapWithMaterial(const ExtendedText('Hello')));
+
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.byType(DecoratedBox), findsNothing);
+  });
+
+  testWidgets('renders plain Text when decoration is null', (tester) async {
+    await tester.pumpWidget(
+      wrapWithMaterial(
+        const ExtendedText('Hello', extendedStyle: ExtendedTextStyle(textStyle: TextStyle(fontSize: 20))),
+      ),
+    );
+
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.byType(DecoratedBox), findsNothing);
+
+    final text = tester.widget<Text>(find.text('Hello'));
+    expect(text.style?.fontSize, 20);
+  });
+
+  testWidgets('renders DecoratedBox when decoration is provided', (tester) async {
+    await tester.pumpWidget(
+      wrapWithMaterial(
+        const ExtendedText(
+          'Styled',
+          extendedStyle: ExtendedTextStyle(
+            textStyle: TextStyle(color: Colors.white),
+            decoration: ExtendedTextDecoration(
+              color: Colors.blue,
+              borderRadius: BorderRadius.all(Radius.circular(8)),
+              padding: EdgeInsets.all(12),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Styled'), findsOneWidget);
+    expect(find.byType(DecoratedBox), findsOneWidget);
+
+    final decoratedBox = tester.widget<DecoratedBox>(find.byType(DecoratedBox));
+    final boxDecoration = decoratedBox.decoration as BoxDecoration;
+    expect(boxDecoration.color, Colors.blue);
+    expect(boxDecoration.borderRadius, const BorderRadius.all(Radius.circular(8)));
+
+    final padding = tester.widget<Padding>(find.byType(Padding));
+    expect(padding.padding, const EdgeInsets.all(12));
+  });
+
+  testWidgets('applies textAlign correctly', (tester) async {
+    await tester.pumpWidget(wrapWithMaterial(const ExtendedText('Centered', textAlign: TextAlign.center)));
+
+    final text = tester.widget<Text>(find.text('Centered'));
+    expect(text.textAlign, TextAlign.center);
+  });
+
+  testWidgets('uses EdgeInsets.zero when decoration padding is null', (tester) async {
+    await tester.pumpWidget(
+      wrapWithMaterial(
+        const ExtendedText(
+          'No padding',
+          extendedStyle: ExtendedTextStyle(decoration: ExtendedTextDecoration(color: Colors.red)),
+        ),
+      ),
+    );
+
+    final padding = tester.widget<Padding>(find.byType(Padding));
+    expect(padding.padding, EdgeInsets.zero);
+  });
+}


### PR DESCRIPTION
## Summary
- Add `backgroundBorderRadius` and `backgroundPadding` fields to `TextStyleConfig`
- Add `greetingTextStyle` to `LoginModeSelectPageConfig` for login screen greeting text styling
- Add `ExtendedText` widget with `ExtendedTextStyle` and `ExtendedTextDecoration` for rendering text with rounded background
- Update login screen to use `ExtendedText` for greeting text
- Update `page_configuration.md` docs with `greetingTextStyle` example

## Test plan
- [x] Verify greeting text on login screen renders with dark navy rounded background when configured
- [x] Verify greeting text renders as plain text when no background decoration is configured
- [x] Run `dart analyze` — no issues