### PR TITLE
fix: eliminate write-write SQLite contention via shared DriftIsolate server (WT-1061)

### DIFF
--- a/integration_test/isolate_database_test.dart
+++ b/integration_test/isolate_database_test.dart
@@ -1,0 +1,101 @@
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:drift/isolate.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:webtrit_phone/common/db/isolate_database.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/repositories/call_logs/call_logs_repository.dart';
+
+import 'components/components.dart';
+
+const _dbName = 'test_isolate_db.sqlite';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeAppPath fakeAppPath;
+  late String dbPath;
+
+  setUp(() async {
+    fakeAppPath = FakeAppPath();
+    dbPath = fakeAppPath.applicationDocumentsPath;
+    await DatabaseFileHelper.deleteDatabaseFiles(directoryPath: dbPath, dbName: _dbName);
+    IsolateNameServer.removePortNameMapping(IsolateDatabase.kDbPortName);
+  });
+
+  tearDown(() async {
+    IsolateNameServer.removePortNameMapping(IsolateDatabase.kDbPortName);
+    await DatabaseFileHelper.deleteDatabaseFiles(directoryPath: dbPath, dbName: _dbName);
+    fakeAppPath.cleanup();
+  });
+
+  group('IsolateDatabase.connectOrCreate', () {
+    testWidgets('falls back to direct connection when no port is registered', (tester) async {
+      expect(IsolateNameServer.lookupPortByName(IsolateDatabase.kDbPortName), isNull);
+
+      final db = await IsolateDatabase.connectOrCreate(directoryPath: dbPath, dbName: _dbName);
+      final repo = CallLogsRepository(appDatabase: db);
+      final logs = await repo.watchHistoryByNumber('any').first;
+      await db.close();
+
+      expect(logs, isEmpty);
+    });
+
+    testWidgets('removes stale port mapping after failed connect and falls back to direct connection', (tester) async {
+      final stalePort = ReceivePort();
+      IsolateNameServer.registerPortWithName(stalePort.sendPort, IsolateDatabase.kDbPortName);
+
+      final db = await IsolateDatabase.connectOrCreate(directoryPath: dbPath, dbName: _dbName);
+      await db.close();
+      stalePort.close();
+
+      expect(IsolateNameServer.lookupPortByName(IsolateDatabase.kDbPortName), isNull);
+    });
+  });
+
+  group('IsolateDatabase.spawnServer', () {
+    testWidgets('registers port in IsolateNameServer and client connection is functional', (tester) async {
+      DriftIsolate? server;
+      AppDatabase? db;
+      try {
+        server = await IsolateDatabase.spawnServer(directoryPath: dbPath, dbName: _dbName);
+
+        expect(IsolateNameServer.lookupPortByName(IsolateDatabase.kDbPortName), isNotNull);
+
+        db = AppDatabase(await server.connect());
+        final repo = CallLogsRepository(appDatabase: db);
+        final logs = await repo.watchHistoryByNumber('any').first;
+        expect(logs, isEmpty);
+      } finally {
+        await db?.close();
+        await server?.shutdownAll();
+      }
+    });
+
+    testWidgets('replaces stale port mapping before registering the new server', (tester) async {
+      final stalePort = ReceivePort();
+      IsolateNameServer.registerPortWithName(stalePort.sendPort, IsolateDatabase.kDbPortName);
+
+      DriftIsolate? server;
+      AppDatabase? db;
+      try {
+        server = await IsolateDatabase.spawnServer(directoryPath: dbPath, dbName: _dbName);
+
+        final registeredPort = IsolateNameServer.lookupPortByName(IsolateDatabase.kDbPortName);
+        expect(registeredPort, isNotNull);
+        expect(registeredPort, isNot(same(stalePort.sendPort)));
+
+        db = AppDatabase(await server.connect());
+        await db.close();
+        db = null;
+      } finally {
+        stalePort.close();
+        await db?.close();
+        await server?.shutdownAll();
+      }
+    });
+  });
+}

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -27,6 +27,8 @@ import 'package:webtrit_phone/features/system_notifications/services/services.da
 
 import 'package:webtrit_phone/features/call/call.dart' show onPushNotificationSyncCallback, onSignalingSyncCallback;
 
