### PR TITLE
fix: call drops after theme or lang change

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -141,7 +141,9 @@ class _AppState extends State<App> {
                     context.read<AppAnalyticsRepository>().createObserver(),
                     AutoRouteObserver(),
                   ],
-                  reevaluateListenable: ReevaluateListenable.stream(appBloc.stream),
+                  reevaluateListenable: ReevaluateListenable.stream(
+                    appBloc.stream.distinct((p, n) => p.compareToReevaluate(n)),
+                  ),
                 ),
               );
             },

--- a/lib/blocs/app/app_state.dart
+++ b/lib/blocs/app/app_state.dart
@@ -22,4 +22,15 @@ sealed class AppState with _$AppState {
   ThemeMode get effectiveThemeMode => isThemeModeSupported ? themeMode : ThemeMode.light;
 
   Locale? get effectiveLocale => locale == LocaleExtension.defaultNull ? null : locale;
+
+  /// Compares the current state with another [AppState] to determine if a reevaluation is needed.
+  ///
+  /// Added after bugs when call drops after theme change or locale change
+  bool compareToReevaluate(AppState other) {
+    return status == other.status &&
+        logoutReason == other.logoutReason &&
+        session == other.session &&
+        userAgreementStatus == other.userAgreementStatus &&
+        contactsAgreementStatus == other.contactsAgreementStatus;
+  }
 }


### PR DESCRIPTION
This pull request improves how the app determines when to trigger a reevaluation in response to changes in the application state. The main change is the introduction of a custom comparison method to avoid unnecessary reevaluations, especially after theme or locale changes, which previously caused bugs like dropped calls.

State management improvements:

* Added a `compareToReevaluate` method to the `AppState` class to compare only relevant fields (such as `status`, `logoutReason`, `session`, `userAgreementStatus`, and `contactsAgreementStatus`) for reevaluation, addressing issues where reevaluation was incorrectly triggered by theme or locale changes.
* Updated the `reevaluateListenable` in `app.dart` to use the new `compareToReevaluate` method with `distinct`, ensuring that only meaningful changes in `AppState` trigger a reevaluation.