### PR TITLE
feat: configure gitignore, formatter, and analysis for generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+**/build/
 
 # Web related
 
@@ -57,3 +58,4 @@ makefile.shared
 .aider*
 .claude/settings.local.json
 CLAUDE.local.md
+**/.claude/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,8 +3,14 @@ pre-commit:
   commands:
     format:
       glob: "*.dart"
-      exclude: "(\\.g|\\.freezed)\\.dart$"
-      run: dart format --output=none --set-exit-if-changed {staged_files}
+      # NOTE: `formatter.exclude` in analysis_options.yaml is NOT supported by the current
+      # Dart version (unsupported_option warning). Shell-level filtering is used instead
+      # to exclude generated files (*.g.dart, *.freezed.dart, *.gr.dart) from format checks.
+      run: |
+        files=$(echo {staged_files} | tr ' ' '\n' | grep -vE '\.(g|freezed|gr)\.dart$')
+        if [ -n "$files" ]; then
+          dart format --output=none --set-exit-if-changed $files
+        fi
 
 commit-msg:
   commands:

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -176,12 +176,7 @@ class PushNotificationIsolateManager extends IsolateManager {
   @override
   void _onNoActiveLines() async {
     if (_metadata != null) {
-      final event = HangupEvent(
-        callId: _metadata!.callId,
-        line: -1,
-        reason: 'Missed',
-        code: -1,
-      );
+      final event = HangupEvent(callId: _metadata!.callId, line: -1, reason: 'Missed', code: -1);
       final call = (
         direction: CallDirection.incoming,
         number: _metadata!.handle!.value,

--- a/lib/features/call_routing/cubit/call_routing_cubit.dart
+++ b/lib/features/call_routing/cubit/call_routing_cubit.dart
@@ -11,8 +11,12 @@ import 'package:webtrit_phone/services/services.dart';
 part 'call_routing_state.dart';
 
 class CallRoutingCubit extends Cubit<CallRoutingState?> {
-  CallRoutingCubit(this._userRepository, this._linesStateRepository, this._callerIdSettingsRepository, this._connectivityService)
-    : super(null) {
+  CallRoutingCubit(
+    this._userRepository,
+    this._linesStateRepository,
+    this._callerIdSettingsRepository,
+    this._connectivityService,
+  ) : super(null) {
     _init();
   }
 

--- a/lib/features/messaging/widgets/message_list_view/chat_message_list_view.dart
+++ b/lib/features/messaging/widgets/message_list_view/chat_message_list_view.dart
@@ -264,7 +264,10 @@ class _ChatMessageListViewState extends State<ChatMessageListView> {
               return Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Center(
-                  child: Text(formatChatMessageDate(entry.date), style: const TextStyle(fontSize: 12, color: Colors.grey)),
+                  child: Text(
+                    formatChatMessageDate(entry.date),
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
                 ),
               );
             }

--- a/lib/features/microphone_status/bloc/microphone_status_state.dart
+++ b/lib/features/microphone_status/bloc/microphone_status_state.dart
@@ -2,9 +2,7 @@ part of 'microphone_status_bloc.dart';
 
 @freezed
 class MicrophoneStatusState with _$MicrophoneStatusState {
-  const MicrophoneStatusState({
-    this.microphonePermissionGranted,
-  });
+  const MicrophoneStatusState({this.microphonePermissionGranted});
 
   @override
   final bool? microphonePermissionGranted;

--- a/lib/features/recents/bloc/recents_bloc.dart
+++ b/lib/features/recents/bloc/recents_bloc.dart
@@ -16,8 +16,11 @@ part 'recents_event.dart';
 part 'recents_state.dart';
 
 class RecentsBloc extends Bloc<RecentsEvent, RecentsState> {
-  RecentsBloc({required this.recentsRepository, required this.activeRecentsVisibilityFilterRepository, required this.dateFormat})
-    : super(RecentsState(filter: activeRecentsVisibilityFilterRepository.getActiveRecentsVisibilityFilter())) {
+  RecentsBloc({
+    required this.recentsRepository,
+    required this.activeRecentsVisibilityFilterRepository,
+    required this.dateFormat,
+  }) : super(RecentsState(filter: activeRecentsVisibilityFilterRepository.getActiveRecentsVisibilityFilter())) {
     on<RecentsStarted>(_onStarted, transformer: restartable());
     on<RecentsFiltered>(_onFiltered);
     on<RecentsDeleted>(_onDeleted);

--- a/lib/features/settings/features/media_settings/widgets/choosable_section.dart
+++ b/lib/features/settings/features/media_settings/widgets/choosable_section.dart
@@ -42,17 +42,16 @@ class ChoosableSection<T> extends StatelessWidget {
           // contentPadding: EdgeInsets.zero,
           visualDensity: VisualDensity.compact,
           minTileHeight: 0,
-          trailing: buildOptionTooltipMessage != null ? Tooltip(
-            message: buildOptionTooltipMessage!(null),
-            triggerMode: TooltipTriggerMode.tap,
-            padding: const EdgeInsets.all(16),
-            margin: const EdgeInsets.all(16),
-            showDuration: const Duration(seconds: 10),
-            child: Icon(
-              Icons.info_outline,
-              color: Theme.of(context).colorScheme.secondary,
-            ),
-          ) : null,
+          trailing: buildOptionTooltipMessage != null
+              ? Tooltip(
+                  message: buildOptionTooltipMessage!(null),
+                  triggerMode: TooltipTriggerMode.tap,
+                  padding: const EdgeInsets.all(16),
+                  margin: const EdgeInsets.all(16),
+                  showDuration: const Duration(seconds: 10),
+                  child: Icon(Icons.info_outline, color: Theme.of(context).colorScheme.secondary),
+                )
+              : null,
         ),
         for (final option in options)
           ListTile(
@@ -64,17 +63,16 @@ class ChoosableSection<T> extends StatelessWidget {
             // contentPadding: EdgeInsets.zero,
             visualDensity: VisualDensity.compact,
             minTileHeight: 0,
-            trailing: buildOptionTooltipMessage != null ? Tooltip(
-              message: buildOptionTooltipMessage!(option),
-              triggerMode: TooltipTriggerMode.tap,
-              padding: const EdgeInsets.all(16),
-              margin: const EdgeInsets.all(16),
-              showDuration: const Duration(seconds: 10),
-              child: Icon(
-                Icons.info_outline,
-                color: Theme.of(context).colorScheme.secondary,
-              ),
-            ) : null,
+            trailing: buildOptionTooltipMessage != null
+                ? Tooltip(
+                    message: buildOptionTooltipMessage!(option),
+                    triggerMode: TooltipTriggerMode.tap,
+                    padding: const EdgeInsets.all(16),
+                    margin: const EdgeInsets.all(16),
+                    showDuration: const Duration(seconds: 10),
+                    child: Icon(Icons.info_outline, color: Theme.of(context).colorScheme.secondary),
+                  )
+                : null,
           ),
       ],
     );

--- a/lib/features/settings/features/network/bloc/network_cubit.dart
+++ b/lib/features/settings/features/network/bloc/network_cubit.dart
@@ -14,8 +14,12 @@ part 'network_state.dart';
 part 'network_cubit.freezed.dart';
 
 class NetworkCubit extends Cubit<NetworkState> {
-  NetworkCubit(this._callTriggerConfig, this._deviceInfo, this._incomingCallTypeRepository, this._callkeepBackgroundService)
-    : super(NetworkState(smsFallbackEnabled: _callTriggerConfig.smsFallback.enabled)) {
+  NetworkCubit(
+    this._callTriggerConfig,
+    this._deviceInfo,
+    this._incomingCallTypeRepository,
+    this._callkeepBackgroundService,
+  ) : super(NetworkState(smsFallbackEnabled: _callTriggerConfig.smsFallback.enabled)) {
     _initializeActiveIncomingType();
   }
 

--- a/lib/features/settings/view/settings_screen_page.dart
+++ b/lib/features/settings/view/settings_screen_page.dart
@@ -28,7 +28,7 @@ class SettingsScreenPage extends StatelessWidget {
           userRepository: context.read<UserRepository>(),
           voicemailRepository: context.read<VoicemailRepository>(),
           sessionRepository: context.read(),
-          appPermissions: context.read<AppPermissions>() 
+          appPermissions: context.read<AppPermissions>(),
         );
       },
       child: widget,

--- a/packages/data/app_database/lib/src/daos/active_message_notifications_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/active_message_notifications_dao.g.dart
@@ -6,4 +6,17 @@ part of 'active_message_notifications_dao.dart';
 mixin _$ActiveMessageNotificationsDaoMixin on DatabaseAccessor<AppDatabase> {
   $ActiveMessageNotificationsTableTable get activeMessageNotificationsTable =>
       attachedDatabase.activeMessageNotificationsTable;
+  ActiveMessageNotificationsDaoManager get managers =>
+      ActiveMessageNotificationsDaoManager(this);
+}
+
+class ActiveMessageNotificationsDaoManager {
+  final _$ActiveMessageNotificationsDaoMixin _db;
+  ActiveMessageNotificationsDaoManager(this._db);
+  $$ActiveMessageNotificationsTableTableTableManager
+  get activeMessageNotificationsTable =>
+      $$ActiveMessageNotificationsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.activeMessageNotificationsTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/call_logs_dao.dart
+++ b/packages/data/app_database/lib/src/daos/call_logs_dao.dart
@@ -11,10 +11,7 @@ class CallLogsDao extends DatabaseAccessor<AppDatabase> with _$CallLogsDaoMixin 
   SimpleSelectStatement<$CallLogsTableTable, CallLogData> _selectLastCallLogs(Duration period) {
     return select(callLogsTable)
       ..where((t) => t.createdAt.isBiggerOrEqualValue(clock.agoBy(period)))
-      ..orderBy([
-        (t) => OrderingTerm.desc(t.createdAt),
-        (t) => OrderingTerm.desc(t.acceptedAt),
-      ]);
+      ..orderBy([(t) => OrderingTerm.desc(t.createdAt), (t) => OrderingTerm.desc(t.acceptedAt)]);
   }
 
   SimpleSelectStatement<$CallLogsTableTable, CallLogData> _selectLastCallLogsByNumber(String number, Duration period) {

--- a/packages/data/app_database/lib/src/daos/call_logs_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/call_logs_dao.g.dart
@@ -5,4 +5,12 @@ part of 'call_logs_dao.dart';
 // ignore_for_file: type=lint
 mixin _$CallLogsDaoMixin on DatabaseAccessor<AppDatabase> {
   $CallLogsTableTable get callLogsTable => attachedDatabase.callLogsTable;
+  CallLogsDaoManager get managers => CallLogsDaoManager(this);
+}
+
+class CallLogsDaoManager {
+  final _$CallLogsDaoMixin _db;
+  CallLogsDaoManager(this._db);
+  $$CallLogsTableTableTableManager get callLogsTable =>
+      $$CallLogsTableTableTableManager(_db.attachedDatabase, _db.callLogsTable);
 }

--- a/packages/data/app_database/lib/src/daos/cdrs_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/cdrs_dao.g.dart
@@ -5,4 +5,12 @@ part of 'cdrs_dao.dart';
 // ignore_for_file: type=lint
 mixin _$CdrsDaoMixin on DatabaseAccessor<AppDatabase> {
   $CdrTableTable get cdrTable => attachedDatabase.cdrTable;
+  CdrsDaoManager get managers => CdrsDaoManager(this);
+}
+
+class CdrsDaoManager {
+  final _$CdrsDaoMixin _db;
+  CdrsDaoManager(this._db);
+  $$CdrTableTableTableManager get cdrTable =>
+      $$CdrTableTableTableManager(_db.attachedDatabase, _db.cdrTable);
 }

--- a/packages/data/app_database/lib/src/daos/chats_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/chats_dao.g.dart
@@ -21,4 +21,57 @@ mixin _$ChatsDaoMixin on DatabaseAccessor<AppDatabase> {
       attachedDatabase.chatOutboxMessageDeleteTable;
   $ChatOutboxReadCursorsTableTable get chatOutboxReadCursorsTable =>
       attachedDatabase.chatOutboxReadCursorsTable;
+  ChatsDaoManager get managers => ChatsDaoManager(this);
+}
+
+class ChatsDaoManager {
+  final _$ChatsDaoMixin _db;
+  ChatsDaoManager(this._db);
+  $$ChatsTableTableTableManager get chatsTable =>
+      $$ChatsTableTableTableManager(_db.attachedDatabase, _db.chatsTable);
+  $$ChatMembersTableTableTableManager get chatMembersTable =>
+      $$ChatMembersTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatMembersTable,
+      );
+  $$ChatMessagesTableTableTableManager get chatMessagesTable =>
+      $$ChatMessagesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatMessagesTable,
+      );
+  $$ChatMessageSyncCursorTableTableTableManager
+  get chatMessageSyncCursorTable =>
+      $$ChatMessageSyncCursorTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatMessageSyncCursorTable,
+      );
+  $$ChatMessageReadCursorTableTableTableManager
+  get chatMessageReadCursorTable =>
+      $$ChatMessageReadCursorTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatMessageReadCursorTable,
+      );
+  $$ChatOutboxMessageTableTableTableManager get chatOutboxMessageTable =>
+      $$ChatOutboxMessageTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatOutboxMessageTable,
+      );
+  $$ChatOutboxMessageEditTableTableTableManager
+  get chatOutboxMessageEditTable =>
+      $$ChatOutboxMessageEditTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatOutboxMessageEditTable,
+      );
+  $$ChatOutboxMessageDeleteTableTableTableManager
+  get chatOutboxMessageDeleteTable =>
+      $$ChatOutboxMessageDeleteTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatOutboxMessageDeleteTable,
+      );
+  $$ChatOutboxReadCursorsTableTableTableManager
+  get chatOutboxReadCursorsTable =>
+      $$ChatOutboxReadCursorsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.chatOutboxReadCursorsTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/contact_emails_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/contact_emails_dao.g.dart
@@ -6,4 +6,15 @@ part of 'contact_emails_dao.dart';
 mixin _$ContactEmailsDaoMixin on DatabaseAccessor<AppDatabase> {
   $ContactEmailsTableTable get contactEmailsTable =>
       attachedDatabase.contactEmailsTable;
+  ContactEmailsDaoManager get managers => ContactEmailsDaoManager(this);
+}
+
+class ContactEmailsDaoManager {
+  final _$ContactEmailsDaoMixin _db;
+  ContactEmailsDaoManager(this._db);
+  $$ContactEmailsTableTableTableManager get contactEmailsTable =>
+      $$ContactEmailsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactEmailsTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/contact_phones_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/contact_phones_dao.g.dart
@@ -8,4 +8,22 @@ mixin _$ContactPhonesDaoMixin on DatabaseAccessor<AppDatabase> {
   $ContactPhonesTableTable get contactPhonesTable =>
       attachedDatabase.contactPhonesTable;
   $FavoritesTableTable get favoritesTable => attachedDatabase.favoritesTable;
+  ContactPhonesDaoManager get managers => ContactPhonesDaoManager(this);
+}
+
+class ContactPhonesDaoManager {
+  final _$ContactPhonesDaoMixin _db;
+  ContactPhonesDaoManager(this._db);
+  $$ContactsTableTableTableManager get contactsTable =>
+      $$ContactsTableTableTableManager(_db.attachedDatabase, _db.contactsTable);
+  $$ContactPhonesTableTableTableManager get contactPhonesTable =>
+      $$ContactPhonesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactPhonesTable,
+      );
+  $$FavoritesTableTableTableManager get favoritesTable =>
+      $$FavoritesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.favoritesTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -202,7 +202,10 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
             CaseWhen(contactsTable.aliasName.isNotNull(), then: contactsTable.aliasName.trim().collate(Collate.noCase)),
             CaseWhen(
               contactsTable.firstName.isNotNull() & contactsTable.lastName.isNotNull(),
-              then: contactsTable.firstName.trim().collate(Collate.noCase) + const Constant(' ') + contactsTable.lastName.trim().collate(Collate.noCase),
+              then:
+                  contactsTable.firstName.trim().collate(Collate.noCase) +
+                  const Constant(' ') +
+                  contactsTable.lastName.trim().collate(Collate.noCase),
             ),
             CaseWhen(contactsTable.firstName.isNotNull(), then: contactsTable.firstName.trim().collate(Collate.noCase)),
             CaseWhen(contactsTable.lastName.isNotNull(), then: contactsTable.lastName.trim().collate(Collate.noCase)),

--- a/packages/data/app_database/lib/src/daos/contacts_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.g.dart
@@ -12,4 +12,32 @@ mixin _$ContactsDaoMixin on DatabaseAccessor<AppDatabase> {
   $FavoritesTableTable get favoritesTable => attachedDatabase.favoritesTable;
   $PresenceInfoTableTable get presenceInfoTable =>
       attachedDatabase.presenceInfoTable;
+  ContactsDaoManager get managers => ContactsDaoManager(this);
+}
+
+class ContactsDaoManager {
+  final _$ContactsDaoMixin _db;
+  ContactsDaoManager(this._db);
+  $$ContactsTableTableTableManager get contactsTable =>
+      $$ContactsTableTableTableManager(_db.attachedDatabase, _db.contactsTable);
+  $$ContactPhonesTableTableTableManager get contactPhonesTable =>
+      $$ContactPhonesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactPhonesTable,
+      );
+  $$ContactEmailsTableTableTableManager get contactEmailsTable =>
+      $$ContactEmailsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactEmailsTable,
+      );
+  $$FavoritesTableTableTableManager get favoritesTable =>
+      $$FavoritesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.favoritesTable,
+      );
+  $$PresenceInfoTableTableTableManager get presenceInfoTable =>
+      $$PresenceInfoTableTableTableManager(
+        _db.attachedDatabase,
+        _db.presenceInfoTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/favorites_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/favorites_dao.g.dart
@@ -12,4 +12,32 @@ mixin _$FavoritesDaoMixin on DatabaseAccessor<AppDatabase> {
       attachedDatabase.contactEmailsTable;
   $PresenceInfoTableTable get presenceInfoTable =>
       attachedDatabase.presenceInfoTable;
+  FavoritesDaoManager get managers => FavoritesDaoManager(this);
+}
+
+class FavoritesDaoManager {
+  final _$FavoritesDaoMixin _db;
+  FavoritesDaoManager(this._db);
+  $$FavoritesTableTableTableManager get favoritesTable =>
+      $$FavoritesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.favoritesTable,
+      );
+  $$ContactsTableTableTableManager get contactsTable =>
+      $$ContactsTableTableTableManager(_db.attachedDatabase, _db.contactsTable);
+  $$ContactPhonesTableTableTableManager get contactPhonesTable =>
+      $$ContactPhonesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactPhonesTable,
+      );
+  $$ContactEmailsTableTableTableManager get contactEmailsTable =>
+      $$ContactEmailsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactEmailsTable,
+      );
+  $$PresenceInfoTableTableTableManager get presenceInfoTable =>
+      $$PresenceInfoTableTableTableManager(
+        _db.attachedDatabase,
+        _db.presenceInfoTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/presence_info_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/presence_info_dao.g.dart
@@ -6,4 +6,15 @@ part of 'presence_info_dao.dart';
 mixin _$PresenceInfoDaoMixin on DatabaseAccessor<AppDatabase> {
   $PresenceInfoTableTable get presenceInfoTable =>
       attachedDatabase.presenceInfoTable;
+  PresenceInfoDaoManager get managers => PresenceInfoDaoManager(this);
+}
+
+class PresenceInfoDaoManager {
+  final _$PresenceInfoDaoMixin _db;
+  PresenceInfoDaoManager(this._db);
+  $$PresenceInfoTableTableTableManager get presenceInfoTable =>
+      $$PresenceInfoTableTableTableManager(
+        _db.attachedDatabase,
+        _db.presenceInfoTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/recents_dao.dart
+++ b/packages/data/app_database/lib/src/daos/recents_dao.dart
@@ -29,10 +29,7 @@ class RecentsDao extends DatabaseAccessor<AppDatabase> with _$RecentsDaoMixin {
   Stream<List<RecentData>> watchLastRecents([Duration period = const Duration(days: 14)]) {
     final callsQuery = select(callLogsTable)
       ..where((t) => t.createdAt.isBiggerOrEqualValue(clock.agoBy(period)))
-      ..orderBy([
-        (t) => OrderingTerm.desc(t.createdAt),
-        (t) => OrderingTerm.desc(t.hungUpAt.unixepoch),
-      ]);
+      ..orderBy([(t) => OrderingTerm.desc(t.createdAt), (t) => OrderingTerm.desc(t.hungUpAt.unixepoch)]);
 
     final sourcePhone = alias(contactPhonesTable, 'source_phone');
     final contactPhones = alias(contactPhonesTable, 'contact_phones');

--- a/packages/data/app_database/lib/src/daos/recents_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/recents_dao.g.dart
@@ -12,4 +12,29 @@ mixin _$RecentsDaoMixin on DatabaseAccessor<AppDatabase> {
       attachedDatabase.contactEmailsTable;
   $PresenceInfoTableTable get presenceInfoTable =>
       attachedDatabase.presenceInfoTable;
+  RecentsDaoManager get managers => RecentsDaoManager(this);
+}
+
+class RecentsDaoManager {
+  final _$RecentsDaoMixin _db;
+  RecentsDaoManager(this._db);
+  $$CallLogsTableTableTableManager get callLogsTable =>
+      $$CallLogsTableTableTableManager(_db.attachedDatabase, _db.callLogsTable);
+  $$ContactsTableTableTableManager get contactsTable =>
+      $$ContactsTableTableTableManager(_db.attachedDatabase, _db.contactsTable);
+  $$ContactPhonesTableTableTableManager get contactPhonesTable =>
+      $$ContactPhonesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactPhonesTable,
+      );
+  $$ContactEmailsTableTableTableManager get contactEmailsTable =>
+      $$ContactEmailsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.contactEmailsTable,
+      );
+  $$PresenceInfoTableTableTableManager get presenceInfoTable =>
+      $$PresenceInfoTableTableTableManager(
+        _db.attachedDatabase,
+        _db.presenceInfoTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/sms_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/sms_dao.g.dart
@@ -20,4 +20,51 @@ mixin _$SmsDaoMixin on DatabaseAccessor<AppDatabase> {
       attachedDatabase.smsOutboxReadCursorsTable;
   $UserSmsNumbersTableTable get userSmsNumbersTable =>
       attachedDatabase.userSmsNumbersTable;
+  SmsDaoManager get managers => SmsDaoManager(this);
+}
+
+class SmsDaoManager {
+  final _$SmsDaoMixin _db;
+  SmsDaoManager(this._db);
+  $$SmsConversationsTableTableTableManager get smsConversationsTable =>
+      $$SmsConversationsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.smsConversationsTable,
+      );
+  $$SmsMessagesTableTableTableManager get smsMessagesTable =>
+      $$SmsMessagesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.smsMessagesTable,
+      );
+  $$SmsMessageSyncCursorTableTableTableManager get smsMessageSyncCursorTable =>
+      $$SmsMessageSyncCursorTableTableTableManager(
+        _db.attachedDatabase,
+        _db.smsMessageSyncCursorTable,
+      );
+  $$SmsMessageReadCursorTableTableTableManager get smsMessageReadCursorTable =>
+      $$SmsMessageReadCursorTableTableTableManager(
+        _db.attachedDatabase,
+        _db.smsMessageReadCursorTable,
+      );
+  $$SmsOutboxMessagesTableTableTableManager get smsOutboxMessagesTable =>
+      $$SmsOutboxMessagesTableTableTableManager(
+        _db.attachedDatabase,
+        _db.smsOutboxMessagesTable,
+      );
+  $$SmsOutboxMessageDeleteTableTableTableManager
+  get smsOutboxMessageDeleteTable =>
+      $$SmsOutboxMessageDeleteTableTableTableManager(
+        _db.attachedDatabase,
+        _db.smsOutboxMessageDeleteTable,
+      );
+  $$SmsOutboxReadCursorsTableTableTableManager get smsOutboxReadCursorsTable =>
+      $$SmsOutboxReadCursorsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.smsOutboxReadCursorsTable,
+      );
+  $$UserSmsNumbersTableTableTableManager get userSmsNumbersTable =>
+      $$UserSmsNumbersTableTableTableManager(
+        _db.attachedDatabase,
+        _db.userSmsNumbersTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/system_notifications_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/system_notifications_dao.g.dart
@@ -8,4 +8,22 @@ mixin _$SystemNotificationsDaoMixin on DatabaseAccessor<AppDatabase> {
       attachedDatabase.systemNotificationsTable;
   $SystemNotificationsOutboxTableTable get systemNotificationsOutboxTable =>
       attachedDatabase.systemNotificationsOutboxTable;
+  SystemNotificationsDaoManager get managers =>
+      SystemNotificationsDaoManager(this);
+}
+
+class SystemNotificationsDaoManager {
+  final _$SystemNotificationsDaoMixin _db;
+  SystemNotificationsDaoManager(this._db);
+  $$SystemNotificationsTableTableTableManager get systemNotificationsTable =>
+      $$SystemNotificationsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.systemNotificationsTable,
+      );
+  $$SystemNotificationsOutboxTableTableTableManager
+  get systemNotificationsOutboxTable =>
+      $$SystemNotificationsOutboxTableTableTableManager(
+        _db.attachedDatabase,
+        _db.systemNotificationsOutboxTable,
+      );
 }

--- a/packages/data/app_database/lib/src/daos/voicemail_dao.g.dart
+++ b/packages/data/app_database/lib/src/daos/voicemail_dao.g.dart
@@ -6,4 +6,17 @@ part of 'voicemail_dao.dart';
 mixin _$VoicemailDaoMixin on DatabaseAccessor<AppDatabase> {
   $VoicemailTableTable get voicemailTable => attachedDatabase.voicemailTable;
   $ContactsTableTable get contactsTable => attachedDatabase.contactsTable;
+  VoicemailDaoManager get managers => VoicemailDaoManager(this);
+}
+
+class VoicemailDaoManager {
+  final _$VoicemailDaoMixin _db;
+  VoicemailDaoManager(this._db);
+  $$VoicemailTableTableTableManager get voicemailTable =>
+      $$VoicemailTableTableTableManager(
+        _db.attachedDatabase,
+        _db.voicemailTable,
+      );
+  $$ContactsTableTableTableManager get contactsTable =>
+      $$ContactsTableTableTableManager(_db.attachedDatabase, _db.contactsTable);
 }

--- a/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/blurred_surface_config.g.dart
@@ -6,13 +6,17 @@ part of 'blurred_surface_config.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_BlurredSurfaceConfig _$BlurredSurfaceConfigFromJson(Map<String, dynamic> json) => _BlurredSurfaceConfig(
+_BlurredSurfaceConfig _$BlurredSurfaceConfigFromJson(
+  Map<String, dynamic> json,
+) => _BlurredSurfaceConfig(
   color: json['color'] as String?,
   sigmaX: (json['sigmaX'] as num?)?.toDouble(),
   sigmaY: (json['sigmaY'] as num?)?.toDouble(),
 );
 
-Map<String, dynamic> _$BlurredSurfaceConfigToJson(_BlurredSurfaceConfig instance) => <String, dynamic>{
+Map<String, dynamic> _$BlurredSurfaceConfigToJson(
+  _BlurredSurfaceConfig instance,
+) => <String, dynamic>{
   'color': instance.color,
   'sigmaX': instance.sigmaX,
   'sigmaY': instance.sigmaY,

--- a/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/supported_feature.dart
@@ -18,10 +18,8 @@ sealed class SupportedFeature with _$SupportedFeature {
   /// [logLevel] controls the application log level. Defaults to 'INFO'.
   /// [checkIntervalSec] defines how often the [RtpTrafficMonitor] checks for traffic.
   /// Defaults to 15 seconds.
-  const factory SupportedFeature.loggingConfig({
-    @Default('INFO') String logLevel,
-    @Default(15) int checkIntervalSec,
-  }) = SupportedLoggingConfig;
+  const factory SupportedFeature.loggingConfig({@Default('INFO') String logLevel, @Default(15) int checkIntervalSec}) =
+      SupportedLoggingConfig;
 
   const factory SupportedFeature.systemNotifications({@Default(true) bool enabled}) = SupportedSystemNotifications;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -189,14 +189,31 @@ melos:
     # ===========================
 
     fmt:
-      description: Format all Dart code across the workspace.
-      exec: dart format . --line-length 120
+      description: Format all Dart code across the workspace (excludes generated files).
+      # NOTE: `formatter.exclude` in analysis_options.yaml is NOT supported by the current
+      # Dart version. Shell-level filtering via find+grep is used instead to skip
+      # *.g.dart, *.freezed.dart, *.gr.dart files.
+      exec: >-
+        find . -name "*.dart"
+        -not -path "*/build/*"
+        -not -path "*/.dart_tool/*"
+        -not -name "*.g.dart"
+        -not -name "*.freezed.dart"
+        -not -name "*.gr.dart"
+        | xargs dart format --line-length 120
       packageFilters:
         dirExists: lib
 
     fmt:check:
       description: Check formatting without making changes (exit 1 if unformatted).
-      exec: dart format . --line-length 120 --set-exit-if-changed
+      exec: >-
+        find . -name "*.dart"
+        -not -path "*/build/*"
+        -not -path "*/.dart_tool/*"
+        -not -name "*.g.dart"
+        -not -name "*.freezed.dart"
+        -not -name "*.gr.dart"
+        | xargs dart format --line-length 120 --set-exit-if-changed
       packageFilters:
         dirExists: lib
 

--- a/screenshots/integration_test/take_screenshots_test.dart
+++ b/screenshots/integration_test/take_screenshots_test.dart
@@ -45,17 +45,11 @@ void main() {
     testWidgets(name, (tester) async {
       final screenshotName = '$screenshotNamePrefix/$name';
 
-      final innerWidget = await withClock(
-        Clock.fixed(dFixedTime),
-        buildWidget,
-      );
+      final innerWidget = await withClock(Clock.fixed(dFixedTime), buildWidget);
 
       final wrappedWidget = MultiProvider(
         providers: appContext.providers,
-        child: PresenceViewParams(
-          viewSource: PresenceViewSource.contactInfo,
-          child: innerWidget,
-        ),
+        child: PresenceViewParams(viewSource: PresenceViewSource.contactInfo, child: innerWidget),
       );
 
       await tester.pumpWidget(wrappedWidget);
@@ -80,10 +74,7 @@ void main() {
 
   group('take login screen screenshots', () {
     takeScreenshotTestWidgets('login_screen__modeSelect', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const LoginModeSelectScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const LoginModeSelectScreenScreenshot());
     });
   });
 
@@ -91,188 +82,110 @@ void main() {
     takeScreenshotTestWidgets('main_screen__favorites', () {
       return ScreenshotApp(
         appBloc: appContext.appBloc,
-        child: const MainScreenScreenshot(
-          MainFlavor.favorites,
-          Text(EnvironmentConfig.APP_NAME),
-        ),
+        child: const MainScreenScreenshot(MainFlavor.favorites, Text(EnvironmentConfig.APP_NAME)),
       );
     });
     takeScreenshotTestWidgets('main_screen__recents', () {
       return ScreenshotApp(
         appBloc: appContext.appBloc,
-        child: const MainScreenScreenshot(
-          MainFlavor.recents,
-          Text(EnvironmentConfig.APP_NAME),
-        ),
+        child: const MainScreenScreenshot(MainFlavor.recents, Text(EnvironmentConfig.APP_NAME)),
       );
     });
     takeScreenshotTestWidgets('main_screen__keypad', () {
       return ScreenshotApp(
         appBloc: appContext.appBloc,
-        child: const MainScreenScreenshot(
-          MainFlavor.keypad,
-          Text(EnvironmentConfig.APP_NAME),
-        ),
+        child: const MainScreenScreenshot(MainFlavor.keypad, Text(EnvironmentConfig.APP_NAME)),
       );
     });
   });
 
   group('take call screen screenshots', () {
     takeScreenshotTestWidgets('settings_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const SettingScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const SettingScreenScreenshot());
     });
   });
 
   group('take call screen screenshots', () {
     takeScreenshotTestWidgets('call_screen__audio', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const CallScreenScreenshot(false),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const CallScreenScreenshot(false));
     });
     takeScreenshotTestWidgets('call_screen__video', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const CallScreenScreenshot(true),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const CallScreenScreenshot(true));
     });
   });
 
   group('take contact & messaging screenshots', () {
     takeScreenshotTestWidgets('contact_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const ContactScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const ContactScreenScreenshot());
     });
     takeScreenshotTestWidgets('chat_conversation_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const ChatConversationScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const ChatConversationScreenScreenshot());
     });
     takeScreenshotTestWidgets('sms_conversation_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const SmsConversationScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const SmsConversationScreenScreenshot());
     });
     takeScreenshotTestWidgets('system_notifications_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const SystemNotificationsScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const SystemNotificationsScreenScreenshot());
     });
   });
 
   group('take CDR & call log screenshots', () {
     takeScreenshotTestWidgets('recent_cdrs_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const RecentCdrsScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const RecentCdrsScreenScreenshot());
     });
     takeScreenshotTestWidgets('number_cdrs_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const NumberCdrsScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const NumberCdrsScreenScreenshot());
     });
     takeScreenshotTestWidgets('call_log_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const CallLogScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const CallLogScreenScreenshot());
     });
   });
 
   group('take settings sub-screen screenshots', () {
     takeScreenshotTestWidgets('network_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const NetworkScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const NetworkScreenScreenshot());
     });
     takeScreenshotTestWidgets('language_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const LanguageScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const LanguageScreenScreenshot());
     });
     takeScreenshotTestWidgets('diagnostic_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const DiagnosticScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const DiagnosticScreenScreenshot());
     });
     takeScreenshotTestWidgets('caller_id_settings_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const CallerIdSettingsScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const CallerIdSettingsScreenScreenshot());
     });
     takeScreenshotTestWidgets('presence_settings_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const PresenceSettingsScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const PresenceSettingsScreenScreenshot());
     });
     takeScreenshotTestWidgets('theme_mode_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const ThemeModeScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const ThemeModeScreenScreenshot());
     });
     takeScreenshotTestWidgets('voicemail_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const VoicemailScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const VoicemailScreenScreenshot());
     });
   });
 
   group('take login variant screenshots', () {
     takeScreenshotTestWidgets('login_switch_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const LoginSwitchScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const LoginSwitchScreenScreenshot());
     });
   });
 
   group('take utility screen screenshots', () {
     takeScreenshotTestWidgets('log_records_console_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const LogRecordsConsoleScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const LogRecordsConsoleScreenScreenshot());
     });
     takeScreenshotTestWidgets('contacts_agreement_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const ContactsAgreementScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const ContactsAgreementScreenScreenshot());
     });
     takeScreenshotTestWidgets('teardown_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const TeardownScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const TeardownScreenScreenshot());
     });
     takeScreenshotTestWidgets('permissions_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const PermissionsScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const PermissionsScreenScreenshot());
     });
     takeScreenshotTestWidgets('user_agreement_screen', () {
-      return ScreenshotApp(
-        appBloc: appContext.appBloc,
-        child: const UserAgreementScreenScreenshot(),
-      );
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const UserAgreementScreenScreenshot());
     });
   });
 }

