### PR TITLE
fix: contacts dao test ordering assumption

### DIFF
--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -486,8 +486,8 @@ void main() {
 
       final visibleContacts = await database.contactsDao.getAllContacts(null);
       expect(visibleContacts.length, initialVisibleCount + 1);
-      expect(visibleContacts.first.contact.firstName, 'Abi');
-      expect(visibleContacts.first.contact.kind, ContactKindTypeEnum.visible);
+      final abiContact = visibleContacts.firstWhere((c) => c.contact.firstName == 'Abi');
+      expect(abiContact.contact.kind, ContactKindTypeEnum.visible);
 
       final serviceContacts = await database.contactsDao.getAllContacts(null, kind: ContactKindTypeEnum.service);
       expect(serviceContacts.length, 1);


### PR DESCRIPTION
## Summary
- Fixed flaky test `getAllContacts filters based on kind` in `contacts_dao_test.dart`
- The test used `.first` on an unordered result list, causing it to return a `setUp` contact with `firstName: ''` instead of the expected `'Abi'`
- Replaced `.first` with `.firstWhere((c) => c.contact.firstName == 'Abi')` to find the contact by name regardless of order

## Test plan
- [x] Run `flutter test` in `packages/data/app_database` — all tests should pass