### PR TITLE
fix: sanitize keypad input before initiating a call (WT-1026)

### DIFF
--- a/lib/features/keypad/utils/phone_normalizing_formatter.dart
+++ b/lib/features/keypad/utils/phone_normalizing_formatter.dart
@@ -5,15 +5,15 @@ import 'package:webtrit_phone_number/webtrit_phone_number.dart';
 class PhoneNormalizingFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    final normalized = PhoneParser.normalize(newValue.text);
-    if (normalized == newValue.text) return newValue;
+    final sanitized = PhoneParser.normalize(newValue.text).replaceAll(RegExp(r'[^0-9*#+]'), '');
+    if (sanitized == newValue.text) return newValue;
 
     final prefix = newValue.text.substring(0, newValue.selection.baseOffset.clamp(0, newValue.text.length));
-    final normalizedPrefix = PhoneParser.normalize(prefix);
-    final newOffset = normalizedPrefix.length.clamp(0, normalized.length);
+    final sanitizedPrefix = PhoneParser.normalize(prefix).replaceAll(RegExp(r'[^0-9*#+]'), '');
+    final newOffset = sanitizedPrefix.length.clamp(0, sanitized.length);
 
     return TextEditingValue(
-      text: normalized,
+      text: sanitized,
       selection: TextSelection.collapsed(offset: newOffset),
     );
   }

--- a/lib/features/keypad/utils/phone_normalizing_formatter.dart
+++ b/lib/features/keypad/utils/phone_normalizing_formatter.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/services.dart';
+
+import 'package:webtrit_phone_number/webtrit_phone_number.dart';
+
+class PhoneNormalizingFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    final normalized = PhoneParser.normalize(newValue.text);
+    if (normalized == newValue.text) return newValue;
+
+    final prefix = newValue.text.substring(0, newValue.selection.baseOffset.clamp(0, newValue.text.length));
+    final normalizedPrefix = PhoneParser.normalize(prefix);
+    final newOffset = normalizedPrefix.length.clamp(0, normalized.length);
+
+    return TextEditingValue(
+      text: normalized,
+      selection: TextSelection.collapsed(offset: newOffset),
+    );
+  }
+}

--- a/lib/features/keypad/utils/phone_normalizing_formatter.dart
+++ b/lib/features/keypad/utils/phone_normalizing_formatter.dart
@@ -3,18 +3,30 @@ import 'package:flutter/services.dart';
 import 'package:webtrit_phone_number/webtrit_phone_number.dart';
 
 class PhoneNormalizingFormatter extends TextInputFormatter {
+  static final _nonDialableChars = RegExp(r'[^0-9*#+]');
+
+  static String sanitize(String input) => PhoneParser.normalize(input).replaceAll(_nonDialableChars, '');
+
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    final sanitized = PhoneParser.normalize(newValue.text).replaceAll(RegExp(r'[^0-9*#+]'), '');
+    final sanitized = sanitize(newValue.text);
     if (sanitized == newValue.text) return newValue;
-
-    final prefix = newValue.text.substring(0, newValue.selection.baseOffset.clamp(0, newValue.text.length));
-    final sanitizedPrefix = PhoneParser.normalize(prefix).replaceAll(RegExp(r'[^0-9*#+]'), '');
-    final newOffset = sanitizedPrefix.length.clamp(0, sanitized.length);
 
     return TextEditingValue(
       text: sanitized,
-      selection: TextSelection.collapsed(offset: newOffset),
+      selection: TextSelection(
+        baseOffset: _translateOffset(newValue.text, newValue.selection.baseOffset, sanitized.length),
+        extentOffset: _translateOffset(newValue.text, newValue.selection.extentOffset, sanitized.length),
+        affinity: newValue.selection.affinity,
+        isDirectional: newValue.selection.isDirectional,
+      ),
     );
+  }
+
+  int _translateOffset(String originalText, int offset, int sanitizedLength) {
+    if (offset < 0) return offset;
+    final prefix = originalText.substring(0, offset.clamp(0, originalText.length));
+    final sanitizedPrefix = sanitize(prefix);
+    return sanitizedPrefix.length.clamp(0, sanitizedLength);
   }
 }

--- a/lib/features/keypad/utils/utils.dart
+++ b/lib/features/keypad/utils/utils.dart
@@ -1,0 +1,1 @@
+export 'phone_normalizing_formatter.dart';

