### PR TITLE
feat: appBar blurred surface config and theme updates

### DIFF
--- a/assets/themes/original.page.dark.config.json
+++ b/assets/themes/original.page.dark.config.json
@@ -271,6 +271,11 @@
     }
   },
   "about": {
+    "appBarBlurredSurface": {
+      "color": "#96111315",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "mainLogo": {
       "uri": "asset://assets/images/secondary_onboarding_logo.svg",
       "render": {
@@ -300,6 +305,11 @@
     }
   },
   "settings": {
+    "appBarBlurredSurface": {
+      "color": "#96111315",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "dark",
@@ -323,6 +333,11 @@
     }
   },
   "keypad": {
+    "appBarBlurredSurface": {
+      "color": "#96111315",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "dark",
@@ -346,6 +361,11 @@
     }
   },
   "contacts": {
+    "appBarBlurredSurface": {
+      "color": "#96111315",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "dark",
@@ -369,6 +389,11 @@
     }
   },
   "favorites": {
+    "appBarBlurredSurface": {
+      "color": "#96111315",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "dark",
@@ -392,6 +417,11 @@
     }
   },
   "conversations": {
+    "appBarBlurredSurface": {
+      "color": "#96111315",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "dark",
@@ -415,6 +445,11 @@
     }
   },
   "recents": {
+    "appBarBlurredSurface": {
+      "color": "#96111315",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "dark",

--- a/assets/themes/original.page.light.config.json
+++ b/assets/themes/original.page.light.config.json
@@ -265,6 +265,11 @@
     }
   },
   "about": {
+    "appBarBlurredSurface": {
+      "color": "#CCD5E8F2",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "mainLogo": {
       "uri": "asset://assets/images/secondary_onboarding_logo.svg",
       "render": {
@@ -294,6 +299,11 @@
     }
   },
   "settings": {
+    "appBarBlurredSurface": {
+      "color": "#CCD5E8F2",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "light",
@@ -317,6 +327,11 @@
     }
   },
   "keypad": {
+    "appBarBlurredSurface": {
+      "color": "#CCD5E8F2",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "light",
@@ -340,6 +355,11 @@
     }
   },
   "contacts": {
+    "appBarBlurredSurface": {
+      "color": "#CCD5E8F2",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "light",
@@ -363,6 +383,11 @@
     }
   },
   "favorites": {
+    "appBarBlurredSurface": {
+      "color": "#CCD5E8F2",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "light",
@@ -386,6 +411,11 @@
     }
   },
   "conversations": {
+    "appBarBlurredSurface": {
+      "color": "#CCD5E8F2",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "light",
@@ -409,6 +439,11 @@
     }
   },
   "recents": {
+    "appBarBlurredSurface": {
+      "color": "#CCD5E8F2",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "__themeOverride": "Configuration to force a specific theme mode (Light/Dark) for this screen, overriding the system or global app theme. Contains 'mode' (system/light/dark) and 'applyToAppBar' (bool).",
     "_themeOverride": {
       "mode": "light",

--- a/assets/themes/original.page.light.config.json
+++ b/assets/themes/original.page.light.config.json
@@ -266,7 +266,7 @@
   },
   "about": {
     "appBarBlurredSurface": {
-      "color": "#CCD5E8F2",
+      "color": "#96EEF5FA",
       "sigmaX": 10,
       "sigmaY": 10
     },
@@ -300,7 +300,7 @@
   },
   "settings": {
     "appBarBlurredSurface": {
-      "color": "#CCD5E8F2",
+      "color": "#96EEF5FA",
       "sigmaX": 10,
       "sigmaY": 10
     },
@@ -328,7 +328,7 @@
   },
   "keypad": {
     "appBarBlurredSurface": {
-      "color": "#CCD5E8F2",
+      "color": "#96EEF5FA",
       "sigmaX": 10,
       "sigmaY": 10
     },
@@ -356,7 +356,7 @@
   },
   "contacts": {
     "appBarBlurredSurface": {
-      "color": "#CCD5E8F2",
+      "color": "#96EEF5FA",
       "sigmaX": 10,
       "sigmaY": 10
     },
@@ -384,7 +384,7 @@
   },
   "favorites": {
     "appBarBlurredSurface": {
-      "color": "#CCD5E8F2",
+      "color": "#96EEF5FA",
       "sigmaX": 10,
       "sigmaY": 10
     },
@@ -412,7 +412,7 @@
   },
   "conversations": {
     "appBarBlurredSurface": {
-      "color": "#CCD5E8F2",
+      "color": "#96EEF5FA",
       "sigmaX": 10,
       "sigmaY": 10
     },
@@ -440,7 +440,7 @@
   },
   "recents": {
     "appBarBlurredSurface": {
-      "color": "#CCD5E8F2",
+      "color": "#96EEF5FA",
       "sigmaX": 10,
       "sigmaY": 10
     },

--- a/assets/themes/original.widget.dark.config.json
+++ b/assets/themes/original.widget.dark.config.json
@@ -2,7 +2,7 @@
   "fonts": {
     "fontFamily": "Montserrat"
   },
-  "_button": {
+  "button": {
     "__primaryElevatedButton": "Styling for the primary elevated button used across the app. Supports textStyle, colors, shape, elevation, padding, and more.",
     "primaryElevatedButton": {
       "backgroundColor": "#A5C6E4",
@@ -21,7 +21,7 @@
       }
     }
   },
-  "_group": {
+  "group": {
     "__groupTitleListTile": "Styling for group title tiles in list views (e.g., section headers in contacts or settings).",
     "groupTitleListTile": {
       "backgroundColor": "#1D2022",
@@ -34,7 +34,7 @@
       }
     }
   },
-  "_bar": {
+  "bar": {
     "__bottomNavigationBar": "Bottom navigation bar styling.",
     "bottomNavigationBar": {
       "backgroundColor": "#111315",
@@ -45,8 +45,9 @@
     "appBarConfig": {
       "primary": true,
       "showBackButton": true,
-      "backgroundColor": "#111315",
+      "backgroundColor": "#00000000",
       "foregroundColor": "#E2E2E2",
+      "surfaceTintColor": "#00000000",
       "centerTitle": true,
       "elevation": 0,
       "scrolledUnderElevation": 0,
@@ -61,9 +62,9 @@
     "__tabBarConfig": "Tab bar styling including indicator, labels, alignment, and animation.",
     "tabBarConfig": {
       "indicatorColor": "#A5C6E4",
-      "labelColor": "#A5C6E4",
+      "labelColor": "#092D4A",
       "unselectedLabelColor": "#8E918F",
-      "dividerColor": "#444749",
+      "dividerColor": "#00000000",
       "indicatorSize": "tab",
       "tabAlignment": "fill"
     }
@@ -119,7 +120,7 @@
       }
     }
   },
-  "_input": {
+  "input": {
     "__primary": "Primary text form field styling. Controls label color and border colors for different states (disabled, focused, default).",
     "primary": {
       "labelColor": "#A5C6E4",
@@ -139,7 +140,7 @@
       }
     }
   },
-  "_text": {
+  "text": {
     "__selection": "Text selection styling: cursor, selection highlight, and drag handles.",
     "selection": {
       "cursorColor": "#A5C6E4",

--- a/assets/themes/original.widget.light.config.json
+++ b/assets/themes/original.widget.light.config.json
@@ -57,6 +57,10 @@
           "weight": 600
         },
         "color": "#30302F"
+      },
+      "systemOverlayStyle": {
+        "statusBarIconBrightness": "dark",
+        "statusBarBrightness": "light"
       }
     },
     "__tabBarConfig": "Tab bar styling including indicator, labels, alignment, and animation.",

--- a/assets/themes/original.widget.light.config.json
+++ b/assets/themes/original.widget.light.config.json
@@ -2,7 +2,7 @@
   "fonts": {
     "fontFamily": "Montserrat"
   },
-  "_button": {
+  "button": {
     "__primaryElevatedButton": "Styling for the primary elevated button used across the app. Supports textStyle, colors, shape, elevation, padding, and more.",
     "primaryElevatedButton": {
       "backgroundColor": "#5CACE3",
@@ -21,7 +21,7 @@
       }
     }
   },
-  "_group": {
+  "group": {
     "__groupTitleListTile": "Styling for group title tiles in list views (e.g., section headers in contacts or settings).",
     "groupTitleListTile": {
       "backgroundColor": "#EEF3F6",
@@ -34,7 +34,7 @@
       }
     }
   },
-  "_bar": {
+  "bar": {
     "__bottomNavigationBar": "Bottom navigation bar styling.",
     "bottomNavigationBar": {
       "backgroundColor": "#FFFFFF",
@@ -45,8 +45,9 @@
     "appBarConfig": {
       "primary": true,
       "showBackButton": true,
-      "backgroundColor": "#FFFFFF",
+      "backgroundColor": "#00000000",
       "foregroundColor": "#30302F",
+      "surfaceTintColor": "#00000000",
       "centerTitle": true,
       "elevation": 0,
       "scrolledUnderElevation": 0,
@@ -61,9 +62,9 @@
     "__tabBarConfig": "Tab bar styling including indicator, labels, alignment, and animation.",
     "tabBarConfig": {
       "indicatorColor": "#5CACE3",
-      "labelColor": "#5CACE3",
+      "labelColor": "#FFFFFF",
       "unselectedLabelColor": "#848581",
-      "dividerColor": "#CDCFC9",
+      "dividerColor": "#00000000",
       "indicatorSize": "tab",
       "tabAlignment": "fill"
     }
@@ -119,7 +120,7 @@
       }
     }
   },
-  "_input": {
+  "input": {
     "__primary": "Primary text form field styling. Controls label color and border colors for different states (disabled, focused, default).",
     "primary": {
       "labelColor": "#1F618F",
@@ -139,7 +140,7 @@
       }
     }
   },
-  "_text": {
+  "text": {
     "__selection": "Text selection styling: cursor, selection highlight, and drag handles.",
     "selection": {
       "cursorColor": "#5CACE3",

--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -403,11 +403,13 @@ Every page config that has an app bar supports these optional fields:
 }
 ```
 
-| Key      | Type   | Default | Description                          |
-|----------|--------|---------|--------------------------------------|
-| `color`  | string | `null`  | Overlay color (hex).                 |
-| `sigmaX` | double | `0`     | Horizontal gaussian blur sigma.      |
-| `sigmaY` | double | `0`     | Vertical gaussian blur sigma.        |
+| Key      | Type   | Default | Description                     |
+|----------|--------|---------|---------------------------------|
+| `color`  | string | `null`  | Overlay color (hex).            |
+| `sigmaX` | double | `0`     | Horizontal gaussian blur sigma. Resolved default: 10. |
+| `sigmaY` | double | `0`     | Vertical gaussian blur sigma. Resolved default: 10.   |
+
+When `appBarBlurredSurface` is present (even `{}`), the app bar applies a frosted-glass blur with resolved sigma defaults of 10. When absent (`null`), no blur is applied and the app bar uses the standard theme background.
 
 Applies to: **Keypad**, **Contacts**, **Favorites**, **Recents**, **Conversations**, **Settings**, **About**.
 

--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -19,6 +19,7 @@ back to sensible in-app defaults.
     - [App bar](#app-bar)
     - [Call info](#call-info)
 - [Keypad page](#keypad-page)
+- [Common page fields](#common-page-fields)
 - [Common object formats](#common-object-formats)
 
 ---
@@ -338,19 +339,27 @@ application, including the main call screen and the keypad.
 
 Top-level keys inside `"keypad"`:
 
-| Key                    | Type   | Description                                                                                                            |
-|------------------------|--------|------------------------------------------------------------------------------------------------------------------------|
-| `systemUiOverlayStyle` | object | Status/navigation bars styling.                                                                                        |
-| `textField`            | object | Number input field style (top of page).                                                                                |
-| `contactName`          | object | Resolved contact name style (under input).                                                                             |
-| `keypad`               | object | Numeric keypad layout (digits, spacing, padding).                                                                      |
-| `actionpad`            | object | Layout for action buttons (call, backspace, etc.). Button styles are taken from the global `Action Pad Configuration`. |
+| Key                      | Type   | Description                                                                                                            |
+|--------------------------|--------|------------------------------------------------------------------------------------------------------------------------|
+| `appBarBackgroundColor`  | string | App bar background color (hex). See [Common page fields](#common-page-fields).                                         |
+| `appBarBlurredSurface`   | object | Blurred surface config. See [Common page fields](#common-page-fields).                                                 |
+| `systemUiOverlayStyle`   | object | Status/navigation bars styling.                                                                                        |
+| `textField`              | object | Number input field style (top of page).                                                                                |
+| `contactName`            | object | Resolved contact name style (under input).                                                                             |
+| `keypad`                 | object | Numeric keypad layout (digits, spacing, padding).                                                                      |
+| `actionpad`              | object | Layout for action buttons (call, backspace, etc.). Button styles are taken from the global `Action Pad Configuration`. |
 
 **Minimal example:**
 
 ```json
 {
   "keypad": {
+    "appBarBackgroundColor": "#000000",
+    "appBarBlurredSurface": {
+      "color": "#66000000",
+      "sigmaX": 10,
+      "sigmaY": 10
+    },
     "systemUiOverlayStyle": {
       "statusBarIconBrightness": "dark"
     },
@@ -373,6 +382,37 @@ Top-level keys inside `"keypad"`:
   }
 }
 ```
+
+---
+
+## Common page fields
+
+Every page config that has an app bar supports these optional fields:
+
+| Key                     | Type   | Description                                                        |
+|-------------------------|--------|--------------------------------------------------------------------|
+| `appBarBackgroundColor` | string | Background color for the app bar (hex). Overrides the default.     |
+| `appBarBlurredSurface`  | object | Blurred surface overlay config (frosted-glass effect in app bar).  |
+
+### `appBarBlurredSurface`
+
+```json
+{
+  "appBarBlurredSurface": {
+    "color": "#66000000",
+    "sigmaX": 10,
+    "sigmaY": 10
+  }
+}
+```
+
+| Key      | Type   | Default | Description                          |
+|----------|--------|---------|--------------------------------------|
+| `color`  | string | `null`  | Overlay color (hex).                 |
+| `sigmaX` | double | `0`     | Horizontal gaussian blur sigma.      |
+| `sigmaY` | double | `0`     | Vertical gaussian blur sigma.        |
+
+Applies to: **Keypad**, **Contacts**, **Favorites**, **Recents**, **Conversations**, **Settings**, **About**.
 
 ---
 

--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -403,13 +403,13 @@ Every page config that has an app bar supports these optional fields:
 }
 ```
 
-| Key      | Type   | Default | Description                     |
-|----------|--------|---------|---------------------------------|
-| `color`  | string | `null`  | Overlay color (hex).            |
-| `sigmaX` | double | `0`     | Horizontal gaussian blur sigma. Resolved default: 10. |
-| `sigmaY` | double | `0`     | Vertical gaussian blur sigma. Resolved default: 10.   |
+| Key      | Type   | Default | Description                       |
+|----------|--------|---------|-----------------------------------|
+| `color`  | string | `null`  | Overlay color (hex).              |
+| `sigmaX` | double | `null`  | Horizontal gaussian blur sigma. Defaults to 10 when omitted. |
+| `sigmaY` | double | `null`  | Vertical gaussian blur sigma. Defaults to 10 when omitted.   |
 
-When `appBarBlurredSurface` is present (even `{}`), the app bar applies a frosted-glass blur with resolved sigma defaults of 10. When absent (`null`), no blur is applied and the app bar uses the standard theme background.
+When `appBarBlurredSurface` is present (even `{}`), the app bar applies a frosted-glass blur. `sigmaX`/`sigmaY` default to 10 when omitted. When `appBarBlurredSurface` is absent (`null`), no blur is applied and the app bar uses the standard theme background.
 
 Applies to: **Keypad**, **Contacts**, **Favorites**, **Recents**, **Conversations**, **Settings**, **About**.
 

--- a/docs/page_configuration.md
+++ b/docs/page_configuration.md
@@ -341,7 +341,6 @@ Top-level keys inside `"keypad"`:
 
 | Key                      | Type   | Description                                                                                                            |
 |--------------------------|--------|------------------------------------------------------------------------------------------------------------------------|
-| `appBarBackgroundColor`  | string | App bar background color (hex). See [Common page fields](#common-page-fields).                                         |
 | `appBarBlurredSurface`   | object | Blurred surface config. See [Common page fields](#common-page-fields).                                                 |
 | `systemUiOverlayStyle`   | object | Status/navigation bars styling.                                                                                        |
 | `textField`              | object | Number input field style (top of page).                                                                                |
@@ -354,7 +353,6 @@ Top-level keys inside `"keypad"`:
 ```json
 {
   "keypad": {
-    "appBarBackgroundColor": "#000000",
     "appBarBlurredSurface": {
       "color": "#66000000",
       "sigmaX": 10,
@@ -391,7 +389,6 @@ Every page config that has an app bar supports these optional fields:
 
 | Key                     | Type   | Description                                                        |
 |-------------------------|--------|--------------------------------------------------------------------|
-| `appBarBackgroundColor` | string | Background color for the app bar (hex). Overrides the default.     |
 | `appBarBlurredSurface`  | object | Blurred surface overlay config (frosted-glass effect in app bar).  |
 
 ### `appBarBlurredSurface`

--- a/lib/features/cdrs/view/recent_cdrs_screen.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen.dart
@@ -55,7 +55,7 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
         title: widget.title,
         context: context,
         backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -127,8 +127,12 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          backgroundColor: themeData.canvasColor.withAlpha(150),
-          flexibleSpace: const BlurredSurface(),
+          backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+          flexibleSpace: BlurredSurface(
+            color: effectiveStyle?.appBarBlurredSurface?.color,
+            sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+            sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+          ),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -127,7 +127,6 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
           flexibleSpace: BlurredSurface(
             color: effectiveStyle?.appBarBlurredSurface?.color,
             sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -127,11 +127,7 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          flexibleSpace: BlurredSurface(
-            color: effectiveStyle?.appBarBlurredSurface?.color,
-            sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
-            sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
-          ),
+          flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/contacts/view/contacts_screen_style.dart
+++ b/lib/features/contacts/view/contacts_screen_style.dart
@@ -2,16 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const ContactsScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const ContactsScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
-  ContactsScreenStyle copyWith({BackgroundStyle? background, ThemeMode? contentThemeOverride, bool? applyToAppBar}) {
+  ContactsScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeMode? contentThemeOverride,
+    bool? applyToAppBar,
+  }) {
     return ContactsScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -23,6 +38,8 @@ class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return ContactsScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -31,6 +48,8 @@ class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static ContactsScreenStyle lerp(ContactsScreenStyle? a, ContactsScreenStyle? b, double t) {
     return ContactsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/contacts/view/contacts_screen_style.dart
+++ b/lib/features/contacts/view/contacts_screen_style.dart
@@ -7,7 +7,6 @@ import 'package:webtrit_phone/widgets/blurred_surface.dart';
 class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
   const ContactsScreenStyle({
     super.background,
-    super.appBarBackgroundColor,
     super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
@@ -18,14 +17,12 @@ class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
   ContactsScreenStyle copyWith({
     BackgroundStyle? background,
-    Color? appBarBackgroundColor,
     BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
   }) {
     return ContactsScreenStyle(
       background: background ?? this.background,
-      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
       appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
@@ -38,7 +35,6 @@ class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return ContactsScreenStyle(
       background: b.background ?? a.background,
-      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
       appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
@@ -48,7 +44,6 @@ class ContactsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static ContactsScreenStyle lerp(ContactsScreenStyle? a, ContactsScreenStyle? b, double t) {
     return ContactsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
-      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
       appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -106,7 +106,6 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
         flexibleSpace: BlurredSurface(
           color: effectiveStyle?.appBarBlurredSurface?.color,
           sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -106,8 +106,12 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
       ),
       body: BlocBuilder<FavoritesBloc, FavoritesState>(
         builder: (context, state) {

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -106,11 +106,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        flexibleSpace: BlurredSurface(
-          color: effectiveStyle?.appBarBlurredSurface?.color,
-          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
-          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
-        ),
+        flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
       ),
       body: BlocBuilder<FavoritesBloc, FavoritesState>(
         builder: (context, state) {

--- a/lib/features/favorites/view/favorites_screen_style.dart
+++ b/lib/features/favorites/view/favorites_screen_style.dart
@@ -2,16 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const FavoritesScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const FavoritesScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
-  FavoritesScreenStyle copyWith({BackgroundStyle? background, ThemeMode? contentThemeOverride, bool? applyToAppBar}) {
+  FavoritesScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeMode? contentThemeOverride,
+    bool? applyToAppBar,
+  }) {
     return FavoritesScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -23,6 +38,8 @@ class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return FavoritesScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -31,6 +48,8 @@ class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
   static FavoritesScreenStyle lerp(FavoritesScreenStyle? a, FavoritesScreenStyle? b, double t) {
     return FavoritesScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/favorites/view/favorites_screen_style.dart
+++ b/lib/features/favorites/view/favorites_screen_style.dart
@@ -7,7 +7,6 @@ import 'package:webtrit_phone/widgets/blurred_surface.dart';
 class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
   const FavoritesScreenStyle({
     super.background,
-    super.appBarBackgroundColor,
     super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
@@ -18,14 +17,12 @@ class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
 
   FavoritesScreenStyle copyWith({
     BackgroundStyle? background,
-    Color? appBarBackgroundColor,
     BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
   }) {
     return FavoritesScreenStyle(
       background: background ?? this.background,
-      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
       appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
@@ -38,7 +35,6 @@ class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return FavoritesScreenStyle(
       background: b.background ?? a.background,
-      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
       appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
@@ -48,7 +44,6 @@ class FavoritesScreenStyle extends BaseScreenStyle with Diagnosticable {
   static FavoritesScreenStyle lerp(FavoritesScreenStyle? a, FavoritesScreenStyle? b, double t) {
     return FavoritesScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
-      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
       appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,

--- a/lib/features/keypad/view/keypad_screen.dart
+++ b/lib/features/keypad/view/keypad_screen.dart
@@ -29,11 +29,7 @@ class KeypadScreen extends StatelessWidget {
       appBar: MainAppBar(
         title: title,
         context: context,
-        flexibleSpace: BlurredSurface(
-          color: effectiveStyle?.appBarBlurredSurface?.color,
-          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
-          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
-        ),
+        flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
       ),
       body: KeypadView(videoEnabled: videoEnabled, transferEnabled: transferEnabled, style: effectiveStyle),
     );

--- a/lib/features/keypad/view/keypad_screen.dart
+++ b/lib/features/keypad/view/keypad_screen.dart
@@ -29,8 +29,12 @@ class KeypadScreen extends StatelessWidget {
       appBar: MainAppBar(
         title: title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
       ),
       body: KeypadView(videoEnabled: videoEnabled, transferEnabled: transferEnabled, style: effectiveStyle),
     );

--- a/lib/features/keypad/view/keypad_screen.dart
+++ b/lib/features/keypad/view/keypad_screen.dart
@@ -29,7 +29,6 @@ class KeypadScreen extends StatelessWidget {
       appBar: MainAppBar(
         title: title,
         context: context,
-        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
         flexibleSpace: BlurredSurface(
           color: effectiveStyle?.appBarBlurredSurface?.color,
           sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,

--- a/lib/features/keypad/view/keypad_screen_style.dart
+++ b/lib/features/keypad/view/keypad_screen_style.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 import '../widgets/actionpad_style.dart';
 import '../widgets/keypad_style.dart';
@@ -14,6 +15,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   /// Creates a keypad screen style.
   const KeypadScreenStyle({
     super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
     this.inputField,
@@ -43,6 +46,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   /// Creates a copy of this style with the given fields replaced with the new values.
   KeypadScreenStyle copyWith({
     BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
     TextFieldStyle? inputField,
@@ -52,6 +57,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   }) {
     return KeypadScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
       inputField: inputField ?? this.inputField,
@@ -68,6 +75,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return KeypadScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
       inputField: TextFieldStyle.merge(a.inputField, b.inputField),
@@ -81,6 +90,8 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   static KeypadScreenStyle lerp(KeypadScreenStyle? a, KeypadScreenStyle? b, double t) {
     return KeypadScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
       inputField: TextFieldStyle.lerp(a?.inputField, b?.inputField, t),

--- a/lib/features/keypad/view/keypad_screen_style.dart
+++ b/lib/features/keypad/view/keypad_screen_style.dart
@@ -15,7 +15,6 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   /// Creates a keypad screen style.
   const KeypadScreenStyle({
     super.background,
-    super.appBarBackgroundColor,
     super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
@@ -46,7 +45,6 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   /// Creates a copy of this style with the given fields replaced with the new values.
   KeypadScreenStyle copyWith({
     BackgroundStyle? background,
-    Color? appBarBackgroundColor,
     BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
@@ -57,7 +55,6 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   }) {
     return KeypadScreenStyle(
       background: background ?? this.background,
-      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
       appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
@@ -75,7 +72,6 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return KeypadScreenStyle(
       background: b.background ?? a.background,
-      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
       appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
@@ -90,7 +86,6 @@ class KeypadScreenStyle extends BaseScreenStyle with Diagnosticable {
   static KeypadScreenStyle lerp(KeypadScreenStyle? a, KeypadScreenStyle? b, double t) {
     return KeypadScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
-      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
       appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,

--- a/lib/features/messaging/features/conversations/view/conversations_screen.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen.dart
@@ -249,8 +249,12 @@ class _ConversationsScreenState extends State<ConversationsScreen> with SingleTi
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          backgroundColor: themeData.canvasColor.withAlpha(150),
-          flexibleSpace: const BlurredSurface(),
+          backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+          flexibleSpace: BlurredSurface(
+            color: effectiveStyle?.appBarBlurredSurface?.color,
+            sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+            sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+          ),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/messaging/features/conversations/view/conversations_screen.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen.dart
@@ -249,11 +249,7 @@ class _ConversationsScreenState extends State<ConversationsScreen> with SingleTi
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          flexibleSpace: BlurredSurface(
-            color: effectiveStyle?.appBarBlurredSurface?.color,
-            sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
-            sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
-          ),
+          flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
           bottom: PreferredSize(
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,

--- a/lib/features/messaging/features/conversations/view/conversations_screen.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen.dart
@@ -249,7 +249,6 @@ class _ConversationsScreenState extends State<ConversationsScreen> with SingleTi
         appBar: MainAppBar(
           title: widget.title,
           context: context,
-          backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
           flexibleSpace: BlurredSurface(
             color: effectiveStyle?.appBarBlurredSurface?.color,
             sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,

--- a/lib/features/messaging/features/conversations/view/conversations_screen_style.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen_style.dart
@@ -7,7 +7,6 @@ import 'package:webtrit_phone/widgets/blurred_surface.dart';
 class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
   const ConversationsScreenStyle({
     super.background,
-    super.appBarBackgroundColor,
     super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
@@ -18,14 +17,12 @@ class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
   ConversationsScreenStyle copyWith({
     BackgroundStyle? background,
-    Color? appBarBackgroundColor,
     BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
   }) {
     return ConversationsScreenStyle(
       background: background ?? this.background,
-      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
       appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
@@ -38,7 +35,6 @@ class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return ConversationsScreenStyle(
       background: b.background ?? a.background,
-      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
       appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
@@ -48,7 +44,6 @@ class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static ConversationsScreenStyle lerp(ConversationsScreenStyle? a, ConversationsScreenStyle? b, double t) {
     return ConversationsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
-      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
       appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,

--- a/lib/features/messaging/features/conversations/view/conversations_screen_style.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen_style.dart
@@ -2,20 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const ConversationsScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const ConversationsScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
   ConversationsScreenStyle copyWith({
     BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
   }) {
     return ConversationsScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -27,6 +38,8 @@ class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return ConversationsScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -35,6 +48,8 @@ class ConversationsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static ConversationsScreenStyle lerp(ConversationsScreenStyle? a, ConversationsScreenStyle? b, double t) {
     return ConversationsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -136,8 +136,12 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -136,11 +136,7 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        flexibleSpace: BlurredSurface(
-          color: effectiveStyle?.appBarBlurredSurface?.color,
-          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
-          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
-        ),
+        flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -136,7 +136,6 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
         flexibleSpace: BlurredSurface(
           color: effectiveStyle?.appBarBlurredSurface?.color,
           sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,

--- a/lib/features/recents/view/recents_screen_style.dart
+++ b/lib/features/recents/view/recents_screen_style.dart
@@ -2,16 +2,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const RecentsScreenStyle({super.background, this.contentThemeOverride, this.applyToAppBar});
+  const RecentsScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.contentThemeOverride,
+    this.applyToAppBar,
+  });
 
   final ThemeMode? contentThemeOverride;
   final bool? applyToAppBar;
 
-  RecentsScreenStyle copyWith({BackgroundStyle? background, ThemeMode? contentThemeOverride, bool? applyToAppBar}) {
+  RecentsScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeMode? contentThemeOverride,
+    bool? applyToAppBar,
+  }) {
     return RecentsScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
     );
@@ -23,6 +38,8 @@ class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return RecentsScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
     );
@@ -31,6 +48,8 @@ class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static RecentsScreenStyle lerp(RecentsScreenStyle? a, RecentsScreenStyle? b, double t) {
     return RecentsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
     );

--- a/lib/features/recents/view/recents_screen_style.dart
+++ b/lib/features/recents/view/recents_screen_style.dart
@@ -7,7 +7,6 @@ import 'package:webtrit_phone/widgets/blurred_surface.dart';
 class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
   const RecentsScreenStyle({
     super.background,
-    super.appBarBackgroundColor,
     super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
@@ -18,14 +17,12 @@ class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
   RecentsScreenStyle copyWith({
     BackgroundStyle? background,
-    Color? appBarBackgroundColor,
     BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
   }) {
     return RecentsScreenStyle(
       background: background ?? this.background,
-      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
       appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
@@ -38,7 +35,6 @@ class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return RecentsScreenStyle(
       background: b.background ?? a.background,
-      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
       appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
@@ -48,7 +44,6 @@ class RecentsScreenStyle extends BaseScreenStyle with Diagnosticable {
   static RecentsScreenStyle lerp(RecentsScreenStyle? a, RecentsScreenStyle? b, double t) {
     return RecentsScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
-      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
       appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -49,8 +49,12 @@ class _AboutScreenState extends State<AboutScreen> {
       extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text(context.l10n.settings_ListViewTileTitle_about),
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: localStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: localStyle?.appBarBlurredSurface?.color,
+          sigmaX: localStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: localStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
       ),
       body: BlocBuilder<AboutBloc, AboutState>(
         builder: (context, state) {

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -49,11 +49,7 @@ class _AboutScreenState extends State<AboutScreen> {
       extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text(context.l10n.settings_ListViewTileTitle_about),
-        flexibleSpace: BlurredSurface(
-          color: localStyle?.appBarBlurredSurface?.color,
-          sigmaX: localStyle?.appBarBlurredSurface?.sigmaX ?? 0,
-          sigmaY: localStyle?.appBarBlurredSurface?.sigmaY ?? 0,
-        ),
+        flexibleSpace: BlurredSurface.fromStyle(localStyle?.appBarBlurredSurface),
       ),
       body: BlocBuilder<AboutBloc, AboutState>(
         builder: (context, state) {

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -49,7 +49,6 @@ class _AboutScreenState extends State<AboutScreen> {
       extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text(context.l10n.settings_ListViewTileTitle_about),
-        backgroundColor: localStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
         flexibleSpace: BlurredSurface(
           color: localStyle?.appBarBlurredSurface?.color,
           sigmaX: localStyle?.appBarBlurredSurface?.sigmaX ?? 0,

--- a/lib/features/settings/features/about/view/about_screen_style.dart
+++ b/lib/features/settings/features/about/view/about_screen_style.dart
@@ -1,28 +1,20 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const AboutScreenStyle({
-    super.background,
-    super.appBarBackgroundColor,
-    super.appBarBlurredSurface,
-    this.pictureLogoStyle,
-  });
+  const AboutScreenStyle({super.background, super.appBarBlurredSurface, this.pictureLogoStyle});
 
   final ThemeImageStyle? pictureLogoStyle;
 
   AboutScreenStyle copyWith({
     BackgroundStyle? background,
-    Color? appBarBackgroundColor,
     BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeImageStyle? pictureLogoStyle,
   }) {
     return AboutScreenStyle(
       background: background ?? this.background,
-      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
       appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       pictureLogoStyle: pictureLogoStyle ?? this.pictureLogoStyle,
     );
@@ -34,7 +26,6 @@ class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return AboutScreenStyle(
       background: b.background ?? a.background,
-      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
       appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       pictureLogoStyle: ThemeImageStyle.merge(a.pictureLogoStyle, b.pictureLogoStyle),
     );
@@ -47,7 +38,6 @@ class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return AboutScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
-      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
       appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       pictureLogoStyle: ThemeImageStyle.lerp(a?.pictureLogoStyle, b?.pictureLogoStyle, t),
     );

--- a/lib/features/settings/features/about/view/about_screen_style.dart
+++ b/lib/features/settings/features/about/view/about_screen_style.dart
@@ -1,15 +1,29 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
-  const AboutScreenStyle({super.background, this.pictureLogoStyle});
+  const AboutScreenStyle({
+    super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
+    this.pictureLogoStyle,
+  });
 
   final ThemeImageStyle? pictureLogoStyle;
 
-  AboutScreenStyle copyWith({BackgroundStyle? background, ThemeImageStyle? pictureLogoStyle}) {
+  AboutScreenStyle copyWith({
+    BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
+    ThemeImageStyle? pictureLogoStyle,
+  }) {
     return AboutScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       pictureLogoStyle: pictureLogoStyle ?? this.pictureLogoStyle,
     );
   }
@@ -20,6 +34,8 @@ class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return AboutScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       pictureLogoStyle: ThemeImageStyle.merge(a.pictureLogoStyle, b.pictureLogoStyle),
     );
   }
@@ -31,6 +47,8 @@ class AboutScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return AboutScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       pictureLogoStyle: ThemeImageStyle.lerp(a?.pictureLogoStyle, b?.pictureLogoStyle, t),
     );
   }

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -45,8 +45,12 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(
         leading: const AutoLeadingButton(),
         title: Text(context.l10n.settings_AppBarTitle_myAccount),
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
+        flexibleSpace: BlurredSurface(
+          color: effectiveStyle?.appBarBlurredSurface?.color,
+          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
+          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
+        ),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -45,7 +45,6 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(
         leading: const AutoLeadingButton(),
         title: Text(context.l10n.settings_AppBarTitle_myAccount),
-        backgroundColor: effectiveStyle?.appBarBackgroundColor ?? themeData.canvasColor.withAlpha(150),
         flexibleSpace: BlurredSurface(
           color: effectiveStyle?.appBarBlurredSurface?.color,
           sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -45,11 +45,7 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(
         leading: const AutoLeadingButton(),
         title: Text(context.l10n.settings_AppBarTitle_myAccount),
-        flexibleSpace: BlurredSurface(
-          color: effectiveStyle?.appBarBlurredSurface?.color,
-          sigmaX: effectiveStyle?.appBarBlurredSurface?.sigmaX ?? 0,
-          sigmaY: effectiveStyle?.appBarBlurredSurface?.sigmaY ?? 0,
-        ),
+        flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),

--- a/lib/features/settings/view/settings_screen_style.dart
+++ b/lib/features/settings/view/settings_screen_style.dart
@@ -14,7 +14,6 @@ import '../widgets/group_title_list_style.dart';
 class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   const SettingScreenStyle({
     super.background,
-    super.appBarBackgroundColor,
     super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
@@ -53,7 +52,6 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
 
   SettingScreenStyle copyWith({
     BackgroundStyle? background,
-    Color? appBarBackgroundColor,
     BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
@@ -67,7 +65,6 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   }) {
     return SettingScreenStyle(
       background: background ?? this.background,
-      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
       appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
@@ -87,7 +84,6 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return SettingScreenStyle(
       background: b.background ?? a.background,
-      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
       appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
@@ -104,7 +100,6 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   static SettingScreenStyle lerp(SettingScreenStyle? a, SettingScreenStyle? b, double t) {
     return SettingScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
-      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
       appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,

--- a/lib/features/settings/view/settings_screen_style.dart
+++ b/lib/features/settings/view/settings_screen_style.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 import '../widgets/group_title_list_style.dart';
 
@@ -13,6 +14,8 @@ import '../widgets/group_title_list_style.dart';
 class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   const SettingScreenStyle({
     super.background,
+    super.appBarBackgroundColor,
+    super.appBarBlurredSurface,
     this.contentThemeOverride,
     this.applyToAppBar,
     this.leadingIconsColor,
@@ -50,6 +53,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
 
   SettingScreenStyle copyWith({
     BackgroundStyle? background,
+    Color? appBarBackgroundColor,
+    BlurredSurfaceStyle? appBarBlurredSurface,
     ThemeMode? contentThemeOverride,
     bool? applyToAppBar,
     Color? leadingIconsColor,
@@ -62,6 +67,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   }) {
     return SettingScreenStyle(
       background: background ?? this.background,
+      appBarBackgroundColor: appBarBackgroundColor ?? this.appBarBackgroundColor,
+      appBarBlurredSurface: appBarBlurredSurface ?? this.appBarBlurredSurface,
       contentThemeOverride: contentThemeOverride ?? this.contentThemeOverride,
       applyToAppBar: applyToAppBar ?? this.applyToAppBar,
       leadingIconsColor: leadingIconsColor ?? this.leadingIconsColor,
@@ -80,6 +87,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
 
     return SettingScreenStyle(
       background: b.background ?? a.background,
+      appBarBackgroundColor: b.appBarBackgroundColor ?? a.appBarBackgroundColor,
+      appBarBlurredSurface: BlurredSurfaceStyle.merge(a.appBarBlurredSurface, b.appBarBlurredSurface),
       contentThemeOverride: b.contentThemeOverride ?? a.contentThemeOverride,
       applyToAppBar: b.applyToAppBar ?? a.applyToAppBar,
       leadingIconsColor: b.leadingIconsColor ?? a.leadingIconsColor,
@@ -95,6 +104,8 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   static SettingScreenStyle lerp(SettingScreenStyle? a, SettingScreenStyle? b, double t) {
     return SettingScreenStyle(
       background: BaseScreenStyle.lerp(a?.background, b?.background, t),
+      appBarBackgroundColor: Color.lerp(a?.appBarBackgroundColor, b?.appBarBackgroundColor, t),
+      appBarBlurredSurface: BlurredSurfaceStyle.lerp(a?.appBarBlurredSurface, b?.appBarBlurredSurface, t),
       contentThemeOverride: t < 0.5 ? a?.contentThemeOverride : b?.contentThemeOverride,
       applyToAppBar: t < 0.5 ? a?.applyToAppBar : b?.applyToAppBar,
       leadingIconsColor: Color.lerp(a?.leadingIconsColor, b?.leadingIconsColor, t),

--- a/lib/features/system_notifications/view/system_notifications_screen.dart
+++ b/lib/features/system_notifications/view/system_notifications_screen.dart
@@ -57,7 +57,7 @@ class _SystemNotificationsScreenState extends State<SystemNotificationsScreen> {
       appBar: AppBar(
         title: Text(context.l10n.system_notifications_screen_title),
         backgroundColor: theme.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(),
+        flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
       ),
       body: BlocBuilder<SystemNotificationsScreenCubit, SystemNotificationScreenState>(
         builder: (context, state) {

--- a/lib/theme/extension/blurred_surface_config_extension.dart
+++ b/lib/theme/extension/blurred_surface_config_extension.dart
@@ -1,0 +1,11 @@
+import 'package:webtrit_appearance_theme/webtrit_appearance_theme.dart';
+
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
+
+import 'theme_json_serializable.dart';
+
+extension BlurredSurfaceConfigExtension on BlurredSurfaceConfig {
+  BlurredSurfaceStyle toStyle() {
+    return BlurredSurfaceStyle(color: color?.toColor(), sigmaX: sigmaX, sigmaY: sigmaY);
+  }
+}

--- a/lib/theme/extension/extension.dart
+++ b/lib/theme/extension/extension.dart
@@ -1,4 +1,5 @@
 export 'alignment_config_extension.dart';
+export 'blurred_surface_config_extension.dart';
 export 'box_fit_config_extension.dart';
 export 'brightness.dart';
 export 'button_style_config.dart';

--- a/lib/theme/factory/styles/about_screen_style_factory.dart
+++ b/lib/theme/factory/styles/about_screen_style_factory.dart
@@ -17,7 +17,12 @@ class AboutScreenStyleFactory implements ThemeStyleFactory<AboutScreenStyles> {
     final backgroundStyle = config?.background?.toStyle();
 
     return AboutScreenStyles(
-      primary: AboutScreenStyle(pictureLogoStyle: pictureLogoStyle, background: backgroundStyle),
+      primary: AboutScreenStyle(
+        pictureLogoStyle: pictureLogoStyle,
+        background: backgroundStyle,
+        appBarBackgroundColor: config?.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config?.appBarBlurredSurface?.toStyle(),
+      ),
     );
   }
 }

--- a/lib/theme/factory/styles/about_screen_style_factory.dart
+++ b/lib/theme/factory/styles/about_screen_style_factory.dart
@@ -20,7 +20,6 @@ class AboutScreenStyleFactory implements ThemeStyleFactory<AboutScreenStyles> {
       primary: AboutScreenStyle(
         pictureLogoStyle: pictureLogoStyle,
         background: backgroundStyle,
-        appBarBackgroundColor: config?.appBarBackgroundColor?.toColor(),
         appBarBlurredSurface: config?.appBarBlurredSurface?.toStyle(),
       ),
     );

--- a/lib/theme/factory/styles/contacts_screen_style_factory.dart
+++ b/lib/theme/factory/styles/contacts_screen_style_factory.dart
@@ -20,7 +20,6 @@ class ContactsScreenStyleFactory implements ThemeStyleFactory<ContactsScreenStyl
     return ContactsScreenStyles(
       primary: ContactsScreenStyle(
         background: backgroundStyle,
-        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
         appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,

--- a/lib/theme/factory/styles/contacts_screen_style_factory.dart
+++ b/lib/theme/factory/styles/contacts_screen_style_factory.dart
@@ -20,6 +20,8 @@ class ContactsScreenStyleFactory implements ThemeStyleFactory<ContactsScreenStyl
     return ContactsScreenStyles(
       primary: ContactsScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/conversations_screen_style_factory.dart
+++ b/lib/theme/factory/styles/conversations_screen_style_factory.dart
@@ -22,6 +22,8 @@ class ConversationsScreenStyleFactory implements ThemeStyleFactory<Conversations
     return ConversationsScreenStyles(
       primary: ConversationsScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/conversations_screen_style_factory.dart
+++ b/lib/theme/factory/styles/conversations_screen_style_factory.dart
@@ -22,7 +22,6 @@ class ConversationsScreenStyleFactory implements ThemeStyleFactory<Conversations
     return ConversationsScreenStyles(
       primary: ConversationsScreenStyle(
         background: backgroundStyle,
-        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
         appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,

--- a/lib/theme/factory/styles/favorites_screen_style_factory.dart
+++ b/lib/theme/factory/styles/favorites_screen_style_factory.dart
@@ -22,6 +22,8 @@ class FavoritesScreenStyleFactory implements ThemeStyleFactory<FavoritesScreenSt
     return FavoritesScreenStyles(
       primary: FavoritesScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/favorites_screen_style_factory.dart
+++ b/lib/theme/factory/styles/favorites_screen_style_factory.dart
@@ -22,7 +22,6 @@ class FavoritesScreenStyleFactory implements ThemeStyleFactory<FavoritesScreenSt
     return FavoritesScreenStyles(
       primary: FavoritesScreenStyle(
         background: backgroundStyle,
-        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
         appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,

--- a/lib/theme/factory/styles/keypad_screen_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_screen_style_factory.dart
@@ -28,7 +28,6 @@ class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> 
     return KeypadScreenStyles(
       primary: KeypadScreenStyle(
         background: backgroundStyle,
-        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
         appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,

--- a/lib/theme/factory/styles/keypad_screen_style_factory.dart
+++ b/lib/theme/factory/styles/keypad_screen_style_factory.dart
@@ -28,6 +28,8 @@ class KeypadScreenStyleFactory implements ThemeStyleFactory<KeypadScreenStyles> 
     return KeypadScreenStyles(
       primary: KeypadScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
         inputField: config.textField?.toStyle(colors: colors, defaultFontFamily: defaultFontFamily),

--- a/lib/theme/factory/styles/recents_screen_style_factory.dart
+++ b/lib/theme/factory/styles/recents_screen_style_factory.dart
@@ -21,7 +21,6 @@ class RecentsScreenStyleFactory implements ThemeStyleFactory<RecentsScreenStyles
     return RecentsScreenStyles(
       primary: RecentsScreenStyle(
         background: backgroundStyle,
-        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
         appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,

--- a/lib/theme/factory/styles/recents_screen_style_factory.dart
+++ b/lib/theme/factory/styles/recents_screen_style_factory.dart
@@ -21,6 +21,8 @@ class RecentsScreenStyleFactory implements ThemeStyleFactory<RecentsScreenStyles
     return RecentsScreenStyles(
       primary: RecentsScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: config.themeOverride.mode.toThemeMode(),
         applyToAppBar: config.themeOverride.applyToAppBar,
       ),

--- a/lib/theme/factory/styles/settings_screen_style_factory.dart
+++ b/lib/theme/factory/styles/settings_screen_style_factory.dart
@@ -36,6 +36,8 @@ class SettingsScreenStyleFactory implements ThemeStyleFactory<SettingsScreenStyl
     return SettingsScreenStyles(
       primary: SettingScreenStyle(
         background: backgroundStyle,
+        appBarBackgroundColor: config?.appBarBackgroundColor?.toColor(),
+        appBarBlurredSurface: config?.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: contentThemeOverride,
         applyToAppBar: applyToAppBar,
         leadingIconsColor: leadingIconsColor,

--- a/lib/theme/factory/styles/settings_screen_style_factory.dart
+++ b/lib/theme/factory/styles/settings_screen_style_factory.dart
@@ -36,7 +36,6 @@ class SettingsScreenStyleFactory implements ThemeStyleFactory<SettingsScreenStyl
     return SettingsScreenStyles(
       primary: SettingScreenStyle(
         background: backgroundStyle,
-        appBarBackgroundColor: config?.appBarBackgroundColor?.toColor(),
         appBarBlurredSurface: config?.appBarBlurredSurface?.toStyle(),
         contentThemeOverride: contentThemeOverride,
         applyToAppBar: applyToAppBar,

--- a/lib/theme/styles/base_screen_style.dart
+++ b/lib/theme/styles/base_screen_style.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
 import 'background_style.dart';
 
@@ -10,10 +13,16 @@ export 'background_style.dart';
 /// managing shared attributes such as [BackgroundStyle].
 abstract class BaseScreenStyle with Diagnosticable {
   /// Creates a base screen style.
-  const BaseScreenStyle({this.background});
+  const BaseScreenStyle({this.background, this.appBarBackgroundColor, this.appBarBlurredSurface});
 
   /// The background style configuration for the screen.
   final BackgroundStyle? background;
+
+  /// Optional color override for the AppBar background.
+  final Color? appBarBackgroundColor;
+
+  /// Style for the AppBar's BlurredSurface flexibleSpace.
+  final BlurredSurfaceStyle? appBarBlurredSurface;
 
   /// Linearly interpolates between two [BackgroundStyle]s.
   ///
@@ -26,5 +35,7 @@ abstract class BaseScreenStyle with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<BackgroundStyle?>('background', background));
+    properties.add(ColorProperty('appBarBackgroundColor', appBarBackgroundColor));
+    properties.add(DiagnosticsProperty<BlurredSurfaceStyle?>('appBarBlurredSurface', appBarBlurredSurface));
   }
 }

--- a/lib/theme/styles/base_screen_style.dart
+++ b/lib/theme/styles/base_screen_style.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/widgets/blurred_surface.dart';
 
@@ -13,13 +12,10 @@ export 'background_style.dart';
 /// managing shared attributes such as [BackgroundStyle].
 abstract class BaseScreenStyle with Diagnosticable {
   /// Creates a base screen style.
-  const BaseScreenStyle({this.background, this.appBarBackgroundColor, this.appBarBlurredSurface});
+  const BaseScreenStyle({this.background, this.appBarBlurredSurface});
 
   /// The background style configuration for the screen.
   final BackgroundStyle? background;
-
-  /// Optional color override for the AppBar background.
-  final Color? appBarBackgroundColor;
 
   /// Style for the AppBar's BlurredSurface flexibleSpace.
   final BlurredSurfaceStyle? appBarBlurredSurface;
@@ -35,7 +31,6 @@ abstract class BaseScreenStyle with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<BackgroundStyle?>('background', background));
-    properties.add(ColorProperty('appBarBackgroundColor', appBarBackgroundColor));
     properties.add(DiagnosticsProperty<BlurredSurfaceStyle?>('appBarBlurredSurface', appBarBlurredSurface));
   }
 }

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -2,13 +2,15 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+export 'blurred_surface_style.dart';
+
 /// A backdrop blur surface intended for use as [AppBar.flexibleSpace].
 ///
 /// Applies a [BackdropFilter] with configurable gaussian blur to create
 /// a frosted-glass effect. When used with [Scaffold.extendBodyBehindAppBar],
 /// scrollable content appears blurred beneath the app bar.
 class BlurredSurface extends StatelessWidget {
-  const BlurredSurface({super.key, this.color, this.sigmaX = 10, this.sigmaY = 10, this.child});
+  const BlurredSurface({super.key, this.color, this.sigmaX = 0, this.sigmaY = 0, this.child});
 
   final Color? color;
   final double sigmaX;
@@ -17,7 +19,6 @@ class BlurredSurface extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = this.color ?? Theme.of(context).canvasColor.withAlpha(150);
     return ClipRect(
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY),

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -31,7 +31,7 @@ class BlurredSurface extends StatelessWidget {
     return ClipRect(
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY),
-        child: child ?? Container(color: color),
+        child: child ?? Container(color: color ?? Colors.transparent),
       ),
     );
   }

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+import 'blurred_surface_style.dart';
 export 'blurred_surface_style.dart';
 
 /// A backdrop blur surface intended for use as [AppBar.flexibleSpace].
@@ -11,6 +12,14 @@ export 'blurred_surface_style.dart';
 /// scrollable content appears blurred beneath the app bar.
 class BlurredSurface extends StatelessWidget {
   const BlurredSurface({super.key, this.color, this.sigmaX = 0, this.sigmaY = 0, this.child});
+
+  /// Creates a [BlurredSurface] from [style], or returns `null` when absent.
+  ///
+  /// Defaults sigmaX/sigmaY to 10 when not specified in [style].
+  static BlurredSurface? fromStyle(BlurredSurfaceStyle? style) {
+    if (style == null) return null;
+    return BlurredSurface(color: style.color, sigmaX: style.sigmaX ?? 10, sigmaY: style.sigmaY ?? 10);
+  }
 
   final Color? color;
   final double sigmaX;

--- a/lib/widgets/blurred_surface_style.dart
+++ b/lib/widgets/blurred_surface_style.dart
@@ -1,0 +1,52 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Visual style for a [BlurredSurface] widget.
+class BlurredSurfaceStyle with Diagnosticable {
+  const BlurredSurfaceStyle({this.color, this.sigmaX, this.sigmaY});
+
+  /// Overlay color for the blurred surface.
+  final Color? color;
+
+  /// Horizontal gaussian blur sigma.
+  final double? sigmaX;
+
+  /// Vertical gaussian blur sigma.
+  final double? sigmaY;
+
+  BlurredSurfaceStyle copyWith({Color? color, double? sigmaX, double? sigmaY}) {
+    return BlurredSurfaceStyle(
+      color: color ?? this.color,
+      sigmaX: sigmaX ?? this.sigmaX,
+      sigmaY: sigmaY ?? this.sigmaY,
+    );
+  }
+
+  static BlurredSurfaceStyle merge(BlurredSurfaceStyle? a, BlurredSurfaceStyle? b) {
+    if (a == null) return b ?? const BlurredSurfaceStyle();
+    if (b == null) return a;
+
+    return BlurredSurfaceStyle(color: b.color ?? a.color, sigmaX: b.sigmaX ?? a.sigmaX, sigmaY: b.sigmaY ?? a.sigmaY);
+  }
+
+  static BlurredSurfaceStyle? lerp(BlurredSurfaceStyle? a, BlurredSurfaceStyle? b, double t) {
+    if (a == null && b == null) return null;
+
+    return BlurredSurfaceStyle(
+      color: Color.lerp(a?.color, b?.color, t),
+      sigmaX: lerpDouble(a?.sigmaX, b?.sigmaX, t),
+      sigmaY: lerpDouble(a?.sigmaY, b?.sigmaY, t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(ColorProperty('color', color))
+      ..add(DoubleProperty('sigmaX', sigmaX))
+      ..add(DoubleProperty('sigmaY', sigmaY));
+  }
+}

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'blurred_surface_config.freezed.dart';
+
+part 'blurred_surface_config.g.dart';
+
+/// Declarative configuration for a blurred surface overlay.
+///
+/// Maps to [BlurredSurface] widget parameters: color, sigmaX, sigmaY.
+@freezed
+abstract class BlurredSurfaceConfig with _$BlurredSurfaceConfig {
+  const factory BlurredSurfaceConfig({
+    /// Overlay color (hex string, e.g. `#000000`).
+    String? color,
+
+    /// Horizontal gaussian blur sigma.
+    @Default(0) double sigmaX,
+
+    /// Vertical gaussian blur sigma.
+    @Default(0) double sigmaY,
+  }) = _BlurredSurfaceConfig;
+
+  factory BlurredSurfaceConfig.fromJson(Map<String, dynamic> json) => _$BlurredSurfaceConfigFromJson(json);
+}

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.dart
@@ -14,10 +14,10 @@ abstract class BlurredSurfaceConfig with _$BlurredSurfaceConfig {
     String? color,
 
     /// Horizontal gaussian blur sigma.
-    @Default(0) double sigmaX,
+    double? sigmaX,
 
     /// Vertical gaussian blur sigma.
-    @Default(0) double sigmaY,
+    double? sigmaY,
   }) = _BlurredSurfaceConfig;
 
   factory BlurredSurfaceConfig.fromJson(Map<String, dynamic> json) => _$BlurredSurfaceConfigFromJson(json);

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'blurred_surface_config.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BlurredSurfaceConfig {
+
+/// Overlay color (hex string, e.g. `#000000`).
+ String? get color;/// Horizontal gaussian blur sigma.
+ double get sigmaX;/// Vertical gaussian blur sigma.
+ double get sigmaY;
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BlurredSurfaceConfigCopyWith<BlurredSurfaceConfig> get copyWith => _$BlurredSurfaceConfigCopyWithImpl<BlurredSurfaceConfig>(this as BlurredSurfaceConfig, _$identity);
+
+  /// Serializes this BlurredSurfaceConfig to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BlurredSurfaceConfig&&(identical(other.color, color) || other.color == color)&&(identical(other.sigmaX, sigmaX) || other.sigmaX == sigmaX)&&(identical(other.sigmaY, sigmaY) || other.sigmaY == sigmaY));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,color,sigmaX,sigmaY);
+
+@override
+String toString() {
+  return 'BlurredSurfaceConfig(color: $color, sigmaX: $sigmaX, sigmaY: $sigmaY)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BlurredSurfaceConfigCopyWith<$Res>  {
+  factory $BlurredSurfaceConfigCopyWith(BlurredSurfaceConfig value, $Res Function(BlurredSurfaceConfig) _then) = _$BlurredSurfaceConfigCopyWithImpl;
+@useResult
+$Res call({
+ String? color, double sigmaX, double sigmaY
+});
+
+
+
+
+}
+/// @nodoc
+class _$BlurredSurfaceConfigCopyWithImpl<$Res>
+    implements $BlurredSurfaceConfigCopyWith<$Res> {
+  _$BlurredSurfaceConfigCopyWithImpl(this._self, this._then);
+
+  final BlurredSurfaceConfig _self;
+  final $Res Function(BlurredSurfaceConfig) _then;
+
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? color = freezed,Object? sigmaX = null,Object? sigmaY = null,}) {
+  return _then(_self.copyWith(
+color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String?,sigmaX: null == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
+as double,sigmaY: null == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BlurredSurfaceConfig].
+extension BlurredSurfaceConfigPatterns on BlurredSurfaceConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BlurredSurfaceConfig value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BlurredSurfaceConfig value)  $default,){
+final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BlurredSurfaceConfig value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? color,  double sigmaX,  double sigmaY)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? color,  double sigmaX,  double sigmaY)  $default,) {final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig():
+return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? color,  double sigmaX,  double sigmaY)?  $default,) {final _that = this;
+switch (_that) {
+case _BlurredSurfaceConfig() when $default != null:
+return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _BlurredSurfaceConfig implements BlurredSurfaceConfig {
+  const _BlurredSurfaceConfig({this.color, this.sigmaX = 0, this.sigmaY = 0});
+  factory _BlurredSurfaceConfig.fromJson(Map<String, dynamic> json) => _$BlurredSurfaceConfigFromJson(json);
+
+/// Overlay color (hex string, e.g. `#000000`).
+@override final  String? color;
+/// Horizontal gaussian blur sigma.
+@override@JsonKey() final  double sigmaX;
+/// Vertical gaussian blur sigma.
+@override@JsonKey() final  double sigmaY;
+
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BlurredSurfaceConfigCopyWith<_BlurredSurfaceConfig> get copyWith => __$BlurredSurfaceConfigCopyWithImpl<_BlurredSurfaceConfig>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BlurredSurfaceConfigToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BlurredSurfaceConfig&&(identical(other.color, color) || other.color == color)&&(identical(other.sigmaX, sigmaX) || other.sigmaX == sigmaX)&&(identical(other.sigmaY, sigmaY) || other.sigmaY == sigmaY));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,color,sigmaX,sigmaY);
+
+@override
+String toString() {
+  return 'BlurredSurfaceConfig(color: $color, sigmaX: $sigmaX, sigmaY: $sigmaY)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BlurredSurfaceConfigCopyWith<$Res> implements $BlurredSurfaceConfigCopyWith<$Res> {
+  factory _$BlurredSurfaceConfigCopyWith(_BlurredSurfaceConfig value, $Res Function(_BlurredSurfaceConfig) _then) = __$BlurredSurfaceConfigCopyWithImpl;
+@override @useResult
+$Res call({
+ String? color, double sigmaX, double sigmaY
+});
+
+
+
+
+}
+/// @nodoc
+class __$BlurredSurfaceConfigCopyWithImpl<$Res>
+    implements _$BlurredSurfaceConfigCopyWith<$Res> {
+  __$BlurredSurfaceConfigCopyWithImpl(this._self, this._then);
+
+  final _BlurredSurfaceConfig _self;
+  final $Res Function(_BlurredSurfaceConfig) _then;
+
+/// Create a copy of BlurredSurfaceConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? color = freezed,Object? sigmaX = null,Object? sigmaY = null,}) {
+  return _then(_BlurredSurfaceConfig(
+color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String?,sigmaX: null == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
+as double,sigmaY: null == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.freezed.dart
@@ -17,8 +17,8 @@ mixin _$BlurredSurfaceConfig {
 
 /// Overlay color (hex string, e.g. `#000000`).
  String? get color;/// Horizontal gaussian blur sigma.
- double get sigmaX;/// Vertical gaussian blur sigma.
- double get sigmaY;
+ double? get sigmaX;/// Vertical gaussian blur sigma.
+ double? get sigmaY;
 /// Create a copy of BlurredSurfaceConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -51,7 +51,7 @@ abstract mixin class $BlurredSurfaceConfigCopyWith<$Res>  {
   factory $BlurredSurfaceConfigCopyWith(BlurredSurfaceConfig value, $Res Function(BlurredSurfaceConfig) _then) = _$BlurredSurfaceConfigCopyWithImpl;
 @useResult
 $Res call({
- String? color, double sigmaX, double sigmaY
+ String? color, double? sigmaX, double? sigmaY
 });
 
 
@@ -68,12 +68,12 @@ class _$BlurredSurfaceConfigCopyWithImpl<$Res>
 
 /// Create a copy of BlurredSurfaceConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? color = freezed,Object? sigmaX = null,Object? sigmaY = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? color = freezed,Object? sigmaX = freezed,Object? sigmaY = freezed,}) {
   return _then(_self.copyWith(
 color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
-as String?,sigmaX: null == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
-as double,sigmaY: null == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
-as double,
+as String?,sigmaX: freezed == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
+as double?,sigmaY: freezed == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 
@@ -158,7 +158,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? color,  double sigmaX,  double sigmaY)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? color,  double? sigmaX,  double? sigmaY)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _BlurredSurfaceConfig() when $default != null:
 return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
@@ -179,7 +179,7 @@ return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? color,  double sigmaX,  double sigmaY)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? color,  double? sigmaX,  double? sigmaY)  $default,) {final _that = this;
 switch (_that) {
 case _BlurredSurfaceConfig():
 return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
@@ -199,7 +199,7 @@ return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? color,  double sigmaX,  double sigmaY)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? color,  double? sigmaX,  double? sigmaY)?  $default,) {final _that = this;
 switch (_that) {
 case _BlurredSurfaceConfig() when $default != null:
 return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
@@ -214,15 +214,15 @@ return $default(_that.color,_that.sigmaX,_that.sigmaY);case _:
 @JsonSerializable()
 
 class _BlurredSurfaceConfig implements BlurredSurfaceConfig {
-  const _BlurredSurfaceConfig({this.color, this.sigmaX = 0, this.sigmaY = 0});
+  const _BlurredSurfaceConfig({this.color, this.sigmaX, this.sigmaY});
   factory _BlurredSurfaceConfig.fromJson(Map<String, dynamic> json) => _$BlurredSurfaceConfigFromJson(json);
 
 /// Overlay color (hex string, e.g. `#000000`).
 @override final  String? color;
 /// Horizontal gaussian blur sigma.
-@override@JsonKey() final  double sigmaX;
+@override final  double? sigmaX;
 /// Vertical gaussian blur sigma.
-@override@JsonKey() final  double sigmaY;
+@override final  double? sigmaY;
 
 /// Create a copy of BlurredSurfaceConfig
 /// with the given fields replaced by the non-null parameter values.
@@ -257,7 +257,7 @@ abstract mixin class _$BlurredSurfaceConfigCopyWith<$Res> implements $BlurredSur
   factory _$BlurredSurfaceConfigCopyWith(_BlurredSurfaceConfig value, $Res Function(_BlurredSurfaceConfig) _then) = __$BlurredSurfaceConfigCopyWithImpl;
 @override @useResult
 $Res call({
- String? color, double sigmaX, double sigmaY
+ String? color, double? sigmaX, double? sigmaY
 });
 
 
@@ -274,12 +274,12 @@ class __$BlurredSurfaceConfigCopyWithImpl<$Res>
 
 /// Create a copy of BlurredSurfaceConfig
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? color = freezed,Object? sigmaX = null,Object? sigmaY = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? color = freezed,Object? sigmaX = freezed,Object? sigmaY = freezed,}) {
   return _then(_BlurredSurfaceConfig(
 color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
-as String?,sigmaX: null == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
-as double,sigmaY: null == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
-as double,
+as String?,sigmaX: freezed == sigmaX ? _self.sigmaX : sigmaX // ignore: cast_nullable_to_non_nullable
+as double?,sigmaY: freezed == sigmaY ? _self.sigmaY : sigmaY // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
@@ -6,17 +6,13 @@ part of 'blurred_surface_config.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_BlurredSurfaceConfig _$BlurredSurfaceConfigFromJson(
-  Map<String, dynamic> json,
-) => _BlurredSurfaceConfig(
+_BlurredSurfaceConfig _$BlurredSurfaceConfigFromJson(Map<String, dynamic> json) => _BlurredSurfaceConfig(
   color: json['color'] as String?,
-  sigmaX: (json['sigmaX'] as num?)?.toDouble() ?? 0,
-  sigmaY: (json['sigmaY'] as num?)?.toDouble() ?? 0,
+  sigmaX: (json['sigmaX'] as num?)?.toDouble(),
+  sigmaY: (json['sigmaY'] as num?)?.toDouble(),
 );
 
-Map<String, dynamic> _$BlurredSurfaceConfigToJson(
-  _BlurredSurfaceConfig instance,
-) => <String, dynamic>{
+Map<String, dynamic> _$BlurredSurfaceConfigToJson(_BlurredSurfaceConfig instance) => <String, dynamic>{
   'color': instance.color,
   'sigmaX': instance.sigmaX,
   'sigmaY': instance.sigmaY,

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'blurred_surface_config.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_BlurredSurfaceConfig _$BlurredSurfaceConfigFromJson(
+  Map<String, dynamic> json,
+) => _BlurredSurfaceConfig(
+  color: json['color'] as String?,
+  sigmaX: (json['sigmaX'] as num?)?.toDouble() ?? 0,
+  sigmaY: (json['sigmaY'] as num?)?.toDouble() ?? 0,
+);
+
+Map<String, dynamic> _$BlurredSurfaceConfigToJson(
+  _BlurredSurfaceConfig instance,
+) => <String, dynamic>{
+  'color': instance.color,
+  'sigmaX': instance.sigmaX,
+  'sigmaY': instance.sigmaY,
+};

--- a/packages/webtrit_appearance_theme/lib/models/common/common.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/common.dart
@@ -1,3 +1,4 @@
+export 'blurred_surface_config.dart';
 export 'border_config.dart';
 export 'button_style_config.dart';
 export 'geometry_config.dart';

--- a/packages/webtrit_appearance_theme/lib/models/pages/base_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/pages/base_page_config.dart
@@ -4,7 +4,5 @@ import 'page_background.dart';
 abstract class BasePageConfig {
   PageBackground? get background;
 
-  String? get appBarBackgroundColor;
-
   BlurredSurfaceConfig? get appBarBlurredSurface;
 }

--- a/packages/webtrit_appearance_theme/lib/models/pages/base_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/pages/base_page_config.dart
@@ -1,5 +1,10 @@
+import '../common/blurred_surface_config.dart';
 import 'page_background.dart';
 
 abstract class BasePageConfig {
   PageBackground? get background;
+
+  String? get appBarBackgroundColor;
+
+  BlurredSurfaceConfig? get appBarBlurredSurface;
 }

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -196,7 +196,6 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
     this.buttonSignupStyleType = ElevatedButtonStyleType.primary,
     this.background,
     this.greetingTextStyle,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -222,9 +221,6 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
   final TextStyleConfig? greetingTextStyle;
 
   @override
-  final String? appBarBackgroundColor;
-
-  @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory LoginModeSelectPageConfig.fromJson(Map<String, Object?> json) => _$LoginModeSelectPageConfigFromJson(json);
@@ -240,7 +236,6 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
     this.background,
     this.themeOverride = const ThemeOverrideConfig(),
     this.segmentButtonStyle,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -257,9 +252,6 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
   final ButtonStyleConfig? segmentButtonStyle;
 
   @override
-  final String? appBarBackgroundColor;
-
-  @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory LoginSwitchPageConfig.fromJson(Map<String, Object?> json) => _$LoginSwitchPageConfigFromJson(json);
@@ -271,13 +263,7 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
-  const AboutPageConfig({
-    this.mainLogo,
-    this.metadata = const Metadata(),
-    this.background,
-    this.appBarBackgroundColor,
-    this.appBarBlurredSurface,
-  });
+  const AboutPageConfig({this.mainLogo, this.metadata = const Metadata(), this.background, this.appBarBlurredSurface});
 
   @override
   final ImageSource? mainLogo;
@@ -287,9 +273,6 @@ class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
@@ -313,7 +296,6 @@ class CallPageConfig with _$CallPageConfig implements BasePageConfig {
     this.actions,
     this.background,
     this.appBarStyle,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -331,9 +313,6 @@ class CallPageConfig with _$CallPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
@@ -430,7 +409,6 @@ class KeypadPageConfig with _$KeypadPageConfig implements BasePageConfig {
     this.actionpad,
     this.background,
     this.themeOverride = const ThemeOverrideConfig(),
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -455,9 +433,6 @@ class KeypadPageConfig with _$KeypadPageConfig implements BasePageConfig {
   /// Configuration to force override the theme mode (e.g., force Dark mode).
   @override
   final ThemeOverrideConfig themeOverride;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
@@ -502,7 +477,6 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
     this.showSeparators = true,
     this.background,
     this.itemTextStyle,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -532,9 +506,6 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
   final TextStyleConfig? itemTextStyle;
 
   @override
-  final String? appBarBackgroundColor;
-
-  @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory SettingsPageConfig.fromJson(Map<String, Object?> json) => _$SettingsPageConfigFromJson(json);
@@ -548,7 +519,6 @@ class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
   const ContactsPageConfig({
     this.themeOverride = const ThemeOverrideConfig(),
     this.background,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -558,9 +528,6 @@ class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
@@ -576,7 +543,6 @@ class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
   const EmbeddedPageConfig({
     this.themeOverride = const ThemeOverrideConfig(),
     this.background,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -586,9 +552,6 @@ class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
@@ -604,7 +567,6 @@ class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
   const FavoritesPageConfig({
     this.themeOverride = const ThemeOverrideConfig(),
     this.background,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -614,9 +576,6 @@ class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
@@ -632,7 +591,6 @@ class ConversationsPageConfig with _$ConversationsPageConfig implements BasePage
   const ConversationsPageConfig({
     this.themeOverride = const ThemeOverrideConfig(),
     this.background,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -642,9 +600,6 @@ class ConversationsPageConfig with _$ConversationsPageConfig implements BasePage
 
   @override
   final PageBackground? background;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
@@ -660,7 +615,6 @@ class RecentsPageConfig with _$RecentsPageConfig implements BasePageConfig {
   const RecentsPageConfig({
     this.themeOverride = const ThemeOverrideConfig(),
     this.background,
-    this.appBarBackgroundColor,
     this.appBarBlurredSurface,
   });
 
@@ -670,9 +624,6 @@ class RecentsPageConfig with _$RecentsPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
-
-  @override
-  final String? appBarBackgroundColor;
 
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -196,6 +196,8 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
     this.buttonSignupStyleType = ElevatedButtonStyleType.primary,
     this.background,
     this.greetingTextStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   @override
@@ -219,6 +221,12 @@ class LoginModeSelectPageConfig with _$LoginModeSelectPageConfig implements Base
   @override
   final TextStyleConfig? greetingTextStyle;
 
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
+
   factory LoginModeSelectPageConfig.fromJson(Map<String, Object?> json) => _$LoginModeSelectPageConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$LoginModeSelectPageConfigToJson(this);
@@ -232,6 +240,8 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
     this.background,
     this.themeOverride = const ThemeOverrideConfig(),
     this.segmentButtonStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   @override
@@ -246,6 +256,12 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
   @override
   final ButtonStyleConfig? segmentButtonStyle;
 
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
+
   factory LoginSwitchPageConfig.fromJson(Map<String, Object?> json) => _$LoginSwitchPageConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$LoginSwitchPageConfigToJson(this);
@@ -255,7 +271,13 @@ class LoginSwitchPageConfig with _$LoginSwitchPageConfig implements BasePageConf
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
-  const AboutPageConfig({this.mainLogo, this.metadata = const Metadata(), this.background});
+  const AboutPageConfig({
+    this.mainLogo,
+    this.metadata = const Metadata(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   @override
   final ImageSource? mainLogo;
@@ -265,6 +287,12 @@ class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory AboutPageConfig.fromJson(Map<String, Object?> json) => _$AboutPageConfigFromJson(json);
 
@@ -279,7 +307,15 @@ class AboutPageConfig with _$AboutPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class CallPageConfig with _$CallPageConfig implements BasePageConfig {
-  const CallPageConfig({this.systemUiOverlayStyle, this.callInfo, this.actions, this.background, this.appBarStyle});
+  const CallPageConfig({
+    this.systemUiOverlayStyle,
+    this.callInfo,
+    this.actions,
+    this.background,
+    this.appBarStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   @override
   final OverlayStyleModel? systemUiOverlayStyle;
@@ -295,6 +331,12 @@ class CallPageConfig with _$CallPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory CallPageConfig.fromJson(Map<String, Object?> json) => _$CallPageConfigFromJson(json);
 
@@ -388,6 +430,8 @@ class KeypadPageConfig with _$KeypadPageConfig implements BasePageConfig {
     this.actionpad,
     this.background,
     this.themeOverride = const ThemeOverrideConfig(),
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   @override
@@ -411,6 +455,12 @@ class KeypadPageConfig with _$KeypadPageConfig implements BasePageConfig {
   /// Configuration to force override the theme mode (e.g., force Dark mode).
   @override
   final ThemeOverrideConfig themeOverride;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory KeypadPageConfig.fromJson(Map<String, Object?> json) => _$KeypadPageConfigFromJson(json);
 
@@ -452,6 +502,8 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
     this.showSeparators = true,
     this.background,
     this.itemTextStyle,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
   });
 
   /// Configuration to force override the theme mode.
@@ -479,6 +531,12 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
   @override
   final TextStyleConfig? itemTextStyle;
 
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
+
   factory SettingsPageConfig.fromJson(Map<String, Object?> json) => _$SettingsPageConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$SettingsPageConfigToJson(this);
@@ -487,7 +545,12 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
-  const ContactsPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const ContactsPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -495,6 +558,12 @@ class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory ContactsPageConfig.fromJson(Map<String, Object?> json) => _$ContactsPageConfigFromJson(json);
 
@@ -504,7 +573,12 @@ class ContactsPageConfig with _$ContactsPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
-  const EmbeddedPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const EmbeddedPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -512,6 +586,12 @@ class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory EmbeddedPageConfig.fromJson(Map<String, Object?> json) => _$EmbeddedPageConfigFromJson(json);
 
@@ -521,7 +601,12 @@ class EmbeddedPageConfig with _$EmbeddedPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
-  const FavoritesPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const FavoritesPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -529,6 +614,12 @@ class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory FavoritesPageConfig.fromJson(Map<String, Object?> json) => _$FavoritesPageConfigFromJson(json);
 
@@ -538,7 +629,12 @@ class FavoritesPageConfig with _$FavoritesPageConfig implements BasePageConfig {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class ConversationsPageConfig with _$ConversationsPageConfig implements BasePageConfig {
-  const ConversationsPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const ConversationsPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -546,6 +642,12 @@ class ConversationsPageConfig with _$ConversationsPageConfig implements BasePage
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory ConversationsPageConfig.fromJson(Map<String, Object?> json) => _$ConversationsPageConfigFromJson(json);
 
@@ -555,7 +657,12 @@ class ConversationsPageConfig with _$ConversationsPageConfig implements BasePage
 @freezed
 @JsonSerializable(explicitToJson: true)
 class RecentsPageConfig with _$RecentsPageConfig implements BasePageConfig {
-  const RecentsPageConfig({this.themeOverride = const ThemeOverrideConfig(), this.background});
+  const RecentsPageConfig({
+    this.themeOverride = const ThemeOverrideConfig(),
+    this.background,
+    this.appBarBackgroundColor,
+    this.appBarBlurredSurface,
+  });
 
   /// Configuration to force override the theme mode.
   @override
@@ -563,6 +670,12 @@ class RecentsPageConfig with _$RecentsPageConfig implements BasePageConfig {
 
   @override
   final PageBackground? background;
+
+  @override
+  final String? appBarBackgroundColor;
+
+  @override
+  final BlurredSurfaceConfig? appBarBlurredSurface;
 
   factory RecentsPageConfig.fromJson(Map<String, Object?> json) => _$RecentsPageConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -1333,7 +1333,7 @@ case _:
 /// @nodoc
 mixin _$LoginModeSelectPageConfig {
 
- ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background; TextStyleConfig? get greetingTextStyle;
+ ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background; TextStyleConfig? get greetingTextStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1344,16 +1344,16 @@ $LoginModeSelectPageConfigCopyWith<LoginModeSelectPageConfig> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background)&&(identical(other.greetingTextStyle, greetingTextStyle) || other.greetingTextStyle == greetingTextStyle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background)&&(identical(other.greetingTextStyle, greetingTextStyle) || other.greetingTextStyle == greetingTextStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background,greetingTextStyle);
+int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background,greetingTextStyle,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background, greetingTextStyle: $greetingTextStyle)';
+  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background, greetingTextStyle: $greetingTextStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1364,7 +1364,7 @@ abstract mixin class $LoginModeSelectPageConfigCopyWith<$Res>  {
   factory $LoginModeSelectPageConfigCopyWith(LoginModeSelectPageConfig value, $Res Function(LoginModeSelectPageConfig) _then) = _$LoginModeSelectPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background, TextStyleConfig? greetingTextStyle
+ ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background, TextStyleConfig? greetingTextStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1381,7 +1381,7 @@ class _$LoginModeSelectPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,Object? greetingTextStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,Object? greetingTextStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(LoginModeSelectPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
@@ -1390,7 +1390,9 @@ as ImageSource?,buttonLoginStyleType: null == buttonLoginStyleType ? _self.butto
 as ElevatedButtonStyleType,buttonSignupStyleType: null == buttonSignupStyleType ? _self.buttonSignupStyleType : buttonSignupStyleType // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonStyleType,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,greetingTextStyle: freezed == greetingTextStyle ? _self.greetingTextStyle : greetingTextStyle // ignore: cast_nullable_to_non_nullable
-as TextStyleConfig?,
+as TextStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -1525,7 +1527,7 @@ case _:
 /// @nodoc
 mixin _$LoginSwitchPageConfig {
 
- ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background; ButtonStyleConfig? get segmentButtonStyle;
+ ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background; ButtonStyleConfig? get segmentButtonStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1536,16 +1538,16 @@ $LoginSwitchPageConfigCopyWith<LoginSwitchPageConfig> get copyWith => _$LoginSwi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background)&&(identical(other.segmentButtonStyle, segmentButtonStyle) || other.segmentButtonStyle == segmentButtonStyle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background)&&(identical(other.segmentButtonStyle, segmentButtonStyle) || other.segmentButtonStyle == segmentButtonStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background,segmentButtonStyle);
+int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background,segmentButtonStyle,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background, segmentButtonStyle: $segmentButtonStyle)';
+  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background, segmentButtonStyle: $segmentButtonStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1556,7 +1558,7 @@ abstract mixin class $LoginSwitchPageConfigCopyWith<$Res>  {
   factory $LoginSwitchPageConfigCopyWith(LoginSwitchPageConfig value, $Res Function(LoginSwitchPageConfig) _then) = _$LoginSwitchPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride, ButtonStyleConfig? segmentButtonStyle
+ ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride, ButtonStyleConfig? segmentButtonStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1573,13 +1575,15 @@ class _$LoginSwitchPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,Object? segmentButtonStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,Object? segmentButtonStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(LoginSwitchPageConfig(
 mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo // ignore: cast_nullable_to_non_nullable
 as ImageSource?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,segmentButtonStyle: freezed == segmentButtonStyle ? _self.segmentButtonStyle : segmentButtonStyle // ignore: cast_nullable_to_non_nullable
-as ButtonStyleConfig?,
+as ButtonStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -1714,7 +1718,7 @@ case _:
 /// @nodoc
 mixin _$AboutPageConfig {
 
- ImageSource? get mainLogo; Metadata get metadata; PageBackground? get background;
+ ImageSource? get mainLogo; Metadata get metadata; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of AboutPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1725,16 +1729,16 @@ $AboutPageConfigCopyWith<AboutPageConfig> get copyWith => _$AboutPageConfigCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutPageConfig&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutPageConfig&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,mainLogo,metadata,background);
+int get hashCode => Object.hash(runtimeType,mainLogo,metadata,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'AboutPageConfig(mainLogo: $mainLogo, metadata: $metadata, background: $background)';
+  return 'AboutPageConfig(mainLogo: $mainLogo, metadata: $metadata, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1745,7 +1749,7 @@ abstract mixin class $AboutPageConfigCopyWith<$Res>  {
   factory $AboutPageConfigCopyWith(AboutPageConfig value, $Res Function(AboutPageConfig) _then) = _$AboutPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ImageSource? mainLogo, Metadata metadata, PageBackground? background
+ ImageSource? mainLogo, Metadata metadata, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1762,12 +1766,14 @@ class _$AboutPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of AboutPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? metadata = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? metadata = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(AboutPageConfig(
 mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo // ignore: cast_nullable_to_non_nullable
 as ImageSource?,metadata: null == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
 as Metadata,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -1902,7 +1908,7 @@ case _:
 /// @nodoc
 mixin _$CallPageConfig {
 
- OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageActionsConfig? get actions; PageBackground? get background;
+ OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageActionsConfig? get actions; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1913,16 +1919,16 @@ $CallPageConfigCopyWith<CallPageConfig> get copyWith => _$CallPageConfigCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,actions,background);
+int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,actions,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions, background: $background)';
+  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1933,7 +1939,7 @@ abstract mixin class $CallPageConfigCopyWith<$Res>  {
   factory $CallPageConfigCopyWith(CallPageConfig value, $Res Function(CallPageConfig) _then) = _$CallPageConfigCopyWithImpl;
 @useResult
 $Res call({
- OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle
+ OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1950,14 +1956,16 @@ class _$CallPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(CallPageConfig(
 systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
 as OverlayStyleModel?,callInfo: freezed == callInfo ? _self.callInfo : callInfo // ignore: cast_nullable_to_non_nullable
 as CallPageInfoConfig?,actions: freezed == actions ? _self.actions : actions // ignore: cast_nullable_to_non_nullable
 as CallPageActionsConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,appBarStyle: freezed == appBarStyle ? _self.appBarStyle : appBarStyle // ignore: cast_nullable_to_non_nullable
-as AppBarConfig?,
+as AppBarConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -2475,7 +2483,7 @@ case _:
 /// @nodoc
 mixin _$KeypadPageConfig {
 
- OverlayStyleModel? get systemUiOverlayStyle; TextFieldConfig? get textField; TextFieldConfig? get contactName; KeypadStyleConfig? get keypad; ActionPadWidgetConfig? get actionpad; PageBackground? get background; ThemeOverrideConfig get themeOverride;
+ OverlayStyleModel? get systemUiOverlayStyle; TextFieldConfig? get textField; TextFieldConfig? get contactName; KeypadStyleConfig? get keypad; ActionPadWidgetConfig? get actionpad; PageBackground? get background; ThemeOverrideConfig get themeOverride; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of KeypadPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2486,16 +2494,16 @@ $KeypadPageConfigCopyWith<KeypadPageConfig> get copyWith => _$KeypadPageConfigCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is KeypadPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.textField, textField) || other.textField == textField)&&(identical(other.contactName, contactName) || other.contactName == contactName)&&(identical(other.keypad, keypad) || other.keypad == keypad)&&(identical(other.actionpad, actionpad) || other.actionpad == actionpad)&&(identical(other.background, background) || other.background == background)&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is KeypadPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.textField, textField) || other.textField == textField)&&(identical(other.contactName, contactName) || other.contactName == contactName)&&(identical(other.keypad, keypad) || other.keypad == keypad)&&(identical(other.actionpad, actionpad) || other.actionpad == actionpad)&&(identical(other.background, background) || other.background == background)&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,textField,contactName,keypad,actionpad,background,themeOverride);
+int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,textField,contactName,keypad,actionpad,background,themeOverride,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'KeypadPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, textField: $textField, contactName: $contactName, keypad: $keypad, actionpad: $actionpad, background: $background, themeOverride: $themeOverride)';
+  return 'KeypadPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, textField: $textField, contactName: $contactName, keypad: $keypad, actionpad: $actionpad, background: $background, themeOverride: $themeOverride, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -2506,7 +2514,7 @@ abstract mixin class $KeypadPageConfigCopyWith<$Res>  {
   factory $KeypadPageConfigCopyWith(KeypadPageConfig value, $Res Function(KeypadPageConfig) _then) = _$KeypadPageConfigCopyWithImpl;
 @useResult
 $Res call({
- OverlayStyleModel? systemUiOverlayStyle, TextFieldConfig? textField, TextFieldConfig? contactName, KeypadStyleConfig? keypad, ActionPadWidgetConfig? actionpad, PageBackground? background, ThemeOverrideConfig themeOverride
+ OverlayStyleModel? systemUiOverlayStyle, TextFieldConfig? textField, TextFieldConfig? contactName, KeypadStyleConfig? keypad, ActionPadWidgetConfig? actionpad, PageBackground? background, ThemeOverrideConfig themeOverride, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -2523,7 +2531,7 @@ class _$KeypadPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of KeypadPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? textField = freezed,Object? contactName = freezed,Object? keypad = freezed,Object? actionpad = freezed,Object? background = freezed,Object? themeOverride = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? textField = freezed,Object? contactName = freezed,Object? keypad = freezed,Object? actionpad = freezed,Object? background = freezed,Object? themeOverride = null,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(KeypadPageConfig(
 systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
 as OverlayStyleModel?,textField: freezed == textField ? _self.textField : textField // ignore: cast_nullable_to_non_nullable
@@ -2532,7 +2540,9 @@ as TextFieldConfig?,keypad: freezed == keypad ? _self.keypad : keypad // ignore:
 as KeypadStyleConfig?,actionpad: freezed == actionpad ? _self.actionpad : actionpad // ignore: cast_nullable_to_non_nullable
 as ActionPadWidgetConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
-as ThemeOverrideConfig,
+as ThemeOverrideConfig,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -2855,7 +2865,7 @@ case _:
 /// @nodoc
 mixin _$SettingsPageConfig {
 
- ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle;
+ ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2866,16 +2876,16 @@ $SettingsPageConfigCopyWith<SettingsPageConfig> get copyWith => _$SettingsPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,background,itemTextStyle);
+int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,background,itemTextStyle,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, background: $background, itemTextStyle: $itemTextStyle)';
+  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, background: $background, itemTextStyle: $itemTextStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -2886,7 +2896,7 @@ abstract mixin class $SettingsPageConfigCopyWith<$Res>  {
   factory $SettingsPageConfigCopyWith(SettingsPageConfig value, $Res Function(SettingsPageConfig) _then) = _$SettingsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, PageBackground? background, TextStyleConfig? itemTextStyle
+ ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, PageBackground? background, TextStyleConfig? itemTextStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -2903,7 +2913,7 @@ class _$SettingsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? background = freezed,Object? itemTextStyle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? background = freezed,Object? itemTextStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(SettingsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,leadingIconsColor: freezed == leadingIconsColor ? _self.leadingIconsColor : leadingIconsColor // ignore: cast_nullable_to_non_nullable
@@ -2913,7 +2923,9 @@ as String?,groupTitleListTile: freezed == groupTitleListTile ? _self.groupTitleL
 as GroupTitleListTileWidgetConfig?,showSeparators: null == showSeparators ? _self.showSeparators : showSeparators // ignore: cast_nullable_to_non_nullable
 as bool,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,itemTextStyle: freezed == itemTextStyle ? _self.itemTextStyle : itemTextStyle // ignore: cast_nullable_to_non_nullable
-as TextStyleConfig?,
+as TextStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3048,7 +3060,7 @@ case _:
 /// @nodoc
 mixin _$ContactsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of ContactsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3059,16 +3071,16 @@ $ContactsPageConfigCopyWith<ContactsPageConfig> get copyWith => _$ContactsPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContactsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContactsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'ContactsPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'ContactsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3079,7 +3091,7 @@ abstract mixin class $ContactsPageConfigCopyWith<$Res>  {
   factory $ContactsPageConfigCopyWith(ContactsPageConfig value, $Res Function(ContactsPageConfig) _then) = _$ContactsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3096,11 +3108,13 @@ class _$ContactsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of ContactsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(ContactsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3235,7 +3249,7 @@ case _:
 /// @nodoc
 mixin _$EmbeddedPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of EmbeddedPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3246,16 +3260,16 @@ $EmbeddedPageConfigCopyWith<EmbeddedPageConfig> get copyWith => _$EmbeddedPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddedPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddedPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'EmbeddedPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'EmbeddedPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3266,7 +3280,7 @@ abstract mixin class $EmbeddedPageConfigCopyWith<$Res>  {
   factory $EmbeddedPageConfigCopyWith(EmbeddedPageConfig value, $Res Function(EmbeddedPageConfig) _then) = _$EmbeddedPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3283,11 +3297,13 @@ class _$EmbeddedPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddedPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(EmbeddedPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3422,7 +3438,7 @@ case _:
 /// @nodoc
 mixin _$FavoritesPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of FavoritesPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3433,16 +3449,16 @@ $FavoritesPageConfigCopyWith<FavoritesPageConfig> get copyWith => _$FavoritesPag
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FavoritesPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FavoritesPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'FavoritesPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'FavoritesPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3453,7 +3469,7 @@ abstract mixin class $FavoritesPageConfigCopyWith<$Res>  {
   factory $FavoritesPageConfigCopyWith(FavoritesPageConfig value, $Res Function(FavoritesPageConfig) _then) = _$FavoritesPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3470,11 +3486,13 @@ class _$FavoritesPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of FavoritesPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(FavoritesPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3609,7 +3627,7 @@ case _:
 /// @nodoc
 mixin _$ConversationsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of ConversationsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3620,16 +3638,16 @@ $ConversationsPageConfigCopyWith<ConversationsPageConfig> get copyWith => _$Conv
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConversationsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConversationsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'ConversationsPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'ConversationsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3640,7 +3658,7 @@ abstract mixin class $ConversationsPageConfigCopyWith<$Res>  {
   factory $ConversationsPageConfigCopyWith(ConversationsPageConfig value, $Res Function(ConversationsPageConfig) _then) = _$ConversationsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3657,11 +3675,13 @@ class _$ConversationsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of ConversationsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(ConversationsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 
@@ -3796,7 +3816,7 @@ case _:
 /// @nodoc
 mixin _$RecentsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of RecentsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3807,16 +3827,16 @@ $RecentsPageConfigCopyWith<RecentsPageConfig> get copyWith => _$RecentsPageConfi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'RecentsPageConfig(themeOverride: $themeOverride, background: $background)';
+  return 'RecentsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3827,7 +3847,7 @@ abstract mixin class $RecentsPageConfigCopyWith<$Res>  {
   factory $RecentsPageConfigCopyWith(RecentsPageConfig value, $Res Function(RecentsPageConfig) _then) = _$RecentsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background
+ ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3844,11 +3864,13 @@ class _$RecentsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of RecentsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(RecentsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,
+as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as BlurredSurfaceConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -1333,7 +1333,7 @@ case _:
 /// @nodoc
 mixin _$LoginModeSelectPageConfig {
 
- ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background; TextStyleConfig? get greetingTextStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; OverlayStyleModel? get systemUiOverlayStyle; ImageSource? get mainLogo; ElevatedButtonStyleType get buttonLoginStyleType; ElevatedButtonStyleType get buttonSignupStyleType; PageBackground? get background; TextStyleConfig? get greetingTextStyle; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1344,16 +1344,16 @@ $LoginModeSelectPageConfigCopyWith<LoginModeSelectPageConfig> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background)&&(identical(other.greetingTextStyle, greetingTextStyle) || other.greetingTextStyle == greetingTextStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginModeSelectPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.buttonLoginStyleType, buttonLoginStyleType) || other.buttonLoginStyleType == buttonLoginStyleType)&&(identical(other.buttonSignupStyleType, buttonSignupStyleType) || other.buttonSignupStyleType == buttonSignupStyleType)&&(identical(other.background, background) || other.background == background)&&(identical(other.greetingTextStyle, greetingTextStyle) || other.greetingTextStyle == greetingTextStyle)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background,greetingTextStyle,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,systemUiOverlayStyle,mainLogo,buttonLoginStyleType,buttonSignupStyleType,background,greetingTextStyle,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background, greetingTextStyle: $greetingTextStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'LoginModeSelectPageConfig(themeOverride: $themeOverride, systemUiOverlayStyle: $systemUiOverlayStyle, mainLogo: $mainLogo, buttonLoginStyleType: $buttonLoginStyleType, buttonSignupStyleType: $buttonSignupStyleType, background: $background, greetingTextStyle: $greetingTextStyle, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1364,7 +1364,7 @@ abstract mixin class $LoginModeSelectPageConfigCopyWith<$Res>  {
   factory $LoginModeSelectPageConfigCopyWith(LoginModeSelectPageConfig value, $Res Function(LoginModeSelectPageConfig) _then) = _$LoginModeSelectPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background, TextStyleConfig? greetingTextStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, OverlayStyleModel? systemUiOverlayStyle, ImageSource? mainLogo, ElevatedButtonStyleType buttonLoginStyleType, ElevatedButtonStyleType buttonSignupStyleType, PageBackground? background, TextStyleConfig? greetingTextStyle, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1381,7 +1381,7 @@ class _$LoginModeSelectPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginModeSelectPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,Object? greetingTextStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? systemUiOverlayStyle = freezed,Object? mainLogo = freezed,Object? buttonLoginStyleType = null,Object? buttonSignupStyleType = null,Object? background = freezed,Object? greetingTextStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(LoginModeSelectPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
@@ -1390,8 +1390,7 @@ as ImageSource?,buttonLoginStyleType: null == buttonLoginStyleType ? _self.butto
 as ElevatedButtonStyleType,buttonSignupStyleType: null == buttonSignupStyleType ? _self.buttonSignupStyleType : buttonSignupStyleType // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonStyleType,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,greetingTextStyle: freezed == greetingTextStyle ? _self.greetingTextStyle : greetingTextStyle // ignore: cast_nullable_to_non_nullable
-as TextStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -1527,7 +1526,7 @@ case _:
 /// @nodoc
 mixin _$LoginSwitchPageConfig {
 
- ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background; ButtonStyleConfig? get segmentButtonStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; ImageSource? get mainLogo; PageBackground? get background; ButtonStyleConfig? get segmentButtonStyle; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1538,16 +1537,16 @@ $LoginSwitchPageConfigCopyWith<LoginSwitchPageConfig> get copyWith => _$LoginSwi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background)&&(identical(other.segmentButtonStyle, segmentButtonStyle) || other.segmentButtonStyle == segmentButtonStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginSwitchPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.background, background) || other.background == background)&&(identical(other.segmentButtonStyle, segmentButtonStyle) || other.segmentButtonStyle == segmentButtonStyle)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background,segmentButtonStyle,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,mainLogo,background,segmentButtonStyle,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background, segmentButtonStyle: $segmentButtonStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'LoginSwitchPageConfig(themeOverride: $themeOverride, mainLogo: $mainLogo, background: $background, segmentButtonStyle: $segmentButtonStyle, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1558,7 +1557,7 @@ abstract mixin class $LoginSwitchPageConfigCopyWith<$Res>  {
   factory $LoginSwitchPageConfigCopyWith(LoginSwitchPageConfig value, $Res Function(LoginSwitchPageConfig) _then) = _$LoginSwitchPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride, ButtonStyleConfig? segmentButtonStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ImageSource? mainLogo, PageBackground? background, ThemeOverrideConfig themeOverride, ButtonStyleConfig? segmentButtonStyle, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1575,14 +1574,13 @@ class _$LoginSwitchPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of LoginSwitchPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,Object? segmentButtonStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? background = freezed,Object? themeOverride = null,Object? segmentButtonStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(LoginSwitchPageConfig(
 mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo // ignore: cast_nullable_to_non_nullable
 as ImageSource?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,segmentButtonStyle: freezed == segmentButtonStyle ? _self.segmentButtonStyle : segmentButtonStyle // ignore: cast_nullable_to_non_nullable
-as ButtonStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as ButtonStyleConfig?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -1718,7 +1716,7 @@ case _:
 /// @nodoc
 mixin _$AboutPageConfig {
 
- ImageSource? get mainLogo; Metadata get metadata; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ImageSource? get mainLogo; Metadata get metadata; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of AboutPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1729,16 +1727,16 @@ $AboutPageConfigCopyWith<AboutPageConfig> get copyWith => _$AboutPageConfigCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutPageConfig&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutPageConfig&&(identical(other.mainLogo, mainLogo) || other.mainLogo == mainLogo)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,mainLogo,metadata,background,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,mainLogo,metadata,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'AboutPageConfig(mainLogo: $mainLogo, metadata: $metadata, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'AboutPageConfig(mainLogo: $mainLogo, metadata: $metadata, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1749,7 +1747,7 @@ abstract mixin class $AboutPageConfigCopyWith<$Res>  {
   factory $AboutPageConfigCopyWith(AboutPageConfig value, $Res Function(AboutPageConfig) _then) = _$AboutPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ImageSource? mainLogo, Metadata metadata, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ImageSource? mainLogo, Metadata metadata, PageBackground? background, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1766,13 +1764,12 @@ class _$AboutPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of AboutPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? metadata = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainLogo = freezed,Object? metadata = null,Object? background = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(AboutPageConfig(
 mainLogo: freezed == mainLogo ? _self.mainLogo : mainLogo // ignore: cast_nullable_to_non_nullable
 as ImageSource?,metadata: null == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
 as Metadata,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as PageBackground?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -1908,7 +1905,7 @@ case _:
 /// @nodoc
 mixin _$CallPageConfig {
 
- OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageActionsConfig? get actions; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageActionsConfig? get actions; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1919,16 +1916,16 @@ $CallPageConfigCopyWith<CallPageConfig> get copyWith => _$CallPageConfigCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,actions,background,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,actions,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1939,7 +1936,7 @@ abstract mixin class $CallPageConfigCopyWith<$Res>  {
   factory $CallPageConfigCopyWith(CallPageConfig value, $Res Function(CallPageConfig) _then) = _$CallPageConfigCopyWithImpl;
 @useResult
 $Res call({
- OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1956,15 +1953,14 @@ class _$CallPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(CallPageConfig(
 systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
 as OverlayStyleModel?,callInfo: freezed == callInfo ? _self.callInfo : callInfo // ignore: cast_nullable_to_non_nullable
 as CallPageInfoConfig?,actions: freezed == actions ? _self.actions : actions // ignore: cast_nullable_to_non_nullable
 as CallPageActionsConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,appBarStyle: freezed == appBarStyle ? _self.appBarStyle : appBarStyle // ignore: cast_nullable_to_non_nullable
-as AppBarConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as AppBarConfig?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -2483,7 +2479,7 @@ case _:
 /// @nodoc
 mixin _$KeypadPageConfig {
 
- OverlayStyleModel? get systemUiOverlayStyle; TextFieldConfig? get textField; TextFieldConfig? get contactName; KeypadStyleConfig? get keypad; ActionPadWidgetConfig? get actionpad; PageBackground? get background; ThemeOverrideConfig get themeOverride; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ OverlayStyleModel? get systemUiOverlayStyle; TextFieldConfig? get textField; TextFieldConfig? get contactName; KeypadStyleConfig? get keypad; ActionPadWidgetConfig? get actionpad; PageBackground? get background; ThemeOverrideConfig get themeOverride; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of KeypadPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2494,16 +2490,16 @@ $KeypadPageConfigCopyWith<KeypadPageConfig> get copyWith => _$KeypadPageConfigCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is KeypadPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.textField, textField) || other.textField == textField)&&(identical(other.contactName, contactName) || other.contactName == contactName)&&(identical(other.keypad, keypad) || other.keypad == keypad)&&(identical(other.actionpad, actionpad) || other.actionpad == actionpad)&&(identical(other.background, background) || other.background == background)&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is KeypadPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.textField, textField) || other.textField == textField)&&(identical(other.contactName, contactName) || other.contactName == contactName)&&(identical(other.keypad, keypad) || other.keypad == keypad)&&(identical(other.actionpad, actionpad) || other.actionpad == actionpad)&&(identical(other.background, background) || other.background == background)&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,textField,contactName,keypad,actionpad,background,themeOverride,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,textField,contactName,keypad,actionpad,background,themeOverride,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'KeypadPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, textField: $textField, contactName: $contactName, keypad: $keypad, actionpad: $actionpad, background: $background, themeOverride: $themeOverride, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'KeypadPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, textField: $textField, contactName: $contactName, keypad: $keypad, actionpad: $actionpad, background: $background, themeOverride: $themeOverride, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -2514,7 +2510,7 @@ abstract mixin class $KeypadPageConfigCopyWith<$Res>  {
   factory $KeypadPageConfigCopyWith(KeypadPageConfig value, $Res Function(KeypadPageConfig) _then) = _$KeypadPageConfigCopyWithImpl;
 @useResult
 $Res call({
- OverlayStyleModel? systemUiOverlayStyle, TextFieldConfig? textField, TextFieldConfig? contactName, KeypadStyleConfig? keypad, ActionPadWidgetConfig? actionpad, PageBackground? background, ThemeOverrideConfig themeOverride, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ OverlayStyleModel? systemUiOverlayStyle, TextFieldConfig? textField, TextFieldConfig? contactName, KeypadStyleConfig? keypad, ActionPadWidgetConfig? actionpad, PageBackground? background, ThemeOverrideConfig themeOverride, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -2531,7 +2527,7 @@ class _$KeypadPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of KeypadPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? textField = freezed,Object? contactName = freezed,Object? keypad = freezed,Object? actionpad = freezed,Object? background = freezed,Object? themeOverride = null,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? textField = freezed,Object? contactName = freezed,Object? keypad = freezed,Object? actionpad = freezed,Object? background = freezed,Object? themeOverride = null,Object? appBarBlurredSurface = freezed,}) {
   return _then(KeypadPageConfig(
 systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
 as OverlayStyleModel?,textField: freezed == textField ? _self.textField : textField // ignore: cast_nullable_to_non_nullable
@@ -2540,8 +2536,7 @@ as TextFieldConfig?,keypad: freezed == keypad ? _self.keypad : keypad // ignore:
 as KeypadStyleConfig?,actionpad: freezed == actionpad ? _self.actionpad : actionpad // ignore: cast_nullable_to_non_nullable
 as ActionPadWidgetConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
-as ThemeOverrideConfig,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as ThemeOverrideConfig,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -2865,7 +2860,7 @@ case _:
 /// @nodoc
 mixin _$SettingsPageConfig {
 
- ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2876,16 +2871,16 @@ $SettingsPageConfigCopyWith<SettingsPageConfig> get copyWith => _$SettingsPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,background,itemTextStyle,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,background,itemTextStyle,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, background: $background, itemTextStyle: $itemTextStyle, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, background: $background, itemTextStyle: $itemTextStyle, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -2896,7 +2891,7 @@ abstract mixin class $SettingsPageConfigCopyWith<$Res>  {
   factory $SettingsPageConfigCopyWith(SettingsPageConfig value, $Res Function(SettingsPageConfig) _then) = _$SettingsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, PageBackground? background, TextStyleConfig? itemTextStyle, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, PageBackground? background, TextStyleConfig? itemTextStyle, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -2913,7 +2908,7 @@ class _$SettingsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? background = freezed,Object? itemTextStyle = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? background = freezed,Object? itemTextStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(SettingsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,leadingIconsColor: freezed == leadingIconsColor ? _self.leadingIconsColor : leadingIconsColor // ignore: cast_nullable_to_non_nullable
@@ -2923,8 +2918,7 @@ as String?,groupTitleListTile: freezed == groupTitleListTile ? _self.groupTitleL
 as GroupTitleListTileWidgetConfig?,showSeparators: null == showSeparators ? _self.showSeparators : showSeparators // ignore: cast_nullable_to_non_nullable
 as bool,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,itemTextStyle: freezed == itemTextStyle ? _self.itemTextStyle : itemTextStyle // ignore: cast_nullable_to_non_nullable
-as TextStyleConfig?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -3060,7 +3054,7 @@ case _:
 /// @nodoc
 mixin _$ContactsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of ContactsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3071,16 +3065,16 @@ $ContactsPageConfigCopyWith<ContactsPageConfig> get copyWith => _$ContactsPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContactsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContactsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'ContactsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'ContactsPageConfig(themeOverride: $themeOverride, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3091,7 +3085,7 @@ abstract mixin class $ContactsPageConfigCopyWith<$Res>  {
   factory $ContactsPageConfigCopyWith(ContactsPageConfig value, $Res Function(ContactsPageConfig) _then) = _$ContactsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, PageBackground? background, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3108,12 +3102,11 @@ class _$ContactsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of ContactsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(ContactsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as PageBackground?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -3249,7 +3242,7 @@ case _:
 /// @nodoc
 mixin _$EmbeddedPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of EmbeddedPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3260,16 +3253,16 @@ $EmbeddedPageConfigCopyWith<EmbeddedPageConfig> get copyWith => _$EmbeddedPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddedPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddedPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'EmbeddedPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'EmbeddedPageConfig(themeOverride: $themeOverride, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3280,7 +3273,7 @@ abstract mixin class $EmbeddedPageConfigCopyWith<$Res>  {
   factory $EmbeddedPageConfigCopyWith(EmbeddedPageConfig value, $Res Function(EmbeddedPageConfig) _then) = _$EmbeddedPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, PageBackground? background, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3297,12 +3290,11 @@ class _$EmbeddedPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddedPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(EmbeddedPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as PageBackground?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -3438,7 +3430,7 @@ case _:
 /// @nodoc
 mixin _$FavoritesPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of FavoritesPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3449,16 +3441,16 @@ $FavoritesPageConfigCopyWith<FavoritesPageConfig> get copyWith => _$FavoritesPag
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FavoritesPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FavoritesPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'FavoritesPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'FavoritesPageConfig(themeOverride: $themeOverride, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3469,7 +3461,7 @@ abstract mixin class $FavoritesPageConfigCopyWith<$Res>  {
   factory $FavoritesPageConfigCopyWith(FavoritesPageConfig value, $Res Function(FavoritesPageConfig) _then) = _$FavoritesPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, PageBackground? background, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3486,12 +3478,11 @@ class _$FavoritesPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of FavoritesPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(FavoritesPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as PageBackground?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -3627,7 +3618,7 @@ case _:
 /// @nodoc
 mixin _$ConversationsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of ConversationsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3638,16 +3629,16 @@ $ConversationsPageConfigCopyWith<ConversationsPageConfig> get copyWith => _$Conv
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConversationsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConversationsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'ConversationsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'ConversationsPageConfig(themeOverride: $themeOverride, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3658,7 +3649,7 @@ abstract mixin class $ConversationsPageConfigCopyWith<$Res>  {
   factory $ConversationsPageConfigCopyWith(ConversationsPageConfig value, $Res Function(ConversationsPageConfig) _then) = _$ConversationsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, PageBackground? background, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3675,12 +3666,11 @@ class _$ConversationsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of ConversationsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(ConversationsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as PageBackground?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }
@@ -3816,7 +3806,7 @@ case _:
 /// @nodoc
 mixin _$RecentsPageConfig {
 
- ThemeOverrideConfig get themeOverride; PageBackground? get background; String? get appBarBackgroundColor; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of RecentsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3827,16 +3817,16 @@ $RecentsPageConfigCopyWith<RecentsPageConfig> get copyWith => _$RecentsPageConfi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBackgroundColor, appBarBackgroundColor) || other.appBarBackgroundColor == appBarBackgroundColor)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBackgroundColor,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'RecentsPageConfig(themeOverride: $themeOverride, background: $background, appBarBackgroundColor: $appBarBackgroundColor, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'RecentsPageConfig(themeOverride: $themeOverride, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -3847,7 +3837,7 @@ abstract mixin class $RecentsPageConfigCopyWith<$Res>  {
   factory $RecentsPageConfigCopyWith(RecentsPageConfig value, $Res Function(RecentsPageConfig) _then) = _$RecentsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, PageBackground? background, String? appBarBackgroundColor, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, PageBackground? background, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -3864,12 +3854,11 @@ class _$RecentsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of RecentsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBackgroundColor = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? background = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(RecentsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
-as PageBackground?,appBarBackgroundColor: freezed == appBarBackgroundColor ? _self.appBarBackgroundColor : appBarBackgroundColor // ignore: cast_nullable_to_non_nullable
-as String?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
+as PageBackground?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,
   ));
 }

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -216,7 +216,6 @@ LoginModeSelectPageConfig _$LoginModeSelectPageConfigFromJson(
       : TextStyleConfig.fromJson(
           json['greetingTextStyle'] as Map<String, dynamic>,
         ),
-  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
   appBarBlurredSurface: json['appBarBlurredSurface'] == null
       ? null
       : BlurredSurfaceConfig.fromJson(
@@ -236,7 +235,6 @@ Map<String, dynamic> _$LoginModeSelectPageConfigToJson(
       _$ElevatedButtonStyleTypeEnumMap[instance.buttonSignupStyleType]!,
   'background': instance.background?.toJson(),
   'greetingTextStyle': instance.greetingTextStyle?.toJson(),
-  'appBarBackgroundColor': instance.appBarBackgroundColor,
   'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
@@ -266,7 +264,6 @@ LoginSwitchPageConfig _$LoginSwitchPageConfigFromJson(
       : ButtonStyleConfig.fromJson(
           json['segmentButtonStyle'] as Map<String, dynamic>,
         ),
-  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
   appBarBlurredSurface: json['appBarBlurredSurface'] == null
       ? null
       : BlurredSurfaceConfig.fromJson(
@@ -281,7 +278,6 @@ Map<String, dynamic> _$LoginSwitchPageConfigToJson(
   'mainLogo': instance.mainLogo?.toJson(),
   'background': instance.background?.toJson(),
   'segmentButtonStyle': instance.segmentButtonStyle?.toJson(),
-  'appBarBackgroundColor': instance.appBarBackgroundColor,
   'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
@@ -296,7 +292,6 @@ AboutPageConfig _$AboutPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
-      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
       appBarBlurredSurface: json['appBarBlurredSurface'] == null
           ? null
           : BlurredSurfaceConfig.fromJson(
@@ -309,7 +304,6 @@ Map<String, dynamic> _$AboutPageConfigToJson(AboutPageConfig instance) =>
       'mainLogo': instance.mainLogo?.toJson(),
       'metadata': instance.metadata.toJson(),
       'background': instance.background?.toJson(),
-      'appBarBackgroundColor': instance.appBarBackgroundColor,
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
@@ -333,7 +327,6 @@ CallPageConfig _$CallPageConfigFromJson(
   appBarStyle: json['appBarStyle'] == null
       ? null
       : AppBarConfig.fromJson(json['appBarStyle'] as Map<String, dynamic>),
-  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
   appBarBlurredSurface: json['appBarBlurredSurface'] == null
       ? null
       : BlurredSurfaceConfig.fromJson(
@@ -348,7 +341,6 @@ Map<String, dynamic> _$CallPageConfigToJson(CallPageConfig instance) =>
       'callInfo': instance.callInfo?.toJson(),
       'actions': instance.actions?.toJson(),
       'background': instance.background?.toJson(),
-      'appBarBackgroundColor': instance.appBarBackgroundColor,
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
@@ -479,7 +471,6 @@ KeypadPageConfig _$KeypadPageConfigFromJson(Map<String, dynamic> json) =>
           : ThemeOverrideConfig.fromJson(
               json['themeOverride'] as Map<String, dynamic>,
             ),
-      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
       appBarBlurredSurface: json['appBarBlurredSurface'] == null
           ? null
           : BlurredSurfaceConfig.fromJson(
@@ -496,7 +487,6 @@ Map<String, dynamic> _$KeypadPageConfigToJson(KeypadPageConfig instance) =>
       'actionpad': instance.actionpad?.toJson(),
       'background': instance.background?.toJson(),
       'themeOverride': instance.themeOverride.toJson(),
-      'appBarBackgroundColor': instance.appBarBackgroundColor,
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
@@ -550,7 +540,6 @@ SettingsPageConfig _$SettingsPageConfigFromJson(Map<String, dynamic> json) =>
           : TextStyleConfig.fromJson(
               json['itemTextStyle'] as Map<String, dynamic>,
             ),
-      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
       appBarBlurredSurface: json['appBarBlurredSurface'] == null
           ? null
           : BlurredSurfaceConfig.fromJson(
@@ -568,7 +557,6 @@ Map<String, dynamic> _$SettingsPageConfigToJson(SettingsPageConfig instance) =>
       'showSeparators': instance.showSeparators,
       'background': instance.background?.toJson(),
       'itemTextStyle': instance.itemTextStyle?.toJson(),
-      'appBarBackgroundColor': instance.appBarBackgroundColor,
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
@@ -582,7 +570,6 @@ ContactsPageConfig _$ContactsPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
-      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
       appBarBlurredSurface: json['appBarBlurredSurface'] == null
           ? null
           : BlurredSurfaceConfig.fromJson(
@@ -594,7 +581,6 @@ Map<String, dynamic> _$ContactsPageConfigToJson(ContactsPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
-      'appBarBackgroundColor': instance.appBarBackgroundColor,
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
@@ -608,7 +594,6 @@ EmbeddedPageConfig _$EmbeddedPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
-      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
       appBarBlurredSurface: json['appBarBlurredSurface'] == null
           ? null
           : BlurredSurfaceConfig.fromJson(
@@ -620,7 +605,6 @@ Map<String, dynamic> _$EmbeddedPageConfigToJson(EmbeddedPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
-      'appBarBackgroundColor': instance.appBarBackgroundColor,
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
@@ -634,7 +618,6 @@ FavoritesPageConfig _$FavoritesPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
-      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
       appBarBlurredSurface: json['appBarBlurredSurface'] == null
           ? null
           : BlurredSurfaceConfig.fromJson(
@@ -647,7 +630,6 @@ Map<String, dynamic> _$FavoritesPageConfigToJson(
 ) => <String, dynamic>{
   'themeOverride': instance.themeOverride.toJson(),
   'background': instance.background?.toJson(),
-  'appBarBackgroundColor': instance.appBarBackgroundColor,
   'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
@@ -662,7 +644,6 @@ ConversationsPageConfig _$ConversationsPageConfigFromJson(
   background: json['background'] == null
       ? null
       : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
-  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
   appBarBlurredSurface: json['appBarBlurredSurface'] == null
       ? null
       : BlurredSurfaceConfig.fromJson(
@@ -675,7 +656,6 @@ Map<String, dynamic> _$ConversationsPageConfigToJson(
 ) => <String, dynamic>{
   'themeOverride': instance.themeOverride.toJson(),
   'background': instance.background?.toJson(),
-  'appBarBackgroundColor': instance.appBarBackgroundColor,
   'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
@@ -689,7 +669,6 @@ RecentsPageConfig _$RecentsPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
-      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
       appBarBlurredSurface: json['appBarBlurredSurface'] == null
           ? null
           : BlurredSurfaceConfig.fromJson(
@@ -701,6 +680,5 @@ Map<String, dynamic> _$RecentsPageConfigToJson(RecentsPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
-      'appBarBackgroundColor': instance.appBarBackgroundColor,
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -216,6 +216,12 @@ LoginModeSelectPageConfig _$LoginModeSelectPageConfigFromJson(
       : TextStyleConfig.fromJson(
           json['greetingTextStyle'] as Map<String, dynamic>,
         ),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$LoginModeSelectPageConfigToJson(
@@ -230,6 +236,8 @@ Map<String, dynamic> _$LoginModeSelectPageConfigToJson(
       _$ElevatedButtonStyleTypeEnumMap[instance.buttonSignupStyleType]!,
   'background': instance.background?.toJson(),
   'greetingTextStyle': instance.greetingTextStyle?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 const _$ElevatedButtonStyleTypeEnumMap = {
@@ -258,6 +266,12 @@ LoginSwitchPageConfig _$LoginSwitchPageConfigFromJson(
       : ButtonStyleConfig.fromJson(
           json['segmentButtonStyle'] as Map<String, dynamic>,
         ),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$LoginSwitchPageConfigToJson(
@@ -267,6 +281,8 @@ Map<String, dynamic> _$LoginSwitchPageConfigToJson(
   'mainLogo': instance.mainLogo?.toJson(),
   'background': instance.background?.toJson(),
   'segmentButtonStyle': instance.segmentButtonStyle?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 AboutPageConfig _$AboutPageConfigFromJson(Map<String, dynamic> json) =>
@@ -280,6 +296,12 @@ AboutPageConfig _$AboutPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$AboutPageConfigToJson(AboutPageConfig instance) =>
@@ -287,6 +309,8 @@ Map<String, dynamic> _$AboutPageConfigToJson(AboutPageConfig instance) =>
       'mainLogo': instance.mainLogo?.toJson(),
       'metadata': instance.metadata.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 CallPageConfig _$CallPageConfigFromJson(
@@ -309,6 +333,12 @@ CallPageConfig _$CallPageConfigFromJson(
   appBarStyle: json['appBarStyle'] == null
       ? null
       : AppBarConfig.fromJson(json['appBarStyle'] as Map<String, dynamic>),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$CallPageConfigToJson(CallPageConfig instance) =>
@@ -318,6 +348,8 @@ Map<String, dynamic> _$CallPageConfigToJson(CallPageConfig instance) =>
       'callInfo': instance.callInfo?.toJson(),
       'actions': instance.actions?.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 CallPageActionsConfig _$CallPageActionsConfigFromJson(
@@ -447,6 +479,12 @@ KeypadPageConfig _$KeypadPageConfigFromJson(Map<String, dynamic> json) =>
           : ThemeOverrideConfig.fromJson(
               json['themeOverride'] as Map<String, dynamic>,
             ),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$KeypadPageConfigToJson(KeypadPageConfig instance) =>
@@ -458,6 +496,8 @@ Map<String, dynamic> _$KeypadPageConfigToJson(KeypadPageConfig instance) =>
       'actionpad': instance.actionpad?.toJson(),
       'background': instance.background?.toJson(),
       'themeOverride': instance.themeOverride.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 ActionPadWidgetConfig _$ActionPadWidgetConfigFromJson(
@@ -510,6 +550,12 @@ SettingsPageConfig _$SettingsPageConfigFromJson(Map<String, dynamic> json) =>
           : TextStyleConfig.fromJson(
               json['itemTextStyle'] as Map<String, dynamic>,
             ),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$SettingsPageConfigToJson(SettingsPageConfig instance) =>
@@ -522,6 +568,8 @@ Map<String, dynamic> _$SettingsPageConfigToJson(SettingsPageConfig instance) =>
       'showSeparators': instance.showSeparators,
       'background': instance.background?.toJson(),
       'itemTextStyle': instance.itemTextStyle?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 ContactsPageConfig _$ContactsPageConfigFromJson(Map<String, dynamic> json) =>
@@ -534,12 +582,20 @@ ContactsPageConfig _$ContactsPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$ContactsPageConfigToJson(ContactsPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 EmbeddedPageConfig _$EmbeddedPageConfigFromJson(Map<String, dynamic> json) =>
@@ -552,12 +608,20 @@ EmbeddedPageConfig _$EmbeddedPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$EmbeddedPageConfigToJson(EmbeddedPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };
 
 FavoritesPageConfig _$FavoritesPageConfigFromJson(Map<String, dynamic> json) =>
@@ -570,6 +634,12 @@ FavoritesPageConfig _$FavoritesPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$FavoritesPageConfigToJson(
@@ -577,6 +647,8 @@ Map<String, dynamic> _$FavoritesPageConfigToJson(
 ) => <String, dynamic>{
   'themeOverride': instance.themeOverride.toJson(),
   'background': instance.background?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 ConversationsPageConfig _$ConversationsPageConfigFromJson(
@@ -590,6 +662,12 @@ ConversationsPageConfig _$ConversationsPageConfigFromJson(
   background: json['background'] == null
       ? null
       : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+  appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+  appBarBlurredSurface: json['appBarBlurredSurface'] == null
+      ? null
+      : BlurredSurfaceConfig.fromJson(
+          json['appBarBlurredSurface'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$ConversationsPageConfigToJson(
@@ -597,6 +675,8 @@ Map<String, dynamic> _$ConversationsPageConfigToJson(
 ) => <String, dynamic>{
   'themeOverride': instance.themeOverride.toJson(),
   'background': instance.background?.toJson(),
+  'appBarBackgroundColor': instance.appBarBackgroundColor,
+  'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
 };
 
 RecentsPageConfig _$RecentsPageConfigFromJson(Map<String, dynamic> json) =>
@@ -609,10 +689,18 @@ RecentsPageConfig _$RecentsPageConfigFromJson(Map<String, dynamic> json) =>
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
+      appBarBackgroundColor: json['appBarBackgroundColor'] as String?,
+      appBarBlurredSurface: json['appBarBlurredSurface'] == null
+          ? null
+          : BlurredSurfaceConfig.fromJson(
+              json['appBarBlurredSurface'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$RecentsPageConfigToJson(RecentsPageConfig instance) =>
     <String, dynamic>{
       'themeOverride': instance.themeOverride.toJson(),
       'background': instance.background?.toJson(),
+      'appBarBackgroundColor': instance.appBarBackgroundColor,
+      'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
     };

--- a/test/widgets/blurred_surface_test.dart
+++ b/test/widgets/blurred_surface_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
+
+void main() {
+  group('BlurredSurface.fromStyle', () {
+    test('returns null when style is null', () {
+      expect(BlurredSurface.fromStyle(null), isNull);
+    });
+
+    testWidgets('defaults sigmaX and sigmaY to 10 when not specified', (tester) async {
+      final widget = BlurredSurface.fromStyle(const BlurredSurfaceStyle());
+      expect(widget, isNotNull);
+      expect(widget!.sigmaX, 10.0);
+      expect(widget.sigmaY, 10.0);
+    });
+
+    testWidgets('uses explicit sigmaX and sigmaY when specified', (tester) async {
+      final widget = BlurredSurface.fromStyle(const BlurredSurfaceStyle(sigmaX: 5, sigmaY: 5));
+      expect(widget, isNotNull);
+      expect(widget!.sigmaX, 5.0);
+      expect(widget.sigmaY, 5.0);
+    });
+
+    testWidgets('applies color from style', (tester) async {
+      final widget = BlurredSurface.fromStyle(const BlurredSurfaceStyle(color: Colors.red));
+      expect(widget, isNotNull);
+      expect(widget!.color, Colors.red);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `BlurredSurface.fromStyle()` factory — returns null when config absent, applies blur with sigma defaults (10) when present
- Remove redundant `appBarBackgroundColor` from page config pipeline (handled by widget-level `appBarConfig.backgroundColor`)
- Configure transparent appBar background + blurred surface overlay in dark/light theme configs
- Fix dark color scheme (was using light theme colors)
- Set dark status bar icons for light theme to prevent white-on-white

## Test plan
- [ ] Verify frosted-glass blur effect on appBar in light and dark themes
- [ ] Verify status bar icons are dark on light theme, light on dark theme
- [ ] Verify tab bar indicator is filled pill style (not underline)
- [ ] Verify tab label text is readable against indicator background
- [ ] Check all 7 screens: keypad, contacts, favorites, recents, conversations, settings, about