--- a/screenshots/lib/data/call.dart
+++ b/screenshots/lib/data/call.dart
@@ -6,10 +6,7 @@ import 'package:webtrit_phone/models/call_direction.dart';
 final dAudioActiveCall = ActiveCall(
   line: 0,
   callId: '123',
-  handle: const CallkeepHandle(
-    type: CallkeepHandleType.number,
-    value: 'Thomas Anderson',
-  ),
+  handle: const CallkeepHandle(type: CallkeepHandleType.number, value: 'Thomas Anderson'),
   direction: CallDirection.incoming,
   video: false,
   createdTime: clock.ago(minutes: 10),
@@ -20,10 +17,7 @@ final dAudioActiveCall = ActiveCall(
 final dVideoActiveCall = ActiveCall(
   line: 0,
   callId: '123',
-  handle: const CallkeepHandle(
-    type: CallkeepHandleType.number,
-    value: 'Thomas Anderson',
-  ),
+  handle: const CallkeepHandle(type: CallkeepHandleType.number, value: 'Thomas Anderson'),
   direction: CallDirection.incoming,
   video: false,
   createdTime: clock.ago(minutes: 10),

--- a/screenshots/lib/data/messaging.dart
+++ b/screenshots/lib/data/messaging.dart
@@ -95,9 +95,7 @@ final dContactsRepository = [
     registered: false,
     userRegistered: false,
     isCurrentUser: false,
-    phones: const [
-      ContactPhone(id: 201, number: '+1987654321', label: 'mobile', favorite: true),
-    ],
+    phones: const [ContactPhone(id: 201, number: '+1987654321', label: 'mobile', favorite: true)],
     emails: const [],
     thumbnail: Uint8List.fromList([0, 1, 2, 3]),
     thumbnailUrl: Uri.parse('https://example.com/avatar.png'),

--- a/screenshots/lib/main.dart
+++ b/screenshots/lib/main.dart
@@ -14,30 +14,22 @@ import 'package:screenshots/router.dart';
 import 'package:screenshots/bootstrap.dart';
 
 void main() async {
-  await withClock(
-    Clock.fixed(dFixedTime),
-    () async {
-      WidgetsFlutterBinding.ensureInitialized();
+  await withClock(Clock.fixed(dFixedTime), () async {
+    WidgetsFlutterBinding.ensureInitialized();
 
-      final context = await bootstrap();
+    final context = await bootstrap();
 
-      runApp(
-        MultiProvider(
-          providers: context.providers,
-          child: ScreenshotsApp(
-            appBloc: context.appBloc,
-          ),
-        ),
-      );
-    },
-  );
+    runApp(
+      MultiProvider(
+        providers: context.providers,
+        child: ScreenshotsApp(appBloc: context.appBloc),
+      ),
+    );
+  });
 }
 
 class ScreenshotsApp extends StatelessWidget {
-  const ScreenshotsApp({
-    super.key,
-    required this.appBloc,
-  });
+  const ScreenshotsApp({super.key, required this.appBloc});
 
   final AppBloc appBloc;
 
@@ -45,10 +37,7 @@ class ScreenshotsApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return PresenceViewParams(
       viewSource: PresenceViewSource.contactInfo,
-      child: BlocProvider.value(
-        value: appBloc,
-        child: const AppPairingContent(),
-      ),
+      child: BlocProvider.value(value: appBloc, child: const AppPairingContent()),
     );
   }
 }

--- a/screenshots/lib/mocks/mock_about_bloc.dart
+++ b/screenshots/lib/mocks/mock_about_bloc.dart
@@ -8,25 +8,21 @@ class MockAboutBloc extends MockBloc<AboutEvent, AboutState> implements AboutBlo
 
   // Single source of truth for the default/base state
   static AboutState _defaultState({bool progress = false, Version? coreVersion}) => AboutState(
-        progress: false,
-        embeddedLinks: const [],
-        packageName: 'com.webtrit.phone',
-        userAgent: 'WebTrit/0.0.0 (Pixel 9; Android: 16)',
-        appInfo: 'WebTrit/0.0.0',
-        deviceInfo: 'Pixel 9; Android: 16',
-        appIdentifier: 'com.webtrit.phone',
-        coreUrl: Uri.parse('https://core.example.com'),
-        fcmPushToken: 'fcm-token-demo',
-        coreVersion: coreVersion,
-      );
+    progress: false,
+    embeddedLinks: const [],
+    packageName: 'com.webtrit.phone',
+    userAgent: 'WebTrit/0.0.0 (Pixel 9; Android: 16)',
+    appInfo: 'WebTrit/0.0.0',
+    deviceInfo: 'Pixel 9; Android: 16',
+    appIdentifier: 'com.webtrit.phone',
+    coreUrl: Uri.parse('https://core.example.com'),
+    fcmPushToken: 'fcm-token-demo',
+    coreVersion: coreVersion,
+  );
 
   // Small helper to seed the mock with an initial state
   static void _seed(MockAboutBloc mock, AboutState initial) {
-    whenListen(
-      mock,
-      const Stream<AboutState>.empty(),
-      initialState: initial,
-    );
+    whenListen(mock, const Stream<AboutState>.empty(), initialState: initial);
   }
 
   factory MockAboutBloc.idle({AboutState? state}) {

--- a/screenshots/lib/mocks/mock_call_bloc.dart
+++ b/screenshots/lib/mocks/mock_call_bloc.dart
@@ -14,9 +14,7 @@ class MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
       mock,
       const Stream<CallState>.empty(),
       initialState: const CallState(
-        callServiceState: CallServiceState(
-          signalingClientStatus: SignalingClientStatus.connect,
-        ),
+        callServiceState: CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
       ),
     );
     return mock;
@@ -28,9 +26,7 @@ class MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
       mock,
       const Stream<CallState>.empty(),
       initialState: const CallState(
-        callServiceState: CallServiceState(
-          signalingClientStatus: SignalingClientStatus.connect,
-        ),
+        callServiceState: CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
       ),
     );
     return mock;
@@ -42,12 +38,8 @@ class MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
       mock,
       const Stream<CallState>.empty(),
       initialState: CallState(
-        callServiceState: const CallServiceState(
-          signalingClientStatus: SignalingClientStatus.connect,
-        ),
-        activeCalls: [
-          if (video) dVideoActiveCall else dAudioActiveCall,
-        ],
+        callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+        activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
       ),
     );
     return mock;

