### PR TITLE
fix: call or transfer to myself handling

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -847,6 +847,20 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final contactName = await contactNameResolver.resolveWithNumber(handle.value);
     final displayName = contactName ?? event.callerDisplayName;
 
+    final activeCallWithSameId = state.retrieveActiveCall(event.callId);
+    if (activeCallWithSameId != null && activeCallWithSameId.line != event.line) {
+      _logger.info(
+        '__onCallSignalingEventIncoming: received incoming call with existing callId but different line - callId: ${event.callId}, probably call to myself or transfer to myself',
+      );
+      final declineRequest = DeclineRequest(
+        transaction: WebtritSignalingClient.generateTransactionId(),
+        line: event.line,
+        callId: event.callId,
+      );
+      await _signalingModule.signalingClient?.execute(declineRequest);
+      return;
+    }
+
     final error = await callkeep.reportNewIncomingCall(event.callId, handle, displayName: displayName, hasVideo: video);
 
     // Check if a call instance already exists in the callkeep, which might have been added via push notifications


### PR DESCRIPTION
This pull request adds a safeguard to the call handling logic to prevent issues when receiving an incoming call with an existing `callId` but a different line. The code now checks for this scenario and declines such calls, which helps avoid situations like accidentally answering a call to oneself or handling a transferred call incorrectly.

Call handling improvements:

* Added a check in `CallBloc` (`call_bloc.dart`) to detect incoming calls with an existing `callId` but a different `line`, log the event, and automatically decline the call to prevent handling calls to oneself or transfers to oneself.