### PR TITLE
feat: allow feat/ as valid branch prefix alongside feature/

### DIFF
--- a/.github/workflows/git-lint.yml
+++ b/.github/workflows/git-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Validate Branch Name
         run: |
           BRANCH="${{ github.head_ref }}"
-          REGEX="^(feature|refactor|fix|chore|build|style|docs|release)/.+$"
+          REGEX="^(feat|feature|refactor|fix|chore|build|style|docs|release)/.+$"
           
           if [[ ! "$BRANCH" =~ $REGEX ]]; then
             echo "Invalid branch name: '$BRANCH'"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to WebTrit Phone
+
+## Branch Naming
+
+Branches must follow the pattern `<type>/<description>`, where `<description>` uses kebab-case.
+
+**Accepted prefixes:**
+
+| Prefix | When to use |
+|--------|-------------|
+| `feature/` or `feat/` | New feature or enhancement |
+| `fix/` | Bug fix |
+| `refactor/` | Code refactoring without behaviour change |
+| `chore/` | Maintenance, dependency updates, tooling |
+| `docs/` | Documentation only |
+| `style/` | Code style / formatting changes |
+| `build/` | Build system or CI changes |
+| `release/` | Release preparation |
+
+> Both `feature/` and `feat/` are accepted as equivalent aliases for feature branches.
+
+Examples:
+
+```
+feature/add-login-form
+feat/add-login-form
+fix/null-pointer-crash
+release/1.2.0
+```
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>[(scope)]: <lowercase description>
+```
+
+Accepted types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `style`, `ci`, `perf`, `build`, `revert`.
+
+- Description must start with a **lowercase** letter.
+- No Cyrillic characters anywhere in commit messages.
+
+Examples:
+
+```
+feat: add biometric login
+fix(api): handle null response from signaling
+chore: upgrade flutter to 3.32.4
+```
+
+## Git Hooks
+
+Hooks are managed with [Lefthook](https://github.com/evilmartians/lefthook).
+
+```bash
+brew install lefthook
+lefthook install
+```
+
+Hooks run automatically:
+
+- **pre-commit** — `dart format` on staged Dart files (generated files excluded)
+- **commit-msg** — validates commit message format
+- **pre-push** — validates branch name, runs `flutter analyze` and `flutter test`

--- a/tool/scripts/branch-name-check.sh
+++ b/tool/scripts/branch-name-check.sh
@@ -5,9 +5,9 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "🔍 Current branch: $BRANCH"
 
-if ! [[ "$BRANCH" =~ ^(feature|refactor|fix|chore|build|style|docs|release)/.+$ ]]; then
+if ! [[ "$BRANCH" =~ ^(feat|feature|refactor|fix|chore|build|style|docs|release)/.+$ ]]; then
   echo "❌ Invalid branch name: '$BRANCH'"
-  echo "💡 Use: feature/name, fix/bug-name, release/1.0.0, etc."
+  echo "💡 Use: feature/name, feat/name, fix/bug-name, release/1.0.0, etc."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add `feat/` as an accepted branch name prefix in `tool/scripts/branch-name-check.sh`
- Add `feat/` to the branch regex in `.github/workflows/git-lint.yml`
- Create `CONTRIBUTING.md` documenting branch naming conventions and commit message format

Both `feat/` and `feature/` are now treated as equivalent aliases for feature branches. Commit convention (Conventional Commits) is unchanged.

## Test plan

- [ ] Verify pre-push hook passes for branches named `feat/*`
- [ ] Verify pre-push hook passes for branches named `feature/*`
- [ ] Verify CI branch validation passes for both prefixes
- [ ] Confirm existing prefixes (`fix/`, `chore/`, `release/`, etc.) still work