+import 'package:drift/isolate.dart';
+
 import 'app/session/session.dart';
 import 'firebase_options.dart';
 import 'services/services.dart';
@@ -106,6 +108,13 @@ Future<InstanceRegistry> bootstrap() async {
   // Utilities - Capturing instances that were previously just `await Class.init()`
   final pushEnvironment = await PushEnvironment.init();
   final appPath = await AppPath.init();
+
+  // Spawn the shared DriftIsolate database server. All isolates (FCM background,
+  // WorkManager) connect to this single server via IsolateNameServer, eliminating
+  // write-write SQLite contention.
+  final driftIsolate = await IsolateDatabase.spawnServer(directoryPath: appPath.applicationDocumentsPath);
+  registry.register<DriftIsolate>(driftIsolate);
+
   final appPermissions = await _createAppPermissions(featureAccess, contactsAgreementStatusRepository);
   final appTime = await AppTime.init();
   final appLabels = await DefaultAppMetadataProvider.init(

--- a/lib/common/db/app_database_scope.dart
+++ b/lib/common/db/app_database_scope.dart
@@ -18,7 +18,7 @@ abstract final class AppDatabaseScope {
     required Future<T> Function(AppDatabase db) action,
     String dbName = 'db.sqlite',
   }) async {
-    final db = IsolateDatabase.create(directoryPath: directoryPath, dbName: dbName);
+    final db = await IsolateDatabase.connectOrCreate(directoryPath: directoryPath, dbName: dbName);
     try {
       return await action(db);
     } finally {

--- a/lib/common/db/isolate_database.dart
+++ b/lib/common/db/isolate_database.dart
@@ -1,9 +1,81 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:drift/drift.dart';
+import 'package:drift/isolate.dart';
+
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/environment_config.dart';
 
+/// The [IsolateNameServer] key under which the [DriftIsolate] server's [SendPort] is registered.
+///
+/// Used by background isolates (e.g. FCM handler, WorkManager) to connect to the shared
+/// database server spawned by the main isolate, eliminating write-write contention.
+const _kDbPortName = 'webtrit_app_db';
+
+/// Entry point for the dedicated [DriftIsolate] database server isolate.
+///
+/// This function is spawned via [Isolate.spawn] and runs in a separate isolate.
+/// It creates a synchronous [NativeDatabase], starts a [DriftIsolate] server,
+/// and sends back the [SendPort] so that any isolate can connect to it.
+@pragma('vm:entry-point')
+void _driftServerEntryPoint(List<dynamic> args) {
+  final sendPort = args[0] as SendPort;
+  final directoryPath = args[1] as String;
+  final dbName = args[2] as String;
+  final logStatements = args[3] as bool;
+
+  final executor = createAppDatabaseNative(directoryPath, dbName, logStatements: logStatements);
+
+  final server = DriftIsolate.inCurrent(() => DatabaseConnection(executor));
+  sendPort.send(server.connectPort);
+}
+
 /// Helper for creating [AppDatabase] instances in different isolates.
 abstract final class IsolateDatabase {
-  /// Opens a new [AppDatabase] instance for [directoryPath]/[dbName].
+  /// The [IsolateNameServer] key used to share the [DriftIsolate] [SendPort].
+  static const kDbPortName = _kDbPortName;
+
+  /// Spawns a dedicated [DriftIsolate] server isolate that owns the single database
+  /// connection for [directoryPath]/[dbName], and registers its [SendPort] in
+  /// [IsolateNameServer] under [kDbPortName].
+  ///
+  /// Call this once from the main isolate (e.g. in [bootstrap]) before [runApp].
+  /// All other isolates should use [connectOrCreate] to obtain a client connection.
+  static Future<DriftIsolate> spawnServer({required String directoryPath, String dbName = 'db.sqlite'}) async {
+    final receivePort = ReceivePort();
+    await Isolate.spawn(_driftServerEntryPoint, [
+      receivePort.sendPort,
+      directoryPath,
+      dbName,
+      EnvironmentConfig.DATABASE_LOG_STATEMENTS,
+    ]);
+    final connectPort = await receivePort.first as SendPort;
+    receivePort.close();
+    IsolateNameServer.registerPortWithName(connectPort, kDbPortName);
+    return DriftIsolate.fromConnectPort(connectPort);
+  }
+
+  /// Connects to the shared [DriftIsolate] server registered in [IsolateNameServer],
+  /// or falls back to a direct [NativeDatabase] connection if none is found.
+  ///
+  /// Use this in isolates that may run concurrently with the main app
+  /// (e.g. FCM background handler, WorkManager) instead of [create].
+  static Future<AppDatabase> connectOrCreate({required String directoryPath, String dbName = 'db.sqlite'}) async {
+    final sendPort = IsolateNameServer.lookupPortByName(kDbPortName);
+    if (sendPort != null) {
+      try {
+        final driftIsolate = DriftIsolate.fromConnectPort(sendPort);
+        return AppDatabase(await driftIsolate.connect());
+      } catch (_) {
+        // Stale port (e.g. after hot reload or app restart) — fall through to direct connection.
+      }
+    }
+    return create(directoryPath: directoryPath, dbName: dbName);
+  }
+
+  /// Opens a new direct [AppDatabase] instance for [directoryPath]/[dbName].
   ///
   /// Note: This creates a new SQLite connection each time. Avoid calling it repeatedly in
   /// concurrent code paths; prefer [use] to ensure connections are closed deterministically.

--- a/lib/common/db/isolate_database.dart
+++ b/lib/common/db/isolate_database.dart
@@ -45,15 +45,65 @@ abstract final class IsolateDatabase {
   /// All other isolates should use [connectOrCreate] to obtain a client connection.
   static Future<DriftIsolate> spawnServer({required String directoryPath, String dbName = 'db.sqlite'}) async {
     final receivePort = ReceivePort();
-    await Isolate.spawn(_driftServerEntryPoint, [
-      receivePort.sendPort,
-      directoryPath,
-      dbName,
-      EnvironmentConfig.DATABASE_LOG_STATEMENTS,
-    ]);
-    final connectPort = await receivePort.first as SendPort;
-    receivePort.close();
-    IsolateNameServer.registerPortWithName(connectPort, kDbPortName);
+    final errorPort = ReceivePort();
+    final exitPort = ReceivePort();
+
+    final completer = Completer<SendPort>();
+
+    final receiveSub = receivePort.listen((message) {
+      if (!completer.isCompleted) completer.complete(message as SendPort);
+    });
+
+    final errorSub = errorPort.listen((message) {
+      if (completer.isCompleted) return;
+      final error = message is List ? message[0] : message;
+      final rawStack = message is List && message.length > 1 ? message[1] : null;
+      final stackTrace = rawStack is String ? StackTrace.fromString(rawStack) : StackTrace.current;
+      completer.completeError(DatabaseInitializationException('Database isolate error: $error', stackTrace));
+    });
+
+    final exitSub = exitPort.listen((_) {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          DatabaseInitializationException('Database isolate exited before sending connect port', StackTrace.current),
+        );
+      }
+    });
+
+    final isolate = await Isolate.spawn(
+      _driftServerEntryPoint,
+      [receivePort.sendPort, directoryPath, dbName, EnvironmentConfig.DATABASE_LOG_STATEMENTS],
+      onError: errorPort.sendPort,
+      onExit: exitPort.sendPort,
+    );
+
+    SendPort connectPort;
+    try {
+      connectPort = await completer.future.timeout(
+        const Duration(seconds: 30),
+        onTimeout: () {
+          isolate.kill(priority: Isolate.immediate);
+          throw DatabaseInitializationException('Timed out waiting for database isolate to start', StackTrace.current);
+        },
+      );
+    } finally {
+      await receiveSub.cancel();
+      await errorSub.cancel();
+      await exitSub.cancel();
+      receivePort.close();
+      errorPort.close();
+      exitPort.close();
+    }
+
+    // Remove any stale mapping (e.g. from hot restart) before registering.
+    IsolateNameServer.removePortNameMapping(kDbPortName);
+    final registered = IsolateNameServer.registerPortWithName(connectPort, kDbPortName);
+    if (!registered) {
+      throw DatabaseInitializationException(
+        'Failed to register DriftIsolate SendPort under "$kDbPortName"',
+        StackTrace.current,
+      );
+    }
     return DriftIsolate.fromConnectPort(connectPort);
   }
 
@@ -69,7 +119,8 @@ abstract final class IsolateDatabase {
         final driftIsolate = DriftIsolate.fromConnectPort(sendPort);
         return AppDatabase(await driftIsolate.connect());
       } catch (_) {
-        // Stale port (e.g. after hot reload or app restart) — fall through to direct connection.
+        // Stale port (e.g. after hot reload or app restart) — remove mapping and fall through to direct connection.
+        IsolateNameServer.removePortNameMapping(kDbPortName);
       }
     }
     return create(directoryPath: directoryPath, dbName: dbName);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:drift/drift.dart';
+import 'package:drift/isolate.dart';
 
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -159,9 +162,10 @@ class RootApp extends StatelessWidget {
   }
 
   AppDatabaseLifecycleHolder _createAppDatabaseLifecycleHolder(BuildContext context) {
-    final db = IsolateDatabase.create(directoryPath: context.read<AppPath>().applicationDocumentsPath);
-
-    return AppDatabaseLifecycleHolder(db)..attach();
+    final driftIsolate = instanceRegistry.get<DriftIsolate>();
+    // Connect lazily: the actual IPC handshake to the server isolate happens on first query.
+    final db = AppDatabase(DatabaseConnection.delayed(driftIsolate.connect()));
+    return AppDatabaseLifecycleHolder(db, driftIsolate)..attach();
   }
 
   Future<void> _disposeAppDatabaseLifecycleHolder(BuildContext _, AppDatabaseLifecycleHolder holder) async {
@@ -189,9 +193,10 @@ class RootApp extends StatelessWidget {
 }
 
 class AppDatabaseLifecycleHolder with WidgetsBindingObserver {
-  AppDatabaseLifecycleHolder(this.db);
+  AppDatabaseLifecycleHolder(this.db, this._driftIsolate);
 
   final AppDatabase db;
+  final DriftIsolate _driftIsolate;
 
   void attach() => WidgetsBinding.instance.addObserver(this);
 
@@ -200,13 +205,15 @@ class AppDatabaseLifecycleHolder with WidgetsBindingObserver {
   Future<void> dispose() async {
     detach();
     await db.close();
+    IsolateNameServer.removePortNameMapping(IsolateDatabase.kDbPortName);
+    _driftIsolate.shutdownAll();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.detached) {
-      // NOTE: `close()` is async and unawaited here; another isolate may open DB before it fully closes,
-      // potentially increasing lock contention (`database is locked`).
+      // Close the main-isolate client connection. The server isolate stays alive
+      // until dispose() is called or all clients disconnect.
       unawaited(db.close());
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -163,7 +163,7 @@ class RootApp extends StatelessWidget {
 
   AppDatabaseLifecycleHolder _createAppDatabaseLifecycleHolder(BuildContext context) {
     final driftIsolate = instanceRegistry.get<DriftIsolate>();
-    // Connect lazily: the actual IPC handshake to the server isolate happens on first query.
+    // Establish the connection; the IPC handshake to the server isolate starts when this Future is created.
     final db = AppDatabase(DatabaseConnection.delayed(driftIsolate.connect()));
     return AppDatabaseLifecycleHolder(db, driftIsolate)..attach();
   }

--- a/packages/data/app_database/lib/src/connection/native.dart
+++ b/packages/data/app_database/lib/src/connection/native.dart
@@ -4,6 +4,32 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:path/path.dart' show join;
 
+/// Creates a synchronous [NativeDatabase] for use inside a dedicated isolate
+/// (e.g. a [DriftIsolate] server). Unlike [createAppDatabaseConnection], this
+/// does NOT use [NativeDatabase.createInBackground] because the caller is
+/// expected to already run in its own isolate.
+NativeDatabase createAppDatabaseNative(
+  String directoryPath,
+  String name, {
+  bool logStatements = false,
+  bool? isWalEnabled = true,
+  int? busyTimeoutMs = 5000,
+}) {
+  final databasePath = join(directoryPath, name);
+  return NativeDatabase(
+    File(databasePath),
+    logStatements: logStatements,
+    setup: (database) {
+      if (isWalEnabled == true) {
+        database.execute('PRAGMA journal_mode=WAL;');
+      }
+      if (busyTimeoutMs != null && busyTimeoutMs >= 0) {
+        database.execute('PRAGMA busy_timeout=$busyTimeoutMs;');
+      }
+    },
+  );
+}
+
 DatabaseConnection createAppDatabaseConnection(
   String? path,
   String name, {

--- a/packages/data/app_database/lib/src/connection/unsupported.dart
+++ b/packages/data/app_database/lib/src/connection/unsupported.dart
@@ -1,5 +1,15 @@
 import 'package:drift/drift.dart';
 
+QueryExecutor createAppDatabaseNative(
+  String directoryPath,
+  String name, {
+  bool logStatements = false,
+  bool? isWalEnabled = true,
+  int? busyTimeoutMs = 5000,
+}) {
+  throw UnsupportedError('No suitable database implementation was found on this platform.');
+}
+
 DatabaseConnection createAppDatabaseConnection(
   String? path,
   String name, {

--- a/packages/data/app_database/lib/src/connection/web.dart
+++ b/packages/data/app_database/lib/src/connection/web.dart
@@ -1,6 +1,17 @@
 import 'package:drift/drift.dart';
 import 'package:drift/wasm.dart';
 
+/// Not supported on Web — [DriftIsolate] server spawning is a native-only feature.
+QueryExecutor createAppDatabaseNative(
+  String directoryPath,
+  String name, {
+  bool logStatements = false,
+  bool? isWalEnabled = true,
+  int? busyTimeoutMs = 5000,
+}) {
+  throw UnsupportedError('createAppDatabaseNative is not supported on Web.');
+}
+
 DatabaseConnection createAppDatabaseConnection(
   String? path,
   String name, {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -442,7 +442,7 @@ packages:
     source: hosted
     version: "1.1.55"
   drift:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: drift
       sha256: "5ea2f718558c0b31d4b8c36a3d8e5b7016f1265f46ceb5a5920e16117f0c0d6a"
@@ -1153,10 +1153,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: "direct main"
     description:
@@ -1774,26 +1774,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   connectivity_plus: ^7.0.0
   cross_file: ^0.3.5
   device_info_plus: ^12.2.0
+  drift: ^2.29.0
   equatable: ^2.0.7
   firebase_analytics: ^12.0.4
   firebase_app_installations: ^0.4.0+4


### PR DESCRIPTION
## Summary

- Spawns a single dedicated `DriftIsolate` server in `bootstrap()` that owns the one true SQLite connection and registers its `SendPort` in `IsolateNameServer`
- Background isolates (FCM handler, WorkManager) call `IsolateDatabase.connectOrCreate()` which looks up the port and creates a client connection — all writes go through the same server isolate, serialized automatically
- Falls back to a direct `NativeDatabase` connection when the main app is not running (cold FCM push, no foreground process)
- Adds `createAppDatabaseNative()` to `app_database` package for synchronous `NativeDatabase` creation inside the server isolate (no `createInBackground` needed — the isolate itself is the background)
- `AppDatabaseLifecycleHolder` now shuts down the server isolate and unregisters `IsolateNameServer` port on dispose

## Root cause addressed

WAL mode (`PRAGMA journal_mode=WAL`) eliminates read-write contention but not write-write. Two isolates opening independent `NativeDatabase` connections to the same file can both try to write simultaneously — the loser waits for `busy_timeout=5000ms` and then gets `SqliteException(code=5)`. With a single server isolate, write-write contention is physically impossible.

## Related

YouTrack: https://youtrack.portaone.com/issue/WT-1061

## Test plan

- [ ] Cold start with FCM background service running — app draws first frame normally
- [ ] Receive FCM `MessagePush` while app is in foreground — message saved to DB without error
- [ ] Receive FCM `PendingCallPush` — contact name resolved from DB, incoming call displayed
- [ ] WorkManager system notifications task runs without `SqliteException`
- [ ] App shutdown — no dangling isolates or open ports