### PR TITLE
fix: transfer to same recipient

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1590,12 +1590,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final line = activeCallBlindTransferInitiated?.line ?? currentCall.line;
     final callId = activeCallBlindTransferInitiated?.callId ?? currentCall.callId;
 
-    // Check if the number is already in active calls
-    final isNumberAlreadyConnected = state.activeCalls.any((call) => call.handle.value == event.number);
-    if (isNumberAlreadyConnected) {
-      submitNotification(ActiveLineBlindTransferWarningNotification());
-      return;
-    }
+    // Commented out to emphasize that the check is disabled by intention
+    // to not add it again in future, to see why open ticket [WT-1160]
+    // final isNumberAlreadyConnected = state.activeCalls.any((call) => call.handle.value == event.number);
+    // if (isNumberAlreadyConnected) {
+    //   submitNotification(ActiveLineBlindTransferWarningNotification());
+    //   return;
+    // }
 
     try {
       final transferRequest = TransferRequest(


### PR DESCRIPTION
This pull request makes a targeted change to the `CallBloc` class in `call_bloc.dart` by intentionally disabling a check that prevents blind transfers to numbers already present in active calls. The code is commented out with a note referencing ticket [WT-1160], clarifying that this is a deliberate and temporary measure.

Key change:

* Disabled the check that blocks blind transfers to numbers already in `activeCalls`, and added a comment referencing ticket [WT-1160] to indicate this is intentional and should not be re-enabled without review.