### PR TITLE
fix: call dropped when user taps before app fully initializes

### DIFF
--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 const kApiClientConnectionTimeout = Duration(seconds: 5);
 
 const kSignalingClientConnectionTimeout = Duration(seconds: 10);
+const kCallRoutingStateTimeout = Duration(seconds: 10);
 const kSignalingClientReconnectDelay = Duration(seconds: 3);
 const kSignalingClientFastReconnectDelay = Duration(seconds: 1);
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1810,9 +1810,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     try {
       final activeCall = state.retrieveActiveCall(event.callId);
       final peerConnection = await _createPeerConnection(event.callId, activeCall!.line);
-      localStream.getTracks().forEach((track) async {
-        await peerConnection.addTrack(track, localStream);
-      });
+      await Future.wait(localStream.getTracks().map((track) => peerConnection.addTrack(track, localStream)));
 
       final localDescription = await peerConnection.createOffer({});
       sdpMunger?.apply(localDescription);

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1713,8 +1713,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     /// Ensuring that the signaling client is connected before attempting to make an outgoing call
     ///
 
-    bool signalingConnected = state.callServiceState.signalingClientStatus.isConnect;
-    bool registrationKnown = state.callServiceState.registration?.status != null;
+    var currentState = state;
+    bool signalingConnected = currentState.callServiceState.signalingClientStatus.isConnect;
+    bool registrationKnown = currentState.callServiceState.registration?.status != null;
 
     // Attempt to wait for the desired signaling client status within the signaling client connection timeout period
     if (signalingConnected == false || registrationKnown == false) {
@@ -1724,7 +1725,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         }),
       );
 
-      final nextStatus = await stream
+      currentState = await stream
           .firstWhere((next) {
             // Stop waiting as soon as signaling is fully ready or has failed —
             // avoids blocking for the full timeout on a definitive failure.
@@ -1733,7 +1734,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             return signalingReady || signalingFailed;
           }, orElse: () => state)
           .timeout(kSignalingClientConnectionTimeout, onTimeout: () => state);
-      signalingConnected = nextStatus.callServiceState.signalingClientStatus.isConnect;
+      signalingConnected = currentState.callServiceState.signalingClientStatus.isConnect;
       if (isClosed) return;
     }
 
@@ -1756,7 +1757,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     }
 
     // If registration status is not registered after signaling is established, notify user
