### PR TITLE
feat: extract appBar background color and blurred surface to config pipeline

### DIFF
--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -19,6 +19,7 @@ back to sensible in-app defaults.
     - [App bar](#app-bar)
     - [Call info](#call-info)
 - [Keypad page](#keypad-page)
+- [Common page fields](#common-page-fields)
 - [Common object formats](#common-object-formats)
 
 ---
@@ -338,19 +339,27 @@ application, including the main call screen and the keypad.
 
 Top-level keys inside `"keypad"`:
 
-| Key                    | Type   | Description                                                                                                            |
-|------------------------|--------|------------------------------------------------------------------------------------------------------------------------|
-| `systemUiOverlayStyle` | object | Status/navigation bars styling.                                                                                        |
-| `textField`            | object | Number input field style (top of page).                                                                                |
-| `contactName`          | object | Resolved contact name style (under input).                                                                             |
-| `keypad`               | object | Numeric keypad layout (digits, spacing, padding).                                                                      |
-| `actionpad`            | object | Layout for action buttons (call, backspace, etc.). Button styles are taken from the global `Action Pad Configuration`. |
+| Key                      | Type   | Description                                                                                                            |
+|--------------------------|--------|------------------------------------------------------------------------------------------------------------------------|
+| `appBarBackgroundColor`  | string | App bar background color (hex). See [Common page fields](#common-page-fields).                                         |
+| `appBarBlurredSurface`   | object | Blurred surface config. See [Common page fields](#common-page-fields).                                                 |
+| `systemUiOverlayStyle`   | object | Status/navigation bars styling.                                                                                        |
+| `textField`              | object | Number input field style (top of page).                                                                                |
+| `contactName`            | object | Resolved contact name style (under input).                                                                             |
+| `keypad`                 | object | Numeric keypad layout (digits, spacing, padding).                                                                      |
+| `actionpad`              | object | Layout for action buttons (call, backspace, etc.). Button styles are taken from the global `Action Pad Configuration`. |
 
 **Minimal example:**
 
 ```json
 {
   "keypad": {
+    "appBarBackgroundColor": "#000000",
+    "appBarBlurredSurface": {
+      "color": "#66000000",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "systemUiOverlayStyle": {
       "statusBarIconBrightness": "dark"
     },
@@ -373,6 +382,37 @@ Top-level keys inside `"keypad"`:
   }
 }
 ```
+
+---
+
+## Common page fields
+
+Every page config that has an app bar supports these optional fields:
+
+| Key                     | Type   | Description                                                        |
+|-------------------------|--------|--------------------------------------------------------------------|
+| `appBarBackgroundColor` | string | Background color for the app bar (hex). Overrides the default.     |
+| `appBarBlurredSurface`  | object | Blurred surface overlay config (frosted-glass effect in app bar).  |
+
+### `appBarBlurredSurface`
+
+```json
+{
+  "appBarBlurredSurface": {
+    "color": "#66000000",
+    "sigmaX": 10,
+    "sigmaY": 10
+  }
+}
+```
+
+| Key      | Type   | Default | Description                          |
+|----------|--------|---------|--------------------------------------|
+| `color`  | string | `null`  | Overlay color (hex).                 |
+| `sigmaX` | double | `0`     | Horizontal gaussian blur sigma.      |
+| `sigmaY` | double | `0`     | Vertical gaussian blur sigma.        |
+
+Applies to: **Keypad**, **Contacts**, **Favorites**, **Recents**, **Conversations**, **Settings**, **About**.
 
 ---
 

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -127,8 +127,12 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          backgroundColor: themeData.canvasColor.withAlpha(150),
-          flexibleSpace: const BlurredSurface(),
+          backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+          flexibleSpace: BlurredSurface(
+            color: effectiveStyle?.appBarBlurredSurface?.color,
+            sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+            sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+          ),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/contacts/view/contacts_screen_style.dart
+++ b/lib/features/contacts/view/contacts_screen_style.dart
@@ -2,16 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const ContactsScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const ContactsScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
-  ContactsScreenStyle copyWith({BackgroundStyle? background, ThemeMode? contentThemeOverride, bool? applyToAppBar}) {
+  ContactsScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeMode? contentThemeOverride,
+    bool? applyToAppBar,
+  }) {
     return ContactsScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -23,6 +38,8 @@ class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return ContactsScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -31,6 +48,8 @@ class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static ContactsScreenStyle lerp(ContactsScreenStyle? a, ContactsScreenStyle? b, double t) {
     return ContactsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -106,8 +106,12 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
       ),
       body: BlocBuilder<FavoritesBloc, FavoritesState>(
         builder: (context, state) {

--- a/lib/features/favorites/view/favorites_screen_style.dart
+++ b/lib/features/favorites/view/favorites_screen_style.dart
@@ -2,16 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const FavoritesScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const FavoritesScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
-  FavoritesScreenStyle copyWith({BackgroundStyle? background, ThemeMode? contentThemeOverride, bool? applyToAppBar}) {
+  FavoritesScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeMode? contentThemeOverride,
+    bool? applyToAppBar,
+  }) {
     return FavoritesScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -23,6 +38,8 @@ class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return FavoritesScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -31,6 +48,8 @@ class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
   static FavoritesScreenStyle lerp(FavoritesScreenStyle? a, FavoritesScreenStyle? b, double t) {
     return FavoritesScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/keypad/view/keypad_screen.dart
+++ b/lib/features/keypad/view/keypad_screen.dart
@@ -29,8 +29,12 @@ class KeypadScreen extends StatelessWidget {
       appBar: MainAppBar(
         title: title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
       ),
       body: KeypadView(videoEnabled: videoEnabled, transferEnabled: transferEnabled, style: effectiveStyle),
     );

--- a/lib/features/keypad/view/keypad_screen_style.dart
+++ b/lib/features/keypad/view/keypad_screen_style.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 import '../widgets/actionpad_style.dart';
 import '../widgets/keypad_style.dart';
@@ -14,6 +15,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   /// Creates a keypad screen style.
   const KeypadScreenStyle({
     super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
     this.inputField,
@@ -43,6 +46,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   /// Creates a copy of this style with the given fields replaced with the new values.
   KeypadScreenStyle copyWith({
     BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
     TextFieldStyle? inputField,
@@ -52,6 +57,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   }) {
     return KeypadScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
       inputField: inputField ?? this.inputField,
@@ -68,6 +75,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return KeypadScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
       inputField: TextFieldStyle.merge(a.inputField, b.inputField),
@@ -81,6 +90,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   static KeypadScreenStyle lerp(KeypadScreenStyle? a, KeypadScreenStyle? b, double t) {
     return KeypadScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
       inputField: TextFieldStyle.lerp(a?.inputField, b?.inputField, t),

--- a/lib/features/messaging/features/conversations/view/conversations_screen.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen.dart
@@ -249,8 +249,12 @@ class _ConversationsScreenState extends State<ConversationsScreen> with SingleTi
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          backgroundColor: themeData.canvasColor.withAlpha(150),
-          flexibleSpace: const BlurredSurface(),
+          backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+          flexibleSpace: BlurredSurface(
+            color: effectiveStyle?.appBarBlurredSurface?.color,
+            sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+            sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+          ),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/messaging/features/conversations/view/conversations_screen_style.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen_style.dart
@@ -2,20 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const ConversationsScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const ConversationsScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
   ConversationsScreenStyle copyWith({
     BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
   }) {
     return ConversationsScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -27,6 +38,8 @@ class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return ConversationsScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -35,6 +48,8 @@ class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static ConversationsScreenStyle lerp(ConversationsScreenStyle? a, ConversationsScreenStyle? b, double t) {
     return ConversationsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -136,8 +136,12 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/lib/features/recents/view/recents_screen_style.dart
+++ b/lib/features/recents/view/recents_screen_style.dart
@@ -2,16 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const RecentsScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const RecentsScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
-  RecentsScreenStyle copyWith({BackgroundStyle? background, ThemeMode? contentThemeOverride, bool? applyToAppBar}) {
+  RecentsScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeMode? contentThemeOverride,
+    bool? applyToAppBar,
+  }) {
     return RecentsScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -23,6 +38,8 @@ class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return RecentsScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -31,6 +48,8 @@ class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static RecentsScreenStyle lerp(RecentsScreenStyle? a, RecentsScreenStyle? b, double t) {
     return RecentsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -49,8 +49,12 @@ class _AboutScreenState extends State<AboutScreen> {
       extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text(context.l10n.settings_ListViewTileTitle_about),
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: localStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: localStyle?.appBarBlurredSurface?.color,
+          sigmaX: localStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: localStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
       ),
       body: BlocBuilder<AboutBloc, AboutState>(
         builder: (context, state) {

--- a/lib/features/settings/features/about/view/about_screen_style.dart
+++ b/lib/features/settings/features/about/view/about_screen_style.dart
@@ -1,15 +1,29 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const AboutScreenStyle({super.background, this.pictureLogoStyle});
+  const AboutScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.pictureLogoStyle,
+  });
 
   final ThemeImageStyle? pictureLogoStyle;
 
-  AboutScreenStyle copyWith({BackgroundStyle? background, ThemeImageStyle? pictureLogoStyle}) {
+  AboutScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeImageStyle? pictureLogoStyle,
+  }) {
     return AboutScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       pictureLogoStyle: pictureLogoStyle ?? this.pictureLogoStyle,
     );
   }
@@ -20,6 +34,8 @@ class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return AboutScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       pictureLogoStyle: ThemeImageStyle.merge(a.pictureLogoStyle, b.pictureLogoStyle),
     );
   }
@@ -31,6 +47,8 @@ class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return AboutScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       pictureLogoStyle: ThemeImageStyle.lerp(a?.pictureLogoStyle, b?.pictureLogoStyle, t),
     );
   }

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -45,8 +45,12 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(
         leading: const AutoLeadingButton(),
         title: Text(context.l10n.settings_AppBarTitle_myAccount),
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),

--- a/lib/features/settings/view/settings_screen_style.dart
+++ b/lib/features/settings/view/settings_screen_style.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 import '../widgets/group_title_list_style.dart';
 
@@ -13,6 +14,8 @@ import '../widgets/group_title_list_style.dart';
 class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   const SettingScreenStyle({
     super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
     this.leadingIconsColor,
@@ -50,6 +53,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
 
   SettingScreenStyle copyWith({
     BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
     Color? leadingIconsColor,
@@ -62,6 +67,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   }) {
     return SettingScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
       leadingIconsColor: leadingIconsColor ?? this.leadingIconsColor,
@@ -80,6 +87,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return SettingScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
       leadingIconsColor: b.leadingIconsColor ?? a.leadingIconsColor,
@@ -95,6 +104,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   static SettingScreenStyle lerp(SettingScreenStyle? a, SettingScreenStyle? b, double t) {
     return SettingScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
       leadingIconsColor: Color.lerp(a?.leadingIconsColor, b?.leadingIconsColor, t),

--- a/lib/theme/extension/blurred_surface_config_extension.dart
+++ b/lib/theme/extension/blurred_surface_config_extension.dart
@@ -1,0 +1,11 @@
+import 'package:webtrit_appearance_theme/webtrit_appearance_theme.dart';
+
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
+
+import 'theme_json_serializable.dart';
+
+extension BlurredSurfaceConfigExtension on BlurredSurfaceConfig {
+  BlurredSurfaceStyle toStyle() {
+    return BlurredSurfaceStyle(color: color?.toColor(), sigmaX: sigmaX, sigmaY: sigmaY);
+  }
+}

--- a/lib/theme/extension/extension.dart
+++ b/lib/theme/extension/extension.dart
@@ -1,4 +1,5 @@
 export 'alignment_config_extension.dart';
+export 'blurred_surface_config_extension.dart';
 export 'box_fit_config_extension.dart';
 export 'brightness.dart';
 export 'button_style_config.dart';

--- a/lib/theme/factory/styles/about_screen_style_factory.dart
+++ b/lib/theme/factory/styles/about_screen_style_factory.dart
@@ -17,7 +17,12 @@ class AboutScreenStyleFactory implements ThemeStyleFactory<AboutScreenStyles> {
     final backgroundStyle = config?.background?.toStyle();
 
     return AboutScreenStyles(
-      primary: AboutScreenStyle(pictureLogoStyle: pictureLogoStyle, background: backgroundStyle),
+      primary: AboutScreenStyle(
+        pictureLogoStyle: pictureLogoStyle,
+        background: backgroundStyle,
+        appBarBackgroundColor: config?.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config?.appBarBlurredSurface?.toStyle(),
+      ),
     );
   }
 }

--- a/lib/theme/factory/styles/contacts_screen_style_factory.dart
+++ b/lib/theme/factory/styles/contacts_screen_style_factory.dart
@@ -20,6 +20,8 @@ class ContactsScreenStyleFactory implements ThemeStyleFactory<ContactsScreenStyl
     return ContactsScreenStyles(
       primary: ContactsScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/conversations_screen_style_factory.dart
+++ b/lib/theme/factory/styles/conversations_screen_style_factory.dart
@@ -22,6 +22,8 @@ class ConversationsScreenStyleFactory implements ThemeStyleFactory<Conversations
     return ConversationsScreenStyles(
       primary: ConversationsScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/favorites_screen_style_factory.dart
+++ b/lib/theme/factory/styles/favorites_screen_style_factory.dart
@@ -22,6 +22,8 @@ class FavoritesScreenStyleFactory implements ThemeStyleFactory<FavoritesScreenSt
     return FavoritesScreenStyles(
       primary: FavoritesScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/keypad_screen_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_screen_style_factory.dart
@@ -28,6 +28,8 @@ class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> 
     return KeypadScreenStyles(
       primary: KeypadScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
         inputField: config.textField?.toStyle(colors: colors, defaultFontFamily: defaultFontFamily),

--- a/lib/theme/factory/styles/recents_screen_style_factory.dart
+++ b/lib/theme/factory/styles/recents_screen_style_factory.dart
@@ -21,6 +21,8 @@ class RecentsScreenStyleFactory implements ThemeStyleFactory<RecentsScreenStyles
     return RecentsScreenStyles(
       primary: RecentsScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/settings_screen_style_factory.dart
+++ b/lib/theme/factory/styles/settings_screen_style_factory.dart
@@ -36,6 +36,8 @@ class SettingsScreenStyleFactory implements ThemeStyleFactory<SettingsScreenStyl
     return SettingsScreenStyles(
       primary: SettingScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config?.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config?.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: contentThemeOverride,
         applyToAppBar: applyToAppBar,
         leadingIconsColor: leadingIconsColor,

--- a/lib/theme/styles/base_screen_style.dart
+++ b/lib/theme/styles/base_screen_style.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 import 'background_style.dart';
 
@@ -10,10 +13,16 @@ export 'background_style.dart';
 /// managing shared attributes such as [BackgroundStyle].
 abstract class BaseScreenStyle with Diagnosticable {
   /// Creates a base screen style.
-  const BaseScreenStyle({this.background});
+  const BaseScreenStyle({this.background, this.appBarBackgroundColor, this.appBarBlurredSurface});
 
   /// The background style configuration for the screen.
   final BackgroundStyle? background;
+
+  /// Optional color override for the AppBar background.
+  final Color? appBarBackgroundColor;
+
+  /// Style for the AppBar's BlurredSurface flexibleSpace.
+  final BlurredSurfaceStyle? appBarBlurredSurface;
 
   /// Linearly interpolates between two [BackgroundStyle]s.
   ///
@@ -26,5 +35,7 @@ abstract class BaseScreenStyle with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<BackgroundStyle?>('background', background));
+    properties.add(ColorProperty('appBarBackgroundColor', appBarBackgroundColor));
+    properties.add(DiagnosticsProperty<BlurredSurfaceStyle?>('appBarBlurredSurface', appBarBlurredSurface));
   }
 }

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -2,13 +2,15 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+export 'blurred_surface_style.dart';
+
 /// A backdrop blur surface intended for use as [AppBar.flexibleSpace].
 ///
 /// Applies a [BackdropFilter] with configurable gaussian blur to create
 /// a frosted-glass effect. When used with [Scaffold.extendBodyBehindAppBar],
 /// scrollable content appears blurred beneath the app bar.
 class BlurredSurface extends StatelessWidget {
-  const BlurredSurface({super.key, this.color, this.sigmaX = 10, this.sigmaY = 10, this.child});
+  const BlurredSurface({super.key, this.color, this.sigmaX = 0, this.sigmaY = 0, this.child});
 
   final Color? color;
   final double sigmaX;
@@ -17,7 +19,6 @@ class BlurredSurface extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = this.color ?? Theme.of(context).canvasColor.withAlpha(150);
     return ClipRect(
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY),

--- a/lib/widgets/blurred_surface_style.dart
+++ b/lib/widgets/blurred_surface_style.dart
@@ -1,0 +1,52 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Visual style for a [BlurredSurface] widget.
+class BlurredSurfaceStyle with Diagnosticable {
+  const BlurredSurfaceStyle({this.color, this.sigmaX, this.sigmaY});
+
+  /// Overlay color for the blurred surface.
+  final Color? color;
+
+  /// Horizontal gaussian blur sigma.
+  final double? sigmaX;
+
+  /// Vertical gaussian blur sigma.
+  final double? sigmaY;
+
+  BlurredSurfaceStyle copyWith({Color? color, double? sigmaX, double? sigmaY}) {
+    return BlurredSurfaceStyle(
+      color: color ?? this.color,
+      sigmaX: sigmaX ?? this.sigmaX,
+      sigmaY: sigmaY ?? this.sigmaY,
+    );
+  }
+
+  static BlurredSurfaceStyle merge(BlurredSurfaceStyle? a, BlurredSurfaceStyle? b) {
+    if (a == null) return b ?? const BlurredSurfaceStyle();
+    if (b == null) return a;
+
+    return BlurredSurfaceStyle(color: b.color ?? a.color, sigmaX: b.sigmaX ?? a.sigmaX, sigmaY: b.sigmaY ?? a.sigmaY);
+  }
+
+  static BlurredSurfaceStyle? lerp(BlurredSurfaceStyle? a, BlurredSurfaceStyle? b, double t) {
+    if (a == null && b == null) return null;
+
+    return BlurredSurfaceStyle(
+      color: Color.lerp(a?.color, b?.color, t),
+      sigmaX: lerpDouble(a?.sigmaX, b?.sigmaX, t),
+      sigmaY: lerpDouble(a?.sigmaY, b?.sigmaY, t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(ColorProperty('color', color))
+      ..add(DoubleProperty('sigmaX', sigmaX))
+      ..add(DoubleProperty('sigmaY', sigmaY));
+  }
+}

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'blurred_surface_config.freezed.dart';
+
+part 'blurred_surface_config.g.dart';
+
+/// Declarative configuration for a blurred surface overlay.
+///
+/// Maps to [BlurredSurface] widget parameters: color, sigmaX, sigmaY.
+@freezed
+abstract class BlurredSurfaceConfig with _$BlurredSurfaceConfig {
+  const factory BlurredSurfaceConfig({
+    /// Overlay color (hex string, e.g. `#000000`).
+    String? color,
+
+    /// Horizontal gaussian blur sigma.
+    @Default(0) double sigmaX,
+
+    /// Vertical gaussian blur sigma.
+    @Default(0) double sigmaY,
+  }) = _BlurredSurfaceConfig;
+
+  factory BlurredSurfaceConfig.fromJson(Map<String, dynamic> json) => _$BlurredSurfaceConfigFromJson(json);
+}

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'blurred_surface_config.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BlurredSurfaceConfig {
+
+/// Overlay color (hex string, e.g. `#000000`).
+ String? get color;/// Horizontal gaussian blur sigma.
+ double get sigmaX;/// Vertical gaussian blur sigma.
+ double get sigmaY;
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BlurredSurfaceConfigCopyWith<BlurredSurfaceConfig> get copyWith => _$BlurredSurfaceConfigCopyWithImpl<BlurredSurfaceConfig>(this as BlurredSurfaceConfig, _$identity);
+
+  /// Serializes this BlurredSurfaceConfig to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BlurredSurfaceConfig&&(identical(other.color, color) || other.color == color)&&(identical(other.sigmaX, sigmaX) || other.sigmaX == sigmaX)&&(identical(other.sigmaY, sigmaY) || other.sigmaY == sigmaY));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,color,sigmaX,sigmaY);
+
+@override
+String toString() {
+  return 'BlurredSurfaceConfig(color: $color, sigmaX: $sigmaX, sigmaY: $sigmaY)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BlurredSurfaceConfigCopyWith<$Res>  {
+  factory $BlurredSurfaceConfigCopyWith(BlurredSurfaceConfig value, $Res Function(BlurredSurfaceConfig) _then) = _$BlurredSurfaceConfigCopyWithImpl;
+@useResult
+$Res call({
+ String? color, double sigmaX, double sigmaY
+});
+
+
+
+
+}
+/// @nodoc
+class _$BlurredSurfaceConfigCopyWithImpl<$Res>
+    implements $BlurredSurfaceConfigCopyWith<$Res> {
+  _$BlurredSurfaceConfigCopyWithImpl(this._self, this._then);
+
+  final BlurredSurfaceConfig _self;
+  final $Res Function(BlurredSurfaceConfig) _then;
+
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? color = freezed,Object? sigmaX = null,Object? sigmaY = null,}) {
+  return _then(_self.copyWith(
+color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String?,sigmaX: null == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
+as double,sigmaY: null == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BlurredSurfaceConfig].
+extension BlurredSurfaceConfigPatterns on BlurredSurfaceConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BlurredSurfaceConfig value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BlurredSurfaceConfig value)  $default,){
+final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BlurredSurfaceConfig value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? color,  double sigmaX,  double sigmaY)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? color,  double sigmaX,  double sigmaY)  $default,) {final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig():
+return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? color,  double sigmaX,  double sigmaY)?  $default,) {final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _BlurredSurfaceConfig implements BlurredSurfaceConfig {
+  const _BlurredSurfaceConfig({this.color, this.sigmaX = 0, this.sigmaY = 0});
+  factory _BlurredSurfaceConfig.fromJson(Map<String, dynamic> json) => _$BlurredSurfaceConfigFromJson(json);
+
+/// Overlay color (hex string, e.g. `#000000`).
+@override final  String? color;
+/// Horizontal gaussian blur sigma.
+@override@JsonKey() final  double sigmaX;
+/// Vertical gaussian blur sigma.
+@override@JsonKey() final  double sigmaY;
+
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BlurredSurfaceConfigCopyWith<_BlurredSurfaceConfig> get copyWith => __$BlurredSurfaceConfigCopyWithImpl<_BlurredSurfaceConfig>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BlurredSurfaceConfigToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BlurredSurfaceConfig&&(identical(other.color, color) || other.color == color)&&(identical(other.sigmaX, sigmaX) || other.sigmaX == sigmaX)&&(identical(other.sigmaY, sigmaY) || other.sigmaY == sigmaY));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,color,sigmaX,sigmaY);
+
+@override
+String toString() {
+  return 'BlurredSurfaceConfig(color: $color, sigmaX: $sigmaX, sigmaY: $sigmaY)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BlurredSurfaceConfigCopyWith<$Res> implements $BlurredSurfaceConfigCopyWith<$Res> {
+  factory _$BlurredSurfaceConfigCopyWith(_BlurredSurfaceConfig value, $Res Function(_BlurredSurfaceConfig) _then) = __$BlurredSurfaceConfigCopyWithImpl;
+@override @useResult
+$Res call({
+ String? color, double sigmaX, double sigmaY
+});
+
+
+
+
+}
+/// @nodoc
+class __$BlurredSurfaceConfigCopyWithImpl<$Res>
+    implements _$BlurredSurfaceConfigCopyWith<$Res> {
+  __$BlurredSurfaceConfigCopyWithImpl(this._self, this._then);
+
+  final _BlurredSurfaceConfig _self;
+  final $Res Function(_BlurredSurfaceConfig) _then;
+
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? color = freezed,Object? sigmaX = null,Object? sigmaY = null,}) {
+  return _then(_BlurredSurfaceConfig(
+color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String?,sigmaX: null == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
+as double,sigmaY: null == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'blurred_surface_config.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_BlurredSurfaceConfig _$BlurredSurfaceConfigFromJson(
+  Map<String, dynamic> json,
+) => _BlurredSurfaceConfig(
+  color: json['color'] as String?,
+  sigmaX: (json['sigmaX'] as num?)?.toDouble() ?? 0,
+  sigmaY: (json['sigmaY'] as num?)?.toDouble() ?? 0,
+);
+
+Map<String, dynamic> _$BlurredSurfaceConfigToJson(
+  _BlurredSurfaceConfig instance,
+) => <String, dynamic>{
+  'color': instance.color,
+  'sigmaX': instance.sigmaX,
+  'sigmaY': instance.sigmaY,
+};

--- a/packages/webtrit_appearance_theme/lib/models/common/common.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/common.dart
@@ -1,3 +1,4 @@
+export 'blurred_surface_config.dart';
 export 'border_config.dart';
 export 'button_style_config.dart';
 export 'geometry_config.dart';

--- a/packages/webtrit_appearance_theme/lib/models/pages/base_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/pages/base_page_config.dart
@@ -1,5 +1,10 @@
+import '../common/blurred_surface_config.dart';
 import 'page_background.dart';
 
 abstract class BasePageConfig {
   PageBackground? get background;
+
+  String? get appBarBackgroundColor;
+
+  BlurredSurfaceConfig? get appBarBlurredSurface;
 }

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -196,6 +196,8 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
     this.buttonSignupStyleType = ElevatedButtonStyleType.primary,
     this.background,
     this.greetingTextStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   @override
@@ -219,6 +221,12 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
   @override
   final TextStyleConfig? greetingTextStyle;
 
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
+
   factory LoginModeSelectPageConfig.fromJson(Map<String, Object?> json) => _$LoginModeSelectPageConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$LoginModeSelectPageConfigToJson(this);
@@ -232,6 +240,8 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
     this.background,
     this.themeOverride = const ThemeOverrideConfig(),
     this.segmentButtonStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   @override
@@ -246,6 +256,12 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
   @override
   final ButtonStyleConfig? segmentButtonStyle;
 
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
+
   factory LoginSwitchPageConfig.fromJson(Map<String, Object?> json) => _$LoginSwitchPageConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$LoginSwitchPageConfigToJson(this);
@@ -255,7 +271,13 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
-  const AboutPageConfig({this.mainLogo, this.metadata = const Metadata(), this.background});
+  const AboutPageConfig({
+    this.mainLogo,
+    this.metadata = const Metadata(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   @override
   final ImageSource? mainLogo;
@@ -265,6 +287,12 @@ class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory AboutPageConfig.fromJson(Map<String, Object?> json) => _$AboutPageConfigFromJson(json);
 
@@ -279,7 +307,15 @@ class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class CallPageConfig with _$CallPageConfig implements BasePageConfig {
-  const CallPageConfig({this.systemUiOverlayStyle, this.callInfo, this.actions, this.background, this.appBarStyle});
+  const CallPageConfig({
+    this.systemUiOverlayStyle,
+    this.callInfo,
+    this.actions,
+    this.background,
+    this.appBarStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   @override
   final OverlayStyleModel? systemUiOverlayStyle;
@@ -295,6 +331,12 @@ class CallPageConfig with _$CallPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory CallPageConfig.fromJson(Map<String, Object?> json) => _$CallPageConfigFromJson(json);
 
@@ -388,6 +430,8 @@ class KeypadPageConfig with _$KeypadPageConfig implements BasePageConfig {
     this.actionpad,
     this.background,
     this.themeOverride = const ThemeOverrideConfig(),
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   @override
@@ -411,6 +455,12 @@ class KeypadPageConfig with _$KeypadPageConfig implements BasePageConfig {
   /// Configuration to force override the theme mode (e.g., force Dark mode).
   @override
   final ThemeOverrideConfig themeOverride;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory KeypadPageConfig.fromJson(Map<String, Object?> json) => _$KeypadPageConfigFromJson(json);
 
@@ -452,6 +502,8 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
     this.showSeparators = true,
     this.background,
     this.itemTextStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   /// Configuration to force override the theme mode.
@@ -479,6 +531,12 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
   @override
   final TextStyleConfig? itemTextStyle;
 
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
+
   factory SettingsPageConfig.fromJson(Map<String, Object?> json) => _$SettingsPageConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$SettingsPageConfigToJson(this);
@@ -487,7 +545,12 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
-  const ContactsPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const ContactsPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -495,6 +558,12 @@ class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory ContactsPageConfig.fromJson(Map<String, Object?> json) => _$ContactsPageConfigFromJson(json);
 
@@ -504,7 +573,12 @@ class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
-  const EmbeddedPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const EmbeddedPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -512,6 +586,12 @@ class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory EmbeddedPageConfig.fromJson(Map<String, Object?> json) => _$EmbeddedPageConfigFromJson(json);
 
@@ -521,7 +601,12 @@ class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
-  const FavoritesPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const FavoritesPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -529,6 +614,12 @@ class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory FavoritesPageConfig.fromJson(Map<String, Object?> json) => _$FavoritesPageConfigFromJson(json);
 
@@ -538,7 +629,12 @@ class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class ConversationsPageConfig with _$ConversationsPageConfig implements BasePageConfig {
-  const ConversationsPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const ConversationsPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -546,6 +642,12 @@ class ConversationsPageConfig with _$ConversationsPageConfig implements BasePage
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory ConversationsPageConfig.fromJson(Map<String, Object?> json) => _$ConversationsPageConfigFromJson(json);
 
@@ -555,7 +657,12 @@ class ConversationsPageConfig with _$ConversationsPageConfig implements BasePage
 @freezed
 @JsonSerializable(explicitToJson: true)
 class RecentsPageConfig with _$RecentsPageConfig implements BasePageConfig {
-  const RecentsPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const RecentsPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -563,6 +670,12 @@ class RecentsPageConfig with _$RecentsPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory RecentsPageConfig.fromJson(Map<String, Object?> json) => _$RecentsPageConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -1333,7 +1333,7 @@ case _:
 /// @nodoc
 mixin _$LoginModeSelectPageConfig {
 
- ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background; TextStyleConfig? get greetingTextStyle;
+ ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background; TextStyleConfig? get greetingTextStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1344,16 +1344,16 @@ $LoginModeSelectPageConfigCopyWith<LoginModeSelectPageConfig> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background)&&(identical(other.greetingTextStyle, greetingTextStyle) || other.greetingTextStyle == greetingTextStyle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background)&&(identical(other.greetingTextStyle, greetingTextStyle) || other.greetingTextStyle == greetingTextStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background,greetingTextStyle);
+int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background,greetingTextStyle,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background, greetingTextStyle: $greetingTextStyle)';
+  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background, greetingTextStyle: $greetingTextStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1364,7 +1364,7 @@ abstract mixin class $LoginModeSelectPageConfigCopyWith<$Res>  {
   factory $LoginModeSelectPageConfigCopyWith(LoginModeSelectPageConfig value, $Res Function(LoginModeSelectPageConfig) _then) = _$LoginModeSelectPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background, TextStyleConfig? greetingTextStyle
+ ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background, TextStyleConfig? greetingTextStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1381,7 +1381,7 @@ class _$LoginModeSelectPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,Object? greetingTextStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,Object? greetingTextStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(LoginModeSelectPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
@@ -1390,7 +1390,9 @@ as ImageSource?,buttonLoginStyleType: null == buttonLoginStyleType ? _self.butto
 as ElevatedButtonStyleType,buttonSignupStyleType: null == buttonSignupStyleType ? _self.buttonSignupStyleType : buttonSignupStyleType // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonStyleType,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,greetingTextStyle: freezed == greetingTextStyle ? _self.greetingTextStyle : greetingTextStyle // ignore: cast_nullable_to_non_nullable
-as TextStyleConfig?,
+as TextStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -1525,7 +1527,7 @@ case _:
 /// @nodoc
 mixin _$LoginSwitchPageConfig {
 
- ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background; ButtonStyleConfig? get segmentButtonStyle;
+ ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background; ButtonStyleConfig? get segmentButtonStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1536,16 +1538,16 @@ $LoginSwitchPageConfigCopyWith<LoginSwitchPageConfig> get copyWith => _$LoginSwi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background)&&(identical(other.segmentButtonStyle, segmentButtonStyle) || other.segmentButtonStyle == segmentButtonStyle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background)&&(identical(other.segmentButtonStyle, segmentButtonStyle) || other.segmentButtonStyle == segmentButtonStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background,segmentButtonStyle);
+int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background,segmentButtonStyle,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background, segmentButtonStyle: $segmentButtonStyle)';
+  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background, segmentButtonStyle: $segmentButtonStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1556,7 +1558,7 @@ abstract mixin class $LoginSwitchPageConfigCopyWith<$Res>  {
   factory $LoginSwitchPageConfigCopyWith(LoginSwitchPageConfig value, $Res Function(LoginSwitchPageConfig) _then) = _$LoginSwitchPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride, ButtonStyleConfig? segmentButtonStyle
+ ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride, ButtonStyleConfig? segmentButtonStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1573,13 +1575,15 @@ class _$LoginSwitchPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,Object? segmentButtonStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,Object? segmentButtonStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(LoginSwitchPageConfig(
 mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo // ignore: cast_nullable_to_non_nullable
 as ImageSource?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,segmentButtonStyle: freezed == segmentButtonStyle ? _self.segmentButtonStyle : segmentButtonStyle // ignore: cast_nullable_to_non_nullable
-as ButtonStyleConfig?,
+as ButtonStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -1714,7 +1718,7 @@ case _:
 /// @nodoc
 mixin _$AboutPageConfig {
 
- ImageSource? get mainLogo; Metadata get metadata; PageBackground? get background;
+ ImageSource? get mainLogo; Metadata get metadata; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of AboutPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1725,16 +1729,16 @@ $AboutPageConfigCopyWith<AboutPageConfig> get copyWith => _$AboutPageConfigCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutPageConfig&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutPageConfig&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,mainLogo,metadata,background);
+int get hashCode => Object.hash(runtimeType,mainLogo,metadata,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'AboutPageConfig(mainLogo: $mainLogo, metadata: $metadata, background: $background)';
+  return 'AboutPageConfig(mainLogo: $mainLogo, metadata: $metadata, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1745,7 +1749,7 @@ abstract mixin class $AboutPageConfigCopyWith<$Res>  {
   factory $AboutPageConfigCopyWith(AboutPageConfig value, $Res Function(AboutPageConfig) _then) = _$AboutPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ImageSource? mainLogo, Metadata metadata, PageBackground? background
+ ImageSource? mainLogo, Metadata metadata, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1762,12 +1766,14 @@ class _$AboutPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of AboutPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? metadata = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? metadata = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(AboutPageConfig(
 mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo // ignore: cast_nullable_to_non_nullable
 as ImageSource?,metadata: null == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
 as Metadata,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -1902,7 +1908,7 @@ case _:
 /// @nodoc
 mixin _$CallPageConfig {
 
- OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageActionsConfig? get actions; PageBackground? get background;
+ OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageActionsConfig? get actions; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1913,16 +1919,16 @@ $CallPageConfigCopyWith<CallPageConfig> get copyWith => _$CallPageConfigCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,actions,background);
+int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,actions,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions, background: $background)';
+  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1933,7 +1939,7 @@ abstract mixin class $CallPageConfigCopyWith<$Res>  {
   factory $CallPageConfigCopyWith(CallPageConfig value, $Res Function(CallPageConfig) _then) = _$CallPageConfigCopyWithImpl;
 @useResult
 $Res call({
- OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle
+ OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1950,14 +1956,16 @@ class _$CallPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(CallPageConfig(
 systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
 as OverlayStyleModel?,callInfo: freezed == callInfo ? _self.callInfo : callInfo // ignore: cast_nullable_to_non_nullable
 as CallPageInfoConfig?,actions: freezed == actions ? _self.actions : actions // ignore: cast_nullable_to_non_nullable
 as CallPageActionsConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,appBarStyle: freezed == appBarStyle ? _self.appBarStyle : appBarStyle // ignore: cast_nullable_to_non_nullable
-as AppBarConfig?,
+as AppBarConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -2475,7 +2483,7 @@ case _:
 /// @nodoc
 mixin _$KeypadPageConfig {
 
- OverlayStyleModel? get systemUiOverlayStyle; TextFieldConfig? get textField; TextFieldConfig? get contactName; KeypadStyleConfig? get keypad; ActionPadWidgetConfig? get actionpad; PageBackground? get background; ThemeOverrideConfig get themeOverride;
+ OverlayStyleModel? get systemUiOverlayStyle; TextFieldConfig? get textField; TextFieldConfig? get contactName; KeypadStyleConfig? get keypad; ActionPadWidgetConfig? get actionpad; PageBackground? get background; ThemeOverrideConfig get themeOverride; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of KeypadPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2486,16 +2494,16 @@ $KeypadPageConfigCopyWith<KeypadPageConfig> get copyWith => _$KeypadPageConfigCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is KeypadPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.textField, textField) || other.textField == textField)&&(identical(other.contactName, contactName) || other.contactName == contactName)&&(identical(other.keypad, keypad) || other.keypad == keypad)&&(identical(other.actionpad, actionpad) || other.actionpad == actionpad)&&(identical(other.background, background) || other.background == background)&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is KeypadPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.textField, textField) || other.textField == textField)&&(identical(other.contactName, contactName) || other.contactName == contactName)&&(identical(other.keypad, keypad) || other.keypad == keypad)&&(identical(other.actionpad, actionpad) || other.actionpad == actionpad)&&(identical(other.background, background) || other.background == background)&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,textField,contactName,keypad,actionpad,background,themeOverride);
+int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,textField,contactName,keypad,actionpad,background,themeOverride,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'KeypadPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, textField: $textField, contactName: $contactName, keypad: $keypad, actionpad: $actionpad, background: $background, themeOverride: $themeOverride)';
+  return 'KeypadPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, textField: $textField, contactName: $contactName, keypad: $keypad, actionpad: $actionpad, background: $background, themeOverride: $themeOverride, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -2506,7 +2514,7 @@ abstract mixin class $KeypadPageConfigCopyWith<$Res>  {
   factory $KeypadPageConfigCopyWith(KeypadPageConfig value, $Res Function(KeypadPageConfig) _then) = _$KeypadPageConfigCopyWithImpl;
 @useResult
 $Res call({
- OverlayStyleModel? systemUiOverlayStyle, TextFieldConfig? textField, TextFieldConfig? contactName, KeypadStyleConfig? keypad, ActionPadWidgetConfig? actionpad, PageBackground? background, ThemeOverrideConfig themeOverride
+ OverlayStyleModel? systemUiOverlayStyle, TextFieldConfig? textField, TextFieldConfig? contactName, KeypadStyleConfig? keypad, ActionPadWidgetConfig? actionpad, PageBackground? background, ThemeOverrideConfig themeOverride, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -2523,7 +2531,7 @@ class _$KeypadPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of KeypadPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? textField = freezed,Object? contactName = freezed,Object? keypad = freezed,Object? actionpad = freezed,Object? background = freezed,Object? themeOverride = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? textField = freezed,Object? contactName = freezed,Object? keypad = freezed,Object? actionpad = freezed,Object? background = freezed,Object? themeOverride = null,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(KeypadPageConfig(
 systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
 as OverlayStyleModel?,textField: freezed == textField ? _self.textField : textField // ignore: cast_nullable_to_non_nullable
@@ -2532,7 +2540,9 @@ as TextFieldConfig?,keypad: freezed == keypad ? _self.keypad : keypad // ignore:
 as KeypadStyleConfig?,actionpad: freezed == actionpad ? _self.actionpad : actionpad // ignore: cast_nullable_to_non_nullable
 as ActionPadWidgetConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
-as ThemeOverrideConfig,
+as ThemeOverrideConfig,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -2855,7 +2865,7 @@ case _:
 /// @nodoc
 mixin _$SettingsPageConfig {
 
- ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle;
+ ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2866,16 +2876,16 @@ $SettingsPageConfigCopyWith<SettingsPageConfig> get copyWith => _$SettingsPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,background,itemTextStyle);
+int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,background,itemTextStyle,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, background: $background, itemTextStyle: $itemTextStyle)';
+  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, background: $background, itemTextStyle: $itemTextStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -2886,7 +2896,7 @@ abstract mixin class $SettingsPageConfigCopyWith<$Res>  {
   factory $SettingsPageConfigCopyWith(SettingsPageConfig value, $Res Function(SettingsPageConfig) _then) = _$SettingsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, PageBackground? background, TextStyleConfig? itemTextStyle
+ ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, PageBackground? background, TextStyleConfig? itemTextStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -2903,7 +2913,7 @@ class _$SettingsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? background = freezed,Object? itemTextStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? background = freezed,Object? itemTextStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(SettingsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,leadingIconsColor: freezed == leadingIconsColor ? _self.leadingIconsColor : leadingIconsColor // ignore: cast_nullable_to_non_nullable
@@ -2913,7 +2923,9 @@ as String?,groupTitleListTile: freezed == groupTitleListTile ? _self.groupTitleL
 as GroupTitleListTileWidgetConfig?,showSeparators: null == showSeparators ? _self.showSeparators : showSeparators // ignore: cast_nullable_to_non_nullable
 as bool,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,itemTextStyle: freezed == itemTextStyle ? _self.itemTextStyle : itemTextStyle // ignore: cast_nullable_to_non_nullable
-as TextStyleConfig?,
+as TextStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3048,7 +3060,7 @@ case _:
 /// @nodoc
 mixin _$ContactsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of ContactsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3059,16 +3071,16 @@ $ContactsPageConfigCopyWith<ContactsPageConfig> get copyWith => _$ContactsPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContactsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContactsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'ContactsPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'ContactsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3079,7 +3091,7 @@ abstract mixin class $ContactsPageConfigCopyWith<$Res>  {
   factory $ContactsPageConfigCopyWith(ContactsPageConfig value, $Res Function(ContactsPageConfig) _then) = _$ContactsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3096,11 +3108,13 @@ class _$ContactsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of ContactsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(ContactsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3235,7 +3249,7 @@ case _:
 /// @nodoc
 mixin _$EmbeddedPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of EmbeddedPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3246,16 +3260,16 @@ $EmbeddedPageConfigCopyWith<EmbeddedPageConfig> get copyWith => _$EmbeddedPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddedPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddedPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'EmbeddedPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'EmbeddedPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3266,7 +3280,7 @@ abstract mixin class $EmbeddedPageConfigCopyWith<$Res>  {
   factory $EmbeddedPageConfigCopyWith(EmbeddedPageConfig value, $Res Function(EmbeddedPageConfig) _then) = _$EmbeddedPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3283,11 +3297,13 @@ class _$EmbeddedPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddedPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(EmbeddedPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3422,7 +3438,7 @@ case _:
 /// @nodoc
 mixin _$FavoritesPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of FavoritesPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3433,16 +3449,16 @@ $FavoritesPageConfigCopyWith<FavoritesPageConfig> get copyWith => _$FavoritesPag
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FavoritesPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FavoritesPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'FavoritesPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'FavoritesPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3453,7 +3469,7 @@ abstract mixin class $FavoritesPageConfigCopyWith<$Res>  {
   factory $FavoritesPageConfigCopyWith(FavoritesPageConfig value, $Res Function(FavoritesPageConfig) _then) = _$FavoritesPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3470,11 +3486,13 @@ class _$FavoritesPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of FavoritesPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(FavoritesPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3609,7 +3627,7 @@ case _:
 /// @nodoc
 mixin _$ConversationsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of ConversationsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3620,16 +3638,16 @@ $ConversationsPageConfigCopyWith<ConversationsPageConfig> get copyWith => _$Conv
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConversationsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConversationsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'ConversationsPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'ConversationsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3640,7 +3658,7 @@ abstract mixin class $ConversationsPageConfigCopyWith<$Res>  {
   factory $ConversationsPageConfigCopyWith(ConversationsPageConfig value, $Res Function(ConversationsPageConfig) _then) = _$ConversationsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3657,11 +3675,13 @@ class _$ConversationsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of ConversationsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(ConversationsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3796,7 +3816,7 @@ case _:
 /// @nodoc
 mixin _$RecentsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of RecentsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3807,16 +3827,16 @@ $RecentsPageConfigCopyWith<RecentsPageConfig> get copyWith => _$RecentsPageConfi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'RecentsPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'RecentsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3827,7 +3847,7 @@ abstract mixin class $RecentsPageConfigCopyWith<$Res>  {
   factory $RecentsPageConfigCopyWith(RecentsPageConfig value, $Res Function(RecentsPageConfig) _then) = _$RecentsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3844,11 +3864,13 @@ class _$RecentsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of RecentsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(RecentsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -216,6 +216,12 @@ LoginModeSelectPageConfig _$LoginModeSelectPageConfigFromJson(
       : TextStyleConfig.fromJson(
           json['greetingTextStyle'] as Map<String, dynamic>,
         ),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$LoginModeSelectPageConfigToJson(
@@ -230,6 +236,8 @@ Map<String, dynamic> _$LoginModeSelectPageConfigToJson(
       _$ElevatedButtonStyleTypeEnumMap[instance.buttonSignupStyleType]!,
   'background': instance.background?.toJson(),
   'greetingTextStyle': instance.greetingTextStyle?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 const _$ElevatedButtonStyleTypeEnumMap = {
@@ -258,6 +266,12 @@ LoginSwitchPageConfig _$LoginSwitchPageConfigFromJson(
       : ButtonStyleConfig.fromJson(
           json['segmentButtonStyle'] as Map<String, dynamic>,
         ),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$LoginSwitchPageConfigToJson(
@@ -267,6 +281,8 @@ Map<String, dynamic> _$LoginSwitchPageConfigToJson(
   'mainLogo': instance.mainLogo?.toJson(),
   'background': instance.background?.toJson(),
   'segmentButtonStyle': instance.segmentButtonStyle?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 AboutPageConfig _$AboutPageConfigFromJson(Map<String, dynamic> json) =>
@@ -280,6 +296,12 @@ AboutPageConfig _$AboutPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$AboutPageConfigToJson(AboutPageConfig instance) =>
@@ -287,6 +309,8 @@ Map<String, dynamic> _$AboutPageConfigToJson(AboutPageConfig instance) =>
       'mainLogo': instance.mainLogo?.toJson(),
       'metadata': instance.metadata.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 CallPageConfig _$CallPageConfigFromJson(
@@ -309,6 +333,12 @@ CallPageConfig _$CallPageConfigFromJson(
   appBarStyle: json['appBarStyle'] == null
       ? null
       : AppBarConfig.fromJson(json['appBarStyle'] as Map<String, dynamic>),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$CallPageConfigToJson(CallPageConfig instance) =>
@@ -318,6 +348,8 @@ Map<String, dynamic> _$CallPageConfigToJson(CallPageConfig instance) =>
       'callInfo': instance.callInfo?.toJson(),
       'actions': instance.actions?.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 CallPageActionsConfig _$CallPageActionsConfigFromJson(
@@ -447,6 +479,12 @@ KeypadPageConfig _$KeypadPageConfigFromJson(Map<String, dynamic> json) =>
           : ThemeOverrideConfig.fromJson(
               json['themeOverride'] as Map<String, dynamic>,
             ),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$KeypadPageConfigToJson(KeypadPageConfig instance) =>
@@ -458,6 +496,8 @@ Map<String, dynamic> _$KeypadPageConfigToJson(KeypadPageConfig instance) =>
       'actionpad': instance.actionpad?.toJson(),
       'background': instance.background?.toJson(),
       'themeOverride': instance.themeOverride.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 ActionPadWidgetConfig _$ActionPadWidgetConfigFromJson(
@@ -510,6 +550,12 @@ SettingsPageConfig _$SettingsPageConfigFromJson(Map<String, dynamic> json) =>
           : TextStyleConfig.fromJson(
               json['itemTextStyle'] as Map<String, dynamic>,
             ),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$SettingsPageConfigToJson(SettingsPageConfig instance) =>
@@ -522,6 +568,8 @@ Map<String, dynamic> _$SettingsPageConfigToJson(SettingsPageConfig instance) =>
       'showSeparators': instance.showSeparators,
       'background': instance.background?.toJson(),
       'itemTextStyle': instance.itemTextStyle?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 ContactsPageConfig _$ContactsPageConfigFromJson(Map<String, dynamic> json) =>
@@ -534,12 +582,20 @@ ContactsPageConfig _$ContactsPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$ContactsPageConfigToJson(ContactsPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 EmbeddedPageConfig _$EmbeddedPageConfigFromJson(Map<String, dynamic> json) =>
@@ -552,12 +608,20 @@ EmbeddedPageConfig _$EmbeddedPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$EmbeddedPageConfigToJson(EmbeddedPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 FavoritesPageConfig _$FavoritesPageConfigFromJson(Map<String, dynamic> json) =>
@@ -570,6 +634,12 @@ FavoritesPageConfig _$FavoritesPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$FavoritesPageConfigToJson(
@@ -577,6 +647,8 @@ Map<String, dynamic> _$FavoritesPageConfigToJson(
 ) => <String, dynamic>{
   'themeOverride': instance.themeOverride.toJson(),
   'background': instance.background?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 ConversationsPageConfig _$ConversationsPageConfigFromJson(
@@ -590,6 +662,12 @@ ConversationsPageConfig _$ConversationsPageConfigFromJson(
   background: json['background'] == null
       ? null
       : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$ConversationsPageConfigToJson(
@@ -597,6 +675,8 @@ Map<String, dynamic> _$ConversationsPageConfigToJson(
 ) => <String, dynamic>{
   'themeOverride': instance.themeOverride.toJson(),
   'background': instance.background?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 RecentsPageConfig _$RecentsPageConfigFromJson(Map<String, dynamic> json) =>
@@ -609,10 +689,18 @@ RecentsPageConfig _$RecentsPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$RecentsPageConfigToJson(RecentsPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };


### PR DESCRIPTION
## Summary
- Add `appBarBackgroundColor` and `appBarBlurredSurface` (`color`, `sigmaX`, `sigmaY`) to `BasePageConfig` and all page configs
- Create `BlurredSurfaceConfig` (freezed DTO) and `BlurredSurfaceStyle` with full config→style→factory→screen pipeline
- Update all 7 main screens (Keypad, Contacts, Favorites, Recents, Conversations, Settings, About) to use configurable blur params
- Update page configuration documentation with new common fields

## Test plan
- [ ] Verify keypad screen renders with configured `appBarBackgroundColor`
- [ ] Verify `appBarBlurredSurface` with custom `color`/`sigmaX`/`sigmaY` produces correct blur effect
- [ ] Verify screens without config values fall back to defaults
- [ ] Run `flutter analyze` — no issues