### PR TITLE
feat: add dart formatter PostToolUse hook

### DIFF
--- a/.claude/hooks/dart_formatter.py
+++ b/.claude/hooks/dart_formatter.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: auto-format .dart files after Write/Edit/MultiEdit."""
+"""PostToolUse hook: auto-format .dart files after Write/Edit/MultiEdit.
+
+Runs `dart format` on every .dart file that Claude writes or edits.
+Line width is intentionally omitted — dart format reads `formatter.page_width`
+from analysis_options.yaml automatically (Dart 3.7+), so the project setting
+is always respected without duplication.
+
+Generated files (*.g.dart, *.freezed.dart, *.gr.dart) are skipped because
+they must never be hand-edited or reformatted outside of build_runner.
+"""
 
 import json
 import subprocess
 import sys
 
+# Suffixes that identify auto-generated Dart files — never reformat these.
 GENERATED_SUFFIXES = ('.g.dart', '.freezed.dart', '.gr.dart')
 
 
 def get_file_path(hook_input: dict) -> str | None:
+    """Return the file_path from a Write/Edit/MultiEdit tool call, or None."""
     tool = hook_input.get('tool_name', '')
     params = hook_input.get('tool_input', {})
     if tool in ('Write', 'Edit', 'MultiEdit'):
@@ -32,7 +43,7 @@ def main() -> None:
         sys.exit(0)
 
     result = subprocess.run(
-        ['dart', 'format', '--line-length', '120', file_path],
+        ['dart', 'format', file_path],
         capture_output=True,
         text=True,
     )

--- a/.claude/hooks/dart_formatter.py
+++ b/.claude/hooks/dart_formatter.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: auto-format .dart files after Write/Edit/MultiEdit."""
+
+import json
+import subprocess
+import sys
+
+GENERATED_SUFFIXES = ('.g.dart', '.freezed.dart', '.gr.dart')
+
+
+def get_file_path(hook_input: dict) -> str | None:
+    tool = hook_input.get('tool_name', '')
+    params = hook_input.get('tool_input', {})
+    if tool in ('Write', 'Edit', 'MultiEdit'):
+        return params.get('file_path')
+    return None
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    file_path = get_file_path(hook_input)
+
+    if not file_path:
+        sys.exit(0)
+    if not file_path.endswith('.dart'):
+        sys.exit(0)
+    if any(file_path.endswith(s) for s in GENERATED_SUFFIXES):
+        sys.exit(0)
+
+    result = subprocess.run(
+        ['dart', 'format', '--line-length', '120', file_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f'dart format failed: {result.stderr}', file=sys.stderr)
+        sys.exit(result.returncode)
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/hooks/dart_formatter.py
+++ b/.claude/hooks/dart_formatter.py
@@ -11,6 +11,7 @@ they must never be hand-edited or reformatted outside of build_runner.
 """
 
 import json
+import os
 import subprocess
 import sys
 from typing import Optional
@@ -36,7 +37,7 @@ def main() -> None:
 
     file_path = get_file_path(hook_input)
 
-    if not file_path:
+    if not file_path or not os.path.isfile(file_path):
         sys.exit(0)
     if not file_path.endswith('.dart'):
         sys.exit(0)

--- a/.claude/hooks/dart_formatter.py
+++ b/.claude/hooks/dart_formatter.py
@@ -13,17 +13,18 @@ they must never be hand-edited or reformatted outside of build_runner.
 import json
 import subprocess
 import sys
+from typing import Optional
 
 # Suffixes that identify auto-generated Dart files — never reformat these.
 GENERATED_SUFFIXES = ('.g.dart', '.freezed.dart', '.gr.dart')
 
 
-def get_file_path(hook_input: dict) -> str | None:
+def get_file_path(hook_input: dict) -> Optional[str]:
     """Return the file_path from a Write/Edit/MultiEdit tool call, or None."""
-    tool = hook_input.get('tool_name', '')
+    tool = hook_input.get('tool') or hook_input.get('tool_name', '')
     params = hook_input.get('tool_input', {})
     if tool in ('Write', 'Edit', 'MultiEdit'):
-        return params.get('file_path')
+        return params.get('file_path') or params.get('path')
     return None
 
 
@@ -48,8 +49,12 @@ def main() -> None:
         text=True,
     )
     if result.returncode != 0:
-        print(f'dart format failed: {result.stderr}', file=sys.stderr)
-        sys.exit(result.returncode)
+        print(
+            f'dart format failed for {file_path} with exit code {result.returncode}\n'
+            f'stdout:\n{result.stdout}\n'
+            f'stderr:\n{result.stderr}',
+            file=sys.stderr,
+        )
 
 
 if __name__ == '__main__':

--- a/.claude/hooks/newline_enforcer.py
+++ b/.claude/hooks/newline_enforcer.py
@@ -11,6 +11,7 @@ they are managed exclusively by build_runner.
 import json
 import os
 import sys
+from typing import Optional
 
 # Extensions treated as binary or otherwise not touched.
 BINARY_EXTENSIONS = {
@@ -24,12 +25,12 @@ BINARY_EXTENSIONS = {
 GENERATED_DART_SUFFIXES = ('.g.dart', '.freezed.dart', '.gr.dart')
 
 
-def get_file_path(hook_input: dict) -> str | None:
+def get_file_path(hook_input: dict) -> Optional[str]:
     """Return the file_path from a Write/Edit/MultiEdit tool call, or None."""
-    tool = hook_input.get('tool_name', '')
+    tool = hook_input.get('tool') or hook_input.get('tool_name', '')
     params = hook_input.get('tool_input', {})
     if tool in ('Write', 'Edit', 'MultiEdit'):
-        return params.get('file_path')
+        return params.get('file_path') or params.get('path')
     return None
 
 

--- a/.claude/hooks/newline_enforcer.py
+++ b/.claude/hooks/newline_enforcer.py
@@ -26,6 +26,11 @@ ALLOWED_EXTENSIONS = {
     '.txt',
 }
 
+# Generated Dart files must never be modified outside of build_runner.
+# os.path.splitext('foo.g.dart') returns ('.g', '.dart'), so extension-based
+# allowlist alone is not enough — explicit suffix check is required.
+GENERATED_DART_SUFFIXES = ('.g.dart', '.freezed.dart', '.gr.dart')
+
 
 def get_file_path(hook_input: dict) -> Optional[str]:
     """Return the file_path from a Write/Edit/MultiEdit tool call, or None."""
@@ -37,6 +42,8 @@ def get_file_path(hook_input: dict) -> Optional[str]:
 
 
 def should_apply(file_path: str) -> bool:
+    if any(file_path.endswith(s) for s in GENERATED_DART_SUFFIXES):
+        return False
     _, ext = os.path.splitext(file_path)
     return ext.lower() in ALLOWED_EXTENSIONS
 

--- a/.claude/hooks/newline_enforcer.py
+++ b/.claude/hooks/newline_enforcer.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: ensure every text file written or edited ends with a newline.
+"""PostToolUse hook: ensure text files written or edited end with a newline.
 
 Prevents the "no newline at end of file" warning in Git diffs and code review tools.
-Applies to all text-based file types; silently skips binary files and generated Dart files.
-
-Generated Dart files (*.g.dart, *.freezed.dart, *.gr.dart) are skipped because
-they are managed exclusively by build_runner.
+Only applies to explicitly allowlisted extensions — all other files are ignored.
 """
 
 import json
@@ -13,16 +10,21 @@ import os
 import sys
 from typing import Optional
 
-# Extensions treated as binary or otherwise not touched.
-BINARY_EXTENSIONS = {
-    '.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp',
-    '.ttf', '.otf', '.woff', '.woff2',
-    '.pdf', '.zip', '.tar', '.gz',
-    '.jks', '.keystore', '.p12', '.pem', '.key', '.p8',
+# Only these extensions will have a trailing newline enforced.
+ALLOWED_EXTENSIONS = {
+    '.dart',
+    '.yaml', '.yml',
+    '.json',
+    '.md',
+    '.py',
+    '.sh',
+    '.kt', '.kts',
+    '.swift',
+    '.gradle',
+    '.xml',
+    '.html',
+    '.txt',
 }
-
-# Generated Dart files must never be modified outside of build_runner.
-GENERATED_DART_SUFFIXES = ('.g.dart', '.freezed.dart', '.gr.dart')
 
 
 def get_file_path(hook_input: dict) -> Optional[str]:
@@ -34,13 +36,9 @@ def get_file_path(hook_input: dict) -> Optional[str]:
     return None
 
 
-def should_skip(file_path: str) -> bool:
+def should_apply(file_path: str) -> bool:
     _, ext = os.path.splitext(file_path)
-    if ext.lower() in BINARY_EXTENSIONS:
-        return True
-    if any(file_path.endswith(s) for s in GENERATED_DART_SUFFIXES):
-        return True
-    return False
+    return ext.lower() in ALLOWED_EXTENSIONS
 
 
 def main() -> None:
@@ -52,7 +50,7 @@ def main() -> None:
     file_path = get_file_path(hook_input)
     if not file_path or not os.path.isfile(file_path):
         sys.exit(0)
-    if should_skip(file_path):
+    if not should_apply(file_path):
         sys.exit(0)
 
     try:

--- a/.claude/hooks/newline_enforcer.py
+++ b/.claude/hooks/newline_enforcer.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: ensure every text file written or edited ends with a newline.
+
+Prevents the "no newline at end of file" warning in Git diffs and code review tools.
+Applies to all text-based file types; silently skips binary files and generated Dart files.
+
+Generated Dart files (*.g.dart, *.freezed.dart, *.gr.dart) are skipped because
+they are managed exclusively by build_runner.
+"""
+
+import json
+import os
+import sys
+
+# Extensions treated as binary or otherwise not touched.
+BINARY_EXTENSIONS = {
+    '.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp',
+    '.ttf', '.otf', '.woff', '.woff2',
+    '.pdf', '.zip', '.tar', '.gz',
+    '.jks', '.keystore', '.p12', '.pem', '.key', '.p8',
+}
+
+# Generated Dart files must never be modified outside of build_runner.
+GENERATED_DART_SUFFIXES = ('.g.dart', '.freezed.dart', '.gr.dart')
+
+
+def get_file_path(hook_input: dict) -> str | None:
+    """Return the file_path from a Write/Edit/MultiEdit tool call, or None."""
+    tool = hook_input.get('tool_name', '')
+    params = hook_input.get('tool_input', {})
+    if tool in ('Write', 'Edit', 'MultiEdit'):
+        return params.get('file_path')
+    return None
+
+
+def should_skip(file_path: str) -> bool:
+    _, ext = os.path.splitext(file_path)
+    if ext.lower() in BINARY_EXTENSIONS:
+        return True
+    if any(file_path.endswith(s) for s in GENERATED_DART_SUFFIXES):
+        return True
+    return False
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    file_path = get_file_path(hook_input)
+    if not file_path or not os.path.isfile(file_path):
+        sys.exit(0)
+    if should_skip(file_path):
+        sys.exit(0)
+
+    try:
+        with open(file_path, 'rb') as f:
+            content = f.read()
+    except OSError:
+        sys.exit(0)
+
+    if content and not content.endswith(b'\n'):
+        with open(file_path, 'ab') as f:
+            f.write(b'\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,16 @@
             "command": "python3 .claude/hooks/md_formatter.py"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/dart_formatter.py",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,6 +60,15 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/newline_enforcer.py"
+          }
+        ]
       }
     ],
     "PreToolUse": [


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/dart_formatter.py` — PostToolUse hook that auto-runs `dart format` on every `.dart` file after Claude writes or edits it
- Adds `.claude/hooks/newline_enforcer.py` — PostToolUse hook that ensures files end with a trailing newline; applies only to allowlisted text extensions (`.dart`, `.yaml`, `.yml`, `.json`, `.md`, `.py`, `.sh`, `.kt`, `.kts`, `.swift`, `.gradle`, `.xml`, `.html`, `.txt`)
- Line width for `dart format` is read from `formatter.page_width` in `analysis_options.yaml` automatically (Dart 3.7+) — no hardcoded value
- Both hooks skip generated files (`*.g.dart`, `*.freezed.dart`, `*.gr.dart`)
- Both hooks registered in `.claude/settings.json` alongside existing `md_formatter.py`

## Test plan

- [ ] Edit any `.dart` file via Claude — confirm `dart format` runs automatically
- [ ] Edit a file without trailing newline — confirm `\n` is appended
- [ ] Edit a `*.g.dart` path — confirm both hooks exit without changes
- [ ] Edit a non-allowlisted file (e.g. `.log`) — confirm `newline_enforcer` skips it
- [ ] Confirm `md_formatter.py` still works for `.md` files (no regression)