### PR TITLE
fix: add 10s timeout to reportNewIncomingCall in background message handler (WT-1061)

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -305,12 +305,14 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
     // due to concurrent database access from multiple isolates.
     final displayName = await _resolveContactDisplayNameWithFallback(appPush, logger);
 
-    await AndroidCallkeepServices.backgroundPushNotificationBootstrapService.reportNewIncomingCall(
-      appPush.call.id,
-      CallkeepHandle.number(appPush.call.handle),
-      displayName: displayName,
-      hasVideo: appPush.call.hasVideo,
-    );
+    await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
+        .reportNewIncomingCall(
+          appPush.call.id,
+          CallkeepHandle.number(appPush.call.handle),
+          displayName: displayName,
+          hasVideo: appPush.call.hasVideo,
+        )
+        .timeout(const Duration(seconds: 10), onTimeout: () => _onReportIncomingCallTimeout(logger));
   }
 
   if (appPush is MessagePush) {
@@ -365,6 +367,11 @@ Future<String> _resolveContactDisplayNameWithFallback(PendingCallPush appPush, L
       return contact?.maybeName ?? appPush.call.displayName;
     },
   );
+}
+
+CallkeepIncomingCallError? _onReportIncomingCallTimeout(Logger logger) {
+  logger.warning('reportNewIncomingCall timed out — Telecom may be overloaded');
+  return null;
 }
 
 Future _initLocalPushs() async {


### PR DESCRIPTION
## Problem

`reportNewIncomingCall()` in `_handleBackgroundMessage()` was awaited without a timeout. On devices with a polluted Android Telecom state (phantom PhoneAccount registrations, DEAD PhoneConnectionService connections), Telecom responds very slowly — causing the background handler to hang for up to 11 minutes and blocking subsequent cold starts by keeping `FlutterFirebaseMessagingBackgroundService` alive.

**YouTrack:** https://youtrack.portaone.com/issue/WT-1061

## Fix

Added `.timeout(10s)` to `reportNewIncomingCall()` with a `logger.warning` on timeout. The `onTimeout` callback is extracted to a private function `_onReportIncomingCallTimeout` per project callback rules (no multi-statement lambdas).

## Changes

- `lib/bootstrap.dart` — `.timeout(const Duration(seconds: 10))` on `reportNewIncomingCall()`, private helper `_onReportIncomingCallTimeout(Logger)`

## Acceptance Criteria

- [x] `.timeout(10s)` added with a warning log on timeout
- [x] Background handler completes within timeout even if Telecom is slow
- [x] `FlutterFirebaseMessagingBackgroundService` lifetime is bounded