### PR TITLE
fix: hide video for held call

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -88,9 +88,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
         builder: (context, orientation) {
           return Stack(
             children: [
-              // Its important to hide video if held to avoid showing frozen/last frames when held,
-              // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
-              if (activeCall.remoteVideo && activeCall.held == false)
+              if (activeCall.remoteVideo)
                 RemoteVideoViewOverlay(
                   activeCallWasAccepted: activeCall.wasAccepted,
                   remoteStream: activeCall.remoteStream,
@@ -98,6 +96,9 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                   onTap: _compactController.toggle,
                   remotePlaceholderBuilder: widget.remotePlaceholderBuilder,
                   backgroundMode: _backgroundMode,
+                  // Its important to hide video if held to avoid showing frozen/last frames when held,
+                  // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
+                  hideVideo: activeCall.held,
                 ),
               AnimatedBuilder(
                 animation: _compactController,

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -88,7 +88,9 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
         builder: (context, orientation) {
           return Stack(
             children: [
-              if (activeCall.remoteVideo)
+              // Its important to hide video if held to avoid showing frozen/last frames when held,
+              // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
+              if (activeCall.remoteVideo && activeCall.held == false)
                 RemoteVideoViewOverlay(
                   activeCallWasAccepted: activeCall.wasAccepted,
                   remoteStream: activeCall.remoteStream,

--- a/lib/features/call/widgets/call_active_thumbnail.dart
+++ b/lib/features/call/widgets/call_active_thumbnail.dart
@@ -28,6 +28,27 @@ class CallActiveThumbnail extends StatelessWidget {
     final frameSize = ThumbnailLayout.calcFrameSize(orientation: orientation, smallerSide: smallerSide);
     final hasRemoteVideo = activeCall.remoteStream?.getVideoTracks().isNotEmpty ?? false;
 
+    // Its important to hide video if held to avoid showing frozen/last frames when held,
+    // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
+    final displayStream = hasRemoteVideo && activeCall.held == false;
+
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isAccepted = activeCall.wasAccepted;
+
+    final duration = isAccepted ? const Duration(milliseconds: 2500) : const Duration(milliseconds: 1500);
+
+    final baseAlpha = 0.75;
+    final highlightAlpha = 0.95;
+
+    final baseColor = isAccepted
+        ? colorScheme.primary.withValues(alpha: baseAlpha)
+        : colorScheme.surfaceContainerHighest.withValues(alpha: highlightAlpha);
+
+    final highlightColor = isAccepted
+        ? colorScheme.surface.withValues(alpha: baseAlpha)
+        : colorScheme.surface.withValues(alpha: highlightAlpha);
+
     return Card(
       child: SizedBox.fromSize(
         size: frameSize,
@@ -38,32 +59,11 @@ class CallActiveThumbnail extends StatelessWidget {
             child: Stack(
               fit: StackFit.expand,
               children: [
-                StreamThumbnail(
-                  stream: activeCall.remoteStream,
-                  placeholderBuilder: (context) {
-                    final theme = Theme.of(context);
-                    final colorScheme = theme.colorScheme;
-                    final isAccepted = activeCall.wasAccepted;
-
-                    final duration = isAccepted
-                        ? const Duration(milliseconds: 2500)
-                        : const Duration(milliseconds: 1500);
-
-                    final baseAlpha = 0.75;
-                    final highlightAlpha = 0.95;
-
-                    final baseColor = isAccepted
-                        ? colorScheme.primary.withValues(alpha: baseAlpha)
-                        : colorScheme.surfaceContainerHighest.withValues(alpha: highlightAlpha);
-
-                    final highlightColor = isAccepted
-                        ? colorScheme.surface.withValues(alpha: baseAlpha)
-                        : colorScheme.surface.withValues(alpha: highlightAlpha);
-
-                    return Shimmer(duration: duration, baseColor: baseColor, highlightColor: highlightColor);
-                  },
-                ),
-                if (!hasRemoteVideo) _AvatarOverlay(activeCall: activeCall, contactResolver: contactResolver),
+                Shimmer(duration: duration, baseColor: baseColor, highlightColor: highlightColor),
+                if (displayStream)
+                  StreamThumbnail(stream: activeCall.remoteStream)
+                else
+                  _AvatarOverlay(activeCall: activeCall, contactResolver: contactResolver),
               ],
             ),
           ),

--- a/lib/features/call/widgets/remote_video_view_overlay.dart
+++ b/lib/features/call/widgets/remote_video_view_overlay.dart
@@ -40,6 +40,7 @@ class RemoteVideoViewOverlay extends StatelessWidget {
     super.key,
     this.remotePlaceholderBuilder,
     this.backgroundMode = VideoBackgroundMode.blur,
+    this.hideVideo = false,
   });
 
   /// Whether the call has been accepted and is currently active.
@@ -58,6 +59,9 @@ class RemoteVideoViewOverlay extends StatelessWidget {
 
   /// Optional builder for a placeholder widget while the stream is initializing.
   final WidgetBuilder? remotePlaceholderBuilder;
+
+  /// Whether to hide the video stream entirely.
+  final bool hideVideo;
 
   /// Determines how the empty space behind the video is rendered.
   ///
@@ -78,7 +82,8 @@ class RemoteVideoViewOverlay extends StatelessWidget {
           fit: StackFit.expand,
           children: [
             if (_shouldRenderBackground) _BackgroundLayer(stream: remoteStream, mode: backgroundMode),
-            RTCStreamView(stream: remoteStream, placeholderBuilder: remotePlaceholderBuilder, fit: videoFit),
+            if (!hideVideo)
+              RTCStreamView(stream: remoteStream, placeholderBuilder: remotePlaceholderBuilder, fit: videoFit),
           ],
         ),
       ),


### PR DESCRIPTION
This pull request improves the handling of remote video display during call hold states in the call UI. The main focus is to ensure that video is hidden when a call is held, preventing frozen or outdated frames from being shown to the user.

Changes related to remote video display and call hold state:

* The remote video is now hidden in both the main call view (`CallActiveScaffold`) and the call thumbnail (`CallActiveThumbnail`) when the call is on hold (`activeCall.held == true`), ensuring users do not see frozen or stale video frames during hold scenarios. [[1]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dL91-R93) [[2]](diffhunk://#diff-0ec4d0562872f8cbc23be4b9fe90012eeeaf127f472bdda19da223088cb2b523L31-R39) [[3]](diffhunk://#diff-0ec4d0562872f8cbc23be4b9fe90012eeeaf127f472bdda19da223088cb2b523L63-R66)
* The logic for displaying the video or avatar overlay in the call thumbnail has been refactored to use a new `displayStream` variable, which checks both for the presence of a remote video stream and that the call is not on hold.
* The shimmer placeholder is now consistently shown when the video is hidden, improving the user experience during hold or when no video is available.