### PR TITLE
fix: prevent null crash in InkWell on hardware keyboard event during navigation (WT-1012)

### DIFF
--- a/lib/features/cdrs/widgets/cdr_tile.dart
+++ b/lib/features/cdrs/widgets/cdr_tile.dart
@@ -159,8 +159,6 @@ class _CdrTileState extends State<CdrTile> {
         borderRadius: BorderRadius.circular(16),
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
-          focusColor: Colors.yellow,
-          hoverColor: Colors.yellow,
           splashColor: colorScheme.secondary.withAlpha(50),
           key: tileKey,
           onTap: widget.onTap,

--- a/lib/features/contacts/features/contacts_local_tab/view/contacts_local_tab.dart
+++ b/lib/features/contacts/features/contacts_local_tab/view/contacts_local_tab.dart
@@ -47,6 +47,7 @@ class _ContactsLocalTabState extends State<ContactsLocalTab> with WidgetsBinding
     }
 
     Future routeToDiagnosticScreen() async {
+      FocusScope.of(context).unfocus();
       context.router.push(const SettingsRouterPageRoute(children: [DiagnosticScreenPageRoute()]));
     }
 

--- a/lib/features/system_notifications/widgets/system_notification_badge.dart
+++ b/lib/features/system_notifications/widgets/system_notification_badge.dart
@@ -58,6 +58,7 @@ class _SystemNotificationsBadgeState extends State<SystemNotificationsBadge> wit
                 child: InkWell(
                   onTap: () {
                     controller.reset();
+                    FocusScope.of(context).unfocus();
                     context.router.navigate(const SystemNotificationsPageRoute());
                   },
                   child: SizedBox(

--- a/lib/features/system_notifications/widgets/system_notifications_shell.dart
+++ b/lib/features/system_notifications/widgets/system_notifications_shell.dart
@@ -77,6 +77,7 @@ class _SystemNotificationsShellState extends State<SystemNotificationsShell> {
   }
 
   void openNotificationsScreen() {
+    FocusScope.of(context).unfocus();
     context.router.navigate(const SystemNotificationsPageRoute());
   }
 

--- a/lib/features/system_notifications/widgets/system_notifications_shell.dart
+++ b/lib/features/system_notifications/widgets/system_notifications_shell.dart
@@ -77,7 +77,8 @@ class _SystemNotificationsShellState extends State<SystemNotificationsShell> {
   }
 
   void openNotificationsScreen() {
-    FocusScope.of(context).unfocus();
+    FocusManager.instance.primaryFocus?.unfocus();
+    if (!mounted) return;
     context.router.navigate(const SystemNotificationsPageRoute());
   }
 

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -76,6 +76,7 @@ class MainAppBar extends AppBar {
                          ],
                        ),
                        onPressed: () {
+                         FocusScope.of(context).unfocus();
                          context.router.navigate(const SettingsRouterPageRoute());
                        },
                      );


### PR DESCRIPTION
## Summary

- Remove debug `focusColor`/`hoverColor` (`Colors.yellow`) from `CdrTile`'s `InkWell` — this prevented the widget from subscribing to `_HighlightModeManager` and receiving keyboard events after being removed from the tree
- Add `FocusScope.of(context).unfocus()` before all `fullscreenDialog` navigations (Settings, SystemNotifications) to cover `ListTile`-based widgets (Favorites, Recents, CallLog) that use Flutter's internal InkWell

## Root cause

Flutter's `_HighlightModeManager` notifies all registered `_InkResponseState` listeners on every keyboard event without checking if the element is still mounted. When navigating to a `fullscreenDialog` route, stale InkWell states receive the notification, call `MediaQuery.maybeNavigationModeOf(context)` on a detached tree, and crash.
