### PR TITLE
feat: show progress indicator while sharing logs

### DIFF
--- a/lib/features/log_records_console/cubit/log_records_console_cubit.dart
+++ b/lib/features/log_records_console/cubit/log_records_console_cubit.dart
@@ -44,11 +44,13 @@ class LogRecordsConsoleCubit extends Cubit<LogRecordsConsoleState> {
   Future<void> share() async {
     final state = this.state as LogRecordsConsoleStateSuccess;
 
-    final logRecords = state.logRecords;
-
-    final time = DateTime.now();
-    final name = '$exportFilenamePrefix(${dateFormat.format(time)}).log';
-
-    await shareLogRecords(logRecords, name: name);
+    emit(state.copyWith(isSharing: true));
+    try {
+      final time = DateTime.now();
+      final name = '$exportFilenamePrefix(${dateFormat.format(time)}).log';
+      await shareLogRecords(state.logRecords, name: name);
+    } finally {
+      emit(state.copyWith(isSharing: false));
+    }
   }
 }

--- a/lib/features/log_records_console/cubit/log_records_console_state.dart
+++ b/lib/features/log_records_console/cubit/log_records_console_state.dart
@@ -19,12 +19,17 @@ final class LogRecordsConsoleStateLoading extends LogRecordsConsoleState {
 }
 
 final class LogRecordsConsoleStateSuccess extends LogRecordsConsoleState {
-  const LogRecordsConsoleStateSuccess(this.logRecords);
+  const LogRecordsConsoleStateSuccess(this.logRecords, {this.isSharing = false});
 
   final List<String> logRecords;
+  final bool isSharing;
+
+  LogRecordsConsoleStateSuccess copyWith({bool? isSharing}) {
+    return LogRecordsConsoleStateSuccess(logRecords, isSharing: isSharing ?? this.isSharing);
+  }
 
   @override
-  List<Object?> get props => [EquatablePropToString.list(logRecords)];
+  List<Object?> get props => [EquatablePropToString.list(logRecords), isSharing];
 }
 
 final class LogRecordsConsoleStateFailure extends LogRecordsConsoleState {

--- a/lib/features/log_records_console/view/log_records_console_screen.dart
+++ b/lib/features/log_records_console/view/log_records_console_screen.dart
@@ -21,7 +21,7 @@ class LogRecordsConsoleScreen extends StatelessWidget {
                 icon: const Icon(Icons.delete_outline),
                 style: IconButton.styleFrom(foregroundColor: colorScheme.onSurface),
                 onPressed: switch (state) {
-                  LogRecordsConsoleStateSuccess() => () {
+                  LogRecordsConsoleStateSuccess(isSharing: false) => () {
                     context.read<LogRecordsConsoleCubit>().clear();
                   },
                   _ => null,
@@ -31,11 +31,18 @@ class LogRecordsConsoleScreen extends StatelessWidget {
           ),
           BlocBuilder<LogRecordsConsoleCubit, LogRecordsConsoleState>(
             builder: (context, state) {
+              final isSharing = state is LogRecordsConsoleStateSuccess && state.isSharing;
               return IconButton(
-                icon: const Icon(Icons.share),
+                icon: isSharing
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2, color: colorScheme.onSurface),
+                      )
+                    : const Icon(Icons.share),
                 style: IconButton.styleFrom(foregroundColor: colorScheme.onSurface),
                 onPressed: switch (state) {
-                  LogRecordsConsoleStateSuccess(:final logRecords) when logRecords.isNotEmpty => () {
+                  LogRecordsConsoleStateSuccess(:final logRecords, isSharing: false) when logRecords.isNotEmpty => () {
                     context.read<LogRecordsConsoleCubit>().share();
                   },
                   _ => null,

--- a/lib/features/log_records_console/view/log_records_console_screen.dart
+++ b/lib/features/log_records_console/view/log_records_console_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
 
 class LogRecordsConsoleScreen extends StatelessWidget {
   const LogRecordsConsoleScreen({super.key});
@@ -34,10 +35,11 @@ class LogRecordsConsoleScreen extends StatelessWidget {
               final isSharing = state is LogRecordsConsoleStateSuccess && state.isSharing;
               return IconButton(
                 icon: isSharing
-                    ? SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2, color: colorScheme.onSurface),
+                    ? SizedCircularProgressIndicator(
+                        size: 20,
+                        outerSize: 24,
+                        color: colorScheme.onSurface,
+                        strokeWidth: 2,
                       )
                     : const Icon(Icons.share),
                 style: IconButton.styleFrom(foregroundColor: colorScheme.onSurface),


### PR DESCRIPTION
## Summary

- Add `isSharing` flag to `LogRecordsConsoleStateSuccess` with `copyWith` support
- Cubit `share()` now emits `isSharing: true` before writing the file and `isSharing: false` in `finally`, so the UI always unlocks even on error
- Share button replaces its icon with a `CircularProgressIndicator` while sharing; both delete and share buttons are disabled during the operation

## Problem

When the user pressed Share with ~16 MB of logs, nothing happened visually for several seconds while the file was being written to disk and the native share sheet was loading.

## Test plan

- [ ] Open log console with a large number of log records
- [ ] Tap Share — icon should switch to a spinner immediately
- [ ] Native share sheet appears — spinner should still be visible
- [ ] Dismiss the share sheet — icon returns to normal, both buttons re-enable
- [ ] Verify delete button is also disabled during sharing