### PR TITLE
fix: media settings parsing errors

### DIFF
--- a/lib/mappers/json/encoding_settings_mapper.dart
+++ b/lib/mappers/json/encoding_settings_mapper.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:webtrit_phone/extensions/iterable.dart';
 import 'package:webtrit_phone/models/enableble.dart';
 import 'package:webtrit_phone/models/encoding_settings.dart';
 import 'package:webtrit_phone/models/rtp_codec_profile.dart';
@@ -23,8 +24,8 @@ mixin EncodingSettingsJsonMapper {
       opusBitrate: map['opusBitrate'] as int?,
       opusStereo: map['opusStereo'] as bool?,
       opusDtx: map['opusDtx'] as bool?,
-      audioProfiles: (map['audioProfiles'] as List<dynamic>?)?.map((p) => profileFromMap(p)).toList(),
-      videoProfiles: (map['videoProfiles'] as List<dynamic>?)?.map((p) => profileFromMap(p)).toList(),
+      audioProfiles: (map['audioProfiles'] as List<dynamic>?)?.map((p) => profileFromMap(p)).nonNulls.toList(),
+      videoProfiles: (map['videoProfiles'] as List<dynamic>?)?.map((p) => profileFromMap(p)).nonNulls.toList(),
       removeExtmaps: map['removeExtmaps'] as bool? ?? false,
       removeStaticAudioRtpMaps: map['removeStaticAudioRtpMaps'] as bool? ?? false,
       remapTE8payloadTo101: map['remapTE8payloadTo101'] as bool? ?? false,
@@ -49,7 +50,8 @@ mixin EncodingSettingsJsonMapper {
     };
   }
 
-  Enableble<RTPCodecProfile> profileFromMap(Map<String, dynamic> map) {
+  // returns null if profile is not recognized, which means it should be ignored
+  Enableble<RTPCodecProfile>? profileFromMap(Map<String, dynamic> map) {
     final profile = map['profile'];
     final enabled = map['enabled'];
 
@@ -60,7 +62,10 @@ mixin EncodingSettingsJsonMapper {
     if (profile == 'redAudio') return (option: RTPCodecProfile.redundancy_audio, enabled: enabled);
     if (profile == 'redVideo') return (option: RTPCodecProfile.redundancy_video, enabled: enabled);
 
-    return (option: RTPCodecProfile.values.byName(profile), enabled: enabled);
+    final option = RTPCodecProfile.values.firstWhereOrNull((p) => p.name == profile);
+    if (option == null) return null;
+
+    return (option: option, enabled: enabled);
   }
 
   Map<String, dynamic> profileToMap(Enableble<RTPCodecProfile> param) {

--- a/lib/repositories/encoding_preset/encoding_preset_repository.dart
+++ b/lib/repositories/encoding_preset/encoding_preset_repository.dart
@@ -1,4 +1,5 @@
 import 'package:webtrit_phone/data/app_preferences.dart';
+import 'package:webtrit_phone/extensions/iterable.dart';
 import 'package:webtrit_phone/models/encoding_settings.dart';
 
 abstract interface class EncodingPresetRepository {
@@ -18,11 +19,12 @@ class EncodingPresetRepositoryPrefsImpl implements EncodingPresetRepository {
   @override
   EncodingPreset? getEncodingPreset({EncodingPreset? defaultValue}) {
     final encodingPresetString = _appPreferences.getString(_prefsKey);
+
+    EncodingPreset? preset;
     if (encodingPresetString != null) {
-      return EncodingPreset.values.byName(encodingPresetString);
-    } else {
-      return defaultValue;
+      preset = EncodingPreset.values.firstWhereOrNull((preset) => preset.name == encodingPresetString);
     }
+    return preset ?? defaultValue;
   }
 
   @override


### PR DESCRIPTION
## Problem

After the `fullflex` preset was removed from `EncodingPreset`, any device that had it stored in
preferences would crash on launch — `.byName()` throws `ArgumentError` if the name doesn't exist
in the enum. The same issue applied to `RTPCodecProfile` entries parsed from remote JSON config.

## Changes

### `EncodingPresetRepositoryPrefsImpl.getEncodingPreset()`
Replaced `.byName()` with `firstWhereOrNull` — an unrecognized stored preset now silently falls
back to `defaultValue` instead of throwing.

### `EncodingSettingsJsonMapper.profileFromMap()`
Made the return type nullable (`Enableble<RTPCodecProfile>?`). Unknown profile names return
`null`; callers filter them out with `.nonNulls` when building `audioProfiles`/`videoProfiles`.
