### PR TITLE
fix: use SignalingModule.execute instead of signalingClient getter

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -856,7 +856,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         line: event.line,
         callId: event.callId,
       );
-      await _signalingModule.signalingClient?.execute(declineRequest);
+      await _signalingModule.execute(declineRequest);
       return;
     }
 


### PR DESCRIPTION
## Summary

- `signalingClient` getter is only defined on `SignalingModuleIsolateImpl`, not on the `SignalingModule` abstract interface
- `call_bloc.dart:859` was calling `_signalingModule.signalingClient?.execute(...)` causing a compile-time `undefined_getter` error
- Replaced with `_signalingModule.execute(...)` which is part of the interface and already returns `null` when not connected

## Test plan
- [ ] Verify `dart analyze` reports no errors on `call_bloc.dart`
- [ ] Verify incoming call to same recipient (transfer-to-self path) still declines correctly