### PR TITLE
fix: fixed app is locked in Bluetooth call profile after first call

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -353,8 +353,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   /// Triggered when the last remaining active call ends (N -> 0 active calls).
   ///
-  /// * **iOS:** Resets audio output to the default Receiver state to ensure clean state
-  ///   for future calls, preventing state bleeding between sessions.
+  /// Resets platform audio routing to media profile:
+  /// * **iOS:** Disables speakerphone to release AVAudioSession from voice chat mode,
+  ///   preventing state bleeding between sessions.
+  /// * **Android:** Clears communication device to switch from SCO (call profile)
+  ///   back to A2DP (media profile), fixing degraded audio in YouTube/music after calls.
   void _onLastCallEnded() {
     _logger.info(() => 'Lifecycle: Last call ended');
     if (Platform.isIOS) Helper.setSpeakerphoneOn(false);

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -358,6 +358,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   void _onLastCallEnded() {
     _logger.info(() => 'Lifecycle: Last call ended');
     if (Platform.isIOS) Helper.setSpeakerphoneOn(false);
+    if (Platform.isAndroid) Helper.clearAndroidCommunicationDevice();
   }
 
   void _handleSignalingSessionError({required CallServiceState previous, required CallServiceState current}) {


### PR DESCRIPTION
Fixed situation when user returns to YouTube or music playback, the audio remains degraded, like during a call. This happens only on Android.