-    if (state.callServiceState.registration?.status.isRegistered != true) {
+    if (currentState.callServiceState.registration?.status.isRegistered != true) {
       _logger.info('__onCallPerformEventStarted account is not registered');
       submitNotification(CallWhileUnregisteredNotification());
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1725,12 +1725,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
 
       final nextStatus = await stream
-          .firstWhere(
-            (next) =>
-                (next.isHandshakeEstablished && next.isSignalingEstablished) ||
-                next.callServiceState.signalingClientStatus.isFailure,
-            orElse: () => state,
-          )
+          .firstWhere((next) {
+            // Stop waiting as soon as signaling is fully ready or has failed —
+            // avoids blocking for the full timeout on a definitive failure.
+            final signalingReady = next.isHandshakeEstablished && next.isSignalingEstablished;
+            final signalingFailed = next.callServiceState.signalingClientStatus.isFailure;
+            return signalingReady || signalingFailed;
+          }, orElse: () => state)
           .timeout(kSignalingClientConnectionTimeout, onTimeout: () => state);
       signalingConnected = nextStatus.callServiceState.signalingClientStatus.isConnect;
       if (isClosed) return;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1714,11 +1714,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     ///
 
     var currentState = state;
-    bool signalingConnected = currentState.callServiceState.signalingClientStatus.isConnect;
-    bool registrationKnown = currentState.callServiceState.registration?.status != null;
 
     // Attempt to wait for the desired signaling client status within the signaling client connection timeout period
-    if (signalingConnected == false || registrationKnown == false) {
+    if (!currentState.isHandshakeEstablished || !currentState.isSignalingEstablished) {
       emit(
         state.copyWithMappedActiveCall(event.callId, (activeCall) {
           return activeCall.copyWith(processingStatus: CallProcessingStatus.outgoingConnectingToSignaling);
@@ -1734,12 +1732,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             return signalingReady || signalingFailed;
           }, orElse: () => state)
           .timeout(kSignalingClientConnectionTimeout, onTimeout: () => state);
-      signalingConnected = currentState.callServiceState.signalingClientStatus.isConnect;
       if (isClosed) return;
     }
 
     // If the signaling client is not connected, hung up the call and notify user
-    if (signalingConnected == false) {
+    if (!currentState.isSignalingEstablished) {
       event.fail();
 
       // Notice that the tube was already hung up to avoid sending an extra event to the server

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1725,7 +1725,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
 
       final nextStatus = await stream
-          .firstWhere((state) => state.isHandshakeEstablished && state.isSignalingEstablished, orElse: () => state)
+          .firstWhere(
+            (next) =>
+                (next.isHandshakeEstablished && next.isSignalingEstablished) ||
+                next.callServiceState.signalingClientStatus.isFailure,
+            orElse: () => state,
+          )
           .timeout(kSignalingClientConnectionTimeout, onTimeout: () => state);
       signalingConnected = nextStatus.callServiceState.signalingClientStatus.isConnect;
       if (isClosed) return;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1700,14 +1700,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> __onCallPerformEventStarted(_CallPerformEventStarted event, Emitter<CallState> emit) async {
-    if (state.callServiceState.registration?.status.isRegistered != true) {
-      _logger.info('__onCallPerformEventStarted account is not registered');
-      submitNotification(CallWhileUnregisteredNotification());
-
-      event.fail();
-      return;
-    }
-
     if (await state.performOnActiveCall(event.callId, (activeCall) => activeCall.line != _kUndefinedLine) != true) {
       event.fail();
 
@@ -1722,9 +1714,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     ///
 
     bool signalingConnected = state.callServiceState.signalingClientStatus.isConnect;
+    bool registrationKnown = state.callServiceState.registration?.status != null;
 
     // Attempt to wait for the desired signaling client status within the signaling client connection timeout period
-    if (signalingConnected == false) {
+    if (signalingConnected == false || registrationKnown == false) {
       emit(
         state.copyWithMappedActiveCall(event.callId, (activeCall) {
           return activeCall.copyWith(processingStatus: CallProcessingStatus.outgoingConnectingToSignaling);
@@ -1732,12 +1725,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
 
       final nextStatus = await stream
-          .firstWhere(
-            (state) =>
-                state.callServiceState.signalingClientStatus.isConnect ||
-                state.callServiceState.signalingClientStatus.isFailure,
-            orElse: () => state,
-          )
+          .firstWhere((state) => state.isHandshakeEstablished && state.isSignalingEstablished, orElse: () => state)
           .timeout(kSignalingClientConnectionTimeout, onTimeout: () => state);
       signalingConnected = nextStatus.callServiceState.signalingClientStatus.isConnect;
       if (isClosed) return;
@@ -1758,6 +1746,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       callkeep.endCall(event.callId);
 
       submitNotification(const CallWhileOfflineNotification());
+      return;
+    }
+
+    // If registration status is not registered after signaling is established, notify user
+    if (state.callServiceState.registration?.status.isRegistered != true) {
+      _logger.info('__onCallPerformEventStarted account is not registered');
+      submitNotification(CallWhileUnregisteredNotification());
+
+      event.fail();
       return;
     }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1727,7 +1727,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
       currentState = await stream
           .firstWhere((next) {
-            // Stop waiting as soon as signaling is fully ready or has failed —
+            // Stop waiting as soon as signaling is fully ready or has failed;
             // avoids blocking for the full timeout on a definitive failure.
             final signalingReady = next.isHandshakeEstablished && next.isSignalingEstablished;
             final signalingFailed = next.callServiceState.signalingClientStatus.isFailure;

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -20,14 +20,19 @@ class CallController {
 
   /// Creates a new call using the current call routing state.
   ///
-  /// Handles caller ID logic and available line validation.
-  void createCall({required String destination, String? displayName, bool video = false, String? fromNumber}) {
-    final callRoutingState = callRoutingCubit.state;
-    if (callRoutingState == null) {
-      _logger.warning('Call routing state is null, cannot create call.');
-      notificationsBloc.add(const NotificationsSubmitted(NoInternetConnectionNotification()));
-      return;
-    }
+  /// If the routing state is not yet available (app just launched, internet
+  /// not yet connected), the call is held as pending and automatically
+  /// proceeds once the routing state becomes available.
+  Future<void> createCall({
+    required String destination,
+    String? displayName,
+    bool video = false,
+    String? fromNumber,
+  }) async {
+    final callRoutingState =
+        callRoutingCubit.state ?? await callRoutingCubit.stream.firstWhere((s) => s != null, orElse: () => null);
+
+    if (callRoutingState == null) return;
 
     // Determine fromNumber based on routing settings
     final shouldUseMainLine = fromNumber == callRoutingState.mainNumber;
@@ -50,7 +55,6 @@ class CallController {
       return;
     }
 
-    // All checks passed, create call
     callBloc.add(
       CallControlEvent.started(number: destination, video: video, displayName: displayName, fromNumber: fromNumber),
     );

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
@@ -22,7 +24,12 @@ class CallController {
   /// If the routing state is not yet available (app just launched, internet
   /// not yet connected), the call is held as pending and automatically
   /// proceeds once the routing state becomes available.
-  Future<void> createCall({
+  void createCall({required String destination, String? displayName, bool video = false, String? fromNumber}) =>
+      unawaited(
+        _createCallAsync(destination: destination, displayName: displayName, video: video, fromNumber: fromNumber),
+      );
+
+  Future<void> _createCallAsync({
     required String destination,
     String? displayName,
     bool video = false,

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -44,11 +44,7 @@ class CallController {
     // orElse returns null only if the cubit is closed while waiting (e.g. logout).
     final CallRoutingState? callRoutingState;
     try {
-      callRoutingState =
-          callRoutingCubit.state ??
-          await callRoutingCubit.stream
-              .firstWhere((s) => s != null, orElse: () => null)
-              .timeout(kCallRoutingStateTimeout);
+      callRoutingState = callRoutingCubit.state ?? await _waitForRoutingState();
     } on TimeoutException {
       _logger.warning(
         'createCall: routing state not available after ${kCallRoutingStateTimeout.inSeconds}s, no network',
@@ -89,6 +85,13 @@ class CallController {
       CallControlEvent.started(number: destination, video: video, displayName: displayName, fromNumber: fromNumber),
     );
   }
+
+  /// Waits for the first non-null [CallRoutingState] from the cubit stream.
+  ///
+  /// Returns null if the cubit is closed before any state arrives (e.g. logout).
+  /// Throws [TimeoutException] if no state arrives within [kCallRoutingStateTimeout].
+  Future<CallRoutingState?> _waitForRoutingState() =>
+      callRoutingCubit.stream.firstWhere((s) => s != null, orElse: () => null).timeout(kCallRoutingStateTimeout);
 
   /// Submits a blind transfer for the given destination.
   ///

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -40,7 +40,12 @@ class CallController {
     final callRoutingState =
         callRoutingCubit.state ?? await callRoutingCubit.stream.firstWhere((s) => s != null, orElse: () => null);
 
-    if (callRoutingState == null) return;
+    if (callRoutingState == null) {
+      _logger.warning(
+        'createCall: callRoutingCubit closed before routing state became available, dropping call to $destination',
+      );
+      return;
+    }
 
     // Determine fromNumber based on routing settings
     final shouldUseMainLine = fromNumber == callRoutingState.mainNumber;

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -30,7 +30,14 @@ class CallController {
   /// proceeds once the routing state becomes available.
   void createCall({required String destination, String? displayName, bool video = false, String? fromNumber}) =>
       unawaited(
-        _createCallAsync(destination: destination, displayName: displayName, video: video, fromNumber: fromNumber),
+        _createCallAsync(
+          destination: destination,
+          displayName: displayName,
+          video: video,
+          fromNumber: fromNumber,
+        ).catchError(
+          (Object e, StackTrace st) => _logger.severe('createCall: unexpected error for $destination', e, st),
+        ),
       );
 
   Future<void> _createCallAsync({

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -6,6 +6,8 @@ import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
 
+// TODO(Serdun): Provide CallController as a singleton via RepositoryProvider in MainShell scope
+// instead of instantiating it in each StatefulWidget. All call sites should use context.read<CallController>().
 class CallController {
   CallController({
     required this.callBloc,

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -1,7 +1,6 @@
 import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
-import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
 

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
+import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
 
@@ -38,9 +40,22 @@ class CallController {
     String? fromNumber,
   }) async {
     // Use current state if available, otherwise wait for the first non-null emission.
-    // orElse returns null if the cubit is closed before state arrives (e.g. logout).
-    final callRoutingState =
-        callRoutingCubit.state ?? await callRoutingCubit.stream.firstWhere((s) => s != null, orElse: () => null);
+    // Timeout guards against indefinite wait when there is no network on startup.
+    // orElse returns null only if the cubit is closed while waiting (e.g. logout).
+    final CallRoutingState? callRoutingState;
+    try {
+      callRoutingState =
+          callRoutingCubit.state ??
+          await callRoutingCubit.stream
+              .firstWhere((s) => s != null, orElse: () => null)
+              .timeout(kCallRoutingStateTimeout);
+    } on TimeoutException {
+      _logger.warning(
+        'createCall: routing state not available after ${kCallRoutingStateTimeout.inSeconds}s, no network',
+      );
+      notificationsBloc.add(const NotificationsSubmitted(NoInternetConnectionNotification()));
+      return;
+    }
 
     if (callRoutingState == null) {
       _logger.warning(

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -37,6 +37,8 @@ class CallController {
     bool video = false,
     String? fromNumber,
   }) async {
+    // Use current state if available, otherwise wait for the first non-null emission.
+    // orElse returns null if the cubit is closed before state arrives (e.g. logout).
     final callRoutingState =
         callRoutingCubit.state ?? await callRoutingCubit.stream.firstWhere((s) => s != null, orElse: () => null);
 

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -1,0 +1,148 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
+import 'package:webtrit_phone/features/call/call.dart';
+import 'package:webtrit_phone/features/call/controllers/call_controller.dart';
+import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
+import 'package:webtrit_phone/models/lines_state.dart';
+
+class _MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {}
+
+class _MockCallRoutingCubit extends MockCubit<CallRoutingState?> implements CallRoutingCubit {}
+
+class _MockNotificationsBloc extends MockBloc<NotificationsEvent, NotificationsState> implements NotificationsBloc {}
+
+class _FakeCallRoutingState extends Fake implements CallRoutingState {
+  _FakeCallRoutingState({
+    this.mainNumber = '111',
+    this.additionalNumbers = const [],
+    required this.mainLinesState,
+    this.guestLineState,
+  });
+
+  @override
+  final String? mainNumber;
+
+  @override
+  final List<String> additionalNumbers;
+
+  @override
+  final List<LineState> mainLinesState;
+
+  @override
+  final LineState? guestLineState;
+
+  @override
+  bool get hasIdleMainLine => mainLinesState.any((l) => l == LineState.idle);
+
+  @override
+  bool get hasIdleGuestLine => guestLineState == LineState.idle;
+
+  @override
+  late final allNumbers = <String>[?mainNumber, ...additionalNumbers];
+
+  @override
+  List<Object?> get props => [mainNumber, additionalNumbers, mainLinesState, guestLineState];
+}
+
+void main() {
+  late _MockCallBloc callBloc;
+  late _MockCallRoutingCubit callRoutingCubit;
+  late _MockNotificationsBloc notificationsBloc;
+  late CallController controller;
+
+  setUpAll(() {
+    registerFallbackValue(const CallControlEvent.started(video: false));
+    registerFallbackValue(const NotificationsSubmitted(CallUndefinedLineNotification()));
+  });
+
+  setUp(() {
+    callBloc = _MockCallBloc();
+    callRoutingCubit = _MockCallRoutingCubit();
+    notificationsBloc = _MockNotificationsBloc();
+    controller = CallController(
+      callBloc: callBloc,
+      callRoutingCubit: callRoutingCubit,
+      notificationsBloc: notificationsBloc,
+    );
+    when(() => callBloc.add(any())).thenReturn(null);
+    when(() => notificationsBloc.add(any())).thenReturn(null);
+  });
+
+  group('CallController.createCall', () {
+    group('routing state immediately available', () {
+      test('dispatches CallControlEvent to callBloc when idle main line exists', () async {
+        when(() => callRoutingCubit.state).thenReturn(_FakeCallRoutingState(mainLinesState: [LineState.idle]));
+
+        await controller.createCall(destination: '222');
+
+        verify(() => callBloc.add(any(that: isA<CallControlEvent>()))).called(1);
+        verifyNever(() => notificationsBloc.add(any()));
+      });
+
+      test('submits CallUndefinedLineNotification when all main lines are in use', () async {
+        when(() => callRoutingCubit.state).thenReturn(_FakeCallRoutingState(mainLinesState: [LineState.inUse]));
+
+        await controller.createCall(destination: '222');
+
+        final captured = verify(() => notificationsBloc.add(captureAny())).captured.single;
+        expect(captured, isA<NotificationsSubmitted>());
+        expect((captured as NotificationsSubmitted).notification, isA<CallUndefinedLineNotification>());
+        verifyNever(() => callBloc.add(any()));
+      });
+
+      test('does not dispatch call when no lines at all', () async {
+        when(() => callRoutingCubit.state).thenReturn(_FakeCallRoutingState(mainLinesState: const []));
+
+        await controller.createCall(destination: '222');
+
+        verifyNever(() => callBloc.add(any()));
+      });
+    });
+
+    group('routing state initially null (app still initializing)', () {
+      test('waits and dispatches call when routing state becomes available', () async {
+        final routingState = _FakeCallRoutingState(mainLinesState: [LineState.idle]);
+        when(() => callRoutingCubit.state).thenReturn(null);
+        whenListen(callRoutingCubit, Stream.fromIterable([routingState]));
+
+        await controller.createCall(destination: '222');
+
+        verify(() => callBloc.add(any(that: isA<CallControlEvent>()))).called(1);
+      });
+
+      test('skips null states and proceeds on first non-null routing state', () async {
+        final routingState = _FakeCallRoutingState(mainLinesState: [LineState.idle]);
+        when(() => callRoutingCubit.state).thenReturn(null);
+        whenListen(callRoutingCubit, Stream.fromIterable([null, null, routingState]));
+
+        await controller.createCall(destination: '222');
+
+        verify(() => callBloc.add(any(that: isA<CallControlEvent>()))).called(1);
+      });
+
+      test('silently drops call when cubit is disposed before routing state arrives', () async {
+        when(() => callRoutingCubit.state).thenReturn(null);
+        whenListen(callRoutingCubit, const Stream<CallRoutingState?>.empty());
+
+        await controller.createCall(destination: '222');
+
+        verifyNever(() => callBloc.add(any()));
+        verifyNever(() => notificationsBloc.add(any()));
+      });
+
+      test('submits CallUndefinedLineNotification after wait if lines are all in use', () async {
+        final routingState = _FakeCallRoutingState(mainLinesState: [LineState.inUse]);
+        when(() => callRoutingCubit.state).thenReturn(null);
+        whenListen(callRoutingCubit, Stream.fromIterable([routingState]));
+
+        await controller.createCall(destination: '222');
+
+        verify(() => notificationsBloc.add(any(that: isA<NotificationsSubmitted>()))).called(1);
+        verifyNever(() => callBloc.add(any()));
+      });
+    });
+  });
+}

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -1,8 +1,13 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
+import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
 import 'package:webtrit_phone/models/lines_state.dart';
@@ -143,6 +148,21 @@ void main() {
 
         verify(() => notificationsBloc.add(any(that: isA<NotificationsSubmitted>()))).called(1);
         verifyNever(() => callBloc.add(any()));
+      });
+
+      test('submits NoInternetConnectionNotification when routing state does not arrive before timeout', () {
+        when(() => callRoutingCubit.state).thenReturn(null);
+        whenListen(callRoutingCubit, StreamController<CallRoutingState?>().stream);
+
+        fakeAsync((async) {
+          controller.createCall(destination: '222');
+          async.elapse(kCallRoutingStateTimeout);
+
+          final captured = verify(() => notificationsBloc.add(captureAny())).captured.single;
+          expect(captured, isA<NotificationsSubmitted>());
+          expect((captured as NotificationsSubmitted).notification, isA<NoInternetConnectionNotification>());
+          verifyNever(() => callBloc.add(any()));
+        });
       });
     });
   });

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -70,7 +70,8 @@ void main() {
       test('dispatches CallControlEvent to callBloc when idle main line exists', () async {
         when(() => callRoutingCubit.state).thenReturn(_FakeCallRoutingState(mainLinesState: [LineState.idle]));
 
-        await controller.createCall(destination: '222');
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
 
         verify(() => callBloc.add(any(that: isA<CallControlEvent>()))).called(1);
         verifyNever(() => notificationsBloc.add(any()));
@@ -79,7 +80,8 @@ void main() {
       test('submits CallUndefinedLineNotification when all main lines are in use', () async {
         when(() => callRoutingCubit.state).thenReturn(_FakeCallRoutingState(mainLinesState: [LineState.inUse]));
 
-        await controller.createCall(destination: '222');
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
 
         final captured = verify(() => notificationsBloc.add(captureAny())).captured.single;
         expect(captured, isA<NotificationsSubmitted>());
@@ -90,7 +92,8 @@ void main() {
       test('does not dispatch call when no lines at all', () async {
         when(() => callRoutingCubit.state).thenReturn(_FakeCallRoutingState(mainLinesState: const []));
 
-        await controller.createCall(destination: '222');
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
 
         verifyNever(() => callBloc.add(any()));
       });
@@ -102,7 +105,8 @@ void main() {
         when(() => callRoutingCubit.state).thenReturn(null);
         whenListen(callRoutingCubit, Stream.fromIterable([routingState]));
 
-        await controller.createCall(destination: '222');
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
 
         verify(() => callBloc.add(any(that: isA<CallControlEvent>()))).called(1);
       });
@@ -112,7 +116,8 @@ void main() {
         when(() => callRoutingCubit.state).thenReturn(null);
         whenListen(callRoutingCubit, Stream.fromIterable([null, null, routingState]));
 
-        await controller.createCall(destination: '222');
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
 
         verify(() => callBloc.add(any(that: isA<CallControlEvent>()))).called(1);
       });
@@ -121,7 +126,8 @@ void main() {
         when(() => callRoutingCubit.state).thenReturn(null);
         whenListen(callRoutingCubit, const Stream<CallRoutingState?>.empty());
 
-        await controller.createCall(destination: '222');
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
 
         verifyNever(() => callBloc.add(any()));
         verifyNever(() => notificationsBloc.add(any()));
@@ -132,7 +138,8 @@ void main() {
         when(() => callRoutingCubit.state).thenReturn(null);
         whenListen(callRoutingCubit, Stream.fromIterable([routingState]));
 
-        await controller.createCall(destination: '222');
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
 
         verify(() => notificationsBloc.add(any(that: isA<NotificationsSubmitted>()))).called(1);
         verifyNever(() => callBloc.add(any()));

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -4,7 +4,6 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
 import 'package:webtrit_phone/features/call/call.dart';
-import 'package:webtrit_phone/features/call/controllers/call_controller.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
 import 'package:webtrit_phone/models/lines_state.dart';
 

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -15,24 +15,19 @@ class _MockCallRoutingCubit extends MockCubit<CallRoutingState?> implements Call
 class _MockNotificationsBloc extends MockBloc<NotificationsEvent, NotificationsState> implements NotificationsBloc {}
 
 class _FakeCallRoutingState extends Fake implements CallRoutingState {
-  _FakeCallRoutingState({
-    this.mainNumber = '111',
-    this.additionalNumbers = const [],
-    required this.mainLinesState,
-    this.guestLineState,
-  });
+  _FakeCallRoutingState({required this.mainLinesState});
 
   @override
-  final String? mainNumber;
+  final String? mainNumber = '111';
 
   @override
-  final List<String> additionalNumbers;
+  final List<String> additionalNumbers = const [];
 
   @override
   final List<LineState> mainLinesState;
 
   @override
-  final LineState? guestLineState;
+  final LineState? guestLineState = null;
 
   @override
   bool get hasIdleMainLine => mainLinesState.any((l) => l == LineState.idle);


### PR DESCRIPTION
## Summary

Fix outgoing call being dropped when the user taps call before the app fully initializes.

Two root causes: \`CallController\` was failing immediately when routing state was not yet loaded, and \`CallBloc\` was running the registration guard before the signaling wait completed.

## Changes

- \`CallController\` now waits for routing state instead of failing immediately; shows \`NoInternetConnectionNotification\` if no network after 10 s
- \`CallBloc.__onCallPerformEventStarted\` — registration guard moved after signaling wait; signaling wait now fails fast on \`isFailure\` instead of waiting full timeout; fixed \`forEach(async)\` on \`addTrack\` that caused \`createOffer\` to run before tracks were added

## Test plan

- [x] Open app and immediately tap call — proceeds once app finishes initializing
- [x] Normal call flow unchanged