### PR TITLE
fix(test): update ExternalContactsSyncBloc tests to match current BLoC behaviour

### DIFF
--- a/test/blocs/external_contacts_sync_bloc_test.dart
+++ b/test/blocs/external_contacts_sync_bloc_test.dart
@@ -50,6 +50,7 @@ void main() {
     contactsRepository = MockContactsRepository();
 
     when(() => userRepository.getLocalInfo()).thenAnswer((_) => _testUser);
+    when(() => userRepository.getAndListen()).thenAnswer((_) => Stream.value(_testUser));
     when(() => externalContactsRepository.load()).thenAnswer((_) async {});
     when(() => contactsRepository.syncExternalContacts(any())).thenAnswer((_) async {});
   });
@@ -113,10 +114,10 @@ void main() {
     );
 
     blocTest<ExternalContactsSyncBloc, ExternalContactsSyncState>(
-      'emits RefreshFailure if UserRepository fails during update',
+      'emits UpdateFailure after max retries when UserRepository fails during update',
       build: () {
         when(() => externalContactsRepository.contacts()).thenAnswer((_) => Stream.value([_contactOther]));
-        when(() => userRepository.getLocalInfo()).thenThrow(Exception('User info error'));
+        when(() => userRepository.getAndListen()).thenThrow(Exception('User info error'));
 
         return ExternalContactsSyncBloc(
           userRepository: userRepository,
@@ -125,8 +126,9 @@ void main() {
         );
       },
       act: (bloc) => bloc.add(const ExternalContactsSyncStarted()),
+      wait: const Duration(seconds: 4),
       skip: 1,
-      expect: () => [const ExternalContactsSyncRefreshFailure()],
+      expect: () => [const ExternalContactsSyncUpdateFailure()],
     );
   });
 }


### PR DESCRIPTION
## Summary

- Stub `getAndListen()` on `MockUserRepository` — the BLoC calls `getAndListen().first` to fetch user info during contact sync, not `getLocalInfo()` directly
- Fix failure-case test: `_onUpdated` emits `UpdateFailure` (not `RefreshFailure`) after exhausting retries; added `wait: Duration(seconds: 4)` to cover retry delays
- Rename test description to reflect actual behaviour

## Test plan

- [ ] `flutter test test/blocs/external_contacts_sync_bloc_test.dart` — all 4 tests pass
- [ ] `flutter test` — full suite passes