### PR TITLE
feat: melos exported env support

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -384,13 +384,13 @@ melos:
     l10n:push:
       description: Push localization keys to Localizely (reads LOCALIZELY_TOKEN from .env).
       run: |
-        token=$(grep '^LOCALIZELY_TOKEN=' .env | cut -d '=' -f2)
+        token=$(grep -E '^(export[[:space:]]+)?LOCALIZELY_TOKEN=' .env | cut -d '=' -f2)
         localizely-cli --api-token="$token" push
 
     l10n:pull:
       description: Pull localization keys from Localizely (reads LOCALIZELY_TOKEN from .env).
       run: |
-        token=$(grep '^LOCALIZELY_TOKEN=' .env | cut -d '=' -f2)
+        token=$(grep -E '^(export[[:space:]]+)?LOCALIZELY_TOKEN=' .env | cut -d '=' -f2)
         localizely-cli --api-token="$token" pull
 
     l10n:generate:


### PR DESCRIPTION
This pull request updates the way the `LOCALIZELY_TOKEN` is extracted from the `.env` file in the `melos` scripts within `pubspec.yaml`. The change makes the token extraction more robust by allowing for both plain and `export`-prefixed environment variable declarations.

- **Script Robustness Improvement:**
  * Updated the `l10n:push` and `l10n:pull` scripts to extract `LOCALIZELY_TOKEN` from `.env` even if the variable is prefixed with `export`, improving compatibility with different `.env` formats.