### PR TITLE
fix: cannot make calls after blind transfer — skip hangup + reconnect safety net (WT-1214)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2037,14 +2037,24 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
         });
       } else {
-        final hangupRequest = HangupRequest(
-          transaction: WebtritSignalingClient.generateTransactionId(),
-          line: activeCall.line,
-          callId: activeCall.callId,
-        );
-        await _signalingModule.signalingClient?.execute(hangupRequest).catchError((e, s) {
-          callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
-        });
+        // Skip hangup when a blind transfer has been accepted by the server (Transfering state).
+        // The SIP dialog is already closed server-side via REFER; sending hangup results in a
+        // 4610 "call request on wrong line" rejection and an unexpected WebSocket disconnect.
+        final isBlindTransferCompleted = switch (activeCall.transfer) {
+          Transfering(:final fromBlindTransfer) => fromBlindTransfer,
+          _ => false,
+        };
+
+        if (!isBlindTransferCompleted) {
+          final hangupRequest = HangupRequest(
+            transaction: WebtritSignalingClient.generateTransactionId(),
+            line: activeCall.line,
+            callId: activeCall.callId,
+          );
+          await _signalingModule.signalingClient?.execute(hangupRequest).catchError((e, s) {
+            callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
+          });
+        }
       }
 
       // Need to close peer connection after executing [HangupRequest]

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1746,6 +1746,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     // Attempt to wait for the desired signaling client status within the signaling client connection timeout period
     if (!currentState.isHandshakeEstablished || !currentState.isSignalingEstablished) {
+      // Trigger reconnect so that an outgoing call recovers signaling even when the previous
+      // disconnect was intentional (e.g. post-transfer cleanup) and no reconnect was scheduled.
+      _scheduleReconnect(Duration.zero);
+
       emit(
         state.copyWithMappedActiveCall(event.callId, (activeCall) {
           return activeCall.copyWith(processingStatus: CallProcessingStatus.outgoingConnectingToSignaling);

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2037,15 +2037,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
         });
       } else {
-        // Skip hangup when a blind transfer has been accepted by the server (Transfering state).
-        // The SIP dialog is already closed server-side via REFER; sending hangup results in a
-        // 4610 "call request on wrong line" rejection and an unexpected WebSocket disconnect.
-        final isBlindTransferCompleted = switch (activeCall.transfer) {
+        // Skip hangup when a blind transfer is in Transfering state (server started to process it).
+        // In this state the SIP dialog may already be closed server-side via REFER; sending hangup
+        // results in a 4610 "call request on wrong line" rejection and an unexpected WebSocket disconnect.
+        final isBlindTransferInTransferingState = switch (activeCall.transfer) {
           Transfering(:final fromBlindTransfer) => fromBlindTransfer,
           _ => false,
         };
 
-        if (!isBlindTransferCompleted) {
+        if (!isBlindTransferInTransferingState) {
           final hangupRequest = HangupRequest(
             transaction: WebtritSignalingClient.generateTransactionId(),
             line: activeCall.line,
@@ -2057,9 +2057,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         }
       }
 
-      // Need to close peer connection after executing [HangupRequest]
-      // to prevent "Simulate a "hangup" coming from the application"
-      // because of "No WebRTC media anymore".
+      // Need to close peer connection after the signaling request (decline/hangup) has been sent,
+      // or after skipping it for blind transfer, to prevent "Simulate a 'hangup' coming from the
+      // application" triggered by "No WebRTC media anymore".
       await _peerConnectionManager.disposePeerConnection(activeCall.callId);
       await activeCall.localStream?.dispose();
     });

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -1006,43 +1006,44 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // Transfer — blind transfer completion detection
+  // Transfer — blind transfer Transfering state detection
   //
   // Mirrors the pattern-match logic in CallBloc.__onCallPerformEventEnded that
-  // decides whether to skip the hangup request after a blind transfer.
+  // decides whether to skip the hangup request when a blind transfer is in the
+  // Transfering state (server started to process it).
   // ---------------------------------------------------------------------------
 
-  group('Transfer — isBlindTransferCompleted detection', () {
+  group('Transfer — isBlindTransferInTransferingState detection', () {
     // Replicates the exact switch used in __onCallPerformEventEnded.
-    bool isBlindTransferCompleted(Transfer? transfer) {
+    bool isBlindTransferInTransferingState(Transfer? transfer) {
       return switch (transfer) {
         Transfering(:final fromBlindTransfer) => fromBlindTransfer,
         _ => false,
       };
     }
 
-    test('Transfering(fromBlindTransfer: true) is detected as completed blind transfer', () {
+    test('Transfering(fromBlindTransfer: true) is detected as blind transfer in Transfering state', () {
       const transfer = Transfer.transfering(fromBlindTransfer: true, fromAttendedTransfer: false);
-      expect(isBlindTransferCompleted(transfer), isTrue);
+      expect(isBlindTransferInTransferingState(transfer), isTrue);
     });
 
-    test('Transfering(fromBlindTransfer: false) is not detected as completed blind transfer', () {
+    test('Transfering(fromBlindTransfer: false) is not detected as blind transfer in Transfering state', () {
       const transfer = Transfer.transfering(fromBlindTransfer: false, fromAttendedTransfer: true);
-      expect(isBlindTransferCompleted(transfer), isFalse);
+      expect(isBlindTransferInTransferingState(transfer), isFalse);
     });
 
-    test('BlindTransferTransferSubmitted is not yet a completed transfer', () {
+    test('BlindTransferTransferSubmitted is not yet in Transfering state', () {
       const transfer = Transfer.blindTransferTransferSubmitted(toNumber: '+1234567890');
-      expect(isBlindTransferCompleted(transfer), isFalse);
+      expect(isBlindTransferInTransferingState(transfer), isFalse);
     });
 
-    test('BlindTransferInitiated is not a completed transfer', () {
+    test('BlindTransferInitiated is not in Transfering state', () {
       const transfer = Transfer.blindTransferInitiated();
-      expect(isBlindTransferCompleted(transfer), isFalse);
+      expect(isBlindTransferInTransferingState(transfer), isFalse);
     });
 
-    test('null (no transfer in progress) is not a completed transfer', () {
-      expect(isBlindTransferCompleted(null), isFalse);
+    test('null (no transfer in progress) is not in Transfering state', () {
+      expect(isBlindTransferInTransferingState(null), isFalse);
     });
   });
 

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -1006,6 +1006,47 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // Transfer — blind transfer completion detection
+  //
+  // Mirrors the pattern-match logic in CallBloc.__onCallPerformEventEnded that
+  // decides whether to skip the hangup request after a blind transfer.
+  // ---------------------------------------------------------------------------
+
+  group('Transfer — isBlindTransferCompleted detection', () {
+    // Replicates the exact switch used in __onCallPerformEventEnded.
+    bool isBlindTransferCompleted(Transfer? transfer) {
+      return switch (transfer) {
+        Transfering(:final fromBlindTransfer) => fromBlindTransfer,
+        _ => false,
+      };
+    }
+
+    test('Transfering(fromBlindTransfer: true) is detected as completed blind transfer', () {
+      const transfer = Transfer.transfering(fromBlindTransfer: true, fromAttendedTransfer: false);
+      expect(isBlindTransferCompleted(transfer), isTrue);
+    });
+
+    test('Transfering(fromBlindTransfer: false) is not detected as completed blind transfer', () {
+      const transfer = Transfer.transfering(fromBlindTransfer: false, fromAttendedTransfer: true);
+      expect(isBlindTransferCompleted(transfer), isFalse);
+    });
+
+    test('BlindTransferTransferSubmitted is not yet a completed transfer', () {
+      const transfer = Transfer.blindTransferTransferSubmitted(toNumber: '+1234567890');
+      expect(isBlindTransferCompleted(transfer), isFalse);
+    });
+
+    test('BlindTransferInitiated is not a completed transfer', () {
+      const transfer = Transfer.blindTransferInitiated();
+      expect(isBlindTransferCompleted(transfer), isFalse);
+    });
+
+    test('null (no transfer in progress) is not a completed transfer', () {
+      expect(isBlindTransferCompleted(null), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // JsepValue — SDP media detection
   // ---------------------------------------------------------------------------
 

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -1359,6 +1359,78 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // requestCallIdError (4610) — reconnect hint
+  //
+  // Code 4610 is sent by the server when a client submits a request (e.g.
+  // hangup) on a SIP dialog that is already closed server-side.  This happens
+  // after a blind transfer because the server closes the dialog via REFER while
+  // the client concurrently tries to send a hangup request.
+  //
+  // The key asymmetry:
+  //   - Non-intentional 4610 → recommendedReconnectDelay != null → CallBloc schedules reconnect.
+  //   - Intentional disconnect() followed by server 4610 → recommendedReconnectDelay == null
+  //     → CallBloc does NOT schedule a reconnect automatically.
+  //
+  // The second case was the root cause of WT-1214 (cannot make calls after
+  // blind transfer): post-transfer cleanup called disconnect() (intentional),
+  // then the server echoed back with 4610, suppressing the reconnect hint and
+  // leaving signaling permanently disconnected until the next outgoing call
+  // triggered the safety-net _scheduleReconnect(Duration.zero) added in the fix.
+  // -------------------------------------------------------------------------
+
+  group('SignalingModule - requestCallIdError (4610) reconnect hint', () {
+    test('non-intentional 4610 emits SignalingDisconnected with non-null recommendedReconnectDelay', () async {
+      final client = _FakeSignalingClient();
+      final module = _buildModule(_successFactory(client));
+      addTearDown(module.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      module.connect();
+      await pumpEventQueue();
+
+      // Server closes the WebSocket with 4610 without the client calling disconnect() first.
+      client.injectDisconnect(SignalingDisconnectCode.requestCallIdError.code, 'call request on wrong line');
+      await pumpEventQueue();
+
+      final disconnected = events.whereType<SignalingDisconnected>().single;
+      expect(disconnected.knownCode, SignalingDisconnectCode.requestCallIdError);
+      expect(
+        disconnected.recommendedReconnectDelay,
+        isNotNull,
+        reason: 'Non-intentional 4610 should carry a reconnect hint so CallBloc schedules a reconnect',
+      );
+    });
+
+    test('intentional disconnect() followed by server 4610 emits null recommendedReconnectDelay', () async {
+      final client = _FakeSignalingClient();
+      final module = _buildModule(_successFactory(client));
+      addTearDown(module.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      module.connect();
+      await pumpEventQueue();
+
+      // Client calls disconnect() explicitly (e.g. post-transfer cleanup in onChange),
+      // then the server echoes back with 4610 instead of the expected 1000.
+      unawaited(module.disconnect());
+      await pumpEventQueue();
+      client.injectDisconnect(SignalingDisconnectCode.requestCallIdError.code, 'call request on wrong line');
+      await pumpEventQueue();
+
+      final disconnected = events.whereType<SignalingDisconnected>().single;
+      expect(
+        disconnected.recommendedReconnectDelay,
+        isNull,
+        reason: 'Intentional disconnect suppresses the reconnect hint even when the server closes with 4610',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // disconnect() robustness
   // CallBloc calls disconnect() on lifecycle / connectivity changes; it must
   // not break if the underlying WebSocket close throws.


### PR DESCRIPTION
## Problem

After a successful blind transfer, the user cannot initiate any new outgoing call. The call enters \`outgoingConnectingToSignaling\` and eventually fails with \"connection issue\" (\`CallWhileOfflineNotification\`).

YouTrack: [WT-1214](https://youtrack.portaone.com/issue/WT-1214)

---

## Root cause

### Why does signaling die after a blind transfer?

After the transfer completes (NOTIFY 200 OK + \`subscription_state: terminated\`), two handlers run concurrently for the same call:

**Handler A** — \`__onCallSignalingEventHangup\` (server-initiated BYE):
```
disposePeerConnection
→ emit(copyWithPopActiveCall)   ← call removed from state
→ onChange → _disconnectInitiated()
→ _signalingModule.disconnect()
→ _intentionalDisconnect = true   ← KEY
```

**Handler B** — \`__onCallPerformEventEnded\` (triggered by \`__onCallSignalingEventNotifyRefer\`):
```
execute(HangupRequest)   ← sent on an already-closed SIP dialog
```

The server rejects the invalid HangupRequest and closes the WebSocket:
```
WebSocket close: code 4610 ("request call id error")
```

Per the [signaling disconnect codes docs](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/disconnect_codes.md), code 4610 means the server received a request referencing an unknown or already-closed call ID. The [`hangup` request](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/requests/call/hangup.md) is intended for active calls only — after the REFER/[`notify`](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/events/call/notify.md) sequence completes with \`subscription_state: terminated\`, the SIP dialog is already closed server-side.

By then \`_intentionalDisconnect = true\` is already set (Handler A ran first). So:

```dart
// SignalingModule._onDisconnect:
final recommendedDelay = wasIntentional ? null : _reconnectDelay(knownCode);
// wasIntentional=true → recommendedDelay=null
```

```dart
// CallBloc:
if (recommendedReconnectDelay != null) _scheduleReconnect(...);
// null → no reconnect scheduled
```

Signaling stays permanently disconnected. The user starts a new call → \`__onCallPerformEventStarted\` passively waits for \`signalingReady || signalingFailed\` → neither fires → timeout → fail.

**Before PR #1024**, code 4610 always set \`shouldReconnect = true\` — reconnect happened unconditionally regardless of intent. The regression is that \`_intentionalDisconnect\` now suppresses the reconnect hint even for server-side 4610.

---

## Fixes

### Fix 1 — root cause: skip hangup after blind transfer enters Transfering state

In \`__onCallPerformEventEnded\`, do not send \`HangupRequest\` when the call's transfer state is \`Transfering(fromBlindTransfer: true)\`. Per the [signaling docs](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/events/call/transferring.md), the [`transferring`](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/events/call/transferring.md) event marks that the server has started processing the transfer — at this point the SIP dialog may already be closed server-side via REFER. Sending hangup triggers a 4610 rejection and the unintended WebSocket disconnect.

```dart
final isBlindTransferInTransferingState = switch (activeCall.transfer) {
  Transfering(:final fromBlindTransfer) => fromBlindTransfer,
  _ => false,
};

if (!isBlindTransferInTransferingState) {
  await _signalingModule.signalingClient?.execute(hangupRequest)...;
}
```

### Fix 2 — safety net: trigger reconnect when starting an outgoing call with no signaling

In \`__onCallPerformEventStarted\`, call \`_scheduleReconnect(Duration.zero)\` before waiting on the stream. This makes outgoing calls self-healing regardless of how the previous disconnect was classified.

```dart
if (!currentState.isHandshakeEstablished || !currentState.isSignalingEstablished) {
  _scheduleReconnect(Duration.zero); // ← added
  emit(/* outgoingConnectingToSignaling */);
  currentState = await stream.firstWhere(...).timeout(...);
}
```

Guards inside \`_scheduleReconnect\` (\`signalingRemains\`, \`appActive\`, \`connectionActive\`, \`_connecting\`) prevent side effects when signaling is already active or a connect is already in flight.

---

## Verification

Tested on Google Pixel 9 / Android 16 (logcat \`2026-03-31_173840\`) with both fixes applied:
- Blind transfer completes with NOTIFY 200 OK + \`subscription_state: terminated\`
- Client correctly skips the HangupRequest
- Server sends [`hangup`](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/events/call/hangup.md) event (code 200, "Session Terminated") — no 4610
- WebSocket remains connected after transfer
- Signaling stays \`connected\`, registration stays \`registered\`

---

## Tests

**\`call_state_test.dart\`** — \`Transfer — isBlindTransferInTransferingState detection\` (5 cases):
verifies the switch pattern that guards the hangup skip across all Transfer states.

**\`signaling_module_test.dart\`** — \`SignalingModule - requestCallIdError (4610) reconnect hint\` (2 cases):
- non-intentional 4610 → \`recommendedReconnectDelay != null\` (reconnect scheduled)
- intentional \`disconnect()\` + server 4610 → \`recommendedReconnectDelay == null\` (suppressed — the exact condition that caused WT-1214)

---

## References

- [Signaling disconnect codes](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/disconnect_codes.md)
- [`transfer` request](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/requests/call/transfer.md)
- [`hangup` request](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/requests/call/hangup.md)
- [`transferring` event](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/events/call/transferring.md)
- [`notify` event](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/events/call/notify.md)
- [`hangup` event](https://github.com/WebTrit/webtrit_docs/blob/main/signaling/events/call/hangup.md)