### PR TITLE
fix: stop ringback sound on forced call termination

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -590,6 +590,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> __onResetStateEventCompleteCall(_ResetStateEventCompleteCall event, Emitter<CallState> emit) async {
     _logger.warning('__onResetStateEventCompleteCall: ${event.callId}');
 
+    await _stopRingbackSound();
+
     try {
       emit(
         state.copyWithMappedActiveCall(event.callId, (activeCall) {


### PR DESCRIPTION
## Summary

- Ringback tone continued playing after outgoing call was terminated due to network loss
- `__onResetStateEventCompleteCall` — the path taken on unexpected signaling disconnect — was not calling `_stopRingbackSound()`
- All other termination paths already had this call; this one was missing

## Root cause

Confirmed in logcat: `__onResetStateEventCompleteCall` fired at `13:10:01.417` after network drop, call disappeared from UI, but `stopRingback` was never invoked.

## Test plan

- [ ] Make outgoing call, drop network while ringback is playing — verify tone stops when call disappears from UI
- [ ] Make outgoing call, hang up normally — verify no regression