### PR TITLE
fix(signaling): reconnect silently on server force-close (code 4441)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -758,6 +758,21 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       state.activeCalls.where((e) => e.wasHungUp).forEach((e) => add(_ResetStateEvent.completeCall(e.callId)));
     } else if (code == SignalingDisconnectCode.controllerExitError) {
       _logger.info('__onSignalingClientEventDisconnected: skipping expected system unregistration notification');
+    } else if (code == SignalingDisconnectCode.controllerForceAttachClose) {
+      // Server closed the connection because a duplicate signaling session was detected
+      // (e.g. background push isolate still connected when main engine reconnects).
+      // Reconnect silently: don't set lastSignalingDisconnectCode so connectIssue is never shown.
+      _logger.warning(
+        '__onSignalingClientEventDisconnected: signaling race detected — '
+        'server force-closed duplicate session (code=${event.code}, reason="${event.reason}"). '
+        'Reconnecting silently without showing connectIssue.',
+      );
+      newState = state.copyWith(
+        callServiceState: state.callServiceState.copyWith(
+          signalingClientStatus: SignalingClientStatus.disconnect,
+          lastSignalingDisconnectCode: null,
+        ),
+      );
     } else if (code == SignalingDisconnectCode.sessionMissedError) {
       notificationToShow = const SignalingSessionMissedNotification();
     } else if (code.type == SignalingDisconnectCodeType.auxiliary) {
@@ -786,7 +801,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     emit(newState);
     _signalingClient = null;
     if (notificationToShow != null && !repeated) submitNotification(notificationToShow);
-    if (shouldReconnect) _reconnectInitiated(kSignalingClientReconnectDelay);
+    if (shouldReconnect) {
+      final reconnectDelay = code == SignalingDisconnectCode.controllerForceAttachClose
+          ? kSignalingClientFastReconnectDelay
+          : kSignalingClientReconnectDelay;
+      _reconnectInitiated(reconnectDelay);
+    }
   }
 
   // processing call push events


### PR DESCRIPTION
## Problem

When the server sends disconnect code **4441** (`controllerForceAttachClose`) it means two signaling sessions from the same account were detected simultaneously. This is a known race condition:

1. Background push isolate connects to signaling when an incoming push notification arrives.
2. User taps answer — the main Flutter engine comes to the foreground.
3. Main engine reconnects signaling after a short delay (~1s on resume).
4. For a brief window both sessions are alive at the same time.
5. Server force-closes the **main engine** connection with code 4441.

Previously this code path set `lastSignalingDisconnectCode = 4441`, which triggered `CallStatus.connectIssue` and showed a **"Connection issue" snackbar** to the user — even though the situation is transient and self-healing (background isolate disconnects within ~200ms, reconnect succeeds immediately after).

The race existed before the callkeep process split and can be reproduced on any version.

## Fix

In `__onSignalingClientEventDisconnected()`, for code 4441:

- Emit `lastSignalingDisconnectCode = null` — `CallStatus.connectIssue` is never triggered, no snackbar shown.
- Skip notification entirely.
- Reconnect with `kSignalingClientFastReconnectDelay` (1s) instead of the default 3s — by this time the background isolate has already disconnected, so the reconnect succeeds cleanly.
- Emit a `warning` log so the race is still visible in logs for debugging.

## Test plan

- [ ] Answer an incoming call via push notification — no "Connection issue" snackbar appears after the call connects.
- [ ] Confirm in logs that `signaling race detected` warning is printed when 4441 is received.
- [ ] Normal disconnect codes still show the appropriate notification/snackbar.
- [ ] Repeated non-4441 disconnect does not regress.