### PR TITLE
feat: add integration tests for webtrit_signaling keepalive and disconnect

### DIFF
--- a/packages/_tcp_proxy/AGENTS.md
+++ b/packages/_tcp_proxy/AGENTS.md
@@ -1,0 +1,68 @@
+# _tcp_proxy
+
+Internal test utility — raw TCP proxy with pause/resume for network condition simulation.
+No Flutter dependency, no code generation. Used exclusively in tests.
+
+## Public API
+
+`TcpProxy` is the only public class:
+
+```dart
+final proxy = TcpProxy(
+  host: 'signaling.example.com',
+  port: 443,           // default
+  useTls: true,        // default
+  rewriteHostHeader: 'signaling.example.com',
+);
+
+final port = await proxy.start();
+
+// Connect your client to ws://127.0.0.1:$port/...
+
+proxy.pause();   // simulate network blackhole (drop all bytes)
+proxy.resume();  // restore transparent forwarding
+
+await proxy.stop();
+```
+
+## Architecture
+
+```
+Test client (plain TCP)           TcpProxy               Remote server (TLS)
+  ws://127.0.0.1:$port    →   ServerSocket (IPv4)   →   SecureSocket (TLS SNI)
+                                   ↕ relay                      ↕
+                           _relayWithHostRewrite           rewrite Host header
+                           or _relayRaw                    then raw bytes
+```
+
+Two relay modes selected at connect time:
+
+| Mode | When | Behavior |
+|------|------|----------|
+| `_relayWithHostRewrite` | `rewriteHostHeader != null` | Buffers the first HTTP request until `\r\n\r\n`, rewrites the `Host` header, then switches to raw relay |
+| `_relayRaw` | default | Transparent byte forwarding in both directions |
+
+**pause/resume** — sets `_paused` flag; all forwarding calls check it before writing.
+While paused, `_relayWithHostRewrite` also discards incoming bytes so `headerBuf` does not grow unbounded.
+If `headerBuf` exceeds 64 KB (malformed request guard), both sockets are destroyed.
+
+**TLS SNI** — `SecureSocket.connect(host, port)` uses `host` as SNI, so the remote server
+receives the correct certificate even though the test client connects to `127.0.0.1`.
+
+**Host header rewrite** — when a WebSocket client connects to `ws://127.0.0.1:PORT`, the HTTP
+upgrade request contains `Host: 127.0.0.1:PORT`. Pass `rewriteHostHeader` so the remote server
+receives the real hostname and accepts the upgrade.
+
+## Constraints
+
+- Binds listener on `InternetAddress.loopbackIPv4` (`127.0.0.1`) only — always use `127.0.0.1`
+  (not `localhost`) in test URLs to avoid IPv6-first resolution issues.
+- `publish_to: none` — internal package, not published to pub.dev.
+- No Flutter, no code generation.
+
+## Commands
+
+```bash
+dart analyze
+dart format --line-length 120 lib/
+```

--- a/packages/_tcp_proxy/README.md
+++ b/packages/_tcp_proxy/README.md
@@ -1,0 +1,144 @@
+# _tcp_proxy
+
+Internal test utility - raw TCP proxy with pause/resume for network condition simulation.
+
+> **Not published.** This package is part of the WebTrit Phone monorepo and is used
+> exclusively in tests via workspace path dependency.
+
+## Usage
+
+```dart
+import 'package:_tcp_proxy/_tcp_proxy.dart';
+
+// Connect to a TLS server, rewriting the Host header for WebSocket upgrade.
+final proxy = TcpProxy(
+  host: 'signaling.example.com',
+  rewriteHostHeader: 'signaling.example.com',
+);
+
+final port = await proxy.start();
+
+// Point your WebSocket client at 127.0.0.1 (not localhost - see note below).
+final client = await WebSocket.connect('ws://127.0.0.1:$port/path');
+
+// Simulate a network blackhole (NAT timeout, Wi-Fi drop, firewall).
+proxy.pause();
+
+// Restore transparent forwarding.
+proxy.resume();
+
+await proxy.stop();
+```
+
+> **Note:** Always use `127.0.0.1` instead of `localhost` in test URLs.
+> The proxy binds on IPv4 loopback only; `localhost` may resolve to IPv6 (`::1`) first
+> on some systems, causing a connection failure.
+
+## Using in app-level integration tests
+
+The package is already in the monorepo workspace (`packages/_tcp_proxy`). To use it in
+`integration_test/` at the app root:
+
+**1. Add the dependency to the root `pubspec.yaml`** (`dev_dependencies` section):
+
+```yaml
+dev_dependencies:
+  _tcp_proxy:
+    path: packages/_tcp_proxy
+```
+
+**2. Run `flutter pub get`** (or `melos bootstrap`).
+
+### How the URL injection works
+
+The app derives the signaling WebSocket URL from the `coreUrl` stored in `SecureStorage`
+via `WebtritSignalingUtils.parseCoreUrlToSignalingUrl()`:
+
+```
+https://core.example.com  ->  wss://core.example.com   (TLS WebSocket, real server)
+http://127.0.0.1:PORT     ->  ws://127.0.0.1:PORT      (plain WebSocket, local proxy)
+```
+
+Writing `http://127.0.0.1:$proxyPort` as the `coreUrl` before the signaling client
+connects makes the app route signaling through the proxy transparently. The proxy then
+opens a TLS connection to the real server on the app's behalf:
+
+```
+App (plain ws://)  ->  TcpProxy (127.0.0.1:PORT)  ->  Real server (wss://, TLS)
+```
+
+**3. Import and use in a test:**
+
+```dart
+import 'package:_tcp_proxy/_tcp_proxy.dart';
+import 'package:webtrit_phone/data/secure_storage.dart';
+
+void main() {
+  late TcpProxy proxy;
+  late int proxyPort;
+
+  setUp(() async {
+    const realHost = IntegrationTestEnvironmentConfig.CORE_URL; // e.g. 'core.example.com'
+
+    proxy = TcpProxy(
+      host: realHost,
+      rewriteHostHeader: realHost, // rewrites Host header in the WebSocket upgrade request
+    );
+    proxyPort = await proxy.start();
+  });
+
+  tearDown(() async {
+    await proxy.stop();
+    // Restore the real coreUrl so subsequent tests are not affected.
+    final storage = SecureStorageImpl();
+    await storage.writeCoreUrl('https://${IntegrationTestEnvironmentConfig.CORE_URL}');
+  });
+
+  patrolTest('should reconnect after network drop mid-call', ($) async {
+    // 1. Log in via the real server so a valid session token is stored.
+    await pumpRootAndWaitUntilVisible(instanceRegistry, $);
+    await loginByMethod($, defaultLoginMethod);
+
+    // 2. Redirect signaling through the proxy before CallBloc connects.
+    //    The app reads coreUrl from SecureStorage on every reconnect attempt,
+    //    so writing http:// here makes the next connect go to the proxy.
+    final storage = SecureStorageImpl();
+    await storage.writeCoreUrl('http://127.0.0.1:$proxyPort');
+
+    // 3. Trigger a reconnect so CallBloc picks up the new URL.
+    //    (e.g. toggle airplane mode off, or wait for an automatic reconnect cycle)
+
+    // 4. Wait until the call UI is active (signaling connected through proxy).
+    await $.waitUntilVisible($(CallActiveScaffold));
+
+    // 5. Simulate a network blackhole - drop all bytes in both directions.
+    proxy.pause();
+
+    // 6. Assert the app shows a reconnect indicator.
+    await $.waitUntilVisible($(ReconnectingIndicator));
+
+    // 7. Restore connectivity and verify recovery.
+    proxy.resume();
+    await $.waitUntilVisible($(CallActiveScaffold));
+  });
+}
+```
+
+> **Tip:** The proxy sits between the app and the server at the TCP level - below WebSocket
+> framing and TLS. `pause()` silently discards all bytes in both directions without closing
+> the socket, which is indistinguishable from a NAT timeout or Wi-Fi drop from the app's
+> perspective.
+
+## How it works
+
+The proxy opens a plain-TCP listener on a random local port. For each incoming connection it
+opens a TLS connection to the remote server (using the correct SNI hostname) and relays bytes
+transparently in both directions.
+
+When `rewriteHostHeader` is set, the proxy buffers the first HTTP request until the end of
+headers (`\r\n\r\n`), rewrites the `Host` header to the real server hostname, and then switches
+to a raw byte relay for the rest of the connection lifetime.
+
+Calling `pause()` sets an internal flag that causes all byte forwarding to be silently
+discarded - simulating a network path that is physically broken but where the TCP connection
+itself has not been reset (the most realistic scenario for keepalive timeout testing).

