### PR TITLE
feat: provide CallController as singleton via RepositoryProvider in MainShell

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -42,6 +42,8 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// The [PollingService] instance that handles periodic polling of repositories.
   late PollingService? _polling;
 
+  CallController? _callController;
+
   @override
   void initState() {
     super.initState();
@@ -562,7 +564,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                           final sipPresenceFeature = featureAccess.sipPresenceConfig;
 
                           return CallControllerScope(
-                            controller: CallController(
+                            controller: _callController ??= CallController(
                               callBloc: context.read<CallBloc>(),
                               callRoutingCubit: context.read<CallRoutingCubit>(),
                               notificationsBloc: context.read<NotificationsBloc>(),

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -561,8 +561,8 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         builder: (context) {
                           final sipPresenceFeature = featureAccess.sipPresenceConfig;
 
-                          return RepositoryProvider<CallController>(
-                            create: (context) => CallController(
+                          return CallControllerScope(
+                            controller: CallController(
                               callBloc: context.read<CallBloc>(),
                               callRoutingCubit: context.read<CallRoutingCubit>(),
                               notificationsBloc: context.read<NotificationsBloc>(),

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -561,19 +561,26 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         builder: (context) {
                           final sipPresenceFeature = featureAccess.sipPresenceConfig;
 
-                          return PresenceViewParams(
-                            viewSource: switch (sipPresenceFeature.sipPresenceSupport) {
-                              true => PresenceViewSource.sipPresence,
-                              false => PresenceViewSource.contactInfo,
-                            },
-                            child: CallConfigSynchronizer(
-                              child: CallShell(
-                                child: MessagingShell(
-                                  child: SystemNotificationsShell(
-                                    child: AutoRouter(
-                                      navigatorObservers: () => [
-                                        MainShellNavigatorObserver(context.read<MainShellRouteStateRepository>()),
-                                      ],
+                          return RepositoryProvider<CallController>(
+                            create: (context) => CallController(
+                              callBloc: context.read<CallBloc>(),
+                              callRoutingCubit: context.read<CallRoutingCubit>(),
+                              notificationsBloc: context.read<NotificationsBloc>(),
+                            ),
+                            child: PresenceViewParams(
+                              viewSource: switch (sipPresenceFeature.sipPresenceSupport) {
+                                true => PresenceViewSource.sipPresence,
+                                false => PresenceViewSource.contactInfo,
+                              },
+                              child: CallConfigSynchronizer(
+                                child: CallShell(
+                                  child: MessagingShell(
+                                    child: SystemNotificationsShell(
+                                      child: AutoRouter(
+                                        navigatorObservers: () => [
+                                          MainShellNavigatorObserver(context.read<MainShellRouteStateRepository>()),
+                                        ],
+                                      ),
                                     ),
                                   ),
                                 ),

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -42,6 +42,10 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// The [PollingService] instance that handles periodic polling of repositories.
   late PollingService? _polling;
 
+  /// Lazily initialised on first [build] once [CallBloc], [CallRoutingCubit],
+  /// and [NotificationsBloc] are available in the widget tree. The `??=`
+  /// assignment guarantees a single instance for the lifetime of this [State],
+  /// preventing consumers from holding stale references across rebuilds.
   CallController? _callController;
 
   @override

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -8,8 +8,6 @@ import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
 
-// TODO(Serdun): Provide CallController as a singleton via RepositoryProvider in MainShell scope
-// instead of instantiating it in each StatefulWidget. All call sites should use context.read<CallController>().
 class CallController {
   CallController({
     required this.callBloc,

--- a/lib/features/call/controllers/call_controller_scope.dart
+++ b/lib/features/call/controllers/call_controller_scope.dart
@@ -8,9 +8,9 @@ class CallControllerScope extends InheritedWidget {
   final CallController controller;
 
   static CallController of(BuildContext context) {
-    final result = context.dependOnInheritedWidgetOfExactType<CallControllerScope>();
-    if (result == null) throw Exception('CallControllerScope not found in context');
-    return result.controller;
+    final element = context.getElementForInheritedWidgetOfExactType<CallControllerScope>();
+    assert(element != null, 'CallControllerScope not found in context');
+    return (element!.widget as CallControllerScope).controller;
   }
 
   @override

--- a/lib/features/call/controllers/call_controller_scope.dart
+++ b/lib/features/call/controllers/call_controller_scope.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import 'call_controller.dart';
+
+class CallControllerScope extends InheritedWidget {
+  const CallControllerScope({required this.controller, required super.child, super.key});
+
+  final CallController controller;
+
+  static CallController of(BuildContext context) {
+    final result = context.dependOnInheritedWidgetOfExactType<CallControllerScope>();
+    if (result == null) throw Exception('CallControllerScope not found in context');
+    return result.controller;
+  }
+
+  @override
+  bool updateShouldNotify(CallControllerScope oldWidget) => false;
+}

--- a/lib/features/call/controllers/controllers.dart
+++ b/lib/features/call/controllers/controllers.dart
@@ -1,1 +1,2 @@
 export 'call_controller.dart';
+export 'call_controller_scope.dart';

--- a/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
@@ -34,11 +33,7 @@ class FullRecentCdrsList extends StatefulWidget {
 
 class _FullRecentCdrsListState extends State<FullRecentCdrsList> {
   late final cubit = context.read<FullRecentCdrsCubit>();
-  late final CallController _callController = CallController(
-    callBloc: context.read<CallBloc>(),
-    callRoutingCubit: context.read<CallRoutingCubit>(),
-    notificationsBloc: context.read<NotificationsBloc>(),
-  );
+  late final _callController = context.read<CallController>();
   late final scrollController = ScrollController();
 
   bool scrolledAway = false;

--- a/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
@@ -33,7 +33,7 @@ class FullRecentCdrsList extends StatefulWidget {
 
 class _FullRecentCdrsListState extends State<FullRecentCdrsList> {
   late final cubit = context.read<FullRecentCdrsCubit>();
-  late final _callController = context.read<CallController>();
+  late final _callController = CallControllerScope.of(context);
   late final scrollController = ScrollController();
 
   bool scrolledAway = false;

--- a/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
@@ -33,7 +33,7 @@ class MissedRecentCdrsList extends StatefulWidget {
 
 class _MissedRecentCdrsListState extends State<MissedRecentCdrsList> {
   late final cubit = context.read<MissedRecentCdrsCubit>();
-  late final _callController = context.read<CallController>();
+  late final _callController = CallControllerScope.of(context);
   late final scrollController = ScrollController();
 
   bool scrolledAway = false;

--- a/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
@@ -34,11 +33,7 @@ class MissedRecentCdrsList extends StatefulWidget {
 
 class _MissedRecentCdrsListState extends State<MissedRecentCdrsList> {
   late final cubit = context.read<MissedRecentCdrsCubit>();
-  late final CallController _callController = CallController(
-    callBloc: context.read<CallBloc>(),
-    callRoutingCubit: context.read<CallRoutingCubit>(),
-    notificationsBloc: context.read<NotificationsBloc>(),
-  );
+  late final _callController = context.read<CallController>();
   late final scrollController = ScrollController();
 
   bool scrolledAway = false;

--- a/lib/features/contact/view/contact_screen.dart
+++ b/lib/features/contact/view/contact_screen.dart
@@ -5,7 +5,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
-import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
@@ -51,11 +50,7 @@ class ContactScreen extends StatefulWidget {
 }
 
 class _ContactScreenState extends State<ContactScreen> {
-  late final CallController _callController = CallController(
-    callBloc: context.read<CallBloc>(),
-    callRoutingCubit: context.read<CallRoutingCubit>(),
-    notificationsBloc: context.read<NotificationsBloc>(),
-  );
+  late final _callController = context.read<CallController>();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/contact/view/contact_screen.dart
+++ b/lib/features/contact/view/contact_screen.dart
@@ -50,7 +50,7 @@ class ContactScreen extends StatefulWidget {
 }
 
 class _ContactScreenState extends State<ContactScreen> {
-  late final _callController = context.read<CallController>();
+  late final _callController = CallControllerScope.of(context);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -4,7 +4,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/app/keys.dart';
-import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/call/call.dart';
@@ -44,17 +43,12 @@ class FavoritesScreen extends StatefulWidget {
 }
 
 class _FavoritesScreenState extends State<FavoritesScreen> {
-  late final CallController callController = CallController(
-    callBloc: context.read<CallBloc>(),
-    callRoutingCubit: context.read<CallRoutingCubit>(),
-    notificationsBloc: context.read<NotificationsBloc>(),
-  );
-
+  late final _callController = context.read<CallController>();
   bool isReorderMode = false;
   int? draggingIndex;
 
   void submitTransfer({required String destination}) {
-    callController.submitTransfer(destination);
+    _callController.submitTransfer(destination);
     context.router.maybePop();
   }
 
@@ -218,13 +212,13 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                                                   submitTransfer(destination: favorite.number);
                                                 }
                                               : () {
-                                                  callController.createCall(
+                                                  _callController.createCall(
                                                     destination: favorite.number,
                                                     displayName: contact?.maybeName ?? favorite.number,
                                                   );
                                                 },
                                           onAudioCallPressed: () {
-                                            callController.createCall(
+                                            _callController.createCall(
                                               destination: favorite.number,
                                               displayName: contact?.maybeName ?? favorite.number,
                                               video: false,
@@ -232,7 +226,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                                           },
                                           onVideoCallPressed: widget.videoEnabled
                                               ? () {
-                                                  callController.createCall(
+                                                  _callController.createCall(
                                                     destination: favorite.number,
                                                     displayName: contact?.maybeName ?? favorite.number,
                                                     video: true,

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -43,7 +43,7 @@ class FavoritesScreen extends StatefulWidget {
 }
 
 class _FavoritesScreenState extends State<FavoritesScreen> {
-  late final _callController = context.read<CallController>();
+  late final _callController = CallControllerScope.of(context);
   bool isReorderMode = false;
   int? draggingIndex;
 

--- a/lib/features/keypad/view/keypad_view.dart
+++ b/lib/features/keypad/view/keypad_view.dart
@@ -25,7 +25,7 @@ class KeypadView extends StatefulWidget {
 class KeypadViewState extends State<KeypadView> {
   final _keypadTextFieldKey = GlobalKey();
 
-  late final _callController = context.read<CallController>();
+  late final _callController = CallControllerScope.of(context);
   late TextEditingController _controller;
   late FocusNode _focusNode;
 

--- a/lib/features/keypad/view/keypad_view.dart
+++ b/lib/features/keypad/view/keypad_view.dart
@@ -6,7 +6,6 @@ import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/call_routing.dart';
 
 import 'package:webtrit_phone/theme/theme.dart';
-import 'package:webtrit_phone/app/notifications/notifications.dart';
 
 import '../cubit/keypad_cubit.dart';
 import '../widgets/widgets.dart';
@@ -26,12 +25,7 @@ class KeypadView extends StatefulWidget {
 class KeypadViewState extends State<KeypadView> {
   final _keypadTextFieldKey = GlobalKey();
 
-  // TODO(Serdun): Think about moving this to a controller or bloc.
-  late final CallController _callController = CallController(
-    callBloc: context.read<CallBloc>(),
-    callRoutingCubit: context.read<CallRoutingCubit>(),
-    notificationsBloc: context.read<NotificationsBloc>(),
-  );
+  late final _callController = context.read<CallController>();
   late TextEditingController _controller;
   late FocusNode _focusNode;
 

--- a/lib/features/messaging/features/chat_conversation/widgets/dialog_info.dart
+++ b/lib/features/messaging/features/chat_conversation/widgets/dialog_info.dart
@@ -29,7 +29,7 @@ class DialogInfo extends StatefulWidget {
 
 class _DialogInfoState extends State<DialogInfo> {
   late final conversationCubit = context.read<ConversationCubit>();
-  late final _callController = context.read<CallController>();
+  late final _callController = CallControllerScope.of(context);
 
   Future<void> onDeleteDialog() async {
     final askResult = await showDialog<bool>(

--- a/lib/features/messaging/features/chat_conversation/widgets/dialog_info.dart
+++ b/lib/features/messaging/features/chat_conversation/widgets/dialog_info.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -30,11 +29,7 @@ class DialogInfo extends StatefulWidget {
 
 class _DialogInfoState extends State<DialogInfo> {
   late final conversationCubit = context.read<ConversationCubit>();
-  late final CallController _callController = CallController(
-    callBloc: context.read<CallBloc>(),
-    callRoutingCubit: context.read<CallRoutingCubit>(),
-    notificationsBloc: context.read<NotificationsBloc>(),
-  );
+  late final _callController = context.read<CallController>();
 
   Future<void> onDeleteDialog() async {
     final askResult = await showDialog<bool>(

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/keys.dart';
-import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
@@ -46,12 +45,7 @@ class RecentsScreen extends StatefulWidget {
 }
 
 class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProviderStateMixin {
-  // TODO(Serdun): Think about moving this to a controller or bloc.
-  late final CallController _callController = CallController(
-    callBloc: context.read<CallBloc>(),
-    callRoutingCubit: context.read<CallRoutingCubit>(),
-    notificationsBloc: context.read<NotificationsBloc>(),
-  );
+  late final _callController = context.read<CallController>();
   late TabController _tabController;
 
   @override

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -45,7 +45,7 @@ class RecentsScreen extends StatefulWidget {
 }
 
 class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProviderStateMixin {
-  late final _callController = context.read<CallController>();
+  late final _callController = CallControllerScope.of(context);
   late TabController _tabController;
 
   @override


### PR DESCRIPTION
## Summary

- Introduce `CallControllerScope` (`InheritedWidget`) following the `PresenceViewParams` pattern already in the codebase — semantically correct alternative to `RepositoryProvider` for a UI-tier coordinator
- Register a single `CallController` instance in `MainShell` (stored in `_MainShellState` via `??=` to survive rebuilds) and expose it via `CallControllerScope`
- Remove per-widget instantiation from 7 call sites; each `State` now caches the shared instance with `late final _callController = CallControllerScope.of(context)`
- Remove now-unused imports (`NotificationsBloc`, `notifications.dart`) from affected files

## Test plan

- [x] Existing `call_controller_test.dart` (8 tests) — all pass
- [x] Manual: place a call from Keypad, Recents, Favorites, Contacts, Chat dialog info, CDR list (full & missed)