### PR TITLE
fix: suppress transient network error SnackBar on connectivity restore

### DIFF
--- a/lib/features/register_status/cubit/register_status_cubit.dart
+++ b/lib/features/register_status/cubit/register_status_cubit.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:bloc/bloc.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -21,7 +22,7 @@ class RegisterStatus {
 class RegisterStatusCubit extends Cubit<RegisterStatus> {
   RegisterStatusCubit(this.appRepository, this.registerStatusRepository, {this.handleError})
     : super(RegisterStatus(value: registerStatusRepository.getRegisterStatus())) {
-    fetchStatus();
+    _fetchStatusSilently();
     _connectivitySub = Connectivity().onConnectivityChanged.listen(_handleConnectivity);
   }
 
@@ -32,7 +33,18 @@ class RegisterStatusCubit extends Cubit<RegisterStatus> {
   late final StreamSubscription _connectivitySub;
 
   void _handleConnectivity(List<ConnectivityResult> results) {
-    if (results.any((result) => result != ConnectivityResult.none)) fetchStatus();
+    if (results.any((result) => result != ConnectivityResult.none)) _fetchStatusSilently();
+  }
+
+  Future<void> _fetchStatusSilently() async {
+    try {
+      final status = await appRepository.getRegisterStatus();
+      registerStatusRepository.setRegisterStatus(status);
+      emit(RegisterStatus(value: status));
+    } catch (e, s) {
+      _logger.warning('Failed to get register status', e, s);
+      if (!_isTransientNetworkError(e)) handleError?.call(e, s);
+    }
   }
 
   Future<void> fetchStatus() async {
@@ -45,6 +57,9 @@ class RegisterStatusCubit extends Cubit<RegisterStatus> {
       handleError?.call(e, s);
     }
   }
+
+  bool _isTransientNetworkError(Object error) =>
+      error is SocketException || error is TimeoutException || error is TlsException;
 
   Future<void> setStatus(bool value) async {
     emit(RegisterStatus(value: value, isUpdating: true));


### PR DESCRIPTION
## Summary

- `RegisterStatusCubit` auto-triggered fetches (startup + connectivity restore) now use `_fetchStatusSilently()`, which skips `handleError` for `SocketException`, `TimeoutException`, and `TlsException`
- User-initiated `fetchStatus()` (e.g. settings screen) still calls `handleError` for all errors
- The cubit retries automatically on the next connectivity event, so surfacing transient failures was misleading

## Root cause

On WiFi restore, `_handleConnectivity` fired `fetchStatus()` immediately. The server was momentarily unreachable (`SocketException EHOSTDOWN`), which triggered `handleError` → `DefaultErrorNotification` → "The server is unreachable due to network issues" SnackBar — even though the connection recovered on its own.

## Test plan

- [ ] Background app, disable WiFi, re-enable WiFi — no error SnackBar appears
- [ ] Settings screen register status toggle fails (server down) — error SnackBar still appears
- [ ] `flutter analyze` passes