--- a/packages/_tcp_proxy/analysis_options.yaml
+++ b/packages/_tcp_proxy/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    prefer_single_quotes: true
+
+formatter:
+  page_width: 120

--- a/packages/_tcp_proxy/lib/_tcp_proxy.dart
+++ b/packages/_tcp_proxy/lib/_tcp_proxy.dart
@@ -1,0 +1,1 @@
+export 'src/tcp_proxy.dart';

--- a/packages/_tcp_proxy/lib/src/tcp_proxy.dart
+++ b/packages/_tcp_proxy/lib/src/tcp_proxy.dart
@@ -10,7 +10,7 @@ import 'dart:io';
 /// final proxy = TcpProxy(host: 'example.com');
 /// final port = await proxy.start();
 ///
-/// // Connect your client to ws://localhost:$port/...
+/// // Connect your client to ws://127.0.0.1:$port/...
 ///
 /// proxy.pause();   // simulate network blackhole
 /// proxy.resume();  // restore connectivity
@@ -97,6 +97,8 @@ class TcpProxy {
     }
   }
 
+  static const _maxHeaderBytes = 64 * 1024; // 64 KB guard against unbounded buffering
+
   /// Buffers the first HTTP request, rewrites the Host header, then switches
   /// to a transparent raw-byte relay for the rest of the connection.
   void _relayWithHostRewrite(Socket clientSocket, Socket serverSocket, String targetHost) {
@@ -110,7 +112,16 @@ class TcpProxy {
           return;
         }
 
+        if (_paused) return;
+
         headerBuf.addAll(bytes);
+
+        if (headerBuf.length > _maxHeaderBytes) {
+          clientSocket.destroy();
+          serverSocket.destroy();
+          return;
+        }
+
         final end = _findCrlfCrlf(headerBuf);
         if (end == -1) return;
 

--- a/packages/_tcp_proxy/lib/src/tcp_proxy.dart
+++ b/packages/_tcp_proxy/lib/src/tcp_proxy.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+
+/// Raw TCP proxy that forwards bytes between a local plain-TCP listener and a
+/// remote server (optionally over TLS).
+///
+/// Useful in tests to simulate adverse network conditions without mocks.
+///
+/// ### Basic usage
+/// ```dart
+/// final proxy = TcpProxy(host: 'example.com');
+/// final port = await proxy.start();
+///
+/// // Connect your client to ws://localhost:$port/...
+///
+/// proxy.pause();   // simulate network blackhole
+/// proxy.resume();  // restore connectivity
+///
+/// await proxy.stop();
+/// ```
+///
+/// ### WebSocket over TLS
+/// When proxying WebSocket traffic the HTTP upgrade request contains a
+/// `Host` header set to `localhost:<port>`.  Pass [rewriteHostHeader] so the
+/// remote server receives the correct hostname and accepts the upgrade.
+///
+/// ```dart
+/// final proxy = TcpProxy(
+///   host: 'signaling.example.com',
+///   rewriteHostHeader: 'signaling.example.com',
+/// );
+/// ```
+class TcpProxy {
+  TcpProxy({required this.host, this.port = 443, this.useTls = true, this.rewriteHostHeader});
+
+  /// Remote hostname — used as TLS SNI when [useTls] is true.
+  final String host;
+
+  /// Remote port. Defaults to 443.
+  final int port;
+
+  /// Whether to connect to the remote server over TLS. Defaults to true.
+  final bool useTls;
+
+  /// When set, the `Host` header in the first HTTP request is rewritten to
+  /// this value before being forwarded.  Required for WebSocket proxying when
+  /// the remote server validates the Host header.
+  final String? rewriteHostHeader;
+
+  ServerSocket? _server;
+  bool _paused = false;
+
+  bool get isPaused => _paused;
+
+  /// Binds a local TCP listener on a random port and starts accepting
+  /// connections. Returns the bound port number.
+  Future<int> start() async {
+    _server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    _acceptLoop();
+    return _server!.port;
+  }
+
+  /// Stops accepting new connections and closes the listener socket.
+  /// Existing relayed connections finish naturally.
+  Future<void> stop() async => _server?.close();
+
+  /// Silently drops all incoming bytes in both directions — simulates a
+  /// network blackhole (e.g. NAT timeout, Wi-Fi drop).
+  void pause() => _paused = true;
+
+  /// Resumes transparent byte forwarding.
+  void resume() => _paused = false;
+
+  // ---------------------------------------------------------------------------
+
+  void _acceptLoop() async {
+    await for (final clientSocket in _server!) {
+      _relay(clientSocket);
+    }
+  }
+
+  void _relay(Socket clientSocket) async {
+    try {
+      final Socket serverSocket;
+      if (useTls) {
+        serverSocket = await SecureSocket.connect(host, port, timeout: const Duration(seconds: 15));
+      } else {
+        serverSocket = await Socket.connect(host, port, timeout: const Duration(seconds: 15));
+      }
+
+      if (rewriteHostHeader != null) {
+        _relayWithHostRewrite(clientSocket, serverSocket, rewriteHostHeader!);
+      } else {
+        _relayRaw(clientSocket, serverSocket);
+      }
+    } catch (_) {
+      clientSocket.destroy();
+    }
+  }
+
+  /// Buffers the first HTTP request, rewrites the Host header, then switches
+  /// to a transparent raw-byte relay for the rest of the connection.
+  void _relayWithHostRewrite(Socket clientSocket, Socket serverSocket, String targetHost) {
+    final headerBuf = <int>[];
+    var headersDone = false;
+
+    clientSocket.listen(
+      (bytes) {
+        if (headersDone) {
+          if (!_paused) serverSocket.add(bytes);
+          return;
+        }
+
+        headerBuf.addAll(bytes);
+        final end = _findCrlfCrlf(headerBuf);
+        if (end == -1) return;
+
+        headersDone = true;
+
+        final headerStr = String.fromCharCodes(headerBuf.sublist(0, end + 4));
+        final tail = headerBuf.sublist(end + 4);
+        final rewritten = headerStr.replaceFirstMapped(
+          RegExp(r'^Host: .+$', multiLine: true, caseSensitive: false),
+          (_) => 'Host: $targetHost',
+        );
+
+        if (!_paused) {
+          serverSocket.add(rewritten.codeUnits);
+          if (tail.isNotEmpty) serverSocket.add(tail);
+        }
+      },
+      onDone: () => serverSocket.destroy(),
+      onError: (_) => serverSocket.destroy(),
+      cancelOnError: true,
+    );
+
+    serverSocket.listen(
+      (bytes) {
+        if (!_paused) clientSocket.add(bytes);
+      },
+      onDone: () => clientSocket.destroy(),
+      onError: (_) => clientSocket.destroy(),
+      cancelOnError: true,
+    );
+  }
+
+  void _relayRaw(Socket clientSocket, Socket serverSocket) {
+    clientSocket.listen(
+      (bytes) {
+        if (!_paused) serverSocket.add(bytes);
+      },
+      onDone: () => serverSocket.destroy(),
+      onError: (_) => serverSocket.destroy(),
+      cancelOnError: true,
+    );
+
+    serverSocket.listen(
+      (bytes) {
+        if (!_paused) clientSocket.add(bytes);
+      },
+      onDone: () => clientSocket.destroy(),
+      onError: (_) => clientSocket.destroy(),
+      cancelOnError: true,
+    );
+  }
+
+  static int _findCrlfCrlf(List<int> bytes) {
+    for (var i = 0; i < bytes.length - 3; i++) {
+      if (bytes[i] == 13 && bytes[i + 1] == 10 && bytes[i + 2] == 13 && bytes[i + 3] == 10) return i;
+    }
+    return -1;
+  }
+}

--- a/packages/_tcp_proxy/lib/src/tcp_proxy.dart
+++ b/packages/_tcp_proxy/lib/src/tcp_proxy.dart
@@ -174,6 +174,12 @@ class TcpProxy {
     );
   }
 
