### PR TITLE
feat: add toJson() to all Event subclasses and fix NotifyEvent constructor inconsistency

### DIFF
--- a/packages/webtrit_signaling/AGENTS.md
+++ b/packages/webtrit_signaling/AGENTS.md
@@ -66,10 +66,16 @@ or disconnect.
 All extend `WebtritSignalingException`:
 
 - `WebtritSignalingErrorException` — server returned error code
-- `WebtritSignalingDisconnectedException` — socket closed unexpectedly
-- `WebtritSignalingTransactionTimeoutException` — no response within timeout
-- `WebtritSignalingKeepaliveTransactionTimeoutException` — keepalive timed out
+- `WebtritSignalingDisconnectedException` — `execute()` called after `disconnect()` (subscription already nil)
+- `WebtritSignalingUnknownMessageException` — unrecognised inbound message kind
+- `WebtritSignalingUnknownResponseException` — response with no matching transaction
 - `WebtritSignalingBadStateException` — API misuse (e.g. calling `listen()` twice)
+- `WebtritSignalingTransactionException` ← abstract base for transaction errors
+  - `WebtritSignalingTransactionTimeoutException` — no response within 10 s timeout
+    - `WebtritSignalingKeepaliveTransactionTimeoutException` — keepalive timed out
+  - `WebtritSignalingTransactionUnavailableException` — transaction slot unavailable
+  - `WebtritSignalingTransactionTerminateException` ← abstract base for terminations
+    - `WebtritSignalingTransactionTerminateByDisconnectException` — in-flight transaction cancelled because socket closed
 
 ## Constraints
 
@@ -78,12 +84,37 @@ All extend `WebtritSignalingException`:
 - Callback API, not streams. `listen()` is single-use.
 - Outbound JSON: requests implement `toJson()` — do not bypass.
 
+## Static Helpers
+
+```dart
+WebtritSignalingClient.generateTransactionId()   // random ID for Request.transaction
+WebtritSignalingClient.generateCallId()          // random 24-char call ID
+WebtritSignalingClient.buildTenantUrl(base, id)  // appends /tenant/{id} (@visibleForTesting)
+WebtritSignalingClient.subprotocol               // 'webtrit-protocol'
+WebtritSignalingClient.defaultExecuteTransactionTimeoutDuration  // 10 s
+```
+
 ## Test Patterns
+
+### Unit tests
 
 - JSON fixtures in `test/src/events/event_jsons.dart` and `error_event_jsons.dart`.
 - `MockWebSocketChannel` + `MockWebSocketSink` via `mocktail`; `StreamController` injects server messages.
 - `fake_async` for deterministic keepalive/timeout tests.
 - `FakeWebtritSignalingClient` in `test/src/factories/` for higher-level tests.
+
+### Live tests (`test/live_call_test.dart`, tag `live`)
+
+Two-client strategy — `clientA` (caller) and `clientB` (callee) connect to a real server.
+Callee answers programmatically via `AcceptRequest` (no auto-answer on the test server).
+
+Key patterns:
+
+- Pre-register all `awaitEvent<T>()` futures **before** sending any request to avoid missing events on a broadcast stream.
+- Fetch fresh session tokens in each `setUp` — WebTrit tokens are invalidated when the WebSocket session closes.
+- Use `force=false` in `connect()` — `tearDown` disconnects cleanly so no stale sessions exist.
+- `_LiveClient.awaitEvent<T>` wraps the broadcast stream with a `Completer`; fails immediately on `CallErrorEvent / LineErrorEvent / SessionErrorEvent`.
+- Cleanup after tests where server behaviour is non-deterministic (multi-endpoint SIP accounts) uses `try/catch` around `HangupRequest` instead of awaiting `HangupEvent`.
 
 ## Commands
 
@@ -93,6 +124,14 @@ dart test test/webtrit_signaling_test.dart
 dart test --name "buildTenantUrl"
 dart analyze
 dart format .
+
+# Live integration tests (requires real server credentials)
+WEBTRIT_APP_TEST_CUSTOM_CORE_URL=<host> \
+WEBTRIT_APP_TEST_EMAIL_CREDENTIAL=<caller> \
+WEBTRIT_APP_TEST_EMAIL_VERIFY_CREDENTIAL=<caller-password> \
+WEBTRIT_APP_TEST_CALLEE_CREDENTIAL=<callee> \
+WEBTRIT_APP_TEST_CALLEE_VERIFY_CREDENTIAL=<callee-password> \
+dart test test/live_call_test.dart --tags live --reporter expanded
 ```
 
 Connection endpoint: `wss://<host>/signaling/v1?token=<token>[&force=<true|false>]`

