### PR TITLE
fix: guard RTCVideoRenderer srcObject assignment until initialize() completes

### DIFF
--- a/lib/features/call/widgets/rtc_stream_view.dart
+++ b/lib/features/call/widgets/rtc_stream_view.dart
@@ -22,26 +22,31 @@ class RTCStreamView extends StatefulWidget {
 
 class _RTCStreamViewState extends State<RTCStreamView> {
   late final RTCVideoRenderer renderer = RTCVideoRenderer();
+  bool _initialized = false;
 
   @override
   initState() {
     super.initState();
-    renderer.initialize().then((value) {
+    renderer.initialize().then((_) {
       if (!mounted) return;
+      _initialized = true;
       renderer.srcObject = widget.stream;
     });
   }
 
   @override
   dispose() {
-    super.dispose();
-    renderer.srcObject = null;
+    if (_initialized) {
+      renderer.srcObject = null;
+    }
     renderer.dispose();
+    super.dispose();
   }
 
   @override
   didUpdateWidget(RTCStreamView oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!_initialized) return;
     // Always refresh srcObject to handle the case where the stream reference
     // is the same object but its video tracks were replaced by renegotiation.
     // The native videoRendererSetSrcObject re-scans the stream's current tracks

--- a/lib/features/call/widgets/rtc_stream_view.dart
+++ b/lib/features/call/widgets/rtc_stream_view.dart
@@ -29,8 +29,10 @@ class _RTCStreamViewState extends State<RTCStreamView> {
     super.initState();
     renderer.initialize().then((_) {
       if (!mounted) return;
-      _initialized = true;
-      renderer.srcObject = widget.stream;
+      setState(() {
+        _initialized = true;
+        renderer.srcObject = widget.stream;
+      });
     });
   }
 
@@ -56,6 +58,9 @@ class _RTCStreamViewState extends State<RTCStreamView> {
 
   @override
   Widget build(BuildContext context) {
+    if (!_initialized) {
+      return widget.placeholderBuilder?.call(context) ?? const SizedBox.shrink();
+    }
     return RTCVideoView(
       renderer,
       mirror: widget.mirror,


### PR DESCRIPTION
## Summary

- Fixes a crash: `Call initialize before setting the stream` in `RTCVideoRenderer.srcObject=`
- Root cause: `didUpdateWidget` set `srcObject` before `renderer.initialize()` completed — triggered on fast widget rebuilds during call setup
- Added `_initialized` flag; `didUpdateWidget` and `dispose` now skip `srcObject` assignment until the renderer is ready
- Also always refreshes `srcObject` on update (not just on stream identity change) to handle track replacement during renegotiation

## Test plan

- [ ] Make/receive a call and verify video renders correctly
- [ ] Rapidly navigate during call setup to trigger widget rebuilds before renderer init completes
- [ ] Verify no crash in logcat: `Call initialize before setting the stream`