### PR TITLE
refactor: extract SignalingModuleInterface; migrate CallBloc and IsolateManager; extract toLinesState

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -45,7 +45,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// runs in parallel while the widget tree and [CallBloc] are being built.
   /// Late subscribers (including [CallBloc]) receive all buffered session
   /// events via the replay stream.
-  late final SignalingModule _signalingModule;
+  late final SignalingModuleIsolateImpl _signalingModule;
 
   /// The [PollingService] instance that handles periodic polling of repositories.
   late PollingService? _polling;
@@ -82,7 +82,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     context.read<AppLogger>().updateRemoteLabels();
 
     final session = context.read<AppBloc>().state.session;
-    _signalingModule = SignalingModule(
+    _signalingModule = SignalingModuleIsolateImpl(
       coreUrl: session.coreUrl!,
       tenantId: session.tenantId,
       token: session.token!,

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -308,15 +308,23 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     final linesCount = change.nextState.linesCount;
     final activeCalls = change.nextState.activeCalls;
-    final List<LineState> mainLinesState = [];
-    for (var i = 0; i < linesCount; i++) {
-      final inUse = activeCalls.any((e) => e.line == i);
-      mainLinesState.add(inUse ? LineState.inUse : LineState.idle);
-    }
-    final guestLineInUse = activeCalls.any((e) => e.line == null);
-    final guestLineState = guestLineInUse ? LineState.inUse : LineState.idle;
 
-    linesStateRepository.setState(LinesState(mainLines: mainLinesState, guestLine: guestLineState));
+    // linesCount == 0 means the signaling handshake has not arrived yet.
+    // Keep the repository in blank state so CallRoutingCubit stays unready
+    // and CallController waits instead of blocking calls with "no idle lines".
+    if (linesCount == 0) {
+      linesStateRepository.setState(LinesState.blank());
+    } else {
+      final List<LineState> mainLinesState = [];
+      for (var i = 0; i < linesCount; i++) {
+        final inUse = activeCalls.any((e) => e.line == i);
+        mainLinesState.add(inUse ? LineState.inUse : LineState.idle);
+      }
+      final guestLineInUse = activeCalls.any((e) => e.line == null);
+      final guestLineState = guestLineInUse ? LineState.inUse : LineState.idle;
+
+      linesStateRepository.setState(LinesState(mainLines: mainLinesState, guestLine: guestLineState));
+    }
     _handleSignalingSessionError(
       previous: change.currentState.callServiceState,
       current: change.nextState.callServiceState,

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -84,7 +84,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
 
-  late final SignalingModuleInterface _signalingModule;
+  late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
   Timer? _signalingClientReconnectTimer;
   Timer? _presenceInfoSyncTimer;
@@ -115,7 +115,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     this.webRtcOptionsBuilder,
     this.iceFilter,
     this.peerConnectionPolicyApplier,
-    required SignalingModuleInterface signalingModule,
+    required SignalingModule signalingModule,
     required PeerConnectionManager peerConnectionManager,
     this.onCallEnded,
   }) : super(const CallState()) {

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -84,7 +84,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
 
-  late final SignalingModule _signalingModule;
+  late final SignalingModuleInterface _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
   Timer? _signalingClientReconnectTimer;
   Timer? _presenceInfoSyncTimer;
@@ -115,7 +115,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     this.webRtcOptionsBuilder,
     this.iceFilter,
     this.peerConnectionPolicyApplier,
-    required SignalingModule signalingModule,
+    required SignalingModuleInterface signalingModule,
     required PeerConnectionManager peerConnectionManager,
     this.onCallEnded,
   }) : super(const CallState()) {
@@ -227,7 +227,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           appLifecycleState == AppLifecycleState.detached ||
           appLifecycleState == AppLifecycleState.inactive;
       final hasActiveCalls = change.nextState.isActive;
-      final connected = _signalingModule.signalingClient != null;
+      final connected = _signalingModule.isConnected;
 
       if (appInactive) {
         if (hasActiveCalls && !connected) {
@@ -438,7 +438,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _signalingClientReconnectTimer = Timer(delay, () {
       final appActive = state.currentAppLifecycleState == AppLifecycleState.resumed;
       final connectionActive = state.callServiceState.networkStatus != NetworkStatus.none;
-      final signalingRemains = _signalingModule.signalingClient != null;
+      final signalingRemains = _signalingModule.isConnected;
 
       _logger.info(
         '_scheduleReconnect Timer callback after $delay, isClosed: $isClosed, appActive: $appActive, connectionActive: $connectionActive',
@@ -1148,7 +1148,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             // localDescription should be set before sending the answer to transition into stable state.
             await peerConnection.setLocalDescription(localDescription);
 
-            await _signalingModule.signalingClient?.execute(
+            await _signalingModule.execute(
               UpdateRequest(
                 transaction: WebtritSignalingClient.generateTransactionId(),
                 line: activeCall.line,
@@ -1608,7 +1608,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         number: event.number,
       );
 
-      await _signalingModule.signalingClient?.execute(transferRequest);
+      await _signalingModule.execute(transferRequest);
 
       var newState = state.copyWith(minimized: false);
       newState = newState.copyWithMappedActiveCall(callId, (activeCall) {
@@ -1652,7 +1652,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         replaceCallId: replaceCall.callId,
       );
 
-      await _signalingModule.signalingClient?.execute(transferRequest);
+      await _signalingModule.execute(transferRequest);
 
       emit(
         state.copyWithMappedActiveCall(referorCall.callId, (activeCall) {
@@ -1720,7 +1720,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         referId: referId,
       );
 
-      await _signalingModule.signalingClient?.execute(declineRequest);
+      await _signalingModule.execute(declineRequest);
 
       emit(
         state.copyWithMappedActiveCall(callId, (activeCall) {
@@ -1870,7 +1870,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
       // Need to initiate outgoing call before set localDescription to avoid races
       // between [OutgoingCallRequest] and [IceTrickleRequest]s.
-      await _signalingModule.signalingClient?.execute(
+      await _signalingModule.execute(
         OutgoingCallRequest(
           transaction: WebtritSignalingClient.generateTransactionId(),
           line: activeCall.line,
@@ -1993,7 +1993,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // localDescription should be set before sending the answer to transition into stable state.
       await peerConnection.setLocalDescription(localDescription).catchError((e) => throw SDPConfigurationError(e));
 
-      await _signalingModule.signalingClient?.execute(
+      await _signalingModule.execute(
         AcceptRequest(
           transaction: WebtritSignalingClient.generateTransactionId(),
           line: call.line,
@@ -2011,7 +2011,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
       final declineId = WebtritSignalingClient.generateTransactionId();
       final declineRequest = DeclineRequest(transaction: declineId, line: call.line, callId: call.callId);
-      _signalingModule.signalingClient?.execute(declineRequest).ignore();
+      _signalingModule.execute(declineRequest)?.ignore();
 
       callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
     }
@@ -2052,7 +2052,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           line: activeCall.line,
           callId: activeCall.callId,
         );
-        await _signalingModule.signalingClient?.execute(declineRequest).catchError((e, s) {
+        await _signalingModule.execute(declineRequest)?.catchError((e, s) {
           callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
         });
       } else {
@@ -2070,7 +2070,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             line: activeCall.line,
             callId: activeCall.callId,
           );
-          await _signalingModule.signalingClient?.execute(hangupRequest).catchError((e, s) {
+          await _signalingModule.execute(hangupRequest)?.catchError((e, s) {
             callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
           });
         }
@@ -2092,7 +2092,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     try {
       await state.performOnActiveCall(event.callId, (activeCall) {
         if (event.onHold) {
-          return _signalingModule.signalingClient?.execute(
+          return _signalingModule.execute(
             HoldRequest(
               transaction: WebtritSignalingClient.generateTransactionId(),
               line: activeCall.line,
@@ -2101,7 +2101,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             ),
           );
         } else {
-          return _signalingModule.signalingClient?.execute(
+          return _signalingModule.execute(
             UnholdRequest(
               transaction: WebtritSignalingClient.generateTransactionId(),
               line: activeCall.line,
@@ -2223,7 +2223,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
               line: activeCall.line,
               candidate: null,
             );
-            return _signalingModule.signalingClient?.execute(iceTrickleRequest);
+            return _signalingModule.execute(iceTrickleRequest);
           }
         });
       } catch (e, stackTrace) {
@@ -2267,7 +2267,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
                   callId: activeCall.callId,
                   jsep: localDescription.toMap(),
                 );
-                await _signalingModule.signalingClient?.execute(updateRequest);
+                await _signalingModule.execute(updateRequest);
               } else {
                 _logger.warning(
                   '__onPeerConnectionEventIceConnectionStateChanged: signalingState changed mid-flight ($currentState), skipping setLocalDescription',
@@ -2307,7 +2307,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             line: activeCall.line,
             candidate: event.candidate.toMap(),
           );
-          return _signalingModule.signalingClient?.execute(iceTrickleRequest);
+          return _signalingModule.execute(iceTrickleRequest);
         }
       });
     } catch (e, stackTrace) {
@@ -2510,7 +2510,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
               line: callEvent.line,
               callId: callEvent.callId,
             );
-            await _signalingModule.signalingClient?.execute(hangupRequest).catchError((e, s) {
+            await _signalingModule.execute(hangupRequest)?.catchError((e, s) {
               callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
             });
 
@@ -2522,7 +2522,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
               line: callEvent.line,
               callId: callEvent.callId,
             );
-            await _signalingModule.signalingClient?.execute(declineRequest).catchError((e, s) {
+            await _signalingModule.execute(declineRequest)?.catchError((e, s) {
               callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
             });
             return;
@@ -2891,7 +2891,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       callId: callId,
       jsep: jsep.toMap(),
     );
-    await _signalingModule.signalingClient?.execute(updateRequest);
+    await _signalingModule.execute(updateRequest);
   }
 
   void _addToRecents(ActiveCall activeCall) {
@@ -2979,7 +2979,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (shouldUpdate && canUpdate) {
       _logger.fine('_presenceInfoSyncTimer: updating presence settings');
       try {
-        await _signalingModule.signalingClient?.execute(
+        await _signalingModule.execute(
           PresenceSettingsUpdateRequest(
             transaction: clock.now().millisecondsSinceEpoch.toString(),
             settings: SignalingPresenceSettingsMapper.toSignaling(presenceSettings),

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -306,26 +306,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
     }
 
-    final linesCount = change.nextState.linesCount;
-    final activeCalls = change.nextState.activeCalls;
-
-    // linesCount == 0 before the first handshake means line counts are unknown.
-    // Keep blank so CallRoutingCubit stays unready until the handshake arrives.
-    // After handshake (isHandshakeEstablished), linesCount == 0 is a valid state
-    // (no main lines configured), so compute real LinesState to allow guest-line calls.
-    if (linesCount == 0 && !change.nextState.isHandshakeEstablished) {
-      linesStateRepository.setState(LinesState.blank());
-    } else {
-      final List<LineState> mainLinesState = [];
-      for (var i = 0; i < linesCount; i++) {
-        final inUse = activeCalls.any((e) => e.line == i);
-        mainLinesState.add(inUse ? LineState.inUse : LineState.idle);
-      }
-      final guestLineInUse = activeCalls.any((e) => e.line == null);
-      final guestLineState = guestLineInUse ? LineState.inUse : LineState.idle;
-
-      linesStateRepository.setState(LinesState(mainLines: mainLinesState, guestLine: guestLineState));
-    }
+    linesStateRepository.setState(change.nextState.toLinesState());
     _handleSignalingSessionError(
       previous: change.currentState.callServiceState,
       current: change.nextState.callServiceState,

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -769,6 +769,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final contactName = await contactNameResolver.resolveWithNumber(event.handle.value);
     final displayName = contactName ?? event.displayName;
 
+    // Re-check after the async gap: the signaling path may have created an entry
+    // for this callId while contact resolution was in progress.
+    if (state.activeCalls.any((c) => c.callId == event.callId)) {
+      _logger.fine(
+        '_onCallPushEventIncoming: callId ${event.callId} handled during contact resolution — skipping push duplicate',
+      );
+      return;
+    }
+
     emit(
       state.copyWithPushActiveCall(
         ActiveCall(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -309,10 +309,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final linesCount = change.nextState.linesCount;
     final activeCalls = change.nextState.activeCalls;
 
-    // linesCount == 0 means the signaling handshake has not arrived yet.
-    // Keep the repository in blank state so CallRoutingCubit stays unready
-    // and CallController waits instead of blocking calls with "no idle lines".
-    if (linesCount == 0) {
+    // linesCount == 0 before the first handshake means line counts are unknown.
+    // Keep blank so CallRoutingCubit stays unready until the handshake arrives.
+    // After handshake (isHandshakeEstablished), linesCount == 0 is a valid state
+    // (no main lines configured), so compute real LinesState to allow guest-line calls.
+    if (linesCount == 0 && !change.nextState.isHandshakeEstablished) {
       linesStateRepository.setState(LinesState.blank());
     } else {
       final List<LineState> mainLinesState = [];

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -41,6 +41,24 @@ class CallState with _$CallState {
   /// Indicates that the signaling connection to the server is successfully established.
   bool get isSignalingEstablished => callServiceState.signalingClientStatus.isConnect;
 
+  /// Computes the [LinesState] that reflects the current lines and active calls.
+  ///
+  /// Returns [LinesState.blank] when [linesCount] is 0 and the signaling
+  /// handshake has not yet been received ([isHandshakeEstablished] is false),
+  /// keeping [CallRoutingCubit] in the unready state until server config arrives.
+  ///
+  /// After the handshake, [linesCount] == 0 is a valid server configuration
+  /// (no main lines), so a real [LinesState] is computed to allow guest-line calls.
+  LinesState toLinesState() {
+    if (linesCount == 0 && !isHandshakeEstablished) return LinesState.blank();
+    final mainLines = List.generate(linesCount, (i) {
+      final inUse = activeCalls.any((e) => e.line == i);
+      return inUse ? LineState.inUse : LineState.idle;
+    });
+    final guestLineInUse = activeCalls.any((e) => e.line == null);
+    return LinesState(mainLines: mainLines, guestLine: guestLineInUse ? LineState.inUse : LineState.idle);
+  }
+
   int? retrieveIdleLine() {
     for (var line = 0; line < linesCount; line++) {
       if (!activeCalls.any((activeCall) => activeCall.line == line)) {

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -220,9 +220,17 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
         continue;
       }
 
-      _signalingModule
-          .execute(pending.requestBuilder(lineIndex, pending.callId, WebtritSignalingClient.generateTransactionId()))
-          ?.then((_) => pending.completer.complete())
+      final future = _signalingModule.execute(
+        pending.requestBuilder(lineIndex, pending.callId, WebtritSignalingClient.generateTransactionId()),
+      );
+      if (future == null) {
+        pending.completer.completeError(StateError('Signaling disconnected while flushing callId: ${pending.callId}'));
+        pending.timeoutTimer.cancel();
+        _pendingRequests.remove(pending);
+        continue;
+      }
+      future
+          .then((_) => pending.completer.complete())
           .catchError((e, s) => pending.completer.completeError(e, s))
           .whenComplete(() {
             pending.timeoutTimer.cancel();
@@ -258,7 +266,14 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
     final lineIndex = _lines[callId];
     if (lineIndex == null) return;
 
-    await _signalingModule.execute(requestBuilder(lineIndex, callId, WebtritSignalingClient.generateTransactionId()));
+    final future = _signalingModule.execute(
+      requestBuilder(lineIndex, callId, WebtritSignalingClient.generateTransactionId()),
+    );
+    if (future == null) {
+      logger.warning('execute returned null for callId $callId (disconnected after isConnected check)');
+      return;
+    }
+    await future;
   }
 
   // Callbacks - may be overridden by subclasses.

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -31,7 +31,7 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
   final SecureStorage storage;
   final TrustedCertificates certificates;
 
-  late final SignalingModuleInterface _signalingModule;
+  late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
 
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
@@ -56,10 +56,10 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
 
   Future<void> endCallsOnService();
 
-  /// Initialises the [SignalingModule] and starts connectivity monitoring.
+  /// Initialises the [SignalingModuleIsolateImpl] and starts connectivity monitoring.
   /// Must be called in the constructor body of the child class.
   void initSignaling({required bool enableReconnect}) {
-    _signalingModule = SignalingModule(
+    _signalingModule = SignalingModuleIsolateImpl(
       coreUrl: storage.readCoreUrl() ?? '',
       tenantId: storage.readTenantId() ?? '',
       token: storage.readToken() ?? '',

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -31,7 +31,7 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
   final SecureStorage storage;
   final TrustedCertificates certificates;
 
-  late final SignalingModule _signalingModule;
+  late final SignalingModuleInterface _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
 
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
@@ -78,14 +78,14 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
           if (enableReconnect && !_networkNone) {
             _signalingReconnectTimer?.cancel();
             _signalingReconnectTimer = Timer(recommendedReconnectDelay, () {
-              if (_signalingModule.signalingClient == null) _signalingModule.connect();
+              if (!_signalingModule.isConnected) _signalingModule.connect();
             });
           }
         case SignalingDisconnected(:final recommendedReconnectDelay):
           if (enableReconnect && recommendedReconnectDelay != null && !_networkNone) {
             _signalingReconnectTimer?.cancel();
             _signalingReconnectTimer = Timer(recommendedReconnectDelay, () {
-              if (_signalingModule.signalingClient == null) _signalingModule.connect();
+              if (!_signalingModule.isConnected) _signalingModule.connect();
             });
           }
         default:
@@ -147,7 +147,7 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
         _networkNone = false;
         connectivityNoneCounter = 0;
 
-        if (enableReconnect && _signalingModule.signalingClient == null) {
+        if (enableReconnect && !_signalingModule.isConnected) {
           _signalingModule.connect();
         }
       }
@@ -220,9 +220,9 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
         continue;
       }
 
-      _signalingModule.signalingClient
-          ?.execute(pending.requestBuilder(lineIndex, pending.callId, WebtritSignalingClient.generateTransactionId()))
-          .then((_) => pending.completer.complete())
+      _signalingModule
+          .execute(pending.requestBuilder(lineIndex, pending.callId, WebtritSignalingClient.generateTransactionId()))
+          ?.then((_) => pending.completer.complete())
           .catchError((e, s) => pending.completer.completeError(e, s))
           .whenComplete(() {
             pending.timeoutTimer.cancel();
@@ -232,8 +232,7 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
   }
 
   Future<void> _sendRequest(String callId, Request Function(int line, String callId, String tx) requestBuilder) async {
-    final client = _signalingModule.signalingClient;
-    if (client == null) {
+    if (!_signalingModule.isConnected) {
       logger.warning('Not connected. Queueing request for $callId');
 
       final completer = Completer<void>();
@@ -259,7 +258,7 @@ abstract class IsolateManager implements CallkeepBackgroundServiceDelegate {
     final lineIndex = _lines[callId];
     if (lineIndex == null) return;
 
-    await client.execute(requestBuilder(lineIndex, callId, WebtritSignalingClient.generateTransactionId()));
+    await _signalingModule.execute(requestBuilder(lineIndex, callId, WebtritSignalingClient.generateTransactionId()));
   }
 
   // Callbacks - may be overridden by subclasses.

--- a/lib/features/call/services/signaling_module.dart
+++ b/lib/features/call/services/signaling_module.dart
@@ -76,24 +76,52 @@ class SignalingProtocolEvent extends SignalingModuleEvent {
 
 /// Contract for a signaling module used by [IsolateManager] and other consumers.
 ///
-/// Abstracts the concrete [SignalingModule] so that the integration layer can
-/// be swapped to a plugin-backed implementation without changing consumers.
-/// When the webtrit_signaling_service plugin is integrated, this interface will
-/// be replaced by [SignalingModuleInterface] from the plugin's platform-interface
+/// Abstracts the concrete [SignalingModuleIsolateImpl] so that the integration
+/// layer can be swapped to a plugin-backed implementation without changing
+/// consumers. When the webtrit_signaling_service plugin is integrated, this
+/// interface will be replaced by the one from the plugin's platform-interface
 /// package and this local definition removed.
-abstract class SignalingModuleInterface {
+abstract class SignalingModule {
+  /// Broadcast stream of all module lifecycle and protocol events.
+  ///
+  /// Each new subscriber immediately receives all lifecycle and handshake events
+  /// buffered since the last [connect] call, followed by live events.
+  /// [SignalingProtocolEvent] items are NOT replayed — they are delivered only
+  /// to subscribers already listening when they occur.
   Stream<SignalingModuleEvent> get events;
 
+  /// Whether the signaling client is currently connected.
+  ///
+  /// Returns `true` between a successful [connect] and the next [disconnect]
+  /// or connection failure. Use this to guard [execute] calls.
   bool get isConnected;
 
+  /// Initiates a connection. Fire-and-forget — returns immediately.
+  ///
+  /// The result arrives asynchronously via [events] as [SignalingConnected]
+  /// or [SignalingConnectionFailed]. Calling [connect] when already connected
+  /// or while a connection attempt is in progress is a no-op.
   void connect();
 
+  /// Disconnects the current client gracefully.
+  ///
+  /// Emits [SignalingDisconnecting] immediately. [SignalingDisconnected] is
+  /// emitted later once the underlying WebSocket close-ack arrives. Returns
+  /// immediately — callers must not assume the connection is closed when the
+  /// returned [Future] completes.
   Future<void> disconnect();
 
   /// Sends [request] via the active connection.
-  /// Returns null when not connected.
+  ///
+  /// Returns `null` when not connected; callers must handle this case.
+  /// Returns a [Future] that completes when the request has been written to
+  /// the transport.
   Future<void>? execute(Request request);
 
+  /// Disconnects and closes the event stream.
+  ///
+  /// After [dispose] the module must not be used. Awaiting [dispose] gives
+  /// [SignalingDisconnected] time to be emitted before the stream closes.
   Future<void> dispose();
 }
 
@@ -107,8 +135,8 @@ abstract class SignalingModuleInterface {
 /// Knows only the WebSocket protocol - nothing about [CallState], BLoC, emit,
 /// notifications, or app lifecycle. Can be used in the main isolate, a
 /// background isolate, or an integration test without any UI dependency.
-class SignalingModule implements SignalingModuleInterface {
-  SignalingModule({
+class SignalingModuleIsolateImpl implements SignalingModule {
+  SignalingModuleIsolateImpl({
     required this.coreUrl,
     required this.tenantId,
     required this.token,
@@ -173,7 +201,7 @@ class SignalingModule implements SignalingModuleInterface {
   /// Each new subscriber immediately receives all lifecycle and handshake events
   /// buffered since the last [connect] call (e.g. [SignalingConnecting],
   /// [SignalingConnected], [SignalingHandshakeReceived]), followed by live events.
-  /// This allows [SignalingModule] to be connected before [CallBloc] (or any
+  /// This allows [SignalingModuleIsolateImpl] to be connected before [CallBloc] (or any
   /// other consumer) is created without missing session state.
   ///
   /// Note: [SignalingProtocolEvent] (call events) are NOT replayed - they are

--- a/lib/features/call/services/signaling_module.dart
+++ b/lib/features/call/services/signaling_module.dart
@@ -71,6 +71,33 @@ class SignalingProtocolEvent extends SignalingModuleEvent {
 }
 
 // ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+/// Contract for a signaling module used by [IsolateManager] and other consumers.
+///
+/// Abstracts the concrete [SignalingModule] so that the integration layer can
+/// be swapped to a plugin-backed implementation without changing consumers.
+/// When the webtrit_signaling_service plugin is integrated, this interface will
+/// be replaced by [SignalingModuleInterface] from the plugin's platform-interface
+/// package and this local definition removed.
+abstract class SignalingModuleInterface {
+  Stream<SignalingModuleEvent> get events;
+
+  bool get isConnected;
+
+  void connect();
+
+  Future<void> disconnect();
+
+  /// Sends [request] via the active connection.
+  /// Returns null when not connected.
+  Future<void>? execute(Request request);
+
+  Future<void> dispose();
+}
+
+// ---------------------------------------------------------------------------
 // Module
 // ---------------------------------------------------------------------------
 
@@ -80,7 +107,7 @@ class SignalingProtocolEvent extends SignalingModuleEvent {
 /// Knows only the WebSocket protocol - nothing about [CallState], BLoC, emit,
 /// notifications, or app lifecycle. Can be used in the main isolate, a
 /// background isolate, or an integration test without any UI dependency.
-class SignalingModule {
+class SignalingModule implements SignalingModuleInterface {
   SignalingModule({
     required this.coreUrl,
     required this.tenantId,
@@ -158,6 +185,7 @@ class SignalingModule {
   /// the returned [StreamSubscription] for the consumer's lifetime; calling
   /// it multiple times without cancelling previous subscriptions leaks
   /// controllers.
+  @override
   Stream<SignalingModuleEvent> get events {
     // Take a snapshot of the buffer BEFORE subscribing to the live stream so
     // that any event arriving between snapshot and subscribe is delivered only
@@ -193,12 +221,19 @@ class SignalingModule {
   /// Null when not connected.
   WebtritSignalingClient? get signalingClient => _client;
 
+  @override
+  bool get isConnected => _client != null;
+
+  @override
+  Future<void>? execute(Request request) => _client?.execute(request);
+
   /// Initiates a connection. Fire-and-forget - returns immediately.
   /// The result arrives via [events] as [SignalingConnected] or
   /// [SignalingConnectionFailed].
   ///
   /// Clears the session buffer so that late subscribers receive only events
   /// from the current session, not stale events from a previous one.
+  @override
   void connect() {
     if (_disposed || _connecting) return;
     _sessionBuffer.clear();
@@ -210,6 +245,7 @@ class SignalingModule {
   /// asynchronously, only when the underlying WebSocket close-ack arrives via
   /// the [_onDisconnect] callback - it is NOT guaranteed to arrive before this
   /// Future completes.
+  @override
   Future<void> disconnect() async {
     final client = _client;
     if (client == null) return;
@@ -228,6 +264,7 @@ class SignalingModule {
 
   /// Disconnects and closes the event stream. After [dispose], the module
   /// must not be used.
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/lib/features/call_routing/cubit/call_routing_cubit.dart
+++ b/lib/features/call_routing/cubit/call_routing_cubit.dart
@@ -47,7 +47,12 @@ class CallRoutingCubit extends Cubit<CallRoutingState?> {
         .listen(emit);
   }
 
-  CallRoutingState _combineInfo(UserInfo userInfo, LinesState linesState) {
+  CallRoutingState? _combineInfo(UserInfo userInfo, LinesState linesState) {
+    // The signaling handshake has not arrived yet — line counts are unknown.
+    // Return null so the cubit stays in its unready state and CallController
+    // waits (via _waitForRoutingState) instead of blocking the call immediately.
+    if (linesState.isBlank) return null;
+
     final mainNumber = userInfo.numbers.main;
     final additionalNumbers = userInfo.numbers.additional?.nonNulls.toList() ?? [];
     final mainLinesState = linesState.mainLines;

--- a/lib/features/settings/features/network/bloc/network_cubit.dart
+++ b/lib/features/settings/features/network/bloc/network_cubit.dart
@@ -2,7 +2,6 @@ import 'package:bloc/bloc.dart';
 import 'package:webtrit_phone/extensions/iterable.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/incoming_call_type/incoming_call_type_repository.dart';
@@ -18,7 +17,7 @@ class NetworkCubit extends Cubit<NetworkState> {
     this._callTriggerConfig,
     this._deviceInfo,
     this._incomingCallTypeRepository,
-    this._callkeepBackgroundService,
+    this._onIncomingCallTypeChanged,
   ) : super(NetworkState(smsFallbackEnabled: _callTriggerConfig.smsFallback.enabled)) {
     _initializeActiveIncomingType();
   }
@@ -26,17 +25,14 @@ class NetworkCubit extends Cubit<NetworkState> {
   final CallTriggerConfig _callTriggerConfig;
   final DeviceInfo _deviceInfo;
   final IncomingCallTypeRepository _incomingCallTypeRepository;
-  final BackgroundSignalingBootstrapService _callkeepBackgroundService;
+  final Future<void> Function(IncomingCallType) _onIncomingCallTypeChanged;
 
   bool get smsFallbackAvailable => _callTriggerConfig.smsFallback.available;
 
   void _initializeActiveIncomingType() {
     final currentType = _incomingCallTypeRepository.getIncomingCallType();
-
     final models = _buildIncomingCallTypeModels(currentType);
-
     final incomingCallTypesRemainder = _buildIncomingCallTypesRemainder();
-
     emit(state.copyWith(incomingCallTypeModels: models, incomingCallTypesRemainder: incomingCallTypesRemainder));
   }
 
@@ -54,16 +50,7 @@ class NetworkCubit extends Cubit<NetworkState> {
 
   Future<void> selectIncomingCallType(IncomingCallTypeModel selectedTypeModel) async {
     await _incomingCallTypeRepository.setIncomingCallType(selectedTypeModel.incomingCallType);
-
-    switch (selectedTypeModel.incomingCallType) {
-      case IncomingCallType.pushNotification:
-        await _callkeepBackgroundService.stopService();
-        break;
-      case IncomingCallType.socket:
-        await _callkeepBackgroundService.startService();
-        break;
-    }
-
+    await _onIncomingCallTypeChanged(selectedTypeModel.incomingCallType);
     _initializeActiveIncomingType();
   }
 }

--- a/lib/features/settings/features/network/view/network_screen_page.dart
+++ b/lib/features/settings/features/network/view/network_screen_page.dart
@@ -6,7 +6,6 @@ import 'package:provider/provider.dart';
 
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
-import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/incoming_call_type/incoming_call_type_repository.dart';
 
 import '../bloc/network_cubit.dart';

--- a/lib/features/settings/features/network/view/network_screen_page.dart
+++ b/lib/features/settings/features/network/view/network_screen_page.dart
@@ -4,8 +4,11 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
+
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/incoming_call_type/incoming_call_type_repository.dart';
 
 import '../bloc/network_cubit.dart';
@@ -27,9 +30,18 @@ class NetworkScreenPage extends StatelessWidget {
             featureAccess.callConfig.triggerConfig,
             context.read<DeviceInfo>(),
             context.read<IncomingCallTypeRepository>(),
-            // Signaling service lifecycle control is wired during the plugin
-            // integration step when the signaling service plugin is available.
-            (_) async {},
+            // Delegates start/stop of the background signaling service to the
+            // callkeep bootstrap. Replace this lambda when integrating the
+            // signaling service plugin — NetworkCubit stays unchanged.
+            (type) async {
+              final service = BackgroundSignalingBootstrapService();
+              switch (type) {
+                case IncomingCallType.pushNotification:
+                  await service.stopService();
+                case IncomingCallType.socket:
+                  await service.startService();
+              }
+            },
           ),
         ),
       ],

--- a/lib/features/settings/features/network/view/network_screen_page.dart
+++ b/lib/features/settings/features/network/view/network_screen_page.dart
@@ -4,10 +4,9 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 
-import 'package:webtrit_callkeep/webtrit_callkeep.dart';
-
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/incoming_call_type/incoming_call_type_repository.dart';
 
 import '../bloc/network_cubit.dart';
@@ -29,7 +28,9 @@ class NetworkScreenPage extends StatelessWidget {
             featureAccess.callConfig.triggerConfig,
             context.read<DeviceInfo>(),
             context.read<IncomingCallTypeRepository>(),
-            BackgroundSignalingBootstrapService(),
+            // Signaling service lifecycle control is wired during the plugin
+            // integration step when the signaling service plugin is available.
+            (_) async {},
           ),
         ),
       ],

--- a/lib/models/lines_state.dart
+++ b/lib/models/lines_state.dart
@@ -10,6 +10,13 @@ class LinesState extends Equatable {
 
   factory LinesState.blank() => const LinesState(mainLines: [], guestLine: null);
 
+  /// True when this state was produced by [LinesState.blank] — i.e. the
+  /// signaling handshake has not been received yet and line counts are unknown.
+  ///
+  /// After the first handshake, [CallBloc] always sets a non-null [guestLine],
+  /// so [guestLine] == null is an unambiguous marker for the pre-handshake state.
+  bool get isBlank => mainLines.isEmpty && guestLine == null;
+
   @override
   List<Object?> get props => [mainLines, guestLine];
 

--- a/lib/models/lines_state.dart
+++ b/lib/models/lines_state.dart
@@ -10,13 +10,13 @@ class LinesState extends Equatable {
 
   factory LinesState.blank() => const LinesState(mainLines: [], guestLine: null);
 
-  /// True when this state was produced by [LinesState.blank] — i.e. the
-  /// signaling handshake has not been received yet and line counts are unknown.
+  /// True when this state has no main lines and no guest line.
   ///
-  /// [CallBloc.onChange] sets [LinesState.blank] whenever [CallState.linesCount]
-  /// is 0 (pre-handshake). Once the handshake arrives and [linesCount] > 0,
-  /// [guestLine] is always non-null, so [guestLine] == null is an unambiguous
-  /// marker for the pre-handshake state.
+  /// This occurs in two situations:
+  /// - Pre-handshake: [CallBloc.onChange] sets [LinesState.blank] while
+  ///   [CallState.linesCount] is 0 and [CallState.isHandshakeEstablished] is false.
+  /// - Post-handshake with no lines: a valid server state where both main lines
+  ///   and guest line are absent (treated the same as blank by [CallRoutingCubit]).
   bool get isBlank => mainLines.isEmpty && guestLine == null;
 
   @override

--- a/lib/models/lines_state.dart
+++ b/lib/models/lines_state.dart
@@ -13,8 +13,10 @@ class LinesState extends Equatable {
   /// True when this state was produced by [LinesState.blank] — i.e. the
   /// signaling handshake has not been received yet and line counts are unknown.
   ///
-  /// After the first handshake, [CallBloc] always sets a non-null [guestLine],
-  /// so [guestLine] == null is an unambiguous marker for the pre-handshake state.
+  /// [CallBloc.onChange] sets [LinesState.blank] whenever [CallState.linesCount]
+  /// is 0 (pre-handshake). Once the handshake arrives and [linesCount] > 0,
+  /// [guestLine] is always non-null, so [guestLine] == null is an unambiguous
+  /// marker for the pre-handshake state.
   bool get isBlank => mainLines.isEmpty && guestLine == null;
 
   @override

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -1091,7 +1091,7 @@ void main() {
   // CallState.toLinesState
   // ---------------------------------------------------------------------------
 
-  const _kRegistered = CallServiceState(registration: Registration(status: RegistrationStatus.registered));
+  const kRegistered = CallServiceState(registration: Registration(status: RegistrationStatus.registered));
 
   group('CallState.toLinesState — pre-handshake', () {
     test('returns blank when linesCount is 0 and handshake not established', () {
@@ -1109,7 +1109,7 @@ void main() {
 
   group('CallState.toLinesState — post-handshake with 0 main lines', () {
     test('returns non-blank with idle guest line when no calls', () {
-      final state = CallState(linesCount: 0, callServiceState: _kRegistered);
+      final state = CallState(linesCount: 0, callServiceState: kRegistered);
       final result = state.toLinesState();
       expect(result.isBlank, isFalse);
       expect(result.mainLines, isEmpty);
@@ -1117,7 +1117,7 @@ void main() {
     });
 
     test('returns guest line inUse when guest call is active (line == null)', () {
-      final state = CallState(linesCount: 0, callServiceState: _kRegistered, activeCalls: [_makeCall(line: null)]);
+      final state = CallState(linesCount: 0, callServiceState: kRegistered, activeCalls: [_makeCall(line: null)]);
       final result = state.toLinesState();
       expect(result.mainLines, isEmpty);
       expect(result.guestLine, LineState.inUse);
@@ -1126,7 +1126,7 @@ void main() {
 
   group('CallState.toLinesState — post-handshake with main lines', () {
     test('all lines idle when no active calls', () {
-      final state = CallState(linesCount: 2, callServiceState: _kRegistered);
+      final state = CallState(linesCount: 2, callServiceState: kRegistered);
       final result = state.toLinesState();
       expect(result.mainLines, [LineState.idle, LineState.idle]);
       expect(result.guestLine, LineState.idle);
@@ -1135,7 +1135,7 @@ void main() {
     test('line 0 inUse when call on line 0', () {
       final state = CallState(
         linesCount: 2,
-        callServiceState: _kRegistered,
+        callServiceState: kRegistered,
         activeCalls: [_makeCall(callId: 'c1', line: 0)],
       );
       final result = state.toLinesState();
@@ -1146,7 +1146,7 @@ void main() {
     test('line 1 inUse when call on line 1', () {
       final state = CallState(
         linesCount: 2,
-        callServiceState: _kRegistered,
+        callServiceState: kRegistered,
         activeCalls: [_makeCall(callId: 'c1', line: 1)],
       );
       final result = state.toLinesState();
@@ -1157,7 +1157,7 @@ void main() {
     test('all lines inUse when calls on every line', () {
       final state = CallState(
         linesCount: 2,
-        callServiceState: _kRegistered,
+        callServiceState: kRegistered,
         activeCalls: [
           _makeCall(callId: 'c1', line: 0),
           _makeCall(callId: 'c2', line: 1),
@@ -1170,7 +1170,7 @@ void main() {
     test('guest line inUse when guest call present alongside main calls', () {
       final state = CallState(
         linesCount: 2,
-        callServiceState: _kRegistered,
+        callServiceState: kRegistered,
         activeCalls: [
           _makeCall(callId: 'c1', line: 0),
           _makeCall(callId: 'c2', line: null),
@@ -1185,7 +1185,7 @@ void main() {
     test('guest line idle when no guest call', () {
       final state = CallState(
         linesCount: 1,
-        callServiceState: _kRegistered,
+        callServiceState: kRegistered,
         activeCalls: [_makeCall(callId: 'c1', line: 0)],
       );
       expect(state.toLinesState().guestLine, LineState.idle);

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
 
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -1083,6 +1084,111 @@ void main() {
     test('hasAudio and hasVideo false when SDP is null', () {
       expect(makeJsep(null).hasAudio, isFalse);
       expect(makeJsep(null).hasVideo, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallState.toLinesState
+  // ---------------------------------------------------------------------------
+
+  const _kRegistered = CallServiceState(registration: Registration(status: RegistrationStatus.registered));
+
+  group('CallState.toLinesState — pre-handshake', () {
+    test('returns blank when linesCount is 0 and handshake not established', () {
+      final state = CallState(linesCount: 0);
+      expect(state.isHandshakeEstablished, isFalse);
+      expect(state.toLinesState(), LinesState.blank());
+      expect(state.toLinesState().isBlank, isTrue);
+    });
+
+    test('returns blank regardless of activeCalls before handshake', () {
+      final state = CallState(linesCount: 0, activeCalls: [_makeCall(line: null)]);
+      expect(state.toLinesState(), LinesState.blank());
+    });
+  });
+
+  group('CallState.toLinesState — post-handshake with 0 main lines', () {
+    test('returns non-blank with idle guest line when no calls', () {
+      final state = CallState(linesCount: 0, callServiceState: _kRegistered);
+      final result = state.toLinesState();
+      expect(result.isBlank, isFalse);
+      expect(result.mainLines, isEmpty);
+      expect(result.guestLine, LineState.idle);
+    });
+
+    test('returns guest line inUse when guest call is active (line == null)', () {
+      final state = CallState(linesCount: 0, callServiceState: _kRegistered, activeCalls: [_makeCall(line: null)]);
+      final result = state.toLinesState();
+      expect(result.mainLines, isEmpty);
+      expect(result.guestLine, LineState.inUse);
+    });
+  });
+
+  group('CallState.toLinesState — post-handshake with main lines', () {
+    test('all lines idle when no active calls', () {
+      final state = CallState(linesCount: 2, callServiceState: _kRegistered);
+      final result = state.toLinesState();
+      expect(result.mainLines, [LineState.idle, LineState.idle]);
+      expect(result.guestLine, LineState.idle);
+    });
+
+    test('line 0 inUse when call on line 0', () {
+      final state = CallState(
+        linesCount: 2,
+        callServiceState: _kRegistered,
+        activeCalls: [_makeCall(callId: 'c1', line: 0)],
+      );
+      final result = state.toLinesState();
+      expect(result.mainLines[0], LineState.inUse);
+      expect(result.mainLines[1], LineState.idle);
+    });
+
+    test('line 1 inUse when call on line 1', () {
+      final state = CallState(
+        linesCount: 2,
+        callServiceState: _kRegistered,
+        activeCalls: [_makeCall(callId: 'c1', line: 1)],
+      );
+      final result = state.toLinesState();
+      expect(result.mainLines[0], LineState.idle);
+      expect(result.mainLines[1], LineState.inUse);
+    });
+
+    test('all lines inUse when calls on every line', () {
+      final state = CallState(
+        linesCount: 2,
+        callServiceState: _kRegistered,
+        activeCalls: [
+          _makeCall(callId: 'c1', line: 0),
+          _makeCall(callId: 'c2', line: 1),
+        ],
+      );
+      final result = state.toLinesState();
+      expect(result.mainLines, [LineState.inUse, LineState.inUse]);
+    });
+
+    test('guest line inUse when guest call present alongside main calls', () {
+      final state = CallState(
+        linesCount: 2,
+        callServiceState: _kRegistered,
+        activeCalls: [
+          _makeCall(callId: 'c1', line: 0),
+          _makeCall(callId: 'c2', line: null),
+        ],
+      );
+      final result = state.toLinesState();
+      expect(result.mainLines[0], LineState.inUse);
+      expect(result.mainLines[1], LineState.idle);
+      expect(result.guestLine, LineState.inUse);
+    });
+
+    test('guest line idle when no guest call', () {
+      final state = CallState(
+        linesCount: 1,
+        callServiceState: _kRegistered,
+        activeCalls: [_makeCall(callId: 'c1', line: 0)],
+      );
+      expect(state.toLinesState().guestLine, LineState.idle);
     });
   });
 }

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -138,7 +138,7 @@ final _kHandshake = StateHandshake(
 // Module builder
 // ---------------------------------------------------------------------------
 
-SignalingModule _buildModule(SignalingClientFactory factory) => SignalingModule(
+SignalingModuleIsolateImpl _buildModule(SignalingClientFactory factory) => SignalingModuleIsolateImpl(
   coreUrl: 'https://example.com',
   tenantId: 'test-tenant',
   token: 'test-token',


### PR DESCRIPTION
## Summary

Phase 1 of the signaling plugin migration — pure app-side refactor with no plugin dependency.

**Refactored:**
- `SignalingModuleInterface` abstract class extracted in `signaling_module.dart` — decouples `IsolateManager` and `CallBloc` from the concrete `SignalingModule` so a plugin-backed implementation can be swapped in later
- `IsolateManager._signalingModule` migrated to `SignalingModuleInterface`; all `signalingClient?.execute()` → `execute()`, `signalingClient != null` → `isConnected`
- `CallBloc._signalingModule` migrated to `SignalingModuleInterface`; same replacements (17+ call sites)
- `NetworkCubit` takes `Future<void> Function(IncomingCallType)` callback instead of a concrete callkeep type — wired at call site; migration to plugin = replace the lambda only
- `CallState.toLinesState()` extracted from `CallBloc.onChange` — pure deterministic function, `onChange` reduced to a single line

**Fixed:**
- `LinesState.blank()` was immediately overwritten in `CallBloc.onChange` when `linesCount == 0` — now explicitly preserved until signaling handshake arrives (`isHandshakeEstablished` guard)
- `linesCount == 0` guard now distinguishes pre-handshake blank from valid post-handshake 0-lines state (allows guest-line calls when server has no main lines configured)
- `CallRoutingCubit` no longer emits routing state before signaling handshake (`linesState.isBlank` guard)
- Push dedup race condition in `CallBloc` — re-check for duplicate `callId` after async contact resolution
- `_executePendingRequests`: null `execute()` result now completes completer with error and cleans up instead of silently leaking until timeout
- `_sendRequest`: null `execute()` result (disconnect race) now logs warning and returns early

**Tests:**
- 9 unit tests for `CallState.toLinesState()` covering pre-handshake blank, 0-lines post-handshake with guest line, all main line idle/inUse combinations

## Root cause: «no idle lines» bug

`CallBloc.onChange` fires on every state change, including the initial one where `linesCount == 0`. The old code always set `guestLine = LineState.idle`, making `LinesState.blank()` (`guestLine == null`) live for only milliseconds. If a user tapped Call during that window (slow network / quick tap), `CallRoutingCubit` would see 0 main lines and block with «no idle lines». Fixed by checking `linesCount == 0 && !isHandshakeEstablished` in `onChange`.

## Context

**Branch 1** of a 2-branch split:
- **Branch 1 (this PR)** — app prep: interface extraction, full CallBloc + IsolateManager migration, bug fixes, `toLinesState()` extraction with tests; no plugin dependency
- **Branch 2 / PR#1047** — remove callkeep signaling, integrate `webtrit_signaling_service` plugin; merges into this branch

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 474 tests pass (includes 9 new `toLinesState` unit tests)
- [ ] No plugin dependency introduced (`webtrit_signaling_service` not imported)
- [ ] Incoming call flow works as before
- [ ] Call routing does not emit state before handshake
- [ ] Changing incoming call type (push / socket) correctly starts/stops background signaling service