--- a/packages/webtrit_signaling/lib/src/events/call/accepted_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/accepted_event.dart
@@ -19,6 +19,14 @@ class AcceptedEvent extends CallEvent {
 
   static const typeValue = 'accepted';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(typeValue),
+    if (callee != null) 'callee': callee,
+    if (isFocus != null) 'is_focus': isFocus,
+    if (jsep != null) 'jsep': jsep,
+  };
+
   factory AcceptedEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/accepting_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/accepting_event.dart
@@ -5,6 +5,9 @@ class AcceptingEvent extends CallEvent {
 
   static const typeValue = 'accepting';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory AcceptingEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/call_error_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/call_error_event.dart
@@ -17,6 +17,9 @@ class CallErrorEvent extends CallEvent implements ErrorEvent {
   @override
   List<Object?> get props => [...super.props, code, reason];
 
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(ErrorEvent.typeValue), 'code': code, 'reason': reason};
+
   static CallErrorEvent? tryFromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != ErrorEvent.typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/calling_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/calling_event.dart
@@ -5,6 +5,9 @@ class CallingEvent extends CallEvent {
 
   static const typeValue = 'calling';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory CallingEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/declining_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/declining_event.dart
@@ -17,6 +17,9 @@ class DecliningEvent extends CallEvent {
 
   static const typeValue = 'declining';
 
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(typeValue), 'code': code, if (referId != null) 'refer_id': referId};
+
   factory DecliningEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/hangingup_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/hangingup_event.dart
@@ -5,6 +5,9 @@ class HangingupEvent extends CallEvent {
 
   static const typeValue = 'hangingup';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory HangingupEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/hangup_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/hangup_event.dart
@@ -17,6 +17,9 @@ class HangupEvent extends CallEvent {
 
   static const typeValue = 'hangup';
 
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(typeValue), 'code': code, 'reason': reason};
+
   factory HangupEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/holding_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/holding_event.dart
@@ -5,6 +5,9 @@ class HoldingEvent extends CallEvent {
 
   static const typeValue = 'holding';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory HoldingEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/incoming_call_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/incoming_call_event.dart
@@ -36,6 +36,18 @@ class IncomingCallEvent extends CallEvent {
 
   static const typeValue = 'incoming_call';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(typeValue),
+    'callee': callee,
+    'caller': caller,
+    if (callerDisplayName != null) 'caller_display_name': callerDisplayName,
+    if (referredBy != null) 'referred_by': referredBy,
+    if (replaceCallId != null) 'replace_call_id': replaceCallId,
+    if (isFocus != null) 'is_focus': isFocus,
+    if (jsep != null) 'jsep': jsep,
+  };
+
   factory IncomingCallEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/missed_call_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/missed_call_event.dart
@@ -19,6 +19,14 @@ class MissedCallEvent extends CallEvent {
 
   static const typeValue = 'missed_call';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(typeValue),
+    'callee': callee,
+    'caller': caller,
+    if (callerDisplayName != null) 'caller_display_name': callerDisplayName,
+  };
+
   factory MissedCallEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
@@ -16,6 +16,9 @@ sealed class NotifyEvent extends CallEvent {
   final String? notify;
   final SubscriptionState? subscriptionState;
 
+  @override
+  Map<String, dynamic> toJson();
+
   factory NotifyEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {
@@ -41,13 +44,33 @@ class DialogNotifyEvent extends NotifyEvent with EquatableMixin {
     super.transaction,
     required super.line,
     required super.callId,
-    super.notify,
     super.subscriptionState,
     required this.userActiveCalls,
   });
 
   static const notifyValue = 'dialog';
   final List<UserActiveCall> userActiveCalls;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(NotifyEvent.typeValue),
+    'notify': notifyValue,
+    if (subscriptionState != null) 'subscription_state': subscriptionState!.name,
+    'user_active_calls': userActiveCalls
+        .map(
+          (c) => {
+            'id': c.id,
+            'state': c.state.name,
+            'call_id': c.callId,
+            'direction': c.direction.name,
+            'local_tag': c.localTag,
+            if (c.remoteTag != null) 'remote_tag': c.remoteTag,
+            'remote_number': c.remoteNumber,
+            if (c.remoteDisplayName != null) 'remote_display_name': c.remoteDisplayName,
+          },
+        )
+        .toList(),
+  };
 
   @override
   factory DialogNotifyEvent.fromJson(Map<String, dynamic> json) {
@@ -65,7 +88,6 @@ class DialogNotifyEvent extends NotifyEvent with EquatableMixin {
       transaction: json['transaction'],
       line: json['line'],
       callId: json['call_id'],
-      notify: json['notify'],
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
           : null,
@@ -140,7 +162,6 @@ class PresenceNotifyEvent extends NotifyEvent with EquatableMixin {
     super.transaction,
     required super.line,
     required super.callId,
-    super.notify,
     super.subscriptionState,
     required this.number,
     required this.presenceInfo,
@@ -151,12 +172,33 @@ class PresenceNotifyEvent extends NotifyEvent with EquatableMixin {
   final List<SignalingPresenceInfo> presenceInfo;
 
   @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(NotifyEvent.typeValue),
+    'notify': notifyValue,
+    if (subscriptionState != null) 'subscription_state': subscriptionState!.name,
+    'number': number,
+    'presence_info': presenceInfo
+        .map(
+          (p) => {
+            'id': p.id,
+            'available': p.available,
+            'note': p.note,
+            if (p.statusIcon != null) 'status_icon': p.statusIcon,
+            if (p.device != null) 'device': p.device,
+            if (p.timeOffsetMin != null) 'time_offset_min': p.timeOffsetMin,
+            if (p.timestamp != null) 'timestamp': p.timestamp,
+            'activities': p.activities,
+          },
+        )
+        .toList(),
+  };
+
+  @override
   factory PresenceNotifyEvent.fromJson(Map<String, dynamic> json) {
     return PresenceNotifyEvent(
       transaction: json['transaction'],
       line: json['line'],
       callId: json['call_id'],
-      notify: json['notify'],
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
           : null,
@@ -228,13 +270,24 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
     super.transaction,
     required super.line,
     required super.callId,
-    super.notify,
     super.subscriptionState,
     required this.state,
   });
 
   static const notifyValue = 'refer';
   final ReferNotifyState state;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(NotifyEvent.typeValue),
+    'notify': notifyValue,
+    if (subscriptionState != null) 'subscription_state': subscriptionState!.name,
+    'content': switch (state) {
+      ReferNotifyState.trying => 'SIP/2.0 100 Trying',
+      ReferNotifyState.ok => 'SIP/2.0 200 OK',
+      ReferNotifyState.unknown => '',
+    },
+  };
 
   @override
   factory ReferNotifyEvent.fromJson(Map<String, dynamic> json) {
@@ -249,7 +302,6 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
       transaction: json['transaction'],
       line: json['line'],
       callId: json['call_id'],
-      notify: json['notify'],
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
           : null,
@@ -280,6 +332,15 @@ class UnknownNotifyEvent extends NotifyEvent with EquatableMixin {
 
   final String? content;
   final String? contentType;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(NotifyEvent.typeValue),
+    if (notify != null) 'notify': notify,
+    if (subscriptionState != null) 'subscription_state': subscriptionState!.name,
+    if (content != null) 'content': content,
+    if (contentType != null) 'content_type': contentType,
+  };
 
   @override
   factory UnknownNotifyEvent.fromJson(Map<String, dynamic> json) {

--- a/packages/webtrit_signaling/lib/src/events/call/proceeding_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/proceeding_event.dart
@@ -10,6 +10,9 @@ class ProceedingEvent extends CallEvent {
 
   static const typeValue = 'proceeding';
 
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(typeValue), 'code': code};
+
   factory ProceedingEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/progress_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/progress_event.dart
@@ -19,6 +19,14 @@ class ProgressEvent extends CallEvent {
 
   static const typeValue = 'progress';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(typeValue),
+    'callee': callee,
+    if (isFocus != null) 'is_focus': isFocus,
+    'jsep': jsep,
+  };
+
   factory ProgressEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/resuming_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/resuming_event.dart
@@ -5,6 +5,9 @@ class ResumingEvent extends CallEvent {
 
   static const typeValue = 'resuming';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory ResumingEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/ringing_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/ringing_event.dart
@@ -5,6 +5,9 @@ class RingingEvent extends CallEvent {
 
   static const typeValue = 'ringing';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory RingingEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/transferring_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/transferring_event.dart
@@ -5,6 +5,9 @@ class TransferringEvent extends CallEvent {
 
   static const typeValue = 'transferring';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory TransferringEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/updated_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/updated_event.dart
@@ -5,6 +5,9 @@ class UpdatedEvent extends CallEvent {
 
   static const typeValue = 'updated';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory UpdatedEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/updating_call_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/updating_call_event.dart
@@ -36,6 +36,18 @@ class UpdatingCallEvent extends CallEvent {
 
   static const typeValue = 'updating_call';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...callBaseJson(typeValue),
+    'callee': callee,
+    'caller': caller,
+    if (callerDisplayName != null) 'caller_display_name': callerDisplayName,
+    if (referredBy != null) 'referred_by': referredBy,
+    if (replaceCallId != null) 'replace_call_id': replaceCallId,
+    if (isFocus != null) 'is_focus': isFocus,
+    if (jsep != null) 'jsep': jsep,
+  };
+
   factory UpdatingCallEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call/updating_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/updating_event.dart
@@ -5,6 +5,9 @@ class UpdatingEvent extends CallEvent {
 
   static const typeValue = 'updating';
 
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
   factory UpdatingEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/call_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call_event.dart
@@ -28,6 +28,8 @@ abstract class CallEvent extends LineEvent {
     return _callEventFromJsonDecoders[eventTypeValue]?.call(json) ?? CallErrorEvent.tryFromJson(json);
   }
 
+  Map<String, dynamic> callBaseJson(String typeValue) => {...lineBaseJson(typeValue), 'call_id': callId};
+
   static final Map<String, CallEvent Function(Map<String, dynamic>)> _callEventFromJsonDecoders = {
     AcceptedEvent.typeValue: AcceptedEvent.fromJson,
     AcceptingEvent.typeValue: AcceptingEvent.fromJson,

--- a/packages/webtrit_signaling/lib/src/events/event.dart
+++ b/packages/webtrit_signaling/lib/src/events/event.dart
@@ -24,4 +24,6 @@ abstract class Event extends Equatable {
   static Event? tryFromJson(Map<String, dynamic> json) {
     return SessionEvent.tryFromJson(json);
   }
+
+  Map<String, dynamic> toJson();
 }

--- a/packages/webtrit_signaling/lib/src/events/line/ice_hangup_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_hangup_event.dart
@@ -10,6 +10,9 @@ class IceHangupEvent extends LineEvent {
 
   static const typeValue = 'ice_hangup';
 
+  @override
+  Map<String, dynamic> toJson() => {...lineBaseJson(typeValue), if (reason != null) 'reason': reason};
+
   factory IceHangupEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/line/ice_media_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_media_event.dart
@@ -19,6 +19,9 @@ class IceMediaEvent extends LineEvent {
 
   static const typeValue = 'ice_media';
 
+  @override
+  Map<String, dynamic> toJson() => {...lineBaseJson(typeValue), 'mid': mid, 'type': type.name, 'receiving': receiving};
+
   factory IceMediaEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/line/ice_slowlink_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_slowlink_event.dart
@@ -21,6 +21,15 @@ class IceSlowLinkEvent extends LineEvent {
 
   static const typeValue = 'ice_slowlink';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...lineBaseJson(typeValue),
+    'mid': mid,
+    'media': media.name,
+    'uplink': uplink,
+    'lost': lost,
+  };
+
   factory IceSlowLinkEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/line/ice_trickle_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_trickle_event.dart
@@ -10,6 +10,12 @@ class IceTrickleEvent extends LineEvent {
 
   static const typeValue = 'ice_trickle';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...lineBaseJson(typeValue),
+    'candidate': candidate ?? {'completed': true},
+  };
+
   factory IceTrickleEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/line/ice_webrtcup_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/ice_webrtcup_event.dart
@@ -5,6 +5,9 @@ class IceWebrtcUpEvent extends LineEvent {
 
   static const typeValue = 'ice_webrtcup';
 
+  @override
+  Map<String, dynamic> toJson() => lineBaseJson(typeValue);
+
   factory IceWebrtcUpEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/line/line_error_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/line_error_event.dart
@@ -11,6 +11,9 @@ class LineErrorEvent extends LineEvent implements ErrorEvent {
   @override
   List<Object?> get props => [...super.props, code, reason];
 
+  @override
+  Map<String, dynamic> toJson() => {...lineBaseJson(ErrorEvent.typeValue), 'code': code, 'reason': reason};
+
   static LineErrorEvent? tryFromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != ErrorEvent.typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/line/transfer_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line/transfer_event.dart
@@ -20,6 +20,15 @@ class TransferEvent extends LineEvent {
 
   static const typeValue = 'transfer';
 
+  @override
+  Map<String, dynamic> toJson() => {
+    ...lineBaseJson(typeValue),
+    'refer_id': referId,
+    'refer_to': referTo,
+    if (referredBy != null) 'referred_by': referredBy,
+    if (replaceCallId != null) 'replace_call_id': replaceCallId,
+  };
+
   factory TransferEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/line_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/line_event.dart
@@ -30,6 +30,8 @@ abstract class LineEvent extends SessionEvent {
         LineErrorEvent.tryFromJson(json);
   }
 
+  Map<String, dynamic> lineBaseJson(String typeValue) => {...sessionBaseJson(typeValue), 'line': line};
+
   static final Map<String, LineEvent Function(Map<String, dynamic>)> _lineEventFromJsonDecoders = {
     IceHangupEvent.typeValue: IceHangupEvent.fromJson,
     IceMediaEvent.typeValue: IceMediaEvent.fromJson,

--- a/packages/webtrit_signaling/lib/src/events/session/registered_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/session/registered_event.dart
@@ -5,6 +5,9 @@ class RegisteredEvent extends SessionEvent {
 
   static const typeValue = 'registered';
 
+  @override
+  Map<String, dynamic> toJson() => sessionBaseJson(typeValue);
+
   factory RegisteredEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/session/registering_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/session/registering_event.dart
@@ -5,6 +5,9 @@ class RegisteringEvent extends SessionEvent {
 
   static const typeValue = 'registering';
 
+  @override
+  Map<String, dynamic> toJson() => sessionBaseJson(typeValue);
+
   factory RegisteringEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/session/registration_failed_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/session/registration_failed_event.dart
@@ -11,6 +11,9 @@ class RegistrationFailedEvent extends SessionEvent {
 
   static const typeValue = 'registration_failed';
 
+  @override
+  Map<String, dynamic> toJson() => {...sessionBaseJson(typeValue), 'code': code, 'reason': reason};
+
   factory RegistrationFailedEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/session/session_error_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/session/session_error_event.dart
@@ -11,6 +11,9 @@ class SessionErrorEvent extends SessionEvent implements ErrorEvent {
   @override
   List<Object?> get props => [...super.props, code, reason];
 
+  @override
+  Map<String, dynamic> toJson() => {...sessionBaseJson(ErrorEvent.typeValue), 'code': code, 'reason': reason};
+
   static SessionErrorEvent? tryFromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != ErrorEvent.typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/session/unregistered_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/session/unregistered_event.dart
@@ -5,6 +5,9 @@ class UnregisteredEvent extends SessionEvent {
 
   static const typeValue = 'unregistered';
 
+  @override
+  Map<String, dynamic> toJson() => sessionBaseJson(typeValue);
+
   factory UnregisteredEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/session/unregistering_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/session/unregistering_event.dart
@@ -5,6 +5,9 @@ class UnregisteringEvent extends SessionEvent {
 
   static const typeValue = 'unregistering';
 
+  @override
+  Map<String, dynamic> toJson() => sessionBaseJson(typeValue);
+
   factory UnregisteringEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
     if (eventTypeValue != typeValue) {

--- a/packages/webtrit_signaling/lib/src/events/session_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/session_event.dart
@@ -30,6 +30,11 @@ abstract class SessionEvent extends Event {
         SessionErrorEvent.tryFromJson(json);
   }
 
+  Map<String, dynamic> sessionBaseJson(String typeValue) => {
+    Event.typeKey: typeValue,
+    if (transaction != null) 'transaction': transaction,
+  };
+
   static final Map<String, SessionEvent Function(Map<String, dynamic>)> _sessionEventFromJsonDecoders = {
     RegisteredEvent.typeValue: RegisteredEvent.fromJson,
     RegisteringEvent.typeValue: RegisteringEvent.fromJson,

--- a/packages/webtrit_signaling/test/src/events/call/notify_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/notify_event_test.dart
@@ -34,7 +34,6 @@ void main() {
       transaction: 'transaction 1',
       line: 0,
       callId: 'qwerty',
-      notify: 'refer',
       subscriptionState: SubscriptionState.active,
       state: ReferNotifyState.trying,
     ),
@@ -57,7 +56,6 @@ void main() {
     ReferNotifyEvent(
       line: 0,
       callId: 'qwerty',
-      notify: 'refer',
       subscriptionState: SubscriptionState.active,
       state: ReferNotifyState.trying,
     ),


### PR DESCRIPTION
## Summary

- Adds `toJson()` method to all `Event` subclasses in `webtrit_signaling` (call, line, session events)
- Fixes `NotifyEvent` constructor inconsistency
- Updates `AGENTS.md` for `webtrit_signaling` package

Cherry-picked from #1026 (commit `42f95606`).

## Test plan

- [ ] Run `dart test` in `packages/webtrit_signaling/`
- [ ] Verify `toJson()` round-trips for affected event types