--- a/lib/features/keypad/view/keypad_view.dart
+++ b/lib/features/keypad/view/keypad_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:webtrit_phone_number/webtrit_phone_number.dart';
 
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/call_routing.dart';
@@ -135,7 +136,7 @@ class KeypadViewState extends State<KeypadView> {
   }
 
   String _popNumber() {
-    final number = _controller.text;
+    final number = PhoneParser.normalize(_controller.text);
     _controller.clear();
     return number;
   }

--- a/lib/features/keypad/view/keypad_view.dart
+++ b/lib/features/keypad/view/keypad_view.dart
@@ -137,7 +137,7 @@ class KeypadViewState extends State<KeypadView> {
   }
 
   String _popNumber() {
-    final number = _controller.text;
+    final number = PhoneNormalizingFormatter.sanitize(_controller.text);
     _controller.clear();
     return number;
   }

--- a/lib/features/keypad/view/keypad_view.dart
+++ b/lib/features/keypad/view/keypad_view.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:webtrit_phone_number/webtrit_phone_number.dart';
 
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/call_routing.dart';
@@ -10,6 +8,7 @@ import 'package:webtrit_phone/features/call_routing/call_routing.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 
 import '../cubit/keypad_cubit.dart';
+import '../utils/utils.dart';
 import '../widgets/widgets.dart';
 import 'keypad_screen_style.dart';
 
@@ -81,7 +80,7 @@ class KeypadViewState extends State<KeypadView> {
                     showCursor: inputField?.showCursor ?? true,
                     keyboardType: inputField?.keyboardType ?? TextInputType.none,
                     cursorColor: inputField?.cursorColor,
-                    inputFormatters: [_PhoneNormalizingFormatter()],
+                    inputFormatters: [PhoneNormalizingFormatter()],
                   ),
                   BlocBuilder<KeypadCubit, KeypadState>(
                     builder: (context, state) => Text(
@@ -210,22 +209,5 @@ class KeypadViewState extends State<KeypadView> {
     _keypadTextFieldEditableTextState?.userUpdateTextEditingValue(value, SelectionChangedCause.keyboard);
 
     _keypadTextFieldEditableTextState?.hideToolbar();
-  }
-}
-
-class _PhoneNormalizingFormatter extends TextInputFormatter {
-  @override
-  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    final normalized = PhoneParser.normalize(newValue.text);
-    if (normalized == newValue.text) return newValue;
-
-    final prefix = newValue.text.substring(0, newValue.selection.baseOffset.clamp(0, newValue.text.length));
-    final normalizedPrefix = PhoneParser.normalize(prefix);
-    final newOffset = normalizedPrefix.length.clamp(0, normalized.length);
-
-    return TextEditingValue(
-      text: normalized,
-      selection: TextSelection.collapsed(offset: newOffset),
-    );
   }
 }

--- a/lib/features/keypad/view/keypad_view.dart
+++ b/lib/features/keypad/view/keypad_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone_number/webtrit_phone_number.dart';
@@ -80,6 +81,7 @@ class KeypadViewState extends State<KeypadView> {
                     showCursor: inputField?.showCursor ?? true,
                     keyboardType: inputField?.keyboardType ?? TextInputType.none,
                     cursorColor: inputField?.cursorColor,
+                    inputFormatters: [_PhoneNormalizingFormatter()],
                   ),
                   BlocBuilder<KeypadCubit, KeypadState>(
                     builder: (context, state) => Text(
@@ -136,7 +138,7 @@ class KeypadViewState extends State<KeypadView> {
   }
 
   String _popNumber() {
-    final number = PhoneParser.normalize(_controller.text);
+    final number = _controller.text;
     _controller.clear();
     return number;
   }
@@ -208,5 +210,22 @@ class KeypadViewState extends State<KeypadView> {
     _keypadTextFieldEditableTextState?.userUpdateTextEditingValue(value, SelectionChangedCause.keyboard);
 
     _keypadTextFieldEditableTextState?.hideToolbar();
+  }
+}
+
+class _PhoneNormalizingFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    final normalized = PhoneParser.normalize(newValue.text);
+    if (normalized == newValue.text) return newValue;
+
+    final prefix = newValue.text.substring(0, newValue.selection.baseOffset.clamp(0, newValue.text.length));
+    final normalizedPrefix = PhoneParser.normalize(prefix);
+    final newOffset = normalizedPrefix.length.clamp(0, normalized.length);
+
+    return TextEditingValue(
+      text: normalized,
+      selection: TextSelection.collapsed(offset: newOffset),
+    );
   }
 }

