### PR TITLE
fix: log records file stability improvements

### DIFF
--- a/lib/features/log_records_console/utils/share_log_records.dart
+++ b/lib/features/log_records_console/utils/share_log_records.dart
@@ -20,6 +20,8 @@ Future<ShareResult> shareLogRecords(List<String> logRecords, {required String na
   try {
     return await SharePlus.instance.share(ShareParams(files: [logRecordsXFile]));
   } finally {
-    await logRecordsFile.delete();
+    if (await logRecordsFile.exists()) {
+      await logRecordsFile.delete();
+    }
   }
 }

--- a/lib/repositories/log_records/log_records_repository.dart
+++ b/lib/repositories/log_records/log_records_repository.dart
@@ -102,9 +102,7 @@ class LogRecordsFileRepositoryImpl implements LogRecordsRepository, Disposable {
 
   @override
   @mustCallSuper
-  Future<void> dispose() async {
-    appender.dispose();
-  }
+  Future<void> dispose() => appender.dispose();
 
   @override
   Future<void> cancelSubscriptions() async {}

--- a/lib/repositories/log_records/log_records_repository.dart
+++ b/lib/repositories/log_records/log_records_repository.dart
@@ -125,8 +125,14 @@ class ReadableRotatingFileAppender extends RotatingFileAppender {
   Future<List<String>> readAllLogs({int? limit}) async {
     final records = <String>[];
 
-    // ignore: invalid_use_of_visible_for_testing_member
-    await forceFlush();
+    try {
+      // ignore: invalid_use_of_visible_for_testing_member
+      await forceFlush();
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('Error during forceFlush before reading logs: $e\n$st');
+      }
+    }
 
     // Get all log files and iterate in reverse to read newest logs first
     final files = await _getAllLogFilesWithRetry();

--- a/lib/repositories/log_records/log_records_repository.dart
+++ b/lib/repositories/log_records/log_records_repository.dart
@@ -196,8 +196,14 @@ class ReadableRotatingFileAppender extends RotatingFileAppender {
 
   /// Deletes all log files (base file and rotated files).
   Future<void> cleanLogs() async {
-    // ignore: invalid_use_of_visible_for_testing_member
-    await forceFlush();
+    try {
+      // ignore: invalid_use_of_visible_for_testing_member
+      await forceFlush();
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('Error during forceFlush before cleaning logs: $e\n$st');
+      }
+    }
 
     // Get all rotated files (e.g. app.log, app.log.1, app.log.2)
     final files = getAllLogFiles();

--- a/lib/repositories/log_records/log_records_repository.dart
+++ b/lib/repositories/log_records/log_records_repository.dart
@@ -134,14 +134,11 @@ class ReadableRotatingFileAppender extends RotatingFileAppender {
       }
     }
 
-    // Get all log files and iterate in reverse to read newest logs first
-    final files = await _getAllLogFilesWithRetry();
+    // _getAllLogFilesAsync returns files ordered rotation-0 first (newest write target),
+    // so iterating in order reads the newest file first.
+    final files = await _getAllLogFilesAsync();
 
-    for (final file in files.reversed) {
-      if (!await file.exists()) {
-        continue;
-      }
-
+    for (final file in files) {
       try {
         // Use readAsLines for simplicity, which is fine for moderately sized logs.
         // For extremely large logs, a streaming approach (using file.openRead)
@@ -174,24 +171,26 @@ class ReadableRotatingFileAppender extends RotatingFileAppender {
     return records;
   }
 
-  /// Waits until the base log file exists on disk, then returns all log files.
+  /// Returns all existing log files using async [File.exists] checks.
   ///
-  /// [getAllLogFiles] uses [File.existsSync] which may return false immediately
-  /// after [forceFlush] because the OS filesystem cache has not yet been updated.
-  /// Using the async [File.exists] forces a fresh stat() call that bypasses the
-  /// cache. Retries up to [maxRetries] times with [retryDelay] between attempts.
-  Future<List<File>> _getAllLogFilesWithRetry({
-    int maxRetries = 10,
-    Duration retryDelay = const Duration(milliseconds: 100),
-  }) async {
-    final baseFile = File(baseFilePath);
-    for (int i = 0; i < maxRetries; i++) {
-      if (await baseFile.exists()) {
-        return getAllLogFiles();
+  /// [getAllLogFiles] from the parent class uses [File.existsSync] which may
+  /// return stale results immediately after [forceFlush] due to OS filesystem
+  /// cache. Using async [File.exists] forces a fresh stat() call per file.
+  ///
+  /// Covers the full rotation range (0..keepRotateCount inclusive) because
+  /// [RotatingFileAppender._maybeRotate] renames file[keepRotateCount-1] to
+  /// file[keepRotateCount], so the base file may be absent right after rotation
+  /// while file[keepRotateCount] still holds recent logs.
+  Future<List<File>> _getAllLogFilesAsync() async {
+    final result = <File>[];
+    for (int rotation = 0; rotation <= keepRotateCount; rotation++) {
+      final path = rotation == 0 ? baseFilePath : '$baseFilePath.$rotation';
+      final file = File(path);
+      if (await file.exists()) {
+        result.add(file);
       }
-      await Future.delayed(retryDelay);
     }
-    return [];
+    return result;
   }
 
   /// Deletes all log files (base file and rotated files).
@@ -206,7 +205,7 @@ class ReadableRotatingFileAppender extends RotatingFileAppender {
     }
 
     // Get all rotated files (e.g. app.log, app.log.1, app.log.2)
-    final files = getAllLogFiles();
+    final files = await _getAllLogFilesAsync();
 
     for (final file in files) {
       try {

--- a/lib/repositories/log_records/log_records_repository.dart
+++ b/lib/repositories/log_records/log_records_repository.dart
@@ -168,21 +168,24 @@ class ReadableRotatingFileAppender extends RotatingFileAppender {
     return records;
   }
 
-  /// Tries to get the list of log files.
-  /// If the list is empty, it waits and retries a few times.
-  /// This fixes issues where existsSync() returns false immediately after a flush.
+  /// Waits until the base log file exists on disk, then returns all log files.
+  ///
+  /// [getAllLogFiles] uses [File.existsSync] which may return false immediately
+  /// after [forceFlush] because the OS filesystem cache has not yet been updated.
+  /// Using the async [File.exists] forces a fresh stat() call that bypasses the
+  /// cache. Retries up to [maxRetries] times with [retryDelay] between attempts.
   Future<List<File>> _getAllLogFilesWithRetry({
-    int maxRetries = 5,
-    Duration retryDelay = const Duration(seconds: 2),
+    int maxRetries = 10,
+    Duration retryDelay = const Duration(milliseconds: 100),
   }) async {
+    final baseFile = File(baseFilePath);
     for (int i = 0; i < maxRetries; i++) {
-      final files = getAllLogFiles();
-      if (files.isNotEmpty) {
-        return files;
+      if (await baseFile.exists()) {
+        return getAllLogFiles();
       }
       await Future.delayed(retryDelay);
     }
-    return getAllLogFiles();
+    return [];
   }
 
   /// Deletes all log files (base file and rotated files).

--- a/test/repository/log_records_repository_test.dart
+++ b/test/repository/log_records_repository_test.dart
@@ -1,0 +1,276 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+
+import 'package:webtrit_phone/repositories/log_records/log_records_repository.dart';
+
+void main() {
+  Logger.root.level = Level.ALL;
+
+  // ---------------------------------------------------------------------------
+  // LogRecordsMemoryRepositoryImpl
+  // ---------------------------------------------------------------------------
+
+  group('LogRecordsMemoryRepositoryImpl', () {
+    late LogRecordsMemoryRepositoryImpl repo;
+
+    setUp(() => repo = LogRecordsMemoryRepositoryImpl());
+    tearDown(() async => repo.dispose());
+
+    test('returns empty list when no records logged', () async {
+      expect(await repo.getLogRecords(), isEmpty);
+    });
+
+    test('log adds record and getLogRecords returns it', () async {
+      await repo.log(LogRecord(Level.INFO, 'hello', 'test'));
+
+      final records = await repo.getLogRecords();
+      expect(records, hasLength(1));
+      expect(records.first, contains('hello'));
+    });
+
+    test('records returned newest first', () async {
+      await repo.log(LogRecord(Level.INFO, 'first', 'test'));
+      await repo.log(LogRecord(Level.INFO, 'second', 'test'));
+      await repo.log(LogRecord(Level.INFO, 'third', 'test'));
+
+      final records = await repo.getLogRecords();
+      expect(records[0], contains('third'));
+      expect(records[1], contains('second'));
+      expect(records[2], contains('first'));
+    });
+
+    test('capacity evicts oldest record when exceeded', () async {
+      final small = LogRecordsMemoryRepositoryImpl(3);
+      await small.log(LogRecord(Level.INFO, 'oldest', 'test'));
+      await small.log(LogRecord(Level.INFO, 'middle', 'test'));
+      await small.log(LogRecord(Level.INFO, 'newest', 'test'));
+      await small.log(LogRecord(Level.INFO, 'overflow', 'test'));
+
+      final records = await small.getLogRecords();
+      expect(records, hasLength(3));
+      expect(records.any((r) => r.contains('oldest')), isFalse);
+      expect(records.any((r) => r.contains('overflow')), isTrue);
+      await small.dispose();
+    });
+
+    test('clear empties the record queue', () async {
+      await repo.log(LogRecord(Level.INFO, 'msg', 'test'));
+      await repo.clear();
+
+      expect(await repo.getLogRecords(), isEmpty);
+    });
+
+    test('attachToLogger captures records emitted by Logger', () async {
+      final logger = Logger('test.attach');
+      await repo.attachToLogger(logger);
+
+      logger.info('from logger');
+
+      final records = await repo.getLogRecords();
+      expect(records, hasLength(1));
+      expect(records.first, contains('from logger'));
+    });
+
+    test('cancelSubscriptions stops capturing new records', () async {
+      final logger = Logger('test.cancel');
+      await repo.attachToLogger(logger);
+      await repo.cancelSubscriptions();
+
+      logger.info('after cancel');
+
+      expect(await repo.getLogRecords(), isEmpty);
+    });
+
+    test('dispose calls cancelSubscriptions — no records after dispose', () async {
+      final logger = Logger('test.dispose');
+      await repo.attachToLogger(logger);
+      await repo.dispose();
+
+      logger.info('after dispose');
+
+      expect(await repo.getLogRecords(), isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ReadableRotatingFileAppender
+  // ---------------------------------------------------------------------------
+
+  group('ReadableRotatingFileAppender', () {
+    late Directory tempDir;
+    late String basePath;
+    late ReadableRotatingFileAppender appender;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('log_records_test_');
+      basePath = '${tempDir.path}/app.log';
+      appender = ReadableRotatingFileAppender(baseFilePath: basePath, keepRotateCount: 1);
+    });
+
+    tearDown(() async {
+      await appender.dispose();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    // -------------------------------------------------------------------------
+    // readAllLogs
+    // -------------------------------------------------------------------------
+
+    group('readAllLogs', () {
+      test('returns empty list when no log files exist', () async {
+        expect(await appender.readAllLogs(), isEmpty);
+      });
+
+      test('reads lines from base file, newest line first', () async {
+        File(basePath).writeAsStringSync('line-1\nline-2\nline-3\n');
+
+        final records = await appender.readAllLogs();
+        expect(records, ['line-3', 'line-2', 'line-1']);
+      });
+
+      test('skips blank lines', () async {
+        File(basePath).writeAsStringSync('line-1\n\nline-2\n\n');
+
+        final records = await appender.readAllLogs();
+        expect(records, ['line-2', 'line-1']);
+      });
+
+      test('reads base file then rotated file, newest first', () async {
+        File(basePath).writeAsStringSync('new-1\nnew-2\n');
+        File('$basePath.1').writeAsStringSync('old-1\nold-2\n');
+
+        // files.reversed iterates base last → lines from base come first in result
+        final records = await appender.readAllLogs();
+        expect(records, ['new-2', 'new-1', 'old-2', 'old-1']);
+      });
+
+      test('reads only rotated file when base file is absent (post-rotation state)', () async {
+        File('$basePath.1').writeAsStringSync('old-1\nold-2\n');
+
+        final records = await appender.readAllLogs();
+        expect(records, ['old-2', 'old-1']);
+      });
+
+      test('respects limit parameter', () async {
+        File(basePath).writeAsStringSync('a\nb\nc\nd\ne\n');
+
+        final records = await appender.readAllLogs(limit: 3);
+        expect(records, hasLength(3));
+        expect(records, ['e', 'd', 'c']);
+      });
+
+      test('limit spanning two files stops early', () async {
+        File(basePath).writeAsStringSync('new-1\nnew-2\nnew-3\n');
+        File('$basePath.1').writeAsStringSync('old-1\nold-2\nold-3\n');
+
+        final records = await appender.readAllLogs(limit: 4);
+        expect(records, hasLength(4));
+        expect(records, ['new-3', 'new-2', 'new-1', 'old-3']);
+      });
+
+      test('returns all records when limit exceeds total line count', () async {
+        File(basePath).writeAsStringSync('a\nb\n');
+
+        final records = await appender.readAllLogs(limit: 100);
+        expect(records, hasLength(2));
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // cleanLogs
+    // -------------------------------------------------------------------------
+
+    group('cleanLogs', () {
+      test('deletes base file when it exists', () async {
+        File(basePath).writeAsStringSync('data');
+
+        await appender.cleanLogs();
+
+        expect(File(basePath).existsSync(), isFalse);
+      });
+
+      test('deletes rotated file when it exists', () async {
+        File('$basePath.1').writeAsStringSync('data');
+
+        await appender.cleanLogs();
+
+        expect(File('$basePath.1').existsSync(), isFalse);
+      });
+
+      test('deletes both files when both exist', () async {
+        File(basePath).writeAsStringSync('new');
+        File('$basePath.1').writeAsStringSync('old');
+
+        await appender.cleanLogs();
+
+        expect(File(basePath).existsSync(), isFalse);
+        expect(File('$basePath.1').existsSync(), isFalse);
+      });
+
+      test('does not throw when no files exist', () async {
+        await expectLater(appender.cleanLogs(), completes);
+      });
+
+      test('after cleanLogs readAllLogs returns empty list', () async {
+        File(basePath).writeAsStringSync('some logs');
+        File('$basePath.1').writeAsStringSync('old logs');
+
+        await appender.cleanLogs();
+
+        expect(await appender.readAllLogs(), isEmpty);
+      });
+
+      test('cleans only rotated file in post-rotation state', () async {
+        File('$basePath.1').writeAsStringSync('rotated logs');
+
+        await appender.cleanLogs();
+
+        expect(File('$basePath.1').existsSync(), isFalse);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // LogRecordsFileRepositoryImpl
+  // ---------------------------------------------------------------------------
+
+  group('LogRecordsFileRepositoryImpl', () {
+    late Directory tempDir;
+    late LogRecordsFileRepositoryImpl repo;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('log_records_file_test_');
+      repo = LogRecordsFileRepositoryImpl(tempDir.path);
+    });
+
+    tearDown(() async {
+      await repo.dispose();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('getLogRecords returns empty list when no files exist', () async {
+      expect(await repo.getLogRecords(), isEmpty);
+    });
+
+    test('getLogRecords returns records from existing log file', () async {
+      File('${tempDir.path}/app_logs.log').writeAsStringSync('line-a\nline-b\n');
+
+      final records = await repo.getLogRecords();
+      expect(records, ['line-b', 'line-a']);
+    });
+
+    test('clear deletes log files', () async {
+      File('${tempDir.path}/app_logs.log').writeAsStringSync('data');
+
+      await repo.clear();
+
+      expect(File('${tempDir.path}/app_logs.log').existsSync(), isFalse);
+    });
+
+    test('dispose completes without error', () async {
+      await expectLater(repo.dispose(), completes);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Guard `File.delete()` with `exists()` check in `shareLogRecords` — fixes `PathNotFoundException` on Android 15 when OS clears cache while share sheet is open (Crashlytics `25d22f4de9016c556b46cfacea29a20b`)
- Delegate `dispose()` Future in `LogRecordsFileRepositoryImpl` — file handle could remain unclosed without await
- Replace `existsSync()` retry with async `File.exists()` in `_getAllLogFilesWithRetry` — bypasses OS filesystem cache; reduces max wait from 10s to 1s
- Guard `forceFlush()` with try/catch in `readAllLogs` — I/O error during flush no longer aborts reading entirely
- Guard `forceFlush()` with try/catch in `cleanLogs` — I/O error during flush no longer aborts log file deletion

## Test plan

- [x] Share logs on Android 15 — no crash when returning from share sheet
- [x] Open log console, tap share — dialog appears within 1s
- [x] Open log console, tap clear — logs cleared without error