### PR TITLE
fix: resolve unsafe ancestor lookups on deactivated widgets (WT-578)

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -91,13 +91,16 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     );
     _signalingModule.connect();
 
+    final appBloc = context.read<AppBloc>();
+    final notificationsBloc = context.read<NotificationsBloc>();
+    final sessionExpiredMessage = context.l10n.notifications_errorSnackBar_sessionExpired;
+
     _sessionGuard = RouterLogoutSessionGuard(
       performLogout: () {
-        context.read<AppBloc>().add(const AppLogoutRequested(reason: AppLogoutReason.serverRejection));
+        appBloc.add(const AppLogoutRequested(reason: AppLogoutReason.serverRejection));
       },
       onPreLogout: () {
-        final notification = ErrorMessageNotification(context.l10n.notifications_errorSnackBar_sessionExpired);
-        final notificationsBloc = context.read<NotificationsBloc>();
+        final notification = ErrorMessageNotification(sessionExpiredMessage);
         notificationsBloc.add(NotificationsSubmitted(notification));
       },
     );

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -56,6 +56,11 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// preventing consumers from holding stale references across rebuilds.
   CallController? _callController;
 
+  /// Cached localized string for the session-expired notification.
+  /// Populated in [didChangeDependencies] to avoid calling Localizations
+  /// inside [initState], which is not allowed.
+  late String _sessionExpiredMessage;
+
   @override
   void initState() {
     super.initState();
@@ -93,17 +98,22 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
 
     final appBloc = context.read<AppBloc>();
     final notificationsBloc = context.read<NotificationsBloc>();
-    final sessionExpiredMessage = context.l10n.notifications_errorSnackBar_sessionExpired;
 
     _sessionGuard = RouterLogoutSessionGuard(
       performLogout: () {
         appBloc.add(const AppLogoutRequested(reason: AppLogoutReason.serverRejection));
       },
       onPreLogout: () {
-        final notification = ErrorMessageNotification(sessionExpiredMessage);
+        final notification = ErrorMessageNotification(_sessionExpiredMessage);
         notificationsBloc.add(NotificationsSubmitted(notification));
       },
     );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _sessionExpiredMessage = context.l10n.notifications_errorSnackBar_sessionExpired;
   }
 
   @override

