### PR TITLE
fix(WT-1083): use processingStatus to guard outgoing call reconciliation

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2563,13 +2563,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
 
       // Skips outgoing calls that are still in-flight (OutgoingCallRequest not yet sent).
-      // Once processingStatus reaches outgoingOfferSent or later, the request has reached
-      // the server — if the server has no record of the call in the handshake, treat it as dead.
+      // If the request was already sent but the server has no record of the call, treat it as dead.
       if (activeCall.direction == CallDirection.outgoing &&
           activeCall.acceptedTime == null &&
           activeCall.hungUpTime == null &&
-          activeCall.processingStatus != CallProcessingStatus.outgoingOfferSent &&
-          activeCall.processingStatus != CallProcessingStatus.outgoingRinging) {
+          activeCall.processingStatus.isPreOfferSent) {
         continue activeCallsLoop;
       }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2555,7 +2555,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final activeLineCallIds = [
       ...stateHandshake.lines,
       stateHandshake.guestLine,
-    ].whereType<Line>().map((line) => line.callId).toList();
+    ].whereType<Line>().map((line) => line.callId).toSet();
 
     for (final callId in state.callsToTerminate(activeLineCallIds)) {
       final activeCall = state.retrieveActiveCall(callId);

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2562,14 +2562,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         }
       }
 
-      // Handles an outgoing active call that has not yet started, typically initiated
-      // by the `continueStartCallIntent` callback of `CallkeepDelegate`.
-      //
-      // TODO: Implement a dedicated flag to confirm successful execution of
-      // OutgoingCallRequest, ensuring reliable outgoing active call state tracking.
+      // Skips outgoing calls that are still in-flight (OutgoingCallRequest not yet sent).
+      // Once processingStatus reaches outgoingOfferSent or later, the request has reached
+      // the server — if the server has no record of the call in the handshake, treat it as dead.
       if (activeCall.direction == CallDirection.outgoing &&
           activeCall.acceptedTime == null &&
-          activeCall.hungUpTime == null) {
+          activeCall.hungUpTime == null &&
+          activeCall.processingStatus != CallProcessingStatus.outgoingOfferSent &&
+          activeCall.processingStatus != CallProcessingStatus.outgoingRinging) {
         continue activeCallsLoop;
       }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2549,38 +2549,19 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // Hang up all active calls that are not associated with any line
     // or guest line, indicating that they are no longer valid.
     //