--- a/test/features/keypad/utils/phone_normalizing_formatter_test.dart
+++ b/test/features/keypad/utils/phone_normalizing_formatter_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/keypad/utils/utils.dart';
+
+TextEditingValue _val(String text, {int? base, int? extent}) {
+  final b = base ?? text.length;
+  final e = extent ?? b;
+  return TextEditingValue(
+    text: text,
+    selection: TextSelection(baseOffset: b, extentOffset: e),
+  );
+}
+
+void main() {
+  final formatter = PhoneNormalizingFormatter();
+
+  TextEditingValue format(TextEditingValue newValue) => formatter.formatEditUpdate(TextEditingValue.empty, newValue);
+
+  group('PhoneNormalizingFormatter.sanitize', () {
+    test('keeps digits, *, #, +', () {
+      expect(PhoneNormalizingFormatter.sanitize('+380671234567'), '+380671234567');
+      expect(PhoneNormalizingFormatter.sanitize('*21#'), '*21#');
+    });
+
+    test('strips spaces and formatting characters', () {
+      expect(PhoneNormalizingFormatter.sanitize('+380 (67) 123-45-67'), '+380671234567');
+    });
+
+    test('strips non-dialable characters', () {
+      expect(PhoneNormalizingFormatter.sanitize('*"{'), '*');
+      expect(PhoneNormalizingFormatter.sanitize('abc123'), '123');
+    });
+
+    test('normalizes Unicode lookalike digits', () {
+      // Mathematical bold digits 𝟎–𝟗 → 0–9
+      expect(PhoneNormalizingFormatter.sanitize('𝟏𝟐𝟑'), '123');
+    });
+
+    test('returns empty string for all-invalid input', () {
+      expect(PhoneNormalizingFormatter.sanitize('abc!@\$'), '');
+    });
+  });
+
+  group('PhoneNormalizingFormatter.formatEditUpdate', () {
+    test('returns newValue unchanged when no sanitization needed', () {
+      final value = _val('+380671234567');
+      expect(format(value), value);
+    });
+
+    test('strips spaces on paste', () {
+      final result = format(_val('+380 67 123'));
+      expect(result.text, '+38067123');
+    });
+
+    test('strips non-dialable characters on paste', () {
+      final result = format(_val('*"{'));
+      expect(result.text, '*');
+    });
+
+    test('cursor moves to end when characters before it are removed', () {
+      // Input: '1 2 3', cursor after the space at index 2 → '12', cursor at 2
+      final result = format(_val('1 2 3', base: 2));
+      expect(result.text, '123');
+      expect(result.selection.baseOffset, 1); // only '1' before the space
+    });
+
+    test('cursor stays in place when only trailing chars are removed', () {
+      // Input: '123abc', cursor at 3 (after '3')
+      final result = format(_val('123abc', base: 3));
+      expect(result.text, '123');
+      expect(result.selection.baseOffset, 3);
+    });
+
+    test('preserves selection range (base != extent)', () {
+      // Input: '1 2 3', select from 0 to 3 (covers '1 2')
+      final result = format(_val('1 2 3', base: 0, extent: 3));
+      expect(result.text, '123');
+      expect(result.selection.baseOffset, 0);
+      expect(result.selection.extentOffset, 2); // '1 2' → '12'
+    });
+
+    test('collapses selection when both offsets map to same position', () {
+      final result = format(_val('  123', base: 0, extent: 2));
+      expect(result.text, '123');
+      expect(result.selection.baseOffset, 0);
+      expect(result.selection.extentOffset, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Applied `PhoneParser.normalize()` in `KeypadViewState._popNumber()` so Unicode lookalike digits and stray formatting characters are stripped before the number reaches `CallController` / `CallBloc`.
- Previously, all other phone input entry points (forms via `ExtendedTextFormField`, attended transfer via `CallkeepHandleExtension.normalizedValue()`) already sanitized their numbers — the keypad was the only path that bypassed normalization.

## Changes

`lib/features/keypad/view/keypad_view.dart`
- Added `webtrit_phone_number` import.
- `_popNumber()`: wrap `_controller.text` with `PhoneParser.normalize(...)` before returning.

## Test plan

- [ ] Dial a number using the keypad with normal digits — call should initiate as before.
- [ ] Paste or type Unicode lookalike digits (e.g. mathematical bold `𝟗`) into the keypad field — after pressing call, the number should be normalized to ASCII digits.
- [ ] Verify keypad transfer flow also normalizes the number (`_transferCall` calls `_popNumber()`).

YouTrack: https://youtrack.portaone.com/issue/WT-1026