--- a/lib/features/call/view/call_screen.dart
+++ b/lib/features/call/view/call_screen.dart
@@ -48,7 +48,8 @@ class _CallScreenState extends State<CallScreen> with AutoRouteAwareStateMixin {
 
     final scaffold = BlocConsumer<CallBloc, CallState>(
       bloc: callBloc,
-      listener: (context, state) async {
+      listener: (context, state) {
+        if (!context.mounted) return;
         if (state.isActive) {
           final activeCall = state.activeCalls.current;
           final activeCallFailure = activeCall.failure;

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -89,6 +89,9 @@ class _CallActionsState extends State<CallActions> {
 
   late TextEditingController _keypadTextEditingController;
 
+  late MediaQueryData _mediaQueryData;
+  late ThemeData _themeData;
+
   late InputDecorations? _inputDecorations;
   late TextStyle? _textStyle;
 
@@ -126,20 +129,19 @@ class _CallActionsState extends State<CallActions> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _mediaQueryData = MediaQuery.of(context);
+    _themeData = Theme.of(context);
     computeDimensions();
   }
 
   void computeDimensions() {
-    final themeData = Theme.of(context);
+    _inputDecorations = _themeData.extension<InputDecorations>();
+    _textStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
 
-    _inputDecorations = themeData.extension<InputDecorations>();
-    _textStyle = themeData.textTheme.displaySmall?.copyWith(color: themeData.colorScheme.surface);
+    _iconSize = _themeData.textTheme.headlineLarge?.fontSize;
 
-    _iconSize = themeData.textTheme.headlineLarge?.fontSize;
-
-    final mediaQueryData = MediaQuery.of(context);
-    _isOrientationPortrait = mediaQueryData.orientation == Orientation.portrait;
-    _dimension = min(mediaQueryData.size.width, mediaQueryData.size.height) / 5;
+    _isOrientationPortrait = _mediaQueryData.orientation == Orientation.portrait;
+    _dimension = min(_mediaQueryData.size.width, _mediaQueryData.size.height) / 5;
     if (_isOrientationPortrait) {
       _actionsDelimiterDimension = _dimension / 5;
       if (widget.remoteVideo) {

--- a/lib/features/call/widgets/draggable_thumbnail.dart
+++ b/lib/features/call/widgets/draggable_thumbnail.dart
@@ -108,6 +108,7 @@ class _DraggableThumbnailState extends State<DraggableThumbnail> {
 
     if (_offset != null && !_dragging) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
         final thumbnailRect = _findThumbnailRect();
         final translateX = _lastStickTranslateX(_stickyRect, thumbnailRect);
         final translateY = _boundTranslateY(_stickyRect, thumbnailRect);

--- a/lib/features/call_to_actions/screen/call_to_actions_shell.dart
+++ b/lib/features/call_to_actions/screen/call_to_actions_shell.dart
@@ -20,15 +20,21 @@ class CallToActionsShell extends StatefulWidget {
 }
 
 class _CallToActionsShellState extends State<CallToActionsShell> with RouteAware {
-  late final DemoActionOverlay _actionOverlay = DemoActionOverlay(
-    screenSize: MediaQuery.of(context).size,
-    safePadding: MediaQuery.of(context).padding,
-    stickyPadding: const EdgeInsets.all(8),
-  );
+  DemoActionOverlay? _actionOverlay;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _actionOverlay ??= DemoActionOverlay(
+      screenSize: MediaQuery.sizeOf(context),
+      safePadding: MediaQuery.paddingOf(context),
+      stickyPadding: const EdgeInsets.all(8),
+    );
+  }
 
   @override
   void dispose() {
-    _actionOverlay.remove();
+    _actionOverlay?.remove();
     super.dispose();
   }
 
@@ -69,7 +75,7 @@ class _CallToActionsShellState extends State<CallToActionsShell> with RouteAware
   }
 
   void _removeActionOverlay() {
-    _actionOverlay.remove();
+    _actionOverlay?.remove();
   }
 
   void _updateActionOverlay(BuildContext context, CallToAction action) {
@@ -79,7 +85,7 @@ class _CallToActionsShellState extends State<CallToActionsShell> with RouteAware
     final url = action.url;
     final button = DemoActionButton(title: action.title, description: action.description);
 
-    _actionOverlay.insert(
+    _actionOverlay?.insert(
       context: context,
       child: button,
       onTap: url != null ? () => _navigateToAction(context, url) : null,

--- a/lib/features/call_to_actions/screen/call_to_actions_shell.dart
+++ b/lib/features/call_to_actions/screen/call_to_actions_shell.dart
@@ -25,11 +25,13 @@ class _CallToActionsShellState extends State<CallToActionsShell> with RouteAware
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _actionOverlay ??= DemoActionOverlay(
-      screenSize: MediaQuery.sizeOf(context),
-      safePadding: MediaQuery.paddingOf(context),
-      stickyPadding: const EdgeInsets.all(8),
-    );
+    if (_actionOverlay == null || !_actionOverlay!.inserted) {
+      _actionOverlay = DemoActionOverlay(
+        screenSize: MediaQuery.sizeOf(context),
+        safePadding: MediaQuery.paddingOf(context),
+        stickyPadding: const EdgeInsets.all(8),
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary

- **Root cause (CRITICAL):** `call_to_actions_shell.dart` — `late final DemoActionOverlay` used `MediaQuery.of(context)` in a lazy initializer that could fire for the first time inside `dispose()` on a deactivated context. Replaced with a nullable field initialized in `didChangeDependencies()`.
- **HIGH:** `main_shell.dart` — `RouterLogoutSessionGuard` closures captured `context` directly (`context.l10n`, `context.read`); replaced with values cached in `initState()` before the guard is created.
- **HIGH:** `call_screen.dart` — `BlocConsumer.listener` could fire between `deactivate()` and `dispose()` with a stale context; added `if (!context.mounted) return` guard.
- **MEDIUM:** `draggable_thumbnail.dart` — `addPostFrameCallback` called `setState` without a `mounted` check; added `if (!mounted) return` guard.
- **MEDIUM:** `call_actions.dart` — `computeDimensions()` called `MediaQuery.of(context)` and `Theme.of(context)` before the existing `mounted` guard; moved both lookups into `didChangeDependencies()` as cached fields.

Closes WT-578.

## Test plan

- [ ] Start a call, let it connect, then hang up — verify no "Looking up a deactivated widget's ancestor is unsafe" errors in logs
- [ ] Navigate between screens rapidly to exercise `CallToActionsShell` dispose paths
- [ ] Trigger a session expiry (401) while the app is active — verify logout notification still appears
- [ ] Open call screen, rotate device — verify call action buttons resize correctly
- [ ] Long-press a message in SMS/Chat while keyboard is open — verify popup menu appears after keyboard dismiss