### PR TITLE
fix: reverse date divider in chat

### DIFF
--- a/lib/extensions/datetime.dart
+++ b/lib/extensions/datetime.dart
@@ -7,6 +7,12 @@ extension DateTimeFormatting on DateTime {
   /// Returns date in d MMM format (e.g. 20 Aug)
   String get toDayOfMonth => DateFormat('d MMM').format(toLocal());
 
+  /// Returns day of week
+  String get toWeekday => DateFormat.EEEE().format(toLocal());
+
+  /// Returns date in E, d MMM format (e.g. Tue, 6 Jan)
+  String get toWeekDayOfMonth => DateFormat('E, d MMM').format(toLocal());
+
   /// Returns time in HH:mm(14:30) format if the date is today, otherwise returns date in d MMM(20 Aug) format
   String get timeOrDate {
     final now = DateTime.now();
@@ -17,5 +23,11 @@ extension DateTimeFormatting on DateTime {
     } else {
       return toDayOfMonth;
     }
+  }
+}
+
+extension DateTimeComprassion on DateTime {
+  bool isSameDay(DateTime anotherDate) {
+    return year == anotherDate.year && month == anotherDate.month && day == anotherDate.day;
   }
 }

--- a/lib/features/messaging/widgets/message_list_view/chat_message_list_view.dart
+++ b/lib/features/messaging/widgets/message_list_view/chat_message_list_view.dart
@@ -7,6 +7,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/messaging/messaging.dart';
+import 'package:webtrit_phone/l10n/app_localizations.g.mapper.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -167,6 +168,20 @@ class _ChatMessageListViewState extends State<ChatMessageListView> {
     widget.onDelete(message);
   }
 
+  String formatChatMessageDate(DateTime messageDate) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final date = DateTime(messageDate.year, messageDate.month, messageDate.day);
+
+    final difference = today.difference(date).inDays;
+
+    if (difference == 0) return context.l10n.messaging_MessageView_today;
+    if (difference == 1) return context.l10n.messaging_MessageView_yesterday;
+    if (difference < 7) return messageDate.toWeekday;
+
+    return messageDate.toWeekDayOfMonth;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -249,7 +264,7 @@ class _ChatMessageListViewState extends State<ChatMessageListView> {
               return Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Center(
-                  child: Text(entry.date.toDayOfMonth, style: const TextStyle(fontSize: 12, color: Colors.grey)),
+                  child: Text(formatChatMessageDate(entry.date), style: const TextStyle(fontSize: 12, color: Colors.grey)),
                 ),
               );
             }
