### PR TITLE
chore: update theme template configs

### DIFF
--- a/assets/themes/original.page.dark.config.json
+++ b/assets/themes/original.page.dark.config.json
@@ -25,11 +25,11 @@
       "systemUiOverlayStyle": {
         "statusBarIconBrightness": "light",
         "statusBarBrightness": "dark",
-        "systemNavigationBarColor": "#000000",
+        "systemNavigationBarColor": "#0A1219",
         "systemNavigationBarIconBrightness": "light"
       },
       "mainLogo": {
-        "uri": "asset://assets/images/primary_onboarding_logo_dark.svg",
+        "uri": "asset://assets/images/primary_onboarding_logo.svg",
         "render": {
           "scale": 0.42,
           "alignment": "center",
@@ -39,6 +39,12 @@
             "right": 0.0,
             "bottom": 0.0
           }
+        }
+      },
+      "greetingTextStyle": {
+        "color": "#E2E2E2",
+        "fontWeight": {
+          "weight": 600
         }
       },
       "buttonLoginStyleType": "neutralOnDark",
@@ -66,16 +72,8 @@
         "endX": 0.0,
         "endY": 1.0
       },
-      "background": {
-        "color": "#FFFFFF",
-        "type": "solid"
-      },
-      "themeOverride": {
-        "mode": "light",
-        "applyToAppBar": true
-      },
       "mainLogo": {
-        "uri": "asset://assets/images/secondary_onboarding_logo_dark.svg",
+        "uri": "asset://assets/images/secondary_onboarding_logo.svg",
         "render": {
           "scale": 0.25,
           "padding": {
@@ -178,10 +176,7 @@
         "fontWeight": {
           "weight": 400
         },
-        "color": "#C0C2BE",
-        "fontFeatures": [
-          "tabularFigures"
-        ]
+        "color": "#C0C2BE"
       },
       "processingStatusTextStyle": {
         "fontSize": 14,
@@ -277,7 +272,7 @@
   },
   "about": {
     "mainLogo": {
-      "uri": "asset://assets/images/secondary_onboarding_logo_dark.svg",
+      "uri": "asset://assets/images/secondary_onboarding_logo.svg",
       "render": {
         "scale": 0.25,
         "padding": {

--- a/assets/themes/original.page.light.config.json
+++ b/assets/themes/original.page.light.config.json
@@ -170,10 +170,7 @@
         "fontWeight": {
           "weight": 400
         },
-        "color": "#EEF3F6",
-        "fontFeatures": [
-          "tabularFigures"
-        ]
+        "color": "#EEF3F6"
       },
       "processingStatusTextStyle": {
         "fontSize": 14,

--- a/assets/themes/original.widget.dark.config.json
+++ b/assets/themes/original.widget.dark.config.json
@@ -2,9 +2,75 @@
   "fonts": {
     "fontFamily": "Montserrat"
   },
+  "_button": {
+    "__primaryElevatedButton": "Styling for the primary elevated button used across the app. Supports textStyle, colors, shape, elevation, padding, and more.",
+    "primaryElevatedButton": {
+      "backgroundColor": "#A5C6E4",
+      "foregroundColor": "#092D4A",
+      "disabledBackgroundColor": "#333537",
+      "disabledForegroundColor": "#8E918F",
+      "textStyle": {
+        "fontSize": 14,
+        "fontWeight": {
+          "weight": 500
+        }
+      },
+      "shape": {
+        "type": "rounded",
+        "borderRadius": 8.0
+      }
+    }
+  },
+  "_group": {
+    "__groupTitleListTile": "Styling for group title tiles in list views (e.g., section headers in contacts or settings).",
+    "groupTitleListTile": {
+      "backgroundColor": "#1D2022",
+      "textStyle": {
+        "fontSize": 12,
+        "fontWeight": {
+          "weight": 600
+        },
+        "color": "#A5C6E4"
+      }
+    }
+  },
+  "_bar": {
+    "__bottomNavigationBar": "Bottom navigation bar styling.",
+    "bottomNavigationBar": {
+      "backgroundColor": "#111315",
+      "selectedItemColor": "#A5C6E4",
+      "unSelectedItemColor": "#8E918F"
+    },
+    "__appBarConfig": "Top app bar configuration. Supports colors, elevation, title styling, icon themes, and system overlay style.",
+    "appBarConfig": {
+      "primary": true,
+      "showBackButton": true,
+      "backgroundColor": "#111315",
+      "foregroundColor": "#E2E2E2",
+      "centerTitle": true,
+      "elevation": 0,
+      "scrolledUnderElevation": 0,
+      "titleTextStyle": {
+        "fontSize": 18,
+        "fontWeight": {
+          "weight": 600
+        },
+        "color": "#E2E2E2"
+      }
+    },
+    "__tabBarConfig": "Tab bar styling including indicator, labels, alignment, and animation.",
+    "tabBarConfig": {
+      "indicatorColor": "#A5C6E4",
+      "labelColor": "#A5C6E4",
+      "unselectedLabelColor": "#8E918F",
+      "dividerColor": "#444749",
+      "indicatorSize": "tab",
+      "tabAlignment": "fill"
+    }
+  },
   "imageAssets": {
     "defaultPlaceholderImage": {
-      "uri": "asset://assets/images/secondary_onboarding_logo_dark.svg"
+      "uri": "asset://assets/images/secondary_onboarding_logo.svg"
     },
     "leadingAvatarStyle": {
       "backgroundColor": "#3C4750",
@@ -53,7 +119,45 @@
       }
     }
   },
+  "_input": {
+    "__primary": "Primary text form field styling. Controls label color and border colors for different states (disabled, focused, default).",
+    "primary": {
+      "labelColor": "#A5C6E4",
+      "border": {
+        "disabled": {
+          "typicalColor": "#444749",
+          "errorColor": "#FF897D"
+        },
+        "focused": {
+          "typicalColor": "#A5C6E4",
+          "errorColor": "#FF897D"
+        },
+        "any": {
+          "typicalColor": "#8E918F",
+          "errorColor": "#FF897D"
+        }
+      }
+    }
+  },
+  "_text": {
+    "__selection": "Text selection styling: cursor, selection highlight, and drag handles.",
+    "selection": {
+      "cursorColor": "#A5C6E4",
+      "selectionColor": "#1F618F",
+      "selectionHandleColor": "#A5C6E4"
+    },
+    "__linkify": "Linkify text styling for detected links in messages.",
+    "linkify": {
+      "styleColor": "#E2E2E2",
+      "linkifyStyleColor": "#A5C6E4"
+    }
+  },
   "dialog": {
+    "_confirmDialog": {
+      "activeButtonColor1": "#A5C6E4",
+      "activeButtonColor2": "#FF897D",
+      "defaultButtonColor": "#8E918F"
+    },
     "snackBar": {
       "successBackgroundColor": "#B8E078",
       "errorBackgroundColor": "#FF897D",
@@ -66,7 +170,7 @@
       "online": "#B8E078",
       "offline": "#37393B"
     },
-    "calStatuses": {
+    "callStatuses": {
       "connectivityNone": "#FF897D",
       "connectError": "#FF897D",
       "appUnregistered": "#8E918F",
@@ -79,11 +183,11 @@
     "primaryGradientColorsConfig": {
       "colors": [
         {
-          "color": "#1F618F",
+          "color": "#123752",
           "blend": true
         },
         {
-          "color": "#000000",
+          "color": "#123752",
           "blend": true
         }
       ]

--- a/assets/themes/original.widget.light.config.json
+++ b/assets/themes/original.widget.light.config.json
@@ -2,6 +2,72 @@
   "fonts": {
     "fontFamily": "Montserrat"
   },
+  "_button": {
+    "__primaryElevatedButton": "Styling for the primary elevated button used across the app. Supports textStyle, colors, shape, elevation, padding, and more.",
+    "primaryElevatedButton": {
+      "backgroundColor": "#5CACE3",
+      "foregroundColor": "#FFFFFF",
+      "disabledBackgroundColor": "#DDE0E3",
+      "disabledForegroundColor": "#848581",
+      "textStyle": {
+        "fontSize": 14,
+        "fontWeight": {
+          "weight": 500
+        }
+      },
+      "shape": {
+        "type": "rounded",
+        "borderRadius": 8.0
+      }
+    }
+  },
+  "_group": {
+    "__groupTitleListTile": "Styling for group title tiles in list views (e.g., section headers in contacts or settings).",
+    "groupTitleListTile": {
+      "backgroundColor": "#EEF3F6",
+      "textStyle": {
+        "fontSize": 12,
+        "fontWeight": {
+          "weight": 600
+        },
+        "color": "#1F618F"
+      }
+    }
+  },
+  "_bar": {
+    "__bottomNavigationBar": "Bottom navigation bar styling.",
+    "bottomNavigationBar": {
+      "backgroundColor": "#FFFFFF",
+      "selectedItemColor": "#5CACE3",
+      "unSelectedItemColor": "#848581"
+    },
+    "__appBarConfig": "Top app bar configuration. Supports colors, elevation, title styling, icon themes, and system overlay style.",
+    "appBarConfig": {
+      "primary": true,
+      "showBackButton": true,
+      "backgroundColor": "#FFFFFF",
+      "foregroundColor": "#30302F",
+      "centerTitle": true,
+      "elevation": 0,
+      "scrolledUnderElevation": 0,
+      "titleTextStyle": {
+        "fontSize": 18,
+        "fontWeight": {
+          "weight": 600
+        },
+        "color": "#30302F"
+      }
+    },
+    "__tabBarConfig": "Tab bar styling including indicator, labels, alignment, and animation.",
+    "tabBarConfig": {
+      "indicatorColor": "#5CACE3",
+      "labelColor": "#5CACE3",
+      "unselectedLabelColor": "#848581",
+      "dividerColor": "#CDCFC9",
+      "indicatorSize": "tab",
+      "tabAlignment": "fill"
+    }
+  },
   "imageAssets": {
     "defaultPlaceholderImage": {
       "uri": "asset://assets/images/secondary_onboarding_logo.svg"
@@ -53,7 +119,45 @@
       }
     }
   },
+  "_input": {
+    "__primary": "Primary text form field styling. Controls label color and border colors for different states (disabled, focused, default).",
+    "primary": {
+      "labelColor": "#1F618F",
+      "border": {
+        "disabled": {
+          "typicalColor": "#CDCFC9",
+          "errorColor": "#E74C3C"
+        },
+        "focused": {
+          "typicalColor": "#5CACE3",
+          "errorColor": "#E74C3C"
+        },
+        "any": {
+          "typicalColor": "#848581",
+          "errorColor": "#E74C3C"
+        }
+      }
+    }
+  },
+  "_text": {
+    "__selection": "Text selection styling: cursor, selection highlight, and drag handles.",
+    "selection": {
+      "cursorColor": "#5CACE3",
+      "selectionColor": "#B9E3F9",
+      "selectionHandleColor": "#5CACE3"
+    },
+    "__linkify": "Linkify text styling for detected links in messages.",
+    "linkify": {
+      "styleColor": "#30302F",
+      "linkifyStyleColor": "#5CACE3"
+    }
+  },
   "dialog": {
+    "_confirmDialog": {
+      "activeButtonColor1": "#5CACE3",
+      "activeButtonColor2": "#E74C3C",
+      "defaultButtonColor": "#848581"
+    },
     "snackBar": {
       "successBackgroundColor": "#75B943",
       "errorBackgroundColor": "#E74C3C",
@@ -66,7 +170,7 @@
       "online": "#75B943",
       "offline": "#EEF3F6"
     },
-    "calStatuses": {
+    "callStatuses": {
       "connectivityNone": "#E74C3C",
       "connectError": "#E74C3C",
       "appUnregistered": "#494949",


### PR DESCRIPTION
## Summary
- Fix `calStatuses` typo to `callStatuses` in both widget configs
- Add missing widget sections as disabled examples: button, group, bar, input, text, confirmDialog
- Fix non-existent `_dark` SVG asset references to use existing logos
- Remove unsupported `fontFeatures` from page text styles
- Clean up dark page config duplicate keys in login.switchPage
- Add `greetingTextStyle` for dark login modeSelect visibility
- Update dark widget decoration gradient config

## Test plan
- [x] Verify light theme renders correctly
- [x] Verify dark theme login screen shows greeting text and buttons properly
- [x] Verify no asset loading errors in logs