### PR TITLE
fix: guard _handleRenegotiationNeeded against non-stable signaling state

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -95,6 +95,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Timer? _presenceInfoSyncTimer;
 
   late final PeerConnectionManager _peerConnectionManager;
+  late final RenegotiationHandler _renegotiationHandler;
 
   final _callkeepSound = WebtritCallkeepSound();
 
@@ -129,6 +130,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }) : super(const CallState()) {
     _signalingClientFactory = signalingClientFactory;
     _peerConnectionManager = peerConnectionManager;
+    _renegotiationHandler = RenegotiationHandler(callErrorReporter: callErrorReporter, sdpMunger: sdpMunger);
 
     on<CallStarted>(_onCallStarted, transformer: sequential());
     on<_AppLifecycleStateChanged>(_onAppLifecycleStateChanged, transformer: sequential());
@@ -2782,43 +2784,17 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         onIceCandidate: (candidate) => add(_PeerConnectionEvent.iceCandidateIdentified(callId, candidate)),
         onAddStream: (stream) => add(_PeerConnectionEvent.streamAdded(callId, stream)),
         onRemoveStream: (stream) => add(_PeerConnectionEvent.streamRemoved(callId, stream)),
-        onRenegotiationNeeded: (pc) => _handleRenegotiationNeeded(callId, lineId, pc),
+        onRenegotiationNeeded: (pc) => _renegotiationHandler.handle(callId, lineId, pc, (callId, lineId, jsep) async {
+          final updateRequest = UpdateRequest(
+            transaction: WebtritSignalingClient.generateTransactionId(),
+            line: lineId,
+            callId: callId,
+            jsep: jsep.toMap(),
+          );
+          await _signalingClient?.execute(updateRequest);
+        }),
       ),
     );
-  }
-
-  Future<void> _handleRenegotiationNeeded(String callId, int? lineId, RTCPeerConnection peerConnection) async {
-    final stateBeforeOffer = peerConnection.signalingState;
-    _logger.fine(() => 'onRenegotiationNeeded signalingState: $stateBeforeOffer');
-    if (stateBeforeOffer == RTCSignalingState.RTCSignalingStateStable) {
-      final localDescription = await peerConnection.createOffer({});
-      sdpMunger?.apply(localDescription);
-
-      final stateAfterOffer = peerConnection.signalingState;
-      if (stateAfterOffer != RTCSignalingState.RTCSignalingStateStable) {
-        _logger.fine(
-          () =>
-              'onRenegotiationNeeded: state changed to $stateAfterOffer after createOffer, skipping setLocalDescription',
-        );
-        return;
-      }
-
-      // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
-      // localDescription should be set before sending the offer to transition into have-local-offer state.
-      await peerConnection.setLocalDescription(localDescription);
-
-      try {
-        final updateRequest = UpdateRequest(
-          transaction: WebtritSignalingClient.generateTransactionId(),
-          line: lineId,
-          callId: callId,
-          jsep: localDescription.toMap(),
-        );
-        await _signalingClient?.execute(updateRequest);
-      } catch (e, s) {
-        callErrorReporter.handle(e, s, '_createPeerConnection:onRenegotiationNeeded error');
-      }
-    }
   }
 
   void _addToRecents(ActiveCall activeCall) {

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2784,7 +2784,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         onIceCandidate: (candidate) => add(_PeerConnectionEvent.iceCandidateIdentified(callId, candidate)),
         onAddStream: (stream) => add(_PeerConnectionEvent.streamAdded(callId, stream)),
         onRemoveStream: (stream) => add(_PeerConnectionEvent.streamRemoved(callId, stream)),
-        onRenegotiationNeeded: (pc) => _renegotiationHandler.handle(callId, lineId, pc, _sendRenegotiationUpdate),
+        onRenegotiationNeeded: (pc) =>
+            unawaited(_renegotiationHandler.handle(callId, lineId, pc, _sendRenegotiationUpdate)),
       ),
     );
   }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2784,17 +2784,22 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         onIceCandidate: (candidate) => add(_PeerConnectionEvent.iceCandidateIdentified(callId, candidate)),
         onAddStream: (stream) => add(_PeerConnectionEvent.streamAdded(callId, stream)),
         onRemoveStream: (stream) => add(_PeerConnectionEvent.streamRemoved(callId, stream)),