@@ -407,7 +422,7 @@ _ComputeResult _computeList(_ComputeParams params) {
     if (nextMessage != null) {
       final nextMsgDate = nextMessage.createdAt;
       final msgDate = message.createdAt;
-      lastMsgOfTheDay = nextMsgDate.day != msgDate.day;
+      lastMsgOfTheDay = !nextMsgDate.isSameDay(msgDate);
     }
 
     if (i == messages.length - 1) {
@@ -416,11 +431,7 @@ _ComputeResult _computeList(_ComputeParams params) {
       final prevMessage = messages[i + 1];
       final prevMsgDate = prevMessage.createdAt;
       final msgDate = message.createdAt;
-      firstMsgOfTheDay = prevMsgDate.day != msgDate.day;
-    }
-
-    if (lastMsgOfTheDay) {
-      entries.add(_DateViewEntry(message.createdAt));
+      firstMsgOfTheDay = !prevMsgDate.isSameDay(msgDate);
     }
 
     final lastInSequence = isLast || nextMessage!.senderId != message.senderId || lastMsgOfTheDay;
@@ -439,6 +450,10 @@ _ComputeResult _computeList(_ComputeParams params) {
         firstInSequence: firstInSequence,
       ),
     );
+
+    if (firstMsgOfTheDay) {
+      entries.add(_DateViewEntry(message.createdAt));
+    }
   }
 
   return (entries: entries, dueTime: dueTime);

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2082,6 +2082,18 @@ abstract class AppLocalizations {
   /// **'Copy to clipboard'**
   String get messaging_MessageView_textcopy;
 
+  /// No description provided for @messaging_MessageView_today.
+  ///
+  /// In en, this message translates to:
+  /// **'Today'**
+  String get messaging_MessageView_today;
+
+  /// No description provided for @messaging_MessageView_yesterday.
+  ///
+  /// In en, this message translates to:
+  /// **'Yesterday'**
+  String get messaging_MessageView_yesterday;
+
   /// Shown when a participant in a conversation does not have a known or available name. Condition: the user's name is missing or cannot be retrieved.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 // **************************************************************************
 // L10nMapperGenerator
@@ -29,17 +29,41 @@ extension AppLocalizationsExtension on AppLocalizations {
 }
 
 class L10nHelper {
-  static String parseL10n(
+  // Cache to store localization maps per locale
+  static final Map<String, Map<String, dynamic>> _cache = {};
+
+  static String? parseL10n(
     AppLocalizations localizations,
     String translationKey, {
     List<Object>? arguments,
   }) {
-    const mapper = AppLocalizationsMapper();
-    final object = mapper.toLocalizationMap(localizations)[translationKey];
+    // Get or create cached map for this locale
+    final localeName = localizations.localeName;
+    final cachedMap = _cache[localeName];
+
+    final map =
+        cachedMap ??
+        () {
+          const mapper = AppLocalizationsMapper();
+          final newMap = mapper.toLocalizationMap(localizations);
+          _cache[localeName] = newMap;
+          return newMap;
+        }();
+
+    final object = map[translationKey];
     if (object is String || object == null) return object;
     assert(arguments != null, 'Arguments should not be null!');
     assert(arguments!.isNotEmpty, 'Arguments should not be empty!');
     return Function.apply(object, arguments);
+  }
+
+  /// Clear the cache for a specific locale or all locales
+  static void clearCache([String? localeName]) {
+    if (localeName != null) {
+      _cache.remove(localeName);
+    } else {
+      _cache.clear();
+    }
   }
 }
 
@@ -630,6 +654,9 @@ class AppLocalizationsMapper {
       'messaging_MessageView_reply': localizations.messaging_MessageView_reply,
       'messaging_MessageView_textcopy':
           localizations.messaging_MessageView_textcopy,
+      'messaging_MessageView_today': localizations.messaging_MessageView_today,
+      'messaging_MessageView_yesterday':
+          localizations.messaging_MessageView_yesterday,
       'messaging_ParticipantName_unknown':
           localizations.messaging_ParticipantName_unknown,
       'messaging_ParticipantName_you':

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1112,6 +1112,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get messaging_MessageView_textcopy => 'Copy to clipboard';
 
   @override
+  String get messaging_MessageView_today => 'Today';
+
+  @override
+  String get messaging_MessageView_yesterday => 'Yesterday';
+
+  @override
   String get messaging_ParticipantName_unknown => 'Unknown user';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1119,6 +1119,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get messaging_MessageView_textcopy => 'Copia negli appunti';
 
   @override
+  String get messaging_MessageView_today => 'Oggi';
+
+  @override
+  String get messaging_MessageView_yesterday => 'Ieri';
+
+  @override
   String get messaging_ParticipantName_unknown => 'Utente sconosciuto';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1123,6 +1123,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get messaging_MessageView_textcopy => 'Копіювати в буфер обміну';
 
   @override
+  String get messaging_MessageView_today => 'Сьогодні';
+
+  @override
+  String get messaging_MessageView_yesterday => 'Вчора';
+
+  @override
   String get messaging_ParticipantName_unknown => 'Невідомий користувач';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -928,6 +928,10 @@
   "@messaging_MessageView_reply": {},
   "messaging_MessageView_textcopy": "Copy to clipboard",
   "@messaging_MessageView_textcopy": {},
+  "messaging_MessageView_today": "Today",
+  "@messaging_MessageView_today": {},
+  "messaging_MessageView_yesterday": "Yesterday",
+  "@messaging_MessageView_yesterday": {},
   "messaging_ParticipantName_unknown": "Unknown user",
   "@messaging_ParticipantName_unknown": {
     "description": "Shown when a participant in a conversation does not have a known or available name. Condition: the user's name is missing or cannot be retrieved."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -928,6 +928,10 @@
   "@messaging_MessageView_reply": {},
   "messaging_MessageView_textcopy": "Copia negli appunti",
   "@messaging_MessageView_textcopy": {},
+  "messaging_MessageView_today": "Oggi",
+  "@messaging_MessageView_today": {},
+  "messaging_MessageView_yesterday": "Ieri",
+  "@messaging_MessageView_yesterday": {},
   "messaging_ParticipantName_unknown": "Utente sconosciuto",
   "@messaging_ParticipantName_unknown": {
     "description": "Shown when a participant in a conversation does not have a known or available name. Condition: the user's name is missing or cannot be retrieved."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -928,6 +928,10 @@
   "@messaging_MessageView_reply": {},
   "messaging_MessageView_textcopy": "Копіювати в буфер обміну",
   "@messaging_MessageView_textcopy": {},
+  "messaging_MessageView_today": "Сьогодні",
+  "@messaging_MessageView_today": {},
+  "messaging_MessageView_yesterday": "Вчора",
+  "@messaging_MessageView_yesterday": {},
   "messaging_ParticipantName_unknown": "Невідомий користувач",
   "@messaging_ParticipantName_unknown": {
     "description": "Shown when a participant in a conversation does not have a known or available name. Condition: the user's name is missing or cannot be retrieved."


### PR DESCRIPTION
Placed date divider before bunch of messages. Also changed displaying date in this divider. Added displaying options "Today", "Yesterday", day of week, like "Monday", and date in E, d MMM format, like "Tue, 6 Jan" , depending on comparison between date of message and today's date.