### PR TITLE
fix: add 5s timeout to getInitialMessage() to prevent splash freeze (WT-1061)

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -237,7 +237,10 @@ Future<void> _initFirebaseMessaging() async {
     final appPush = AppRemotePush.fromFCM(message);
     RemotePushBroker.handleOpenedPush(appPush);
   });
-  final initialMessage = await FirebaseMessaging.instance.getInitialMessage();
+  final initialMessage = await FirebaseMessaging.instance.getInitialMessage().timeout(
+    const Duration(seconds: 5),
+    onTimeout: () => null,
+  );
   if (initialMessage != null) {
     logger.info('initialMessage: ${initialMessage.toMap()}');
     final appPush = AppRemotePush.fromFCM(initialMessage);


### PR DESCRIPTION
## Summary

- Adds `.timeout(5s, onTimeout: () => null)` to `FirebaseMessaging.instance.getInitialMessage()` in `bootstrap.dart`
- Without this timeout, when `FlutterFirebaseMessagingBackgroundService` is alive the `await` never returns, blocking `runApp()` and freezing the splash screen indefinitely

## Test plan

- [ ] Verify app draws first frame even when FCM background service is running
- [ ] Verify initial message is still handled (logged + routed) when background service is idle
- [ ] No regression on cold-start with a pending FCM notification

YouTrack: WT-1061