### PR TITLE
fix: update ExternalContactsSyncBloc tests to mock getAndListen instead of getLocalInfo

### DIFF
--- a/test/blocs/external_contacts_sync_bloc_test.dart
+++ b/test/blocs/external_contacts_sync_bloc_test.dart
@@ -49,7 +49,7 @@ void main() {
     externalContactsRepository = MockExternalContactsRepository();
     contactsRepository = MockContactsRepository();
 
-    when(() => userRepository.getLocalInfo()).thenAnswer((_) => _testUser);
+    when(() => userRepository.getAndListen()).thenAnswer((_) => Stream.value(_testUser));
     when(() => externalContactsRepository.load()).thenAnswer((_) async {});
     when(() => contactsRepository.syncExternalContacts(any())).thenAnswer((_) async {});
   });
@@ -116,7 +116,7 @@ void main() {
       'emits RefreshFailure if UserRepository fails during update',
       build: () {
         when(() => externalContactsRepository.contacts()).thenAnswer((_) => Stream.value([_contactOther]));
-        when(() => userRepository.getLocalInfo()).thenThrow(Exception('User info error'));
+        when(() => userRepository.getAndListen()).thenAnswer((_) => Stream.error(Exception('User info error')));
 
         return ExternalContactsSyncBloc(
           userRepository: userRepository,
@@ -126,7 +126,8 @@ void main() {
       },
       act: (bloc) => bloc.add(const ExternalContactsSyncStarted()),
       skip: 1,
-      expect: () => [const ExternalContactsSyncRefreshFailure()],
+      wait: const Duration(seconds: 5),
+      expect: () => [const ExternalContactsSyncUpdateFailure()],
     );
   });
 }


### PR DESCRIPTION
## Summary

- Replaced mock of `userRepository.getLocalInfo()` with `userRepository.getAndListen()` to match the current bloc implementation
- Updated the failure test expectation from `ExternalContactsSyncRefreshFailure` to `ExternalContactsSyncUpdateFailure` (the correct state emitted by `_onUpdated` after retries are exhausted)
- Added `wait: Duration(seconds: 5)` to the failure test to accommodate 3 retry delays of 1 second each

## Test plan

- [ ] `flutter test test/blocs/external_contacts_sync_bloc_test.dart` — all 4 tests pass
- [ ] `flutter test` — all 415 tests pass