### PR TITLE
fix: prevent premature call routing state emission before signaling handshake

### DIFF
--- a/lib/features/call_routing/cubit/call_routing_cubit.dart
+++ b/lib/features/call_routing/cubit/call_routing_cubit.dart
@@ -47,7 +47,12 @@ class CallRoutingCubit extends Cubit<CallRoutingState?> {
         .listen(emit);
   }
 
-  CallRoutingState _combineInfo(UserInfo userInfo, LinesState linesState) {
+  CallRoutingState? _combineInfo(UserInfo userInfo, LinesState linesState) {
+    // The signaling handshake has not arrived yet — line counts are unknown.
+    // Return null so the cubit stays in its unready state and CallController
+    // waits (via _waitForRoutingState) instead of blocking the call immediately.
+    if (linesState.isBlank) return null;
+
     final mainNumber = userInfo.numbers.main;
     final additionalNumbers = userInfo.numbers.additional?.nonNulls.toList() ?? [];
     final mainLinesState = linesState.mainLines;

--- a/lib/models/lines_state.dart
+++ b/lib/models/lines_state.dart
@@ -10,6 +10,13 @@ class LinesState extends Equatable {
 
   factory LinesState.blank() => const LinesState(mainLines: [], guestLine: null);
 
+  /// True when this state was produced by [LinesState.blank] — i.e. the
+  /// signaling handshake has not been received yet and line counts are unknown.
+  ///
+  /// After the first handshake, [CallBloc] always sets a non-null [guestLine],
+  /// so [guestLine] == null is an unambiguous marker for the pre-handshake state.
+  bool get isBlank => mainLines.isEmpty && guestLine == null;
+
   @override
   List<Object?> get props => [mainLines, guestLine];
 


### PR DESCRIPTION
## Problem

At app startup, `LinesStateRepository` initializes with `LinesState.blank()` (`mainLines: [], guestLine: null`). The `combineLatest` in `CallRoutingCubit._startInfoSubscription()` fires immediately when both sources emit — cached `UserInfo` + the initial blank `LinesState`.

This causes `CallRoutingCubit` to emit a **non-null state with empty `mainLines`** before the signaling handshake arrives. `CallController` sees a non-null routing state and skips `_waitForRoutingState()`, then evaluates `hasIdleMainLine = [].any(...) = false` — identical to "all lines busy" — and blocks the call with `CallUndefinedLineNotification` / "no idle lines available".

## Root cause

`_combineInfo` returned `CallRoutingState` (non-null) even for blank lines state. `CallController._createCallAsync()` only waits when `callRoutingCubit.state == null`.

## Fix

**`LinesState.isBlank`** — unambiguous pre-handshake discriminator. After any handshake, `CallBloc.onChange()` always sets `guestLine` to `idle` or `inUse` (never null). Only `LinesState.blank()` has `guestLine == null`.

**`_combineInfo`** return type changed to `CallRoutingState?`. Returns `null` when `linesState.isBlank` so the cubit stays in its unready state and `CallController` correctly waits via `_waitForRoutingState()` (10 s timeout → `NoInternetConnectionNotification`).

No changes to `CallController` — it already handles null state correctly.

## Testing

All existing tests pass (`flutter test test/features/call/controllers/call_controller_test.dart`).