+  /// Returns the index of the first `\r\n\r\n` (CR LF CR LF, bytes 13 10 13 10)
+  /// sequence in [bytes], or -1 if not found.
+  ///
+  /// HTTP headers end with a blank line, encoded as `\r\n\r\n`. Finding this
+  /// sequence marks the boundary between the HTTP request headers and the body
+  /// (or, for a WebSocket upgrade, the start of the WebSocket framing).
   static int _findCrlfCrlf(List<int> bytes) {
     for (var i = 0; i < bytes.length - 3; i++) {
       if (bytes[i] == 13 && bytes[i + 1] == 10 && bytes[i + 2] == 13 && bytes[i + 3] == 10) return i;

--- a/packages/_tcp_proxy/pubspec.yaml
+++ b/packages/_tcp_proxy/pubspec.yaml
@@ -1,0 +1,11 @@
+name: _tcp_proxy
+resolution: workspace
+description: Internal test utility — raw TCP proxy with pause/resume for network simulation.
+publish_to: none
+version: 1.0.0
+
+environment:
+  sdk: ^3.8.0
+
+dependencies:
+  meta: any

--- a/packages/_tcp_proxy/pubspec.yaml
+++ b/packages/_tcp_proxy/pubspec.yaml
@@ -9,3 +9,6 @@ environment:
 
 dependencies:
   meta: any
+
+dev_dependencies:
+  lints: any

--- a/packages/webtrit_signaling/pubspec.yaml
+++ b/packages/webtrit_signaling/pubspec.yaml
@@ -22,3 +22,5 @@ dev_dependencies:
   test: ^1.26.3
   mocktail: ^1.0.4
   fake_async: ^1.3.1
+  _tcp_proxy:
+    path: ../_tcp_proxy

--- a/packages/webtrit_signaling/test/live_signaling_test.dart
+++ b/packages/webtrit_signaling/test/live_signaling_test.dart
@@ -1,0 +1,310 @@
+@Tags(['live'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+
+// ---------------------------------------------------------------------------
+// Credentials — read from environment variables.
+// Match the keys in dart_define.integration_test.json so the same CI config
+// works for both app-level and signaling live tests.
+//
+// Run example:
+//   WEBTRIT_APP_TEST_CUSTOM_CORE_URL=core.demo.turbocompany.com \
+//   WEBTRIT_APP_TEST_EMAIL_CREDENTIAL=test@turbomail.com \
+//   WEBTRIT_APP_TEST_EMAIL_VERIFY_CREDENTIAL=turbopassword \
+//   dart test test/live_signaling_test.dart --tags live
+// ---------------------------------------------------------------------------
+
+String _env(String key, {String defaultValue = ''}) => Platform.environment[key] ?? defaultValue;
+
+const _coreUrlKey = 'WEBTRIT_APP_TEST_CUSTOM_CORE_URL';
+const _loginKey = 'WEBTRIT_APP_TEST_EMAIL_CREDENTIAL';
+const _passwordKey = 'WEBTRIT_APP_TEST_EMAIL_VERIFY_CREDENTIAL';
+
+bool get _credentialsProvided {
+  return _env(_coreUrlKey).isNotEmpty && _env(_loginKey).isNotEmpty && _env(_passwordKey).isNotEmpty;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: obtain a session token via REST API POST /api/v1/session.
+// Uses dart:io HttpClient directly so this package stays dep-free.
+// ---------------------------------------------------------------------------
+
+Future<({String token, String tenantId})> _fetchSessionToken() async {
+  final coreUrl = _env(_coreUrlKey);
+  final login = _env(_loginKey);
+  final password = _env(_passwordKey);
+
+  final uri = Uri.parse('https://$coreUrl/api/v1/session');
+  // ignore: avoid_types_on_closure_parameters
+  final client = HttpClient()
+    ..connectionTimeout = const Duration(seconds: 15)
+    ..badCertificateCallback = (X509Certificate cert, String host, int port) => true;
+
+  try {
+    final request = await client.postUrl(uri);
+    request.headers.set(HttpHeaders.contentTypeHeader, 'application/json');
+    request.write(
+      jsonEncode({'type': 'macos', 'identifier': 'com.webtrit.phone.test', 'login': login, 'password': password}),
+    );
+
+    final response = await request.close();
+    final body = await response.transform(utf8.decoder).join();
+
+    if (response.statusCode != 200) {
+      throw StateError('Session creation failed: HTTP ${response.statusCode} — $body');
+    }
+
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final token = json['token'] as String;
+    final tenantId = json['tenant_id'] as String? ?? '';
+
+    return (token: token, tenantId: tenantId);
+  } finally {
+    client.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Proxy — pure Dart WebSocket relay that can pause packet forwarding.
+//
+// Client connects to ws://localhost:PORT (plain TCP).
+// Proxy connects to wss://<realHost> (TLS) and relays frames in both
+// directions. Calling pause() drops all frames, simulating a network
+// blackhole in the middle of the connection.
+// ---------------------------------------------------------------------------
+
+class _SignalingProxy {
+  final String _realBaseUrl;
+
+  HttpServer? _server;
+  bool _paused = false;
+
+  _SignalingProxy(this._realBaseUrl);
+
+  Future<int> start() async {
+    _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    _acceptLoop();
+    return _server!.port;
+  }
+
+  void _acceptLoop() async {
+    await for (final request in _server!) {
+      if (WebSocketTransformer.isUpgradeRequest(request)) {
+        _relay(request);
+      } else {
+        request.response
+          ..statusCode = HttpStatus.badRequest
+          ..close();
+      }
+    }
+  }
+
+  void _relay(HttpRequest request) async {
+    try {
+      final realUrl = '$_realBaseUrl${request.uri.path}?${request.uri.query}';
+      final clientWs = await WebSocketTransformer.upgrade(request);
+      final serverWs = await WebSocket.connect(realUrl);
+
+      clientWs.listen(
+        (data) {
+          if (!_paused) serverWs.add(data);
+        },
+        onDone: () => serverWs.close(),
+        onError: (_) => serverWs.close(),
+        cancelOnError: true,
+      );
+
+      serverWs.listen(
+        (data) {
+          if (!_paused) clientWs.add(data);
+        },
+        onDone: () => clientWs.close(),
+        onError: (_) => clientWs.close(),
+        cancelOnError: true,
+      );
+    } catch (_) {
+      // Connection to real server failed — nothing to relay.
+    }
+  }
+
+  void pause() => _paused = true;
+  void resume() => _paused = false;
+
+  Future<void> stop() async => _server?.close(force: true);
+}
+
+// ---------------------------------------------------------------------------
+
+void main() {
+  late WebtritSignalingClient client;
+  late String sessionToken;
+  late String tenantId;
+
+  setUpAll(() async {
+    if (!_credentialsProvided) return;
+
+    final session = await _fetchSessionToken();
+    sessionToken = session.token;
+    tenantId = session.tenantId;
+  });
+
+  tearDown(() async {
+    if (!_credentialsProvided) return;
+    await client.disconnect();
+  });
+
+  group('Live signaling — real server', skip: _credentialsProvided ? false : 'credentials not set', () {
+    test('should receive StateHandshake after connecting', () async {
+      client = await WebtritSignalingClient.connect(
+        Uri.parse('wss://${_env(_coreUrlKey)}'),
+        tenantId,
+        sessionToken,
+        false,
+        connectionTimeout: const Duration(seconds: 15),
+      );
+
+      final handshakeCompleter = Completer<StateHandshake>();
+
+      client.listen(
+        onStateHandshake: (sh) {
+          if (!handshakeCompleter.isCompleted) handshakeCompleter.complete(sh);
+        },
+        onEvent: (_) {},
+        onError: (e, st) => fail('Unexpected error: $e\n$st'),
+        onDisconnect: (_, _) {},
+      );
+
+      final handshake = await handshakeCompleter.future.timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => throw TimeoutException('No StateHandshake received within 10 s'),
+      );
+
+      expect(handshake.keepaliveInterval, greaterThan(Duration.zero));
+    });
+
+    test(
+      'should complete at least one keepalive cycle without error',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        client = await WebtritSignalingClient.connect(
+          Uri.parse('wss://${_env(_coreUrlKey)}'),
+          tenantId,
+          sessionToken,
+          false,
+          connectionTimeout: const Duration(seconds: 15),
+        );
+
+        final handshakeCompleter = Completer<StateHandshake>();
+        Object? capturedError;
+
+        client.listen(
+          onStateHandshake: (sh) {
+            if (!handshakeCompleter.isCompleted) handshakeCompleter.complete(sh);
+          },
+          onEvent: (_) {},
+          onError: (e, _) => capturedError = e,
+          onDisconnect: (_, _) {},
+        );
+
+        final handshake = await handshakeCompleter.future.timeout(const Duration(seconds: 10));
+
+        // Wait for one full keepalive cycle + a small buffer.
+        await Future.delayed(handshake.keepaliveInterval + const Duration(seconds: 3));
+
+        expect(capturedError, isNull, reason: 'Keepalive error: $capturedError');
+      },
+    );
+
+    test('should NOT call onDisconnect when disconnect is called manually', () async {
+      client = await WebtritSignalingClient.connect(
+        Uri.parse('wss://${_env(_coreUrlKey)}'),
+        tenantId,
+        sessionToken,
+        false,
+        connectionTimeout: const Duration(seconds: 15),
+      );
+
+      var disconnectFired = false;
+      final handshakeCompleter = Completer<void>();
+
+      client.listen(
+        onStateHandshake: (_) {
+          if (!handshakeCompleter.isCompleted) handshakeCompleter.complete();
+        },
+        onEvent: (_) {},
+        onError: (e, st) => fail('Unexpected error: $e\n$st'),
+        onDisconnect: (_, _) => disconnectFired = true,
+      );
+
+      await handshakeCompleter.future.timeout(const Duration(seconds: 10));
+
+      // disconnect() cancels the stream subscription before closing — onDisconnect must NOT fire.
+      await client.disconnect(1000, 'normal closure');
+      await Future.delayed(const Duration(milliseconds: 200));
+
+      expect(disconnectFired, isFalse);
+    });
+  });
+
+  group('Network simulation via proxy', skip: _credentialsProvided ? false : 'credentials not set', () {
+    late _SignalingProxy proxy;
+    late int proxyPort;
+
+    setUp(() async {
+      proxy = _SignalingProxy('wss://${_env(_coreUrlKey)}');
+      proxyPort = await proxy.start();
+    });
+
+    tearDown(() async => proxy.stop());
+
+    test(
+      'should fire WebtritSignalingKeepaliveTransactionTimeoutException when packets are dropped mid-connection',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        client = await WebtritSignalingClient.connect(
+          Uri.parse('ws://localhost:$proxyPort'),
+          tenantId,
+          sessionToken,
+          false,
+          connectionTimeout: const Duration(seconds: 15),
+        );
+
+        final handshakeCompleter = Completer<StateHandshake>();
+        final errorCompleter = Completer<Object>();
+
+        client.listen(
+          onStateHandshake: (sh) {
+            if (!handshakeCompleter.isCompleted) handshakeCompleter.complete(sh);
+          },
+          onEvent: (_) {},
+          onError: (e, _) {
+            if (!errorCompleter.isCompleted) errorCompleter.complete(e);
+          },
+          onDisconnect: (_, _) {},
+        );
+
+        final handshake = await handshakeCompleter.future.timeout(const Duration(seconds: 10));
+
+        // Simulate network blackhole — drop all packets in both directions.
+        proxy.pause();
+
+        // The next keepalive will be sent after keepaliveInterval.
+        // It will wait 10 s for a response (defaultExecuteTransactionTimeoutDuration).
+        // Total wait: keepaliveInterval + 10 s + small buffer.
+        final error = await errorCompleter.future.timeout(
+          handshake.keepaliveInterval + const Duration(seconds: 15),
+          onTimeout: () => throw TimeoutException('No keepalive timeout error received'),
+        );
+
+        expect(error, isA<WebtritSignalingKeepaliveTransactionTimeoutException>());
+      },
+    );
+  });
+}

--- a/packages/webtrit_signaling/test/live_signaling_test.dart
+++ b/packages/webtrit_signaling/test/live_signaling_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
+import 'package:_tcp_proxy/_tcp_proxy.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
 // ---------------------------------------------------------------------------
@@ -15,9 +16,9 @@ import 'package:webtrit_signaling/webtrit_signaling.dart';
 // works for both app-level and signaling live tests.
 //
 // Run example:
-//   WEBTRIT_APP_TEST_CUSTOM_CORE_URL=core.demo.turbocompany.com \
-//   WEBTRIT_APP_TEST_EMAIL_CREDENTIAL=test@turbomail.com \
-//   WEBTRIT_APP_TEST_EMAIL_VERIFY_CREDENTIAL=turbopassword \
+//   WEBTRIT_APP_TEST_CUSTOM_CORE_URL=core.support.portaone.com \
+//   WEBTRIT_APP_TEST_EMAIL_CREDENTIAL=111000333 \
+//   WEBTRIT_APP_TEST_EMAIL_VERIFY_CREDENTIAL=zzzxxx123 \
 //   dart test test/live_signaling_test.dart --tags live
 // ---------------------------------------------------------------------------
 
@@ -69,105 +70,6 @@ Future<({String token, String tenantId})> _fetchSessionToken() async {
   } finally {
     client.close();
   }
-}
-
-// ---------------------------------------------------------------------------
-// Proxy — raw TCP relay that can pause byte forwarding.
-//
-// Client connects to localhost:PORT over plain TCP.
-// Proxy opens a TLS (SecureSocket) connection to the real server and relays
-// raw bytes in both directions — below the WebSocket framing layer.
-// Calling pause() silently drops all bytes, simulating a network blackhole
-// (NAT timeout / Wi-Fi drop) in the middle of an active connection.
-// ---------------------------------------------------------------------------
-
-class _SignalingProxy {
-  final String _realHost;
-  final int _realPort;
-
-  ServerSocket? _server;
-  bool _paused = false;
-
-  _SignalingProxy({required String host, int port = 443}) : _realHost = host, _realPort = port;
-
-  Future<int> start() async {
-    _server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-    _acceptLoop();
-    return _server!.port;
-  }
-
-  void _acceptLoop() async {
-    await for (final clientSocket in _server!) {
-      _relay(clientSocket);
-    }
-  }
-
-  void _relay(Socket clientSocket) async {
-    try {
-      // SecureSocket uses _realHost as SNI — cert validation works correctly.
-      final serverSocket = await SecureSocket.connect(_realHost, _realPort, timeout: const Duration(seconds: 15));
-
-      // Phase 1: buffer bytes until HTTP headers are complete, then rewrite the
-      // Host header (dart:io sets it to localhost:PORT) so the server accepts
-      // the WebSocket upgrade request.
-      // Phase 2: relay raw bytes transparently — below WebSocket framing.
-      final headerBuf = <int>[];
-      var headersDone = false;
-
-      clientSocket.listen(
-        (bytes) {
-          if (headersDone) {
-            if (!_paused) serverSocket.add(bytes);
-            return;
-          }
-
-          headerBuf.addAll(bytes);
-          final end = _crlfCrlfIndex(headerBuf);
-          if (end == -1) return;
-
-          headersDone = true;
-          final headerStr = String.fromCharCodes(headerBuf.sublist(0, end + 4));
-          final tail = headerBuf.sublist(end + 4);
-          final rewritten = headerStr.replaceFirstMapped(
-            RegExp(r'^Host: .+$', multiLine: true, caseSensitive: false),
-            (_) => 'Host: $_realHost',
-          );
-
-          if (!_paused) {
-            serverSocket.add(rewritten.codeUnits);
-            if (tail.isNotEmpty) serverSocket.add(tail);
-          }
-        },
-        onDone: () => serverSocket.destroy(),
-        onError: (_) => serverSocket.destroy(),
-        cancelOnError: true,
-      );
-
-      // Server → Client: raw bytes.
-      serverSocket.listen(
-        (bytes) {
-          if (!_paused) clientSocket.add(bytes);
-        },
-        onDone: () => clientSocket.destroy(),
-        onError: (_) => clientSocket.destroy(),
-        cancelOnError: true,
-      );
-    } catch (_) {
-      clientSocket.destroy();
-    }
-  }
-
-  static int _crlfCrlfIndex(List<int> bytes) {
-    for (var i = 0; i < bytes.length - 3; i++) {
-      if (bytes[i] == 13 && bytes[i + 1] == 10 && bytes[i + 2] == 13 && bytes[i + 3] == 10) return i;
-    }
-    return -1;
-  }
-
-  void pause() => _paused = true;
-  void resume() => _paused = false;
-
-  Future<void> stop() async => _server?.close();
 }
 
 // ---------------------------------------------------------------------------
@@ -284,11 +186,11 @@ void main() {
   });
 
   group('Network simulation via proxy', skip: _credentialsProvided ? false : 'credentials not set', () {
-    late _SignalingProxy proxy;
+    late TcpProxy proxy;
     late int proxyPort;
 
     setUp(() async {
-      proxy = _SignalingProxy(host: _env(_coreUrlKey));
+      proxy = TcpProxy(host: _env(_coreUrlKey), rewriteHostHeader: _env(_coreUrlKey));
       proxyPort = await proxy.start();
     });
 
@@ -322,7 +224,7 @@ void main() {
 
         final handshake = await handshakeCompleter.future.timeout(const Duration(seconds: 10));
 
-        // Simulate network blackhole — drop all packets in both directions.
+        // Simulate network blackhole — drop all bytes in both directions.
         proxy.pause();
 
         // The next keepalive will be sent after keepaliveInterval.

--- a/packages/webtrit_signaling/test/live_signaling_test.dart
+++ b/packages/webtrit_signaling/test/live_signaling_test.dart
@@ -72,72 +72,102 @@ Future<({String token, String tenantId})> _fetchSessionToken() async {
 }
 
 // ---------------------------------------------------------------------------
-// Proxy — pure Dart WebSocket relay that can pause packet forwarding.
+// Proxy — raw TCP relay that can pause byte forwarding.
 //
-// Client connects to ws://localhost:PORT (plain TCP).
-// Proxy connects to wss://<realHost> (TLS) and relays frames in both
-// directions. Calling pause() drops all frames, simulating a network
-// blackhole in the middle of the connection.
+// Client connects to localhost:PORT over plain TCP.
+// Proxy opens a TLS (SecureSocket) connection to the real server and relays
+// raw bytes in both directions — below the WebSocket framing layer.
+// Calling pause() silently drops all bytes, simulating a network blackhole
+// (NAT timeout / Wi-Fi drop) in the middle of an active connection.
 // ---------------------------------------------------------------------------
 
 class _SignalingProxy {
-  final String _realBaseUrl;
+  final String _realHost;
+  final int _realPort;
 
-  HttpServer? _server;
+  ServerSocket? _server;
   bool _paused = false;
 
-  _SignalingProxy(this._realBaseUrl);
+  _SignalingProxy({required String host, int port = 443}) : _realHost = host, _realPort = port;
 
   Future<int> start() async {
-    _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    _server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
     _acceptLoop();
     return _server!.port;
   }
 
   void _acceptLoop() async {
-    await for (final request in _server!) {
-      if (WebSocketTransformer.isUpgradeRequest(request)) {
-        _relay(request);
-      } else {
-        request.response
-          ..statusCode = HttpStatus.badRequest
-          ..close();
-      }
+    await for (final clientSocket in _server!) {
+      _relay(clientSocket);
     }
   }
 
-  void _relay(HttpRequest request) async {
+  void _relay(Socket clientSocket) async {
     try {
-      final realUrl = '$_realBaseUrl${request.uri.path}?${request.uri.query}';
-      final clientWs = await WebSocketTransformer.upgrade(request);
-      final serverWs = await WebSocket.connect(realUrl);
+      // SecureSocket uses _realHost as SNI — cert validation works correctly.
+      final serverSocket = await SecureSocket.connect(_realHost, _realPort, timeout: const Duration(seconds: 15));
 
-      clientWs.listen(
-        (data) {
-          if (!_paused) serverWs.add(data);
+      // Phase 1: buffer bytes until HTTP headers are complete, then rewrite the
+      // Host header (dart:io sets it to localhost:PORT) so the server accepts
+      // the WebSocket upgrade request.
+      // Phase 2: relay raw bytes transparently — below WebSocket framing.
+      final headerBuf = <int>[];
+      var headersDone = false;
+
+      clientSocket.listen(
+        (bytes) {
+          if (headersDone) {
+            if (!_paused) serverSocket.add(bytes);
+            return;
+          }
+
+          headerBuf.addAll(bytes);
+          final end = _crlfCrlfIndex(headerBuf);
+          if (end == -1) return;
+
+          headersDone = true;
+          final headerStr = String.fromCharCodes(headerBuf.sublist(0, end + 4));
+          final tail = headerBuf.sublist(end + 4);
+          final rewritten = headerStr.replaceFirstMapped(
+            RegExp(r'^Host: .+$', multiLine: true, caseSensitive: false),
+            (_) => 'Host: $_realHost',
+          );
+
+          if (!_paused) {
+            serverSocket.add(rewritten.codeUnits);
+            if (tail.isNotEmpty) serverSocket.add(tail);
+          }
         },
-        onDone: () => serverWs.close(),
-        onError: (_) => serverWs.close(),
+        onDone: () => serverSocket.destroy(),
+        onError: (_) => serverSocket.destroy(),
         cancelOnError: true,
       );
 
-      serverWs.listen(
-        (data) {
-          if (!_paused) clientWs.add(data);
+      // Server → Client: raw bytes.
+      serverSocket.listen(
+        (bytes) {
+          if (!_paused) clientSocket.add(bytes);
         },
-        onDone: () => clientWs.close(),
-        onError: (_) => clientWs.close(),
+        onDone: () => clientSocket.destroy(),
+        onError: (_) => clientSocket.destroy(),
         cancelOnError: true,
       );
     } catch (_) {
-      // Connection to real server failed — nothing to relay.
+      clientSocket.destroy();
     }
+  }
+
+  static int _crlfCrlfIndex(List<int> bytes) {
+    for (var i = 0; i < bytes.length - 3; i++) {
+      if (bytes[i] == 13 && bytes[i + 1] == 10 && bytes[i + 2] == 13 && bytes[i + 3] == 10) return i;
+    }
+    return -1;
   }
 
   void pause() => _paused = true;
   void resume() => _paused = false;
 
-  Future<void> stop() async => _server?.close(force: true);
+  Future<void> stop() async => _server?.close();
 }
 
 // ---------------------------------------------------------------------------
@@ -258,7 +288,7 @@ void main() {
     late int proxyPort;
 
     setUp(() async {
-      proxy = _SignalingProxy('wss://${_env(_coreUrlKey)}');
+      proxy = _SignalingProxy(host: _env(_coreUrlKey));
       proxyPort = await proxy.start();
     });
 

--- a/packages/webtrit_signaling/test/live_signaling_test.dart
+++ b/packages/webtrit_signaling/test/live_signaling_test.dart
@@ -44,9 +44,7 @@ Future<({String token, String tenantId})> _fetchSessionToken() async {
 
   final uri = Uri.parse('https://$coreUrl/api/v1/session');
   // ignore: avoid_types_on_closure_parameters
-  final client = HttpClient()
-    ..connectionTimeout = const Duration(seconds: 15)
-    ..badCertificateCallback = (X509Certificate cert, String host, int port) => true;
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 15);
 
   try {
     final request = await client.postUrl(uri);
@@ -75,7 +73,7 @@ Future<({String token, String tenantId})> _fetchSessionToken() async {
 // ---------------------------------------------------------------------------
 
 void main() {
-  late WebtritSignalingClient client;
+  WebtritSignalingClient? client;
   late String sessionToken;
   late String tenantId;
 
@@ -88,23 +86,24 @@ void main() {
   });
 
   tearDown(() async {
-    if (!_credentialsProvided) return;
-    await client.disconnect();
+    await client?.disconnect();
+    client = null;
   });
 
   group('Live signaling — real server', skip: _credentialsProvided ? false : 'credentials not set', () {
     test('should receive StateHandshake after connecting', () async {
-      client = await WebtritSignalingClient.connect(
+      final signalingClient = await WebtritSignalingClient.connect(
         Uri.parse('wss://${_env(_coreUrlKey)}'),
         tenantId,
         sessionToken,
         false,
         connectionTimeout: const Duration(seconds: 15),
       );
+      client = signalingClient;
 
       final handshakeCompleter = Completer<StateHandshake>();
 
-      client.listen(
+      signalingClient.listen(
         onStateHandshake: (sh) {
           if (!handshakeCompleter.isCompleted) handshakeCompleter.complete(sh);
         },
@@ -125,18 +124,19 @@ void main() {
       'should complete at least one keepalive cycle without error',
       timeout: const Timeout(Duration(minutes: 2)),
       () async {
-        client = await WebtritSignalingClient.connect(
+        final signalingClient = await WebtritSignalingClient.connect(
           Uri.parse('wss://${_env(_coreUrlKey)}'),
           tenantId,
           sessionToken,
           false,
           connectionTimeout: const Duration(seconds: 15),
         );
+        client = signalingClient;
 
         final handshakeCompleter = Completer<StateHandshake>();
         Object? capturedError;
 
-        client.listen(
+        signalingClient.listen(
           onStateHandshake: (sh) {
             if (!handshakeCompleter.isCompleted) handshakeCompleter.complete(sh);
           },
@@ -155,18 +155,19 @@ void main() {
     );
 
     test('should NOT call onDisconnect when disconnect is called manually', () async {
-      client = await WebtritSignalingClient.connect(
+      final signalingClient = await WebtritSignalingClient.connect(
         Uri.parse('wss://${_env(_coreUrlKey)}'),
         tenantId,
         sessionToken,
         false,
         connectionTimeout: const Duration(seconds: 15),
       );
+      client = signalingClient;
 
       var disconnectFired = false;
       final handshakeCompleter = Completer<void>();
 
-      client.listen(
+      signalingClient.listen(
         onStateHandshake: (_) {
           if (!handshakeCompleter.isCompleted) handshakeCompleter.complete();
         },
@@ -178,7 +179,7 @@ void main() {
       await handshakeCompleter.future.timeout(const Duration(seconds: 10));
 
       // disconnect() cancels the stream subscription before closing — onDisconnect must NOT fire.
-      await client.disconnect(1000, 'normal closure');
+      await signalingClient.disconnect(1000, 'normal closure');
       await Future.delayed(const Duration(milliseconds: 200));
 
       expect(disconnectFired, isFalse);
@@ -200,18 +201,19 @@ void main() {
       'should fire WebtritSignalingKeepaliveTransactionTimeoutException when packets are dropped mid-connection',
       timeout: const Timeout(Duration(minutes: 2)),
       () async {
-        client = await WebtritSignalingClient.connect(
-          Uri.parse('ws://localhost:$proxyPort'),
+        final signalingClient = await WebtritSignalingClient.connect(
+          Uri.parse('ws://127.0.0.1:$proxyPort'),
           tenantId,
           sessionToken,
           false,
           connectionTimeout: const Duration(seconds: 15),
         );
+        client = signalingClient;
 
         final handshakeCompleter = Completer<StateHandshake>();
         final errorCompleter = Completer<Object>();
 
-        client.listen(
+        signalingClient.listen(
           onStateHandshake: (sh) {
             if (!handshakeCompleter.isCompleted) handshakeCompleter.complete(sh);
           },

--- a/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
+++ b/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
@@ -297,7 +297,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final request = HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id');
-      await expectLater(() => client.execute(request), throwsA(isA<WebtritSignalingDisconnectedException>()));
+      await expectLater(client.execute(request), throwsA(isA<WebtritSignalingDisconnectedException>()));
     });
   });
 
@@ -354,7 +354,7 @@ void main() {
 
       final request = HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id');
 
-      await expectLater(() => client.execute(request), throwsA(isA<WebtritSignalingBadStateException>()));
+      await expectLater(client.execute(request), throwsA(isA<WebtritSignalingBadStateException>()));
     });
 
     test('should throw WebtritSignalingBadStateException when closeCode is already set', () async {
@@ -371,7 +371,7 @@ void main() {
 
       final request = HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id');
 
-      await expectLater(() => client.execute(request), throwsA(isA<WebtritSignalingBadStateException>()));
+      await expectLater(client.execute(request), throwsA(isA<WebtritSignalingBadStateException>()));
     });
 
     test('should not call sink.add when closeCode is detected before write', () async {

--- a/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
+++ b/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
@@ -12,8 +12,12 @@ class MockWebSocketChannel extends Mock implements WebSocketChannel {}
 
 class MockWebSocketSink extends Mock implements WebSocketSink {}
 
+// Keepalive interval used by _handshakeJson() - drives all timing calculations below.
+const _kKeepaliveIntervalMs = 100;
+const _kKeepaliveInterval = Duration(milliseconds: _kKeepaliveIntervalMs);
+
 /// Helper to create a valid handshake state JSON string.
-String _handshakeJson({int keepaliveInterval = 100}) {
+String _handshakeJson({int keepaliveInterval = _kKeepaliveIntervalMs}) {
   return jsonEncode({
     'handshake': 'state',
     'timestamp': 1705322000000,
@@ -80,7 +84,7 @@ void main() {
         isPhysicalSocketClosed = true;
 
         // Advance past the keepalive interval.
-        async.elapse(const Duration(milliseconds: 200));
+        async.elapse(_kKeepaliveInterval * 2);
 
         verify(() => mockSink.add(any())).called(1);
         expect(errorReported, isFalse, reason: 'Race condition leaked to onError: $reportedError');
@@ -155,8 +159,12 @@ void main() {
         streamController.add(_handshakeJson());
         async.flushMicrotasks();
 
-        // Keepalive fires at 100 ms, transaction timeout at 100 ms + 10 000 ms.
-        async.elapse(const Duration(milliseconds: 10200));
+        // Keepalive fires after _kKeepaliveInterval, then waits defaultExecuteTransactionTimeoutDuration for a response.
+        async.elapse(
+          _kKeepaliveInterval +
+              WebtritSignalingClient.defaultExecuteTransactionTimeoutDuration +
+              const Duration(milliseconds: 100),
+        );
         async.flushMicrotasks();
 
         expect(capturedError, isA<WebtritSignalingKeepaliveTransactionTimeoutException>());
@@ -328,8 +336,10 @@ void main() {
 
           async.flushMicrotasks();
 
-          // Advance past transaction timeout (10 000 ms).
-          async.elapse(const Duration(milliseconds: 10100));
+          // Advance past transaction timeout.
+          async.elapse(
+            WebtritSignalingClient.defaultExecuteTransactionTimeoutDuration + const Duration(milliseconds: 100),
+          );
           async.flushMicrotasks();
 
           expect(executeError, isA<WebtritSignalingTransactionTimeoutException>());

--- a/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
+++ b/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
@@ -39,6 +39,7 @@ void main() {
     when(() => mockChannel.sink).thenReturn(mockSink);
     when(() => mockChannel.stream).thenAnswer((_) => streamController.stream);
     when(() => mockChannel.closeCode).thenReturn(null);
+    when(() => mockChannel.closeReason).thenReturn(null);
     when(() => mockSink.close(any(), any())).thenAnswer((_) => Future.value());
   });
 
@@ -134,6 +135,208 @@ void main() {
         verify(() => mockChannel.closeCode).called(2);
       });
     });
+  });
+
+  group('Keepalive timeout', () {
+    test('should report WebtritSignalingKeepaliveTransactionTimeoutException when server does not respond', () {
+      fakeAsync((async) {
+        final client = WebtritSignalingClient.inner(mockChannel);
+
+        Object? capturedError;
+        when(() => mockSink.add(any())).thenAnswer((_) {});
+
+        client.listen(
+          onStateHandshake: (_) {},
+          onEvent: (_) {},
+          onError: (e, _) => capturedError = e,
+          onDisconnect: (_, _) {},
+        );
+
+        streamController.add(_handshakeJson());
+        async.flushMicrotasks();
+
+        // Keepalive fires at 100 ms, transaction timeout at 100 ms + 10 000 ms.
+        async.elapse(const Duration(milliseconds: 10200));
+        async.flushMicrotasks();
+
+        expect(capturedError, isA<WebtritSignalingKeepaliveTransactionTimeoutException>());
+      });
+    });
+  });
+
+  group('Keepalive normal flow', () {
+    test('should restart keepalive timer after successful echo and send second keepalive', () {
+      fakeAsync((async) {
+        final client = WebtritSignalingClient.inner(mockChannel);
+
+        var keepaliveCount = 0;
+        String? lastTransactionId;
+
+        when(() => mockSink.add(any())).thenAnswer((invocation) {
+          final data = invocation.positionalArguments[0] as String;
+          final decoded = jsonDecode(data) as Map<String, dynamic>;
+          if (decoded['handshake'] == 'keepalive') {
+            keepaliveCount++;
+            lastTransactionId = decoded['transaction'] as String?;
+          }
+        });
+
+        client.listen(onStateHandshake: (_) {}, onEvent: (_) {}, onError: (_, _) {}, onDisconnect: (_, _) {});
+
+        streamController.add(_handshakeJson());
+        async.flushMicrotasks();
+
+        // First keepalive fires.
+        async.elapse(const Duration(milliseconds: 110));
+        async.flushMicrotasks();
+        expect(keepaliveCount, equals(1));
+
+        // Echo the first keepalive.
+        streamController.add(jsonEncode({'handshake': 'keepalive', 'transaction': lastTransactionId}));
+        async.flushMicrotasks();
+
+        // Second keepalive fires.
+        async.elapse(const Duration(milliseconds: 110));
+        async.flushMicrotasks();
+        expect(keepaliveCount, equals(2));
+      });
+    });
+
+    test('should complete three keepalive cycles without error', () {
+      fakeAsync((async) {
+        final client = WebtritSignalingClient.inner(mockChannel);
+
+        var keepaliveCount = 0;
+        var errorCount = 0;
+        final transactionIds = <String?>[];
+
+        when(() => mockSink.add(any())).thenAnswer((invocation) {
+          final data = invocation.positionalArguments[0] as String;
+          final decoded = jsonDecode(data) as Map<String, dynamic>;
+          if (decoded['handshake'] == 'keepalive') {
+            keepaliveCount++;
+            transactionIds.add(decoded['transaction'] as String?);
+          }
+        });
+
+        client.listen(
+          onStateHandshake: (_) {},
+          onEvent: (_) {},
+          onError: (_, _) => errorCount++,
+          onDisconnect: (_, _) {},
+        );
+
+        streamController.add(_handshakeJson());
+        async.flushMicrotasks();
+
+        for (var i = 0; i < 3; i++) {
+          async.elapse(const Duration(milliseconds: 110));
+          async.flushMicrotasks();
+          expect(keepaliveCount, equals(i + 1));
+          streamController.add(jsonEncode({'handshake': 'keepalive', 'transaction': transactionIds.last}));
+          async.flushMicrotasks();
+        }
+
+        expect(errorCount, equals(0));
+      });
+    });
+  });
+
+  group('Disconnect handling', () {
+    test('should call onDisconnect with code and reason when stream closes gracefully', () async {
+      final client = WebtritSignalingClient.inner(mockChannel);
+
+      int? disconnectCode;
+      String? disconnectReason;
+
+      client.listen(
+        onStateHandshake: (_) {},
+        onEvent: (_) {},
+        onError: (_, _) {},
+        onDisconnect: (code, reason) {
+          disconnectCode = code;
+          disconnectReason = reason;
+        },
+      );
+
+      when(() => mockChannel.closeCode).thenReturn(1000);
+      when(() => mockChannel.closeReason).thenReturn('normal closure');
+
+      await streamController.close();
+      await Future.delayed(Duration.zero);
+
+      expect(disconnectCode, equals(1000));
+      expect(disconnectReason, equals('normal closure'));
+    });
+
+    test('should call onError when stream emits an error', () async {
+      final client = WebtritSignalingClient.inner(mockChannel);
+
+      Object? capturedError;
+
+      client.listen(
+        onStateHandshake: (_) {},
+        onEvent: (_) {},
+        onError: (e, _) => capturedError = e,
+        onDisconnect: (_, _) {},
+      );
+
+      final networkError = Exception('network dropped');
+      streamController.addError(networkError);
+      await Future.delayed(Duration.zero);
+
+      expect(capturedError, equals(networkError));
+    });
+
+    test('should throw WebtritSignalingDisconnectedException when execute called after stream closes', () async {
+      final client = WebtritSignalingClient.inner(mockChannel);
+
+      client.listen(onStateHandshake: (_) {}, onEvent: (_) {}, onError: (_, _) {}, onDisconnect: (_, _) {});
+
+      await streamController.close();
+      await Future.delayed(Duration.zero);
+
+      final request = HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id');
+      await expectLater(() => client.execute(request), throwsA(isA<WebtritSignalingDisconnectedException>()));
+    });
+  });
+
+  group('Request transaction timeout', () {
+    test(
+      'should throw WebtritSignalingTransactionTimeoutException (not keepalive variant) when server ignores request',
+      () {
+        fakeAsync((async) {
+          final client = WebtritSignalingClient.inner(mockChannel);
+
+          Object? executeError;
+          when(() => mockSink.add(any())).thenAnswer((_) {});
+
+          client.listen(onStateHandshake: (_) {}, onEvent: (_) {}, onError: (_, _) {}, onDisconnect: (_, _) {});
+
+          // Long keepalive interval to prevent interference with the request timeout.
+          streamController.add(_handshakeJson(keepaliveInterval: 100000));
+          async.flushMicrotasks();
+
+          client
+              .execute(HangupRequest(transaction: 'test-tx', line: 0, callId: 'test-call-id'))
+              .then<void>(
+                (_) {},
+                onError: (Object e, _) {
+                  executeError = e;
+                },
+              );
+
+          async.flushMicrotasks();
+
+          // Advance past transaction timeout (10 000 ms).
+          async.elapse(const Duration(milliseconds: 10100));
+          async.flushMicrotasks();
+
+          expect(executeError, isA<WebtritSignalingTransactionTimeoutException>());
+          expect(executeError, isNot(isA<WebtritSignalingKeepaliveTransactionTimeoutException>()));
+        });
+      },
+    );
   });
 
   group('Transaction cleanup on send failure', () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ workspace:
   - packages/data/app_database
   - packages/_http_client
   - packages/_web_socket_channel
+  - packages/_tcp_proxy
   - screenshots
 # Version format: <Major>.<Minor>.<Patch>[-<Pre-release>]+<Build>
 # Where:


### PR DESCRIPTION
## Summary

- Expand mock-based integration tests for `webtrit_signaling` covering keepalive timeout/normal cycles, graceful disconnect, stream error, execute-after-disconnect, and request transaction timeout
- Add live integration tests against a real server (auto-skipped when env vars not set), including a proxy-based packet-drop scenario
- Add internal `_tcp_proxy` workspace package - raw TCP proxy with pause/resume for realistic network simulation (drops bytes below WebSocket framing, indistinguishable from NAT timeout or Wi-Fi drop)

## Test plan

**Mock tests (no server needed):**
```bash
cd packages/webtrit_signaling
dart test test/webtrit_signaling_integration_test.dart
```

**Live tests (real server + proxy network simulation):**
```bash
WEBTRIT_APP_TEST_CUSTOM_CORE_URL=<host> \
WEBTRIT_APP_TEST_EMAIL_CREDENTIAL=<login> \
WEBTRIT_APP_TEST_EMAIL_VERIFY_CREDENTIAL=<password> \
dart test test/live_signaling_test.dart --tags live
```