### PR TITLE
refactor: decouple AppLogger from LogzioLoggingService via RemoteLoggingService abstraction

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -71,7 +71,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     );
 
     // After authentication, regenerate the labels to include core URL and tenant ID in remote logging labels
-    context.read<AppLogger>().updateRemoteLabels(context.read<AppMetadataProvider>().logLabels);
+    context.read<AppLogger>().updateRemoteLabels();
 
     _sessionGuard = RouterLogoutSessionGuard(
       performLogout: () {

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -71,7 +71,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     );
 
     // After authentication, regenerate the labels to include core URL and tenant ID in remote logging labels
-    context.read<AppLogger>().regenerateRemoteLabels();
+    context.read<AppLogger>().regenerateRemoteLabels(context.read<AppMetadataProvider>().logLabels);
 
     _sessionGuard = RouterLogoutSessionGuard(
       performLogout: () {

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -71,7 +71,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     );
 
     // After authentication, regenerate the labels to include core URL and tenant ID in remote logging labels
-    context.read<AppLogger>().regenerateRemoteLabels(context.read<AppMetadataProvider>().logLabels);
+    context.read<AppLogger>().updateRemoteLabels(context.read<AppMetadataProvider>().logLabels);
 
     _sessionGuard = RouterLogoutSessionGuard(
       performLogout: () {

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -118,7 +118,7 @@ Future<InstanceRegistry> bootstrap() async {
   final appLogger = await AppLogger.init(
     featureAccess.loggingConfig.logLevel,
     LogzioLoggingService.fromEnvironment(featureAccess.loggingConfig.remoteLoggingEnabled),
-    appLabels,
+    appLabels.logLabels,
   );
   final appLoggerRepository = LogRecordsRepository.create(useFileStorage: true, path: appPath.temporaryPath)
     ..attachToLogger(Logger.root);
@@ -287,7 +287,7 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
   await AppLogger.init(
     loggingConfig.logLevel,
     LogzioLoggingService.fromEnvironment(loggingConfig.remoteLoggingEnabled),
-    appLabelsProvider,
+    appLabelsProvider.logLabels,
   );
 
   final appPush = AppRemotePush.fromFCM(message);

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -118,7 +118,7 @@ Future<InstanceRegistry> bootstrap() async {
   final appLogger = await AppLogger.init(
     featureAccess.loggingConfig.logLevel,
     LogzioLoggingService.fromEnvironment(featureAccess.loggingConfig.remoteLoggingEnabled),
-    appLabels.logLabels,
+    () => appLabels.logLabels,
   );
   final appLoggerRepository = LogRecordsRepository.create(useFileStorage: true, path: appPath.temporaryPath)
     ..attachToLogger(Logger.root);
@@ -287,7 +287,7 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
   await AppLogger.init(
     loggingConfig.logLevel,
     LogzioLoggingService.fromEnvironment(loggingConfig.remoteLoggingEnabled),
-    appLabelsProvider.logLabels,
+    () => appLabelsProvider.logLabels,
   );
 
   final appPush = AppRemotePush.fromFCM(message);

--- a/lib/common/logging/logzio_logging_service.dart
+++ b/lib/common/logging/logzio_logging_service.dart
@@ -10,7 +10,7 @@ import 'remote_logging_service.dart';
 final _logger = Logger('LogzioLoggingService');
 
 class LogzioLoggingService implements RemoteLoggingService {
-  LogzioLoggingService({required this.url, required this.token, required this.bufferSize, required this.minLevel});
+  LogzioLoggingService({required this.minLevel, required this.url, required this.token, required this.bufferSize});
 
   static LogzioLoggingService? fromEnvironment(bool enabled) {
     if (!enabled) return null;
@@ -29,11 +29,11 @@ class LogzioLoggingService implements RemoteLoggingService {
     );
   }
 
+  @override
+  final Level minLevel;
   final String url;
   final String token;
   final int bufferSize;
-  @override
-  final Level minLevel;
 
   FilteredLogzIoAppender? _filteredLogzIoAppender;
 

--- a/lib/common/logging/logzio_logging_service.dart
+++ b/lib/common/logging/logzio_logging_service.dart
@@ -32,6 +32,7 @@ class LogzioLoggingService implements RemoteLoggingService {
   final String url;
   final String token;
   final int bufferSize;
+  @override
   final Level minLevel;
 
   FilteredLogzIoAppender? _filteredLogzIoAppender;

--- a/lib/common/logging/remote_logging_service.dart
+++ b/lib/common/logging/remote_logging_service.dart
@@ -1,4 +1,8 @@
+import 'package:logging/logging.dart';
+
 abstract class RemoteLoggingService {
+  Level get minLevel;
+
   void initialize(Map<String, String> labels);
 
   void dispose();

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -24,7 +24,7 @@ class AppLogger {
 
     final instance = AppLogger._(remoteLoggingService);
     instance.applyConfig(logLevel);
-    instance.regenerateRemoteLabels(labels);
+    instance.updateRemoteLabels(labels);
 
     return instance;
   }
@@ -39,8 +39,11 @@ class AppLogger {
     _logger.info('AppLogger log level applied: $logLevel');
   }
 
-  /// Allows regenerating labels when coreUrl and tenantId are available.
-  void regenerateRemoteLabels(Map<String, String> labels) {
+  /// Updates remote logging labels and re-attaches the remote appender.
+  ///
+  /// Call this after authentication when coreUrl and tenantId become available.
+  void updateRemoteLabels(Map<String, String> labels) {
+    _remoteLoggingService?.dispose();
     _remoteLoggingService?.initialize(labels);
   }
 }

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -26,21 +26,22 @@ class AppLogger {
 
     remoteLoggingService?.initialize(labelsProvider.logLabels);
 
-    final instance = AppLogger._(remoteLoggingService, labelsProvider);
+    final remoteMinLevel = remoteLoggingService is LogzioLoggingService ? remoteLoggingService.minLevel : Level.OFF;
+    final instance = AppLogger._(remoteLoggingService, labelsProvider, remoteMinLevel);
     instance.applyConfig(logLevel);
 
     return instance;
   }
 
-  AppLogger._(this._remoteLoggingService, this._labelsProvider);
+  AppLogger._(this._remoteLoggingService, this._labelsProvider, this._remoteMinLevel);
 
   final RemoteLoggingService? _remoteLoggingService;
   final AppMetadataProvider _labelsProvider;
+  final Level _remoteMinLevel;
 
   void applyConfig(Level logLevel) {
     Logger.root.level = logLevel;
-    final remoteMinLevel = _remoteLoggingService is LogzioLoggingService ? _remoteLoggingService.minLevel : Level.OFF;
-    EquatableConfig.stringify = logLevel <= Level.FINE || remoteMinLevel <= Level.FINE;
+    EquatableConfig.stringify = logLevel <= Level.FINE || _remoteMinLevel <= Level.FINE;
     _logger.info('AppLogger log level applied: $logLevel');
   }
 

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -23,8 +23,8 @@ class AppLogger {
     WebtritCallkeepLogs().setLogsDelegate(CallkeepLogs());
 
     final instance = AppLogger._(remoteLoggingService, getLabels);
-    instance.applyConfig(logLevel);
     instance.updateRemoteLabels();
+    instance.applyConfig(logLevel);
 
     return instance;
   }

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -26,22 +26,20 @@ class AppLogger {
 
     remoteLoggingService?.initialize(labelsProvider.logLabels);
 
-    final remoteMinLevel = remoteLoggingService is LogzioLoggingService ? remoteLoggingService.minLevel : Level.OFF;
-    final instance = AppLogger._(remoteLoggingService, labelsProvider, remoteMinLevel);
+    final instance = AppLogger._(remoteLoggingService, labelsProvider);
     instance.applyConfig(logLevel);
 
     return instance;
   }
 
-  AppLogger._(this._remoteLoggingService, this._labelsProvider, this._remoteMinLevel);
+  AppLogger._(this._remoteLoggingService, this._labelsProvider);
 
   final RemoteLoggingService? _remoteLoggingService;
   final AppMetadataProvider _labelsProvider;
-  final Level _remoteMinLevel;
 
   void applyConfig(Level logLevel) {
     Logger.root.level = logLevel;
-    EquatableConfig.stringify = logLevel <= Level.FINE || _remoteMinLevel <= Level.FINE;
+    EquatableConfig.stringify = logLevel <= Level.FINE || (_remoteLoggingService?.minLevel ?? Level.OFF) <= Level.FINE;
     _logger.info('AppLogger log level applied: $logLevel');
   }
 

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -12,7 +12,7 @@ class AppLogger {
   static Future<AppLogger> init(
     Level logLevel,
     RemoteLoggingService? remoteLoggingService,
-    Map<String, String> labels,
+    Map<String, String> Function() getLabels,
   ) async {
     hierarchicalLoggingEnabled = true;
 
@@ -22,16 +22,17 @@ class AppLogger {
 
     WebtritCallkeepLogs().setLogsDelegate(CallkeepLogs());
 
-    final instance = AppLogger._(remoteLoggingService);
+    final instance = AppLogger._(remoteLoggingService, getLabels);
     instance.applyConfig(logLevel);
-    instance.updateRemoteLabels(labels);
+    instance.updateRemoteLabels();
 
     return instance;
   }
 
-  AppLogger._(this._remoteLoggingService);
+  AppLogger._(this._remoteLoggingService, this._getLabels);
 
   final RemoteLoggingService? _remoteLoggingService;
+  final Map<String, String> Function() _getLabels;
 
   void applyConfig(Level logLevel) {
     Logger.root.level = logLevel;
@@ -42,8 +43,8 @@ class AppLogger {
   /// Updates remote logging labels and re-attaches the remote appender.
   ///
   /// Call this after authentication when coreUrl and tenantId become available.
-  void updateRemoteLabels(Map<String, String> labels) {
+  void updateRemoteLabels() {
     _remoteLoggingService?.dispose();
-    _remoteLoggingService?.initialize(labels);
+    _remoteLoggingService?.initialize(_getLabels());
   }
 }

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -6,15 +6,13 @@ import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
 import 'package:webtrit_phone/common/common.dart';
 
-import 'app_metadata_provider.dart';
-
 final _logger = Logger('AppLogger');
 
 class AppLogger {
   static Future<AppLogger> init(
     Level logLevel,
     RemoteLoggingService? remoteLoggingService,
-    AppMetadataProvider labelsProvider,
+    Map<String, String> labels,
   ) async {
     hierarchicalLoggingEnabled = true;
 
@@ -24,18 +22,16 @@ class AppLogger {
 
     WebtritCallkeepLogs().setLogsDelegate(CallkeepLogs());
 
-    remoteLoggingService?.initialize(labelsProvider.logLabels);
-
-    final instance = AppLogger._(remoteLoggingService, labelsProvider);
+    final instance = AppLogger._(remoteLoggingService);
     instance.applyConfig(logLevel);
+    instance.regenerateRemoteLabels(labels);
 
     return instance;
   }
 
-  AppLogger._(this._remoteLoggingService, this._labelsProvider);
+  AppLogger._(this._remoteLoggingService);
 
   final RemoteLoggingService? _remoteLoggingService;
-  final AppMetadataProvider _labelsProvider;
 
   void applyConfig(Level logLevel) {
     Logger.root.level = logLevel;
@@ -44,7 +40,7 @@ class AppLogger {
   }
 
   /// Allows regenerating labels when coreUrl and tenantId are available.
-  void regenerateRemoteLabels() {
-    _remoteLoggingService?.initialize(_labelsProvider.logLabels);
+  void regenerateRemoteLabels(Map<String, String> labels) {
+    _remoteLoggingService?.initialize(labels);
   }
 }

--- a/lib/data/app_logger.dart
+++ b/lib/data/app_logger.dart
@@ -13,7 +13,7 @@ final _logger = Logger('AppLogger');
 class AppLogger {
   static Future<AppLogger> init(
     Level logLevel,
-    LogzioLoggingService? logzioService,
+    RemoteLoggingService? remoteLoggingService,
     AppMetadataProvider labelsProvider,
   ) async {
     hierarchicalLoggingEnabled = true;
@@ -24,27 +24,28 @@ class AppLogger {
 
     WebtritCallkeepLogs().setLogsDelegate(CallkeepLogs());
 
-    logzioService?.initialize(labelsProvider.logLabels);
+    remoteLoggingService?.initialize(labelsProvider.logLabels);
 
-    final instance = AppLogger._(logzioService, labelsProvider);
+    final instance = AppLogger._(remoteLoggingService, labelsProvider);
     instance.applyConfig(logLevel);
 
     return instance;
   }
 
-  AppLogger._(this._logzioService, this._labelsProvider);
+  AppLogger._(this._remoteLoggingService, this._labelsProvider);
 
-  final LogzioLoggingService? _logzioService;
+  final RemoteLoggingService? _remoteLoggingService;
   final AppMetadataProvider _labelsProvider;
 
   void applyConfig(Level logLevel) {
     Logger.root.level = logLevel;
-    EquatableConfig.stringify = logLevel <= Level.FINE || (_logzioService?.minLevel ?? Level.OFF) <= Level.FINE;
+    final remoteMinLevel = _remoteLoggingService is LogzioLoggingService ? _remoteLoggingService.minLevel : Level.OFF;
+    EquatableConfig.stringify = logLevel <= Level.FINE || remoteMinLevel <= Level.FINE;
     _logger.info('AppLogger log level applied: $logLevel');
   }
 
   /// Allows regenerating labels when coreUrl and tenantId are available.
   void regenerateRemoteLabels() {
-    _logzioService?.initialize(_labelsProvider.logLabels);
+    _remoteLoggingService?.initialize(_labelsProvider.logLabels);
   }
 }

--- a/lib/features/call/services/services_isolate.dart
+++ b/lib/features/call/services/services_isolate.dart
@@ -42,7 +42,7 @@ Future<void> _initializeCommonDependencies() async {
   _appLogger ??= await AppLogger.init(
     isolateLoggingConfig.logLevel,
     LogzioLoggingService.fromEnvironment(isolateLoggingConfig.remoteLoggingEnabled),
-    _appLabelsProvider!.logLabels,
+    () => _appLabelsProvider!.logLabels,
   );
   _appCertificates ??= await AppCertificates.init();
   _localPushRepository ??= LocalPushRepositoryFLNImpl();

--- a/lib/features/call/services/services_isolate.dart
+++ b/lib/features/call/services/services_isolate.dart
@@ -42,7 +42,7 @@ Future<void> _initializeCommonDependencies() async {
   _appLogger ??= await AppLogger.init(
     isolateLoggingConfig.logLevel,
     LogzioLoggingService.fromEnvironment(isolateLoggingConfig.remoteLoggingEnabled),
-    _appLabelsProvider!,
+    _appLabelsProvider!.logLabels,
   );
   _appCertificates ??= await AppCertificates.init();
   _localPushRepository ??= LocalPushRepositoryFLNImpl();


### PR DESCRIPTION
This PR refactors the app's logging initialization to fully decouple `AppLogger` from `LogzioLoggingService` by expanding the `RemoteLoggingService` abstraction, replacing stored provider references with a lazy labels callback, and fixing appender lifecycle and initialization order.

## Summary

- Changed `AppLogger.init()` parameter from `LogzioLoggingService?` to `RemoteLoggingService?`, decoupling the logger from the concrete implementation
- Added `Level get minLevel` to `RemoteLoggingService` interface; added `@override` to `LogzioLoggingService.minLevel`
- Replaced stored `AppMetadataProvider` with a lazy `Map<String, String> Function() getLabels` callback — `AppLogger` no longer holds a provider reference
- Renamed `regenerateRemoteLabels` → `updateRemoteLabels()` (no args); now disposes the previous appender before re-initializing to prevent duplicate remote submissions
- Reordered `LogzioLoggingService` fields/constructor params to match `RemoteLoggingService` interface order
- Fixed init order: remote appender is now attached before `applyConfig()` so early startup logs are forwarded to remote

## Test plan

- [ ] `flutter analyze` passes with no issues
- [ ] Remote logging initializes correctly at startup and after authentication (labels include `coreUrl`/`tenantId` post-auth)
- [ ] No duplicate log entries in Logzio after calling `updateRemoteLabels()`
- [ ] Early log `"AppLogger log level applied"` appears in remote logging