-    // This is needed to drop or retain calls after reconnecting to the signaling server
-    activeCallsLoop:
-    for (final activeCall in state.activeCalls) {
-      // Ignore active calls that are already associated with a line or guest line
-      //
-      // If you have troubles with line position mismatch replace this with
-      // following code that deal with it: https://gist.github.com/digiboridev/f7f1020731e8f247b5891983433bd159
-      for (final line in [...stateHandshake.lines, stateHandshake.guestLine]) {
-        if (line != null && line.callId == activeCall.callId) {
-          continue activeCallsLoop;
-        }
-      }
+    // This is needed to drop or retain calls after reconnecting to the signaling server.
+    // If you have troubles with line position mismatch replace the activeLineCallIds
+    // computation with: https://gist.github.com/digiboridev/f7f1020731e8f247b5891983433bd159
+    final activeLineCallIds = [
+      ...stateHandshake.lines,
+      stateHandshake.guestLine,
+    ].whereType<Line>().map((line) => line.callId).toList();
 
-      // Skips outgoing calls that are still in-flight (OutgoingCallRequest not yet sent).
-      // If the request was already sent but the server has no record of the call, treat it as dead.
-      if (activeCall.direction == CallDirection.outgoing &&
-          activeCall.acceptedTime == null &&
-          activeCall.hungUpTime == null &&
-          activeCall.processingStatus.isPreOfferSent) {
-        continue activeCallsLoop;
-      }
-
-      _peerConnectionManager.conditionalCompleteError(activeCall.callId, 'Active call Request Terminated');
-
-      add(
-        _CallSignalingEvent.hangup(
-          line: activeCall.line,
-          callId: activeCall.callId,
-          code: 487,
-          reason: 'Request Terminated',
-        ),
-      );
+    for (final callId in state.callsToTerminate(activeLineCallIds)) {
+      final activeCall = state.retrieveActiveCall(callId);
+      if (activeCall == null) continue;
+      _peerConnectionManager.conditionalCompleteError(callId, 'Active call Request Terminated');
+      add(_CallSignalingEvent.hangup(line: activeCall.line, callId: callId, code: 487, reason: 'Request Terminated'));
     }
 
     final actions = await _handshakeProcessor.process(

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -92,6 +92,22 @@ class CallState with _$CallState {
 
   bool get shouldListenToProximity => isActive && isVoiceChat && minimized != true;
 
+  List<String> callsToTerminate(List<String> activeLineCallIds) {
+    final result = <String>[];
+    activeCallsLoop:
+    for (final activeCall in activeCalls) {
+      if (activeLineCallIds.contains(activeCall.callId)) continue activeCallsLoop;
+      if (activeCall.direction == CallDirection.outgoing &&
+          activeCall.acceptedTime == null &&
+          activeCall.hungUpTime == null &&
+          activeCall.processingStatus.isPreOfferSent) {
+        continue activeCallsLoop;
+      }
+      result.add(activeCall.callId);
+    }
+    return result;
+  }
+
   ActiveCall? retrieveActiveCall(String callId) {
     for (var activeCall in activeCalls) {
       if (activeCall.callId == callId) {

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -92,7 +92,7 @@ class CallState with _$CallState {
 
   bool get shouldListenToProximity => isActive && isVoiceChat && minimized != true;
 
-  List<String> callsToTerminate(List<String> activeLineCallIds) {
+  List<String> callsToTerminate(Set<String> activeLineCallIds) {
     final result = <String>[];
     activeCallsLoop:
     for (final activeCall in activeCalls) {

--- a/lib/features/call/models/processing_status.dart
+++ b/lib/features/call/models/processing_status.dart
@@ -17,5 +17,13 @@ enum CallProcessingStatus {
   outgoingRinging,
 
   connected,
-  disconnecting,
+  disconnecting;
+
+  bool get isPreOfferSent => const {
+    CallProcessingStatus.outgoingCreated,
+    CallProcessingStatus.outgoingCreatedFromRefer,
+    CallProcessingStatus.outgoingConnectingToSignaling,
+    CallProcessingStatus.outgoingInitializingMedia,
+    CallProcessingStatus.outgoingOfferPreparing,
+  }.contains(this);
 }

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -1270,13 +1270,13 @@ void main() {
     test('terminates call absent from handshake lines', () {
       final call = _makeCall(callId: 'c1', processingStatus: CallProcessingStatus.connected);
       final state = CallState(activeCalls: [call]);
-      expect(state.callsToTerminate([]), ['c1']);
+      expect(state.callsToTerminate({}), ['c1']);
     });
 
     test('keeps call that is present in handshake lines', () {
       final call = _makeCall(callId: 'c1', processingStatus: CallProcessingStatus.connected);
       final state = CallState(activeCalls: [call]);
-      expect(state.callsToTerminate(['c1']), isEmpty);
+      expect(state.callsToTerminate({'c1'}), isEmpty);
     });
 
     test('keeps outgoing call with isPreOfferSent status absent from handshake', () {
@@ -1289,7 +1289,7 @@ void main() {
       ]) {
         final call = _makeCall(callId: 'c1', direction: CallDirection.outgoing, processingStatus: status);
         final state = CallState(activeCalls: [call]);
-        expect(state.callsToTerminate([]), isEmpty, reason: 'should skip $status');
+        expect(state.callsToTerminate({}), isEmpty, reason: 'should skip $status');
       }
     });
 
@@ -1300,7 +1300,7 @@ void main() {
         processingStatus: CallProcessingStatus.outgoingOfferSent,
       );
       final state = CallState(activeCalls: [call]);
-      expect(state.callsToTerminate([]), ['c1']);
+      expect(state.callsToTerminate({}), ['c1']);
     });
 
     test('terminates outgoing call at outgoingRinging absent from handshake', () {
@@ -1310,7 +1310,7 @@ void main() {
         processingStatus: CallProcessingStatus.outgoingRinging,
       );
       final state = CallState(activeCalls: [call]);
-      expect(state.callsToTerminate([]), ['c1']);
+      expect(state.callsToTerminate({}), ['c1']);
     });
 
     test('keeps outgoing isPreOfferSent call even if other calls are terminated', () {
@@ -1321,13 +1321,13 @@ void main() {
       );
       final dead = _makeCall(callId: 'dead', processingStatus: CallProcessingStatus.connected);
       final state = CallState(activeCalls: [inFlight, dead]);
-      expect(state.callsToTerminate([]), ['dead']);
+      expect(state.callsToTerminate({}), ['dead']);
     });
 
     test('returns empty when all calls are in handshake lines', () {
       final calls = [_makeCall(callId: 'c1'), _makeCall(callId: 'c2')];
       final state = CallState(activeCalls: calls);
-      expect(state.callsToTerminate(['c1', 'c2']), isEmpty);
+      expect(state.callsToTerminate({'c1', 'c2'}), isEmpty);
     });
   });
 }

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -1262,4 +1262,72 @@ void main() {
       expect(call.processingStatus, CallProcessingStatus.incomingFromOffer);
     });
   });
+  // ---------------------------------------------------------------------------
+  // CallState.callsToTerminate — handshake reconciliation (WT-1083)
+  // ---------------------------------------------------------------------------
+
+  group('CallState.callsToTerminate', () {
+    test('terminates call absent from handshake lines', () {
+      final call = _makeCall(callId: 'c1', processingStatus: CallProcessingStatus.connected);
+      final state = CallState(activeCalls: [call]);
+      expect(state.callsToTerminate([]), ['c1']);
+    });
+
+    test('keeps call that is present in handshake lines', () {
+      final call = _makeCall(callId: 'c1', processingStatus: CallProcessingStatus.connected);
+      final state = CallState(activeCalls: [call]);
+      expect(state.callsToTerminate(['c1']), isEmpty);
+    });
+
+    test('keeps outgoing call with isPreOfferSent status absent from handshake', () {
+      for (final status in [
+        CallProcessingStatus.outgoingCreated,
+        CallProcessingStatus.outgoingCreatedFromRefer,
+        CallProcessingStatus.outgoingConnectingToSignaling,
+        CallProcessingStatus.outgoingInitializingMedia,
+        CallProcessingStatus.outgoingOfferPreparing,
+      ]) {
+        final call = _makeCall(callId: 'c1', direction: CallDirection.outgoing, processingStatus: status);
+        final state = CallState(activeCalls: [call]);
+        expect(state.callsToTerminate([]), isEmpty, reason: 'should skip $status');
+      }
+    });
+
+    test('terminates outgoing call at outgoingOfferSent absent from handshake', () {
+      final call = _makeCall(
+        callId: 'c1',
+        direction: CallDirection.outgoing,
+        processingStatus: CallProcessingStatus.outgoingOfferSent,
+      );
+      final state = CallState(activeCalls: [call]);
+      expect(state.callsToTerminate([]), ['c1']);
+    });
+
+    test('terminates outgoing call at outgoingRinging absent from handshake', () {
+      final call = _makeCall(
+        callId: 'c1',
+        direction: CallDirection.outgoing,
+        processingStatus: CallProcessingStatus.outgoingRinging,
+      );
+      final state = CallState(activeCalls: [call]);
+      expect(state.callsToTerminate([]), ['c1']);
+    });
+
+    test('keeps outgoing isPreOfferSent call even if other calls are terminated', () {
+      final inFlight = _makeCall(
+        callId: 'in-flight',
+        direction: CallDirection.outgoing,
+        processingStatus: CallProcessingStatus.outgoingOfferPreparing,
+      );
+      final dead = _makeCall(callId: 'dead', processingStatus: CallProcessingStatus.connected);
+      final state = CallState(activeCalls: [inFlight, dead]);
+      expect(state.callsToTerminate([]), ['dead']);
+    });
+
+    test('returns empty when all calls are in handshake lines', () {
+      final calls = [_makeCall(callId: 'c1'), _makeCall(callId: 'c2')];
+      final state = CallState(activeCalls: calls);
+      expect(state.callsToTerminate(['c1', 'c2']), isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Fixes a bug where outgoing calls with a failed `OutgoingCallRequest` would get permanently stuck during `StateHandshake` reconciliation
- Replaces the broad `acceptedTime == null && hungUpTime == null` skip with a precise check against `processingStatus`
- No new fields added — `CallProcessingStatus.outgoingOfferSent` already reliably indicates the request reached the server

## Details

During handshake reconciliation, the BLoC previously skipped **all** unacknowledged outgoing calls, even those whose `OutgoingCallRequest` had silently failed. Such calls were never in the server's line list, so they would be skipped on every subsequent handshake and remain stuck forever.

The fix: skip only calls where `processingStatus` is earlier than `outgoingOfferSent` (i.e. the request was never sent). If the status is `outgoingOfferSent` or `outgoingRinging` but the server has no record of the call → force-terminate it as dead.