--- a/screenshots/lib/mocks/mock_call_routing_cubit.dart
+++ b/screenshots/lib/mocks/mock_call_routing_cubit.dart
@@ -20,16 +20,10 @@ class MockCallRoutingCubit extends MockCubit<CallRoutingState?> implements CallR
   }
 
   /// Emit a sequence of states (useful for UI reacting to updates).
-  factory MockCallRoutingCubit.sequence({
-    required List<CallRoutingState?> states,
-  }) {
+  factory MockCallRoutingCubit.sequence({required List<CallRoutingState?> states}) {
     assert(states.isNotEmpty, 'states cannot be empty');
     final mock = MockCallRoutingCubit();
-    whenListen(
-      mock,
-      Stream<CallRoutingState?>.fromIterable(states.skip(1)),
-      initialState: states.first,
-    );
+    whenListen(mock, Stream<CallRoutingState?>.fromIterable(states.skip(1)), initialState: states.first);
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_chat_conversations_cubit.dart
+++ b/screenshots/lib/mocks/mock_chat_conversations_cubit.dart
@@ -10,11 +10,7 @@ class MockChatConversationsCubit extends MockCubit<ChatConversationsState> imple
   factory MockChatConversationsCubit.initial() {
     final mock = MockChatConversationsCubit();
 
-    whenListen(
-      mock,
-      const Stream<ChatConversationsState>.empty(),
-      initialState: ChatConversationsState.initial(),
-    );
+    whenListen(mock, const Stream<ChatConversationsState>.empty(), initialState: ChatConversationsState.initial());
 
     return mock;
   }
@@ -49,10 +45,7 @@ class MockChatConversationsCubit extends MockCubit<ChatConversationsState> imple
 
     whenListen(
       mock,
-      Stream.fromIterable([
-        ChatConversationsState.initial(),
-        ChatConversationsState([], [], false),
-      ]),
+      Stream.fromIterable([ChatConversationsState.initial(), ChatConversationsState([], [], false)]),
       initialState: ChatConversationsState.initial(),
     );
 

--- a/screenshots/lib/mocks/mock_chat_typing_cubit.dart
+++ b/screenshots/lib/mocks/mock_chat_typing_cubit.dart
@@ -7,11 +7,7 @@ class MockChatTypingCubit extends MockCubit<TypingUsers> implements ChatTypingCu
 
   factory MockChatTypingCubit.idle() {
     final mock = MockChatTypingCubit();
-    whenListen(
-      mock,
-      const Stream<TypingUsers>.empty(),
-      initialState: <String>{},
-    );
+    whenListen(mock, const Stream<TypingUsers>.empty(), initialState: <String>{});
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_chats_forwarding_cubit.dart
+++ b/screenshots/lib/mocks/mock_chats_forwarding_cubit.dart
@@ -8,11 +8,7 @@ class MockChatsForwardingCubit extends MockCubit<ChatMessage?> implements ChatsF
 
   factory MockChatsForwardingCubit.initial() {
     final mock = MockChatsForwardingCubit();
-    whenListen(
-      mock,
-      const Stream<ChatMessage?>.empty(),
-      initialState: null,
-    );
+    whenListen(mock, const Stream<ChatMessage?>.empty(), initialState: null);
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_contact_bloc.dart
+++ b/screenshots/lib/mocks/mock_contact_bloc.dart
@@ -12,9 +12,7 @@ class MockContactBloc extends MockBloc<ContactEvent, ContactState> implements Co
     whenListen(
       mock,
       const Stream<ContactState>.empty(),
-      initialState: ContactState(
-        contact: dContactsRepository.first,
-      ),
+      initialState: ContactState(contact: dContactsRepository.first),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_contacts_external_tab_bloc.dart
+++ b/screenshots/lib/mocks/mock_contacts_external_tab_bloc.dart
@@ -11,9 +11,7 @@ class MockContactsExternalTabBloc extends MockBloc<ContactsExternalTabEvent, Con
     whenListen(
       mock,
       const Stream<ContactsExternalTabState>.empty(),
-      initialState: const ContactsExternalTabState(
-        status: ContactsExternalTabStatus.success,
-      ),
+      initialState: const ContactsExternalTabState(status: ContactsExternalTabStatus.success),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_contacts_local_tab_bloc.dart
+++ b/screenshots/lib/mocks/mock_contacts_local_tab_bloc.dart
@@ -11,9 +11,7 @@ class MockContactsLocalTabBloc extends MockBloc<ContactsLocalTabEvent, ContactsL
     whenListen(
       mock,
       const Stream<ContactsLocalTabState>.empty(),
-      initialState: const ContactsLocalTabState(
-        status: ContactsLocalTabStatus.success,
-      ),
+      initialState: const ContactsLocalTabState(status: ContactsLocalTabStatus.success),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_contacts_search_bloc.dart
+++ b/screenshots/lib/mocks/mock_contacts_search_bloc.dart
@@ -11,9 +11,7 @@ class MockContactsSearchBloc extends MockBloc<ContactsEvent, ContactsState> impl
     whenListen(
       mock,
       const Stream<ContactsState>.empty(),
-      initialState: const ContactsState(
-        sourceType: ContactSourceType.local,
-      ),
+      initialState: const ContactsState(sourceType: ContactSourceType.local),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_diagnostic_cubit.dart
+++ b/screenshots/lib/mocks/mock_diagnostic_cubit.dart
@@ -12,10 +12,7 @@ class MockDiagnosticCubit extends MockCubit<DiagnosticState> implements Diagnost
       mock,
       const Stream<DiagnosticState>.empty(),
       initialState: DiagnosticState(
-        pushTokenStatus: PushTokenStatus(
-          token: 'fcm-token-demo-1234567890',
-          type: PushTokenStatusType.success,
-        ),
+        pushTokenStatus: PushTokenStatus(token: 'fcm-token-demo-1234567890', type: PushTokenStatusType.success),
       ),
     );
     return mock;

--- a/screenshots/lib/mocks/mock_embedded_cubit.dart
+++ b/screenshots/lib/mocks/mock_embedded_cubit.dart
@@ -7,11 +7,7 @@ class MockEmbeddedCubit extends MockCubit<EmbeddedState> implements EmbeddedCubi
 
   factory MockEmbeddedCubit.mainScreen() {
     final mock = MockEmbeddedCubit();
-    whenListen(
-      mock,
-      const Stream<EmbeddedState>.empty(),
-      initialState: const EmbeddedState(),
-    );
+    whenListen(mock, const Stream<EmbeddedState>.empty(), initialState: const EmbeddedState());
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_favorites_bloc.dart
+++ b/screenshots/lib/mocks/mock_favorites_bloc.dart
@@ -9,11 +9,7 @@ class MockFavoritesBloc extends MockBloc<FavoritesEvent, FavoritesState> impleme
 
   factory MockFavoritesBloc.mainScreen() {
     final mock = MockFavoritesBloc();
-    whenListen(
-      mock,
-      const Stream<FavoritesState>.empty(),
-      initialState: FavoritesState(favorites: dFavorites),
-    );
+    whenListen(mock, const Stream<FavoritesState>.empty(), initialState: FavoritesState(favorites: dFavorites));
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_full_recent_cdrs_cubit.dart
+++ b/screenshots/lib/mocks/mock_full_recent_cdrs_cubit.dart
@@ -9,11 +9,7 @@ class MockFullRecentCdrsCubit extends MockCubit<FullRecentCdrsState> implements 
 
   factory MockFullRecentCdrsCubit.mainScreen() {
     final mock = MockFullRecentCdrsCubit();
-    whenListen(
-      mock,
-      const Stream<FullRecentCdrsState>.empty(),
-      initialState: FullRecentCdrsState(),
-    );
+    whenListen(mock, const Stream<FullRecentCdrsState>.empty(), initialState: FullRecentCdrsState());
     return mock;
   }
 
@@ -22,10 +18,7 @@ class MockFullRecentCdrsCubit extends MockCubit<FullRecentCdrsState> implements 
     whenListen(
       mock,
       const Stream<FullRecentCdrsState>.empty(),
-      initialState: FullRecentCdrsState(
-        records: dMockCdrRecords,
-        isLoading: false,
-      ),
+      initialState: FullRecentCdrsState(records: dMockCdrRecords, isLoading: false),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_keypad_cubit.dart
+++ b/screenshots/lib/mocks/mock_keypad_cubit.dart
@@ -7,11 +7,7 @@ class MockKeypadCubit extends MockCubit<KeypadState> implements KeypadCubit {
 
   factory MockKeypadCubit.mainScreen() {
     final mock = MockKeypadCubit();
-    whenListen(
-      mock,
-      const Stream<KeypadState>.empty(),
-      initialState: const KeypadState(),
-    );
+    whenListen(mock, const Stream<KeypadState>.empty(), initialState: const KeypadState());
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_login_cubit.dart
+++ b/screenshots/lib/mocks/mock_login_cubit.dart
@@ -13,11 +13,7 @@ class MockLoginCubit extends MockCubit<LoginState> implements LoginCubit {
 
   factory MockLoginCubit.loginModeSelectScreen() {
     final mock = MockLoginCubit();
-    whenListen(
-      mock,
-      const Stream<LoginState>.empty(),
-      initialState: const LoginState(),
-    );
+    whenListen(mock, const Stream<LoginState>.empty(), initialState: const LoginState());
     when(() => mock.isDemoModeEnabled).thenReturn(false);
     when(() => mock.isCredentialsRequestUrlEnabled).thenReturn(false);
     return mock;
@@ -25,11 +21,7 @@ class MockLoginCubit extends MockCubit<LoginState> implements LoginCubit {
 
   factory MockLoginCubit.loginCoreUrlAssignScreen() {
     final mock = MockLoginCubit();
-    whenListen(
-      mock,
-      const Stream<LoginState>.empty(),
-      initialState: const LoginState(),
-    );
+    whenListen(mock, const Stream<LoginState>.empty(), initialState: const LoginState());
     return mock;
   }
 
@@ -53,11 +45,7 @@ class MockLoginCubit extends MockCubit<LoginState> implements LoginCubit {
           const SessionResult.otpProvisional(otpId: '_') as SessionOtpProvisional,
           DateTime.now(),
         ),
-        supportedLoginTypes: [
-          LoginType.otpSignin,
-          LoginType.passwordSignin,
-          LoginType.signup,
-        ],
+        supportedLoginTypes: [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup],
       ),
     );
     when(() => mock.isDemoModeEnabled).thenReturn(false);

--- a/screenshots/lib/mocks/mock_main_bloc.dart
+++ b/screenshots/lib/mocks/mock_main_bloc.dart
@@ -7,11 +7,7 @@ class MockMainBloc extends MockBloc<MainBlocEvent, MainBlocState> implements Mai
 
   factory MockMainBloc.mainScreen() {
     final mock = MockMainBloc();
-    whenListen(
-      mock,
-      const Stream<MainBlocState>.empty(),
-      initialState: MainBlocState.initial(),
-    );
+    whenListen(mock, const Stream<MainBlocState>.empty(), initialState: MainBlocState.initial());
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_media_settings_cubit.dart
+++ b/screenshots/lib/mocks/mock_media_settings_cubit.dart
@@ -17,8 +17,9 @@ class MockMediaSettingsCubit extends MockCubit<MediaSettingsState> implements Me
         audioProcessingSettings: AudioProcessingSettings.blank(),
         videoCapturingSettings: VideoCapturingSettings.blank(),
         iceSettings: IceSettings.blank(),
-        pearConnectionSettings:
-            PeerConnectionSettings(negotiationSettings: NegotiationSettings(includeInactiveVideoInOfferAnswer: false)),
+        pearConnectionSettings: PeerConnectionSettings(
+          negotiationSettings: NegotiationSettings(includeInactiveVideoInOfferAnswer: false),
+        ),
       ),
     );
     return mock;

--- a/screenshots/lib/mocks/mock_messaging_bloc.dart
+++ b/screenshots/lib/mocks/mock_messaging_bloc.dart
@@ -20,15 +20,16 @@ class MockMessagingBloc extends MockBloc<MessagingEvent, MessagingState> impleme
       mock,
       const Stream<MessagingState>.empty(),
       initialState: MessagingState.initial(
-          'user-id',
-          MockPhoenixSocket(),
-          MessagingConfig(
-            coreSmsSupport: true,
-            coreChatsSupport: true,
-            tabEnabled: true,
-            groupChatSupport: true,
-            contactInfoVideoCallSupport: true,
-          )).copyWith(status: ConnectionStatus.connected),
+        'user-id',
+        MockPhoenixSocket(),
+        MessagingConfig(
+          coreSmsSupport: true,
+          coreChatsSupport: true,
+          tabEnabled: true,
+          groupChatSupport: true,
+          contactInfoVideoCallSupport: true,
+        ),
+      ).copyWith(status: ConnectionStatus.connected),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_microphone_status_bloc.dart
+++ b/screenshots/lib/mocks/mock_microphone_status_bloc.dart
@@ -11,9 +11,7 @@ class MockMicrophoneStatusBloc extends MockBloc<MicrophoneStatusEvent, Microphon
     whenListen(
       mock,
       const Stream<MicrophoneStatusState>.empty(),
-      initialState: const MicrophoneStatusState(
-        microphonePermissionGranted: true,
-      ),
+      initialState: const MicrophoneStatusState(microphonePermissionGranted: true),
     );
     return mock;
   }
@@ -23,9 +21,7 @@ class MockMicrophoneStatusBloc extends MockBloc<MicrophoneStatusEvent, Microphon
     whenListen(
       mock,
       const Stream<MicrophoneStatusState>.empty(),
-      initialState: const MicrophoneStatusState(
-        microphonePermissionGranted: false,
-      ),
+      initialState: const MicrophoneStatusState(microphonePermissionGranted: false),
     );
     return mock;
   }
@@ -35,9 +31,7 @@ class MockMicrophoneStatusBloc extends MockBloc<MicrophoneStatusEvent, Microphon
     whenListen(
       mock,
       const Stream<MicrophoneStatusState>.empty(),
-      initialState: MicrophoneStatusState(
-        microphonePermissionGranted: isGranted,
-      ),
+      initialState: MicrophoneStatusState(microphonePermissionGranted: isGranted),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_notifications_bloc.dart
+++ b/screenshots/lib/mocks/mock_notifications_bloc.dart
@@ -7,11 +7,7 @@ class MockNotificationsBloc extends MockBloc<NotificationsEvent, NotificationsSt
 
   factory MockNotificationsBloc.initial() {
     final mock = MockNotificationsBloc();
-    whenListen(
-      mock,
-      const Stream<NotificationsState>.empty(),
-      initialState: const NotificationsState(),
-    );
+    whenListen(mock, const Stream<NotificationsState>.empty(), initialState: const NotificationsState());
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_permissions_cubit.dart
+++ b/screenshots/lib/mocks/mock_permissions_cubit.dart
@@ -10,9 +10,7 @@ class MockPermissionsCubit extends MockCubit<PermissionsState> implements Permis
     whenListen(
       mock,
       const Stream<PermissionsState>.empty(),
-      initialState: const PermissionsState(
-        initialRequestCompleted: false,
-      ),
+      initialState: const PermissionsState(initialRequestCompleted: false),
     );
     return mock;
   }

--- a/screenshots/lib/mocks/mock_recents_bloc.dart
+++ b/screenshots/lib/mocks/mock_recents_bloc.dart
@@ -15,10 +15,7 @@ class MockRecentsBloc extends MockBloc<RecentsEvent, RecentsState> implements Re
     whenListen(
       mock,
       const Stream<RecentsState>.empty(),
-      initialState: RecentsState(
-        recents: dMockRecentCallHistory,
-        filter: RecentsVisibilityFilter.all,
-      ),
+      initialState: RecentsState(recents: dMockRecentCallHistory, filter: RecentsVisibilityFilter.all),
     );
     when(() => mock.dateFormat).thenReturn(DateFormat.yMMMd().add_Hm());
     return mock;

--- a/screenshots/lib/mocks/mock_register_status_cubit.dart
+++ b/screenshots/lib/mocks/mock_register_status_cubit.dart
@@ -7,11 +7,7 @@ class MockRegisterStatusCubit extends MockCubit<RegisterStatus> implements Regis
 
   factory MockRegisterStatusCubit.initial(bool initialValue) {
     final mock = MockRegisterStatusCubit();
-    whenListen(
-      mock,
-      const Stream<RegisterStatus>.empty(),
-      initialState: RegisterStatus(value: initialValue),
-    );
+    whenListen(mock, const Stream<RegisterStatus>.empty(), initialState: RegisterStatus(value: initialValue));
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_session_status_cubit.dart
+++ b/screenshots/lib/mocks/mock_session_status_cubit.dart
@@ -7,11 +7,7 @@ class MockSessionStatusCubit extends MockCubit<SessionStatusState> implements Se
 
   factory MockSessionStatusCubit.initial() {
     final mock = MockSessionStatusCubit();
-    whenListen(
-      mock,
-      const Stream<SessionStatusState>.empty(),
-      initialState: const SessionStatusState(),
-    );
+    whenListen(mock, const Stream<SessionStatusState>.empty(), initialState: const SessionStatusState());
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_settings_bloc.dart
+++ b/screenshots/lib/mocks/mock_settings_bloc.dart
@@ -7,11 +7,7 @@ class MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState> implements
 
   factory MockSettingsBloc.settingsScreen() {
     final mock = MockSettingsBloc();
-    whenListen(
-      mock,
-      const Stream<SettingsState>.empty(),
-      initialState: const SettingsState(progress: false),
-    );
+    whenListen(mock, const Stream<SettingsState>.empty(), initialState: const SettingsState(progress: false));
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_sms_conversations_cubit.dart
+++ b/screenshots/lib/mocks/mock_sms_conversations_cubit.dart
@@ -9,11 +9,7 @@ class MockSmsConversationsCubit extends MockCubit<SmsConversationsState> impleme
 
   factory MockSmsConversationsCubit.initial() {
     final mock = MockSmsConversationsCubit();
-    whenListen(
-      mock,
-      const Stream<SmsConversationsState>.empty(),
-      initialState: SmsConversationsState.initial(),
-    );
+    whenListen(mock, const Stream<SmsConversationsState>.empty(), initialState: SmsConversationsState.initial());
     return mock;
   }
 
@@ -40,10 +36,7 @@ class MockSmsConversationsCubit extends MockCubit<SmsConversationsState> impleme
     final mock = MockSmsConversationsCubit();
     whenListen(
       mock,
-      Stream.fromIterable([
-        SmsConversationsState.initial(),
-        SmsConversationsState([], [], false),
-      ]),
+      Stream.fromIterable([SmsConversationsState.initial(), SmsConversationsState([], [], false)]),
       initialState: SmsConversationsState.initial(),
     );
     return mock;

--- a/screenshots/lib/mocks/mock_sms_typing_cubit.dart
+++ b/screenshots/lib/mocks/mock_sms_typing_cubit.dart
@@ -7,11 +7,7 @@ class MockSmsTypingCubit extends MockCubit<TypingNumbers> implements SmsTypingCu
 
   factory MockSmsTypingCubit.idle() {
     final mock = MockSmsTypingCubit();
-    whenListen(
-      mock,
-      const Stream<TypingNumbers>.empty(),
-      initialState: <String>{},
-    );
+    whenListen(mock, const Stream<TypingNumbers>.empty(), initialState: <String>{});
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_system_notifications_counter_cubit.dart
+++ b/screenshots/lib/mocks/mock_system_notifications_counter_cubit.dart
@@ -10,11 +10,7 @@ class MockSystemNotificationCounterCubit extends MockCubit<int> implements Syste
     Stream<int> stream = const Stream<int>.empty(),
   }) {
     final mock = MockSystemNotificationCounterCubit();
-    whenListen(
-      mock,
-      stream,
-      initialState: initialState,
-    );
+    whenListen(mock, stream, initialState: initialState);
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_system_notifications_screen_cubit.dart
+++ b/screenshots/lib/mocks/mock_system_notifications_screen_cubit.dart
@@ -23,10 +23,7 @@ class MockSystemNotificationsScreenCubit extends MockCubit<SystemNotificationScr
     whenListen(
       mock,
       const Stream<SystemNotificationScreenState>.empty(),
-      initialState: SystemNotificationScreenState(
-        notifications: dMockSystemNotifications,
-        isLoading: false,
-      ),
+      initialState: SystemNotificationScreenState(notifications: dMockSystemNotifications, isLoading: false),
     );
     when(() => mock.markAsSeen(any())).thenAnswer((_) async {});
     return mock;

--- a/screenshots/lib/mocks/mock_unread_count_cubit.dart
+++ b/screenshots/lib/mocks/mock_unread_count_cubit.dart
@@ -9,26 +9,21 @@ class MockUnreadCountCubit extends MockCubit<UnreadCountState> implements Unread
 
   factory MockUnreadCountCubit.initial() {
     final mock = MockUnreadCountCubit();
-    whenListen(
-      mock,
-      const Stream<UnreadCountState>.empty(),
-      initialState: UnreadCountState.initial(),
-    );
+    whenListen(mock, const Stream<UnreadCountState>.empty(), initialState: UnreadCountState.initial());
     return mock;
   }
 
   factory MockUnreadCountCubit.withUnreadMessages() {
     final mock = MockUnreadCountCubit();
 
-    final unreadState =
-        UnreadCountState.fromCountPerChat(dChatUnreadCountsMockUnreadCountCubit, dSmsUnreadCountsMockUnreadCountCubit);
+    final unreadState = UnreadCountState.fromCountPerChat(
+      dChatUnreadCountsMockUnreadCountCubit,
+      dSmsUnreadCountsMockUnreadCountCubit,
+    );
 
     whenListen(
       mock,
-      Stream.fromIterable([
-        UnreadCountState.initial(),
-        unreadState,
-      ]),
+      Stream.fromIterable([UnreadCountState.initial(), unreadState]),
       initialState: UnreadCountState.initial(),
     );
     return mock;
@@ -38,10 +33,7 @@ class MockUnreadCountCubit extends MockCubit<UnreadCountState> implements Unread
     final mock = MockUnreadCountCubit();
     whenListen(
       mock,
-      Stream.fromIterable([
-        UnreadCountState.initial(),
-        UnreadCountState.fromCountPerChat({}, {}),
-      ]),
+      Stream.fromIterable([UnreadCountState.initial(), UnreadCountState.fromCountPerChat({}, {})]),
       initialState: UnreadCountState.initial(),
     );
     return mock;

--- a/screenshots/lib/mocks/mock_user_info_cubit.dart
+++ b/screenshots/lib/mocks/mock_user_info_cubit.dart
@@ -7,11 +7,7 @@ class MockUserInfoCubit extends MockCubit<UserInfoState> implements UserInfoCubi
 
   factory MockUserInfoCubit.initial() {
     final mock = MockUserInfoCubit();
-    whenListen(
-      mock,
-      const Stream<UserInfoState>.empty(),
-      initialState: const UserInfoState(),
-    );
+    whenListen(mock, const Stream<UserInfoState>.empty(), initialState: const UserInfoState());
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_voicemail_cubit.dart
+++ b/screenshots/lib/mocks/mock_voicemail_cubit.dart
@@ -12,10 +12,7 @@ class MockVoicemailCubit extends MockCubit<VoicemailState> implements VoicemailC
     whenListen(
       mock,
       const Stream<VoicemailState>.empty(),
-      initialState: VoicemailState(
-        status: VoicemailStatus.loaded,
-        items: dMockVoicemails,
-      ),
+      initialState: VoicemailState(status: VoicemailStatus.loaded, items: dMockVoicemails),
     );
     return mock;
   }

--- a/screenshots/lib/router.dart
+++ b/screenshots/lib/router.dart
@@ -43,180 +43,68 @@ class _IndexInputScreenState extends State<IndexInputScreen> {
     final appBloc = context.read<AppBloc>();
 
     final screenshots = [
+      ScreenshotApp(appBloc: appBloc, child: const LoginModeSelectScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const LoginCoreUrlAssignScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const LoginOtpSignInScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const LoginOtpVerifyInScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const LoginPasswordSignInScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const LoginSignUpScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const PrivacyScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const LoginSignUpVerifyScreenshot()),
       ScreenshotApp(
         appBloc: appBloc,
-        child: const LoginModeSelectScreenScreenshot(),
+        child: const MainScreenScreenshot(MainFlavor.favorites, Text(EnvironmentConfig.APP_NAME)),
       ),
       ScreenshotApp(
         appBloc: appBloc,
-        child: const LoginCoreUrlAssignScreenScreenshot(),
+        child: const MainScreenScreenshot(MainFlavor.recents, Text(EnvironmentConfig.APP_NAME)),
       ),
       ScreenshotApp(
         appBloc: appBloc,
-        child: const LoginOtpSignInScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const LoginOtpVerifyInScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const LoginPasswordSignInScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const LoginSignUpScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const PrivacyScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const LoginSignUpVerifyScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const MainScreenScreenshot(
-          MainFlavor.favorites,
-          Text(EnvironmentConfig.APP_NAME),
-        ),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const MainScreenScreenshot(
-          MainFlavor.recents,
-          Text(EnvironmentConfig.APP_NAME),
-        ),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const MainScreenScreenshot(
-          MainFlavor.keypad,
-          Text(EnvironmentConfig.APP_NAME),
-        ),
+        child: const MainScreenScreenshot(MainFlavor.keypad, Text(EnvironmentConfig.APP_NAME)),
       ),
       ScreenshotApp(
         appBloc: appBloc,
         child: Builder(
-          builder: (context) => const MainScreenScreenshot(
-            MainFlavor.messaging,
-            Text(EnvironmentConfig.APP_NAME),
-          ),
+          builder: (context) => const MainScreenScreenshot(MainFlavor.messaging, Text(EnvironmentConfig.APP_NAME)),
         ),
       ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const SettingScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: MediaSettingsScreenScreenshot(
-          initialOpenSection: 1,
-        ),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const CallScreenScreenshot(false),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const CallScreenScreenshot(true),
-      ),
+      ScreenshotApp(appBloc: appBloc, child: const SettingScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: MediaSettingsScreenScreenshot(initialOpenSection: 1)),
+      ScreenshotApp(appBloc: appBloc, child: const CallScreenScreenshot(false)),
+      ScreenshotApp(appBloc: appBloc, child: const CallScreenScreenshot(true)),
       // Contact & messaging
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const ContactScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const ChatConversationScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const SmsConversationScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const SystemNotificationsScreenScreenshot(),
-      ),
+      ScreenshotApp(appBloc: appBloc, child: const ContactScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const ChatConversationScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const SmsConversationScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const SystemNotificationsScreenScreenshot()),
       // CDRs & call log
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const RecentCdrsScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const NumberCdrsScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const CallLogScreenScreenshot(),
-      ),
+      ScreenshotApp(appBloc: appBloc, child: const RecentCdrsScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const NumberCdrsScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const CallLogScreenScreenshot()),
       // Settings sub-screens
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const NetworkScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const LanguageScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const DiagnosticScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const CallerIdSettingsScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const PresenceSettingsScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const ThemeModeScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const VoicemailScreenScreenshot(),
-      ),
+      ScreenshotApp(appBloc: appBloc, child: const NetworkScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const LanguageScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const DiagnosticScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const CallerIdSettingsScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const PresenceSettingsScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const ThemeModeScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const VoicemailScreenScreenshot()),
       // Login variant
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const LoginSwitchScreenScreenshot(),
-      ),
+      ScreenshotApp(appBloc: appBloc, child: const LoginSwitchScreenScreenshot()),
       // Utility screens
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const LogRecordsConsoleScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const ContactsAgreementScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const TeardownScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const PermissionsScreenScreenshot(),
-      ),
-      ScreenshotApp(
-        appBloc: appBloc,
-        child: const UserAgreementScreenScreenshot(),
-      ),
+      ScreenshotApp(appBloc: appBloc, child: const LogRecordsConsoleScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const ContactsAgreementScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const TeardownScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const PermissionsScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const UserAgreementScreenScreenshot()),
     ];
 
     return DefaultTabController(
       key: ValueKey(widget.index),
       length: screenshots.length,
       initialIndex: widget.index,
-      child: TabBarView(
-        children: screenshots,
-      ),
+      child: TabBarView(children: screenshots),
     );
   }
 }

--- a/screenshots/lib/widgets/screenshot_app.dart
+++ b/screenshots/lib/widgets/screenshot_app.dart
@@ -12,12 +12,7 @@ import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 
 class ScreenshotApp extends StatelessWidget {
-  const ScreenshotApp({
-    super.key,
-    required this.appBloc,
-    required this.child,
-    this.ignorePointer = true,
-  });
+  const ScreenshotApp({super.key, required this.appBloc, required this.child, this.ignorePointer = true});
 
   final AppBloc appBloc;
   final Widget child;
@@ -58,10 +53,7 @@ class ScreenshotApp extends StatelessWidget {
                 routerDelegate: ScreenshotRouterDelegate(child),
                 routeInformationParser: const _NoOpRouteInformationParser(),
                 builder: (context, child) {
-                  return Theme(
-                    data: themeData,
-                    child: child!,
-                  );
+                  return Theme(data: themeData, child: child!);
                 },
               );
             },
@@ -71,17 +63,11 @@ class ScreenshotApp extends StatelessWidget {
     );
 
     if (ignorePointer) {
-      widgetsApp = IgnorePointer(
-        child: widgetsApp,
-      );
+      widgetsApp = IgnorePointer(child: widgetsApp);
     }
 
     final provider = MultiBlocProvider(
-      providers: [
-        BlocProvider<AppBloc>.value(
-          value: appBloc,
-        ),
-      ],
+      providers: [BlocProvider<AppBloc>.value(value: appBloc)],
       child: _autoStackRouterWrap(widgetsApp),
     );
 
@@ -97,11 +83,7 @@ class ScreenshotRouterDelegate extends RouterDelegate<Object> with ChangeNotifie
   @override
   Widget build(BuildContext context) {
     return Navigator(
-      pages: [
-        MaterialPage(
-          child: child,
-        ),
-      ],
+      pages: [MaterialPage(child: child)],
       // ignore: deprecated_member_use
       onPopPage: (route, result) {
         if (!route.didPop(result)) {

--- a/test/mocks/mock_webtrit_api_client.dart
+++ b/test/mocks/mock_webtrit_api_client.dart
@@ -4,16 +4,28 @@ import 'package:webtrit_api/webtrit_api.dart' as api;
 
 class MockWebtritApiClient extends Mock implements api.WebtritApiClient {
   @override
-  Future<api.UserVoicemailListResponse> getUserVoicemailList(String token, {String? locale, api.RequestOptions options = const api.RequestOptions()}) async {
-    return api.UserVoicemailListResponse(
-      hasNewMessages: false,
-      items: [],
-    );
+  Future<api.UserVoicemailListResponse> getUserVoicemailList(
+    String token, {
+    String? locale,
+    api.RequestOptions options = const api.RequestOptions(),
+  }) async {
+    return api.UserVoicemailListResponse(hasNewMessages: false, items: []);
   }
 
   @override
-  Future<void> deleteUserVoicemail(String token, String messageId, {String? locale, api.RequestOptions options = const api.RequestOptions()}) async {}
+  Future<void> deleteUserVoicemail(
+    String token,
+    String messageId, {
+    String? locale,
+    api.RequestOptions options = const api.RequestOptions(),
+  }) async {}
 
   @override
-  Future<void> updateUserVoicemail(String token, String messageId, {required bool seen, String? locale, api.RequestOptions options = const api.RequestOptions()}) async {}
+  Future<void> updateUserVoicemail(
+    String token,
+    String messageId, {
+    required bool seen,
+    String? locale,
+    api.RequestOptions options = const api.RequestOptions(),
+  }) async {}
 }

--- a/test/repository/voicemail_repository_test.dart
+++ b/test/repository/voicemail_repository_test.dart
@@ -18,7 +18,12 @@ void main() {
   setUp(() {
     appDatabase = AppDatabase(NativeDatabase.memory());
     apiClient = MockWebtritApiClient();
-    dataSource = VoicemailRepositoryImpl(webtritApiClient: apiClient, token: 'user_token', appDatabase: appDatabase, sessionGuard: const EmptySessionGuard());
+    dataSource = VoicemailRepositoryImpl(
+      webtritApiClient: apiClient,
+      token: 'user_token',
+      appDatabase: appDatabase,
+      sessionGuard: const EmptySessionGuard(),
+    );
   });
 
   tearDown(() async {
@@ -50,7 +55,7 @@ void main() {
       expect(voicemails.where((voicemail) => voicemail.seen).length, 3);
       expect(voicemails.where((voicemail) => !voicemail.seen).length, 1);
     });
-  
+
     test('deleteMultipleVoicemails', () async {
       final firstVoicemail = VoicemailsFixtureFactory.createVoicemail(id: '1');
       final secondVoicemail = VoicemailsFixtureFactory.createVoicemail(id: '2');


### PR DESCRIPTION
## Summary

- Add `**/build/` and `**/.claude/` to `.gitignore` to stop tracking package build dirs and Claude project dirs
- Update `lefthook` pre-commit hook to skip `*.g.dart`, `*.freezed.dart`, `*.gr.dart` via shell-level filter (workaround for unsupported `formatter.exclude` in current Dart)
- Replace `melos run fmt` / `fmt:check` scripts with `find`-based commands that exclude generated files
- Update melos v7 integration across features, DAOs, and screenshots mocks

## Test plan

- [x] `melos run fmt` — 0 files changed (no generated files touched)
- [x] `dart run build_runner build` — 0 new outputs
- [x] `melos run analyze` — no issues across all packages
- [x] Pre-commit hook skips `.g.dart` / `.freezed.dart` / `.gr.dart` files