### PR TITLE
fix: await reportNewIncomingCall in background FCM handler

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -302,7 +302,7 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
     // due to concurrent database access from multiple isolates.
     final displayName = await _resolveContactDisplayNameWithFallback(appPush, logger);
 
-    AndroidCallkeepServices.backgroundPushNotificationBootstrapService.reportNewIncomingCall(
+    await AndroidCallkeepServices.backgroundPushNotificationBootstrapService.reportNewIncomingCall(
       appPush.call.id,
       CallkeepHandle.number(appPush.call.handle),
       displayName: displayName,


### PR DESCRIPTION
## Summary

- Missing `await` on `reportNewIncomingCall()` in `_handleBackgroundMessage` caused the background Dart isolate to be destroyed before the Pigeon IPC call reached the Kotlin side
- Without `await`, the `PhoneConnectionService.startIncomingCall()` was never invoked — no incoming call UI, no ringtone
- Fix: add `await` at `lib/bootstrap.dart:305`

## Root Cause

`reportNewIncomingCall` returns `Future<CallkeepIncomingCallError?>`. Without `await`:
1. Pigeon IPC fires but is not awaited
2. `_handleBackgroundMessage` returns immediately
3. `_firebaseMessagingBackgroundHandler` future completes
4. Firebase destroys the background isolate
5. Pending Pigeon call is cancelled — Kotlin side never receives it

## Test plan

- [x] App minimized (not killed), incoming call via FCM push on Android
- [x] Verify `PhoneConnectionService.startIncomingCall` is reached (Kotlin logs)
- [x] Verify incoming call UI and ringtone appear

## Note

A second independent bug was identified during investigation (race condition between
Android window transitions and `IncomingCallService.startForeground()`), tracked separately.