-        onRenegotiationNeeded: (pc) => _renegotiationHandler.handle(callId, lineId, pc, (callId, lineId, jsep) async {
-          final updateRequest = UpdateRequest(
-            transaction: WebtritSignalingClient.generateTransactionId(),
-            line: lineId,
-            callId: callId,
-            jsep: jsep.toMap(),
-          );
-          await _signalingClient?.execute(updateRequest);
-        }),
+        onRenegotiationNeeded: (pc) => _renegotiationHandler.handle(callId, lineId, pc, _sendRenegotiationUpdate),
       ),
     );
+  }
+
+  /// Sends a renegotiation [UpdateRequest] to the signaling server with the given [jsep] offer.
+  ///
+  /// Used as a [RenegotiationExecutor] callback by [RenegotiationHandler].
+  Future<void> _sendRenegotiationUpdate(String callId, int? lineId, RTCSessionDescription jsep) async {
+    final updateRequest = UpdateRequest(
+      transaction: WebtritSignalingClient.generateTransactionId(),
+      line: lineId,
+      callId: callId,
+      jsep: jsep.toMap(),
+    );
+    await _signalingClient?.execute(updateRequest);
   }
 
   void _addToRecents(ActiveCall activeCall) {

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2788,28 +2788,19 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> _handleRenegotiationNeeded(String callId, int? lineId, RTCPeerConnection peerConnection) async {
-    // TODO(Serdun): Handle renegotiation needed
-    // This implementation does not handle all possible signaling states.
-    // Specifically, if the current state is `have-remote-offer`, calling
-    // setLocalDescription with an offer will throw:
-    //   WEBRTC_SET_LOCAL_DESCRIPTION_ERROR: Failed to set local offer sdp: Called in wrong state: have-remote-offer
-    //
-    // Known case: when CalleeVideoOfferPolicy.includeInactiveTrack is used,
-    // the callee may trigger onRenegotiationNeeded before the current remote offer is processed.
-    // This causes a race where the local peer is still in 'have-remote-offer' state,
-    // leading to the above error. Currently this does not severely affect behavior,
-    // since the offer includes only an inactive track, but it should still be handled correctly.
-    //
-    // Proper handling should include:
-    // - Waiting until the signaling state becomes 'stable' before creating and setting a new offer
-    // - Avoiding renegotiation if a remote offer is currently being processed
-    // - Ensuring renegotiation is coordinated and state-aware
-
     final pcState = peerConnection.signalingState;
     _logger.fine(() => 'onRenegotiationNeeded signalingState: $pcState');
-    if (pcState != null) {
+    if (pcState == RTCSignalingState.RTCSignalingStateStable) {
       final localDescription = await peerConnection.createOffer({});
       sdpMunger?.apply(localDescription);
+
+      final currentState = peerConnection.signalingState;
+      if (currentState != RTCSignalingState.RTCSignalingStateStable) {
+        _logger.fine(
+          () => 'onRenegotiationNeeded: state changed to $currentState after createOffer, skipping setLocalDescription',
+        );
+        return;
+      }
 
       // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
       // localDescription should be set before sending the offer to transition into have-local-offer state.

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2788,16 +2788,17 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> _handleRenegotiationNeeded(String callId, int? lineId, RTCPeerConnection peerConnection) async {
-    final pcState = peerConnection.signalingState;
-    _logger.fine(() => 'onRenegotiationNeeded signalingState: $pcState');
-    if (pcState == RTCSignalingState.RTCSignalingStateStable) {
+    final stateBeforeOffer = peerConnection.signalingState;
+    _logger.fine(() => 'onRenegotiationNeeded signalingState: $stateBeforeOffer');
+    if (stateBeforeOffer == RTCSignalingState.RTCSignalingStateStable) {
       final localDescription = await peerConnection.createOffer({});
       sdpMunger?.apply(localDescription);
 
-      final currentState = peerConnection.signalingState;
-      if (currentState != RTCSignalingState.RTCSignalingStateStable) {
+      final stateAfterOffer = peerConnection.signalingState;
+      if (stateAfterOffer != RTCSignalingState.RTCSignalingStateStable) {
         _logger.fine(
-          () => 'onRenegotiationNeeded: state changed to $currentState after createOffer, skipping setLocalDescription',
+          () =>
+              'onRenegotiationNeeded: state changed to $stateAfterOffer after createOffer, skipping setLocalDescription',
         );
         return;
       }

--- a/lib/features/call/utils/renegotiation_handler.dart
+++ b/lib/features/call/utils/renegotiation_handler.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:logging/logging.dart';
+
+import 'call_error_reporter.dart';
+import 'sdp_munger.dart';
+
+final _logger = Logger('RenegotiationHandler');
+
+typedef RenegotiationExecutor = Future<void> Function(String callId, int? lineId, RTCSessionDescription jsep);
+
+class RenegotiationHandler {
+  RenegotiationHandler({required this.callErrorReporter, this.sdpMunger});
+
+  final CallErrorReporter callErrorReporter;
+  final SDPMunger? sdpMunger;
+
+  Future<void> handle(
+    String callId,
+    int? lineId,
+    RTCPeerConnection peerConnection,
+    RenegotiationExecutor execute,
+  ) async {
+    final stateBeforeOffer = peerConnection.signalingState;
+    _logger.fine(() => 'onRenegotiationNeeded signalingState: $stateBeforeOffer');
+    if (stateBeforeOffer == RTCSignalingState.RTCSignalingStateStable) {
+      final localDescription = await peerConnection.createOffer({});
+      sdpMunger?.apply(localDescription);
+
+      final stateAfterOffer = peerConnection.signalingState;
+      if (stateAfterOffer != RTCSignalingState.RTCSignalingStateStable) {
+        _logger.fine(
+          () =>
+              'onRenegotiationNeeded: state changed to $stateAfterOffer after createOffer, skipping setLocalDescription',
+        );
+        return;
+      }
+
+      // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
+      // localDescription should be set before sending the offer to transition into have-local-offer state.
+      await peerConnection.setLocalDescription(localDescription);
+
+      try {
+        await execute(callId, lineId, localDescription);
+      } catch (e, s) {
+        callErrorReporter.handle(e, s, '_createPeerConnection:onRenegotiationNeeded error');
+      }
+    }
+  }
+}

--- a/lib/features/call/utils/renegotiation_handler.dart
+++ b/lib/features/call/utils/renegotiation_handler.dart
@@ -23,26 +23,26 @@ class RenegotiationHandler {
     final stateBeforeOffer = peerConnection.signalingState;
     _logger.fine(() => 'onRenegotiationNeeded signalingState: $stateBeforeOffer');
     if (stateBeforeOffer == RTCSignalingState.RTCSignalingStateStable) {
-      final localDescription = await peerConnection.createOffer({});
-      sdpMunger?.apply(localDescription);
-
-      final stateAfterOffer = peerConnection.signalingState;
-      if (stateAfterOffer != RTCSignalingState.RTCSignalingStateStable) {
-        _logger.fine(
-          () =>
-              'onRenegotiationNeeded: state changed to $stateAfterOffer after createOffer, skipping setLocalDescription',
-        );
-        return;
-      }
-
-      // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
-      // localDescription should be set before sending the offer to transition into have-local-offer state.
-      await peerConnection.setLocalDescription(localDescription);
-
       try {
+        final localDescription = await peerConnection.createOffer({});
+        sdpMunger?.apply(localDescription);
+
+        final stateAfterOffer = peerConnection.signalingState;
+        if (stateAfterOffer != RTCSignalingState.RTCSignalingStateStable) {
+          _logger.fine(
+            () =>
+                'onRenegotiationNeeded: state changed to $stateAfterOffer after createOffer, skipping setLocalDescription',
+          );
+          return;
+        }
+
+        // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
+        // localDescription should be set before sending the offer to transition into have-local-offer state.
+        await peerConnection.setLocalDescription(localDescription);
+
         await execute(callId, lineId, localDescription);
       } catch (e, s) {
-        callErrorReporter.handle(e, s, '_createPeerConnection:onRenegotiationNeeded error');
+        callErrorReporter.handle(e, s, 'RenegotiationHandler.handle error (callId=$callId, lineId=$lineId)');
       }
     }
   }

--- a/lib/features/call/utils/renegotiation_handler.dart
+++ b/lib/features/call/utils/renegotiation_handler.dart
@@ -22,28 +22,31 @@ class RenegotiationHandler {
   ) async {
     final stateBeforeOffer = peerConnection.signalingState;
     _logger.fine(() => 'onRenegotiationNeeded signalingState: $stateBeforeOffer');
-    if (stateBeforeOffer == RTCSignalingState.RTCSignalingStateStable) {
-      try {
-        final localDescription = await peerConnection.createOffer({});
-        sdpMunger?.apply(localDescription);
+    if (stateBeforeOffer != RTCSignalingState.RTCSignalingStateStable) {
+      _logger.fine(() => 'onRenegotiationNeeded skipped: not in stable state ($stateBeforeOffer)');
+      return;
+    }
 
-        final stateAfterOffer = peerConnection.signalingState;
-        if (stateAfterOffer != RTCSignalingState.RTCSignalingStateStable) {
-          _logger.fine(
-            () =>
-                'onRenegotiationNeeded: state changed to $stateAfterOffer after createOffer, skipping setLocalDescription',
-          );
-          return;
-        }
+    try {
+      final localDescription = await peerConnection.createOffer({});
+      sdpMunger?.apply(localDescription);
 
-        // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
-        // localDescription should be set before sending the offer to transition into have-local-offer state.
-        await peerConnection.setLocalDescription(localDescription);
-
-        await execute(callId, lineId, localDescription);
-      } catch (e, s) {
-        callErrorReporter.handle(e, s, 'RenegotiationHandler.handle error (callId=$callId, lineId=$lineId)');
+      final stateAfterOffer = peerConnection.signalingState;
+      if (stateAfterOffer != RTCSignalingState.RTCSignalingStateStable) {
+        _logger.fine(
+          () =>
+              'onRenegotiationNeeded: state changed to $stateAfterOffer after createOffer, skipping setLocalDescription',
+        );
+        return;
       }
+
+      // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
+      // localDescription should be set before sending the offer to transition into have-local-offer state.
+      await peerConnection.setLocalDescription(localDescription);
+
+      await execute(callId, lineId, localDescription);
+    } catch (e, s) {
+      callErrorReporter.handle(e, s, 'RenegotiationHandler.handle error (callId=$callId, lineId=$lineId)');
     }
   }
 }

--- a/lib/features/call/utils/renegotiation_handler.dart
+++ b/lib/features/call/utils/renegotiation_handler.dart
@@ -6,14 +6,53 @@ import 'sdp_munger.dart';
 
 final _logger = Logger('RenegotiationHandler');
 
+/// Callback responsible for sending the renegotiation offer to the remote peer
+/// via the signaling channel. The caller constructs the transport-specific
+/// request; this handler stays decoupled from the signaling layer.
 typedef RenegotiationExecutor = Future<void> Function(String callId, int? lineId, RTCSessionDescription jsep);
 
+/// Handles WebRTC renegotiation triggered by [RTCPeerConnection.onRenegotiationNeeded].
+///
+/// ## Architecture constraints
+///
+/// This handler is designed for a **server-mediated** topology (e.g. Janus SFU)
+/// where offer/answer exchanges are serialised by the media server.
+/// Glare (simultaneous offers from both peers) cannot occur in this topology,
+/// so the simplified skip-on-non-stable strategy is sufficient and safe.
+///
+/// **P2P note:** in a direct peer-to-peer topology, simultaneous offers from
+/// both sides are possible. The current skip logic would silently drop one of
+/// the offers. Full [Perfect Negotiation](https://www.w3.org/TR/webrtc/#perfect-negotiation-example)
+/// with rollback must be implemented before removing the media server.
+///
+/// ## Stable-state guards
+///
+/// Two checks enforce the RTCPeerConnection state machine rules
+/// (RFC 8829 §4, W3C WebRTC §4.7):
+///
+/// 1. **Before `createOffer`** — skips if the current signaling state is not
+///    `stable`. In a server-mediated call the skipped renegotiation is safe:
+///    if the event was triggered by an incoming remote offer
+///    (e.g. [CalleeVideoOfferPolicy.includeInactiveTrack]), the pending track
+///    will already be included in the answer; if it was triggered by a genuine
+///    local change, libwebrtc will re-fire [onRenegotiationNeeded] once the
+///    peer connection returns to `stable`.
+///
+/// 2. **After `createOffer` (TOCTOU guard)** — re-checks the state before
+///    calling `setLocalDescription`. The `await createOffer()` yields control
+///    to the event loop; a concurrent signaling event may transition the
+///    connection out of `stable` in the meantime.
 class RenegotiationHandler {
   RenegotiationHandler({required this.callErrorReporter, this.sdpMunger});
 
   final CallErrorReporter callErrorReporter;
   final SDPMunger? sdpMunger;
 
+  /// Executes a renegotiation cycle for [callId] on [peerConnection].
+  ///
+  /// Skips silently when the signaling state is not `stable` (see class-level
+  /// doc). All WebRTC and signaling errors are forwarded to [callErrorReporter]
+  /// and do not propagate to the caller.
   Future<void> handle(
     String callId,
     int? lineId,

--- a/lib/features/call/utils/utils.dart
+++ b/lib/features/call/utils/utils.dart
@@ -7,6 +7,7 @@ export 'ice_filter.dart';
 export 'logging_rtp_traffic_monitor_delegate.dart';
 export 'peer_connection_factory.dart';
 export 'peer_connection_manager.dart';
+export 'renegotiation_handler.dart';
 export 'peer_connection_policy_applier.dart';
 export 'rtp_traffic_monitor.dart';
 export 'sdp_mod_builder.dart';

--- a/test/features/call/utils/renegotiation_handler_test.dart
+++ b/test/features/call/utils/renegotiation_handler_test.dart
@@ -151,12 +151,14 @@ void main() {
   });
 
   group('RenegotiationHandler — execute error handling', () {
+    setUp(() {
+      when(() => mockErrorReporter.handle(any(), any(), any())).thenReturn(null);
+    });
+
     test('reports error via callErrorReporter when execute throws', () async {
       when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
       when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
       when(() => mockPC.setLocalDescription(any())).thenAnswer((_) async {});
-      when(() => mockErrorReporter.handle(any(), any(), any())).thenReturn(null);
-
       handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
       final exception = Exception('signaling error');
 
@@ -165,12 +167,33 @@ void main() {
       verify(() => mockErrorReporter.handle(exception, any(), any())).called(1);
     });
 
+    test('reports error via callErrorReporter when createOffer throws', () async {
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
+      final exception = Exception('createOffer error');
+      when(() => mockPC.createOffer(any())).thenThrow(exception);
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async {});
+
+      verify(() => mockErrorReporter.handle(exception, any(), any())).called(1);
+    });
+
+    test('reports error via callErrorReporter when setLocalDescription throws', () async {
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
+      when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
+      final exception = Exception('setLocalDescription error');
+      when(() => mockPC.setLocalDescription(any())).thenThrow(exception);
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async {});
+
+      verify(() => mockErrorReporter.handle(exception, any(), any())).called(1);
+    });
+
     test('does not rethrow when execute throws', () async {
       when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
       when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
       when(() => mockPC.setLocalDescription(any())).thenAnswer((_) async {});
-      when(() => mockErrorReporter.handle(any(), any(), any())).thenReturn(null);
-
       handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
 
       await expectLater(

--- a/test/features/call/utils/renegotiation_handler_test.dart
+++ b/test/features/call/utils/renegotiation_handler_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/features/call/utils/call_error_reporter.dart';
+import 'package:webtrit_phone/features/call/utils/renegotiation_handler.dart';
+import 'package:webtrit_phone/features/call/utils/sdp_munger.dart';
+
+class MockRTCPeerConnection extends Mock implements RTCPeerConnection {}
+
+class MockCallErrorReporter extends Mock implements CallErrorReporter {}
+
+class MockSDPMunger extends Mock implements SDPMunger {}
+
+void main() {
+  late MockRTCPeerConnection mockPC;
+  late MockCallErrorReporter mockErrorReporter;
+  late MockSDPMunger mockMunger;
+  late RenegotiationHandler handler;
+
+  const kCallId = 'call-1';
+  const kLineId = 0;
+  final kOffer = RTCSessionDescription('v=0\r\n', 'offer');
+
+  setUpAll(() {
+    registerFallbackValue(RTCSessionDescription('', ''));
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    mockPC = MockRTCPeerConnection();
+    mockErrorReporter = MockCallErrorReporter();
+    mockMunger = MockSDPMunger();
+  });
+
+  group('RenegotiationHandler — state guard (before offer)', () {
+    test('skips entirely when state is have-remote-offer', () async {
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateHaveRemoteOffer);
+
+      var executeCalled = false;
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async => executeCalled = true);
+
+      verifyNever(() => mockPC.createOffer(any()));
+      expect(executeCalled, isFalse);
+    });
+
+    test('skips entirely when state is have-local-offer', () async {
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateHaveLocalOffer);
+
+      var executeCalled = false;
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async => executeCalled = true);
+
+      verifyNever(() => mockPC.createOffer(any()));
+      expect(executeCalled, isFalse);
+    });
+
+    test('skips entirely when state is closed', () async {
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateClosed);
+
+      var executeCalled = false;
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async => executeCalled = true);
+
+      verifyNever(() => mockPC.createOffer(any()));
+      expect(executeCalled, isFalse);
+    });
+
+    test('skips entirely when state is null', () async {
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+      when(() => mockPC.signalingState).thenReturn(null);
+
+      var executeCalled = false;
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async => executeCalled = true);
+
+      verifyNever(() => mockPC.createOffer(any()));
+      expect(executeCalled, isFalse);
+    });
+  });
+
+  group('RenegotiationHandler — TOCTOU guard (after offer)', () {
+    test('skips setLocalDescription when state changed to have-remote-offer after createOffer', () async {
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+
+      var callCount = 0;
+      when(() => mockPC.signalingState).thenAnswer(
+        (_) => callCount++ == 0
+            ? RTCSignalingState.RTCSignalingStateStable
+            : RTCSignalingState.RTCSignalingStateHaveRemoteOffer,
+      );
+      when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
+
+      var executeCalled = false;
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async => executeCalled = true);
+
+      verifyNever(() => mockPC.setLocalDescription(any()));
+      expect(executeCalled, isFalse);
+    });
+  });
+
+  group('RenegotiationHandler — happy path', () {
+    setUp(() {
+      var callCount = 0;
+      when(
+        () => mockPC.signalingState,
+      ).thenAnswer((_) => callCount++ == 0 ? RTCSignalingState.RTCSignalingStateStable : null);
+      when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
+      when(() => mockPC.setLocalDescription(any())).thenAnswer((_) async {});
+    });
+
+    test('calls setLocalDescription and execute when both states are stable', () async {
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+
+      RTCSessionDescription? capturedJsep;
+      String? capturedCallId;
+      int? capturedLineId;
+
+      await handler.handle(kCallId, kLineId, mockPC, (callId, lineId, jsep) async {
+        capturedCallId = callId;
+        capturedLineId = lineId;
+        capturedJsep = jsep;
+      });
+
+      verify(() => mockPC.setLocalDescription(kOffer)).called(1);
+      expect(capturedCallId, kCallId);
+      expect(capturedLineId, kLineId);
+      expect(capturedJsep, kOffer);
+    });
+
+    test('applies sdpMunger before setLocalDescription', () async {
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
+      when(() => mockMunger.apply(any())).thenReturn(null);
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter, sdpMunger: mockMunger);
+
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async {});
+
+      verify(() => mockMunger.apply(kOffer)).called(1);
+      verify(() => mockPC.setLocalDescription(kOffer)).called(1);
+    });
+
+    test('does not call sdpMunger when it is null', () async {
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async {});
+
+      verifyNever(() => mockMunger.apply(any()));
+    });
+  });
+
+  group('RenegotiationHandler — execute error handling', () {
+    test('reports error via callErrorReporter when execute throws', () async {
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
+      when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
+      when(() => mockPC.setLocalDescription(any())).thenAnswer((_) async {});
+      when(() => mockErrorReporter.handle(any(), any(), any())).thenReturn(null);
+
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+      final exception = Exception('signaling error');
+
+      await handler.handle(kCallId, kLineId, mockPC, (_, _, _) async => throw exception);
+
+      verify(() => mockErrorReporter.handle(exception, any(), any())).called(1);
+    });
+
+    test('does not rethrow when execute throws', () async {
+      when(() => mockPC.signalingState).thenReturn(RTCSignalingState.RTCSignalingStateStable);
+      when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
+      when(() => mockPC.setLocalDescription(any())).thenAnswer((_) async {});
+      when(() => mockErrorReporter.handle(any(), any(), any())).thenReturn(null);
+
+      handler = RenegotiationHandler(callErrorReporter: mockErrorReporter);
+
+      await expectLater(
+        handler.handle(kCallId, kLineId, mockPC, (_, _, _) async => throw Exception('error')),
+        completes,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Replace `pcState != null` guard with `pcState == RTCSignalingState.RTCSignalingStateStable` to prevent `setLocalDescription` from being called in `have-remote-offer` or other non-stable states
- Add TOCTOU re-check after the async `createOffer({})` gap — if state changed in the meantime, log and skip `setLocalDescription`
- Remove outdated TODO comment that described this exact bug

## Problem

`_handleRenegotiationNeeded` was proceeding whenever `signalingState != null`, which includes `have-remote-offer`. This caused:

```
WEBRTC_SET_LOCAL_DESCRIPTION_ERROR: Failed to set local offer sdp: Called in wrong state: have-remote-offer
```

Triggered notably when `CalleeVideoOfferPolicy.includeInactiveTrack` fires `onRenegotiationNeeded` before the remote offer is processed.

## Test plan

- [x] Hold/unhold during active call — no crash
- [x] Mute/unmute video with `includeInactiveTrack` policy — renegotiation completes correctly
- [ ] Logs confirm `onRenegotiationNeeded signalingState` skips when state is `have-remote-offer`
- [ ] No regression on outgoing/incoming calls