### PR TITLE
fix: fall back to audio-only when camera permission is denied on incoming video call (WT-1049)

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -439,6 +439,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
 
                       // Initialize media builder with app-configured audio/video constraints
                       // Used to capture synchronized MediaStream (audio+video) for WebRTC track addition.
+                      final appPermissions = context.read<AppPermissions>();
                       final userMediaBuilder = DefaultUserMediaBuilder(
                         audioConstraintsBuilder: AudioConstraintsWithAppSettingsBuilder(
                           audioProcessingSettingsRepository,
@@ -446,6 +447,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         videoConstraintsBuilder: VideoConstraintsWithAppSettingsBuilder(
                           videoCapturingSettingsRepository,
                         ),
+                        isCameraPermissionGranted: () => appPermissions.isPermissionGranted(Permission.camera),
                       );
                       // Initialize peer connection policy applier with app-specific negotiation rules
                       final pearConnectionPolicyApplier = ModifyWithSettingsPeerConnectionPolicyApplier(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2028,24 +2028,19 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         }),
       );
 
-      late final MediaStream localStream;
-      var resolvedVideo = offer.hasVideo;
-      try {
-        localStream = await userMediaBuilder.build(video: offer.hasVideo, frontCamera: call.frontCamera);
-      } on UserMediaError {
-        if (!offer.hasVideo) rethrow;
-        _logger.warning('__onCallPerformEventAnswered: camera unavailable, falling back to audio-only');
-        localStream = await userMediaBuilder.build(video: false);
-        resolvedVideo = false;
+      final videoEnabled = offer.hasVideo && await userMediaBuilder.isVideoAvailable();
+      if (offer.hasVideo && !videoEnabled) {
+        _logger.info('__onCallPerformEventAnswered: camera permission not granted, answering audio-only');
       }
 
+      final localStream = await userMediaBuilder.build(video: videoEnabled, frontCamera: call.frontCamera);
       final peerConnection = await _createPeerConnection(event.callId, call.line);
       await Future.forEach(localStream.getTracks(), (t) => peerConnection.addTrack(t, localStream));
 
       emit(
         state.copyWithMappedActiveCall(event.callId, (call) {
           return call.copyWith(
-            video: resolvedVideo,
+            video: videoEnabled,
             localStream: localStream,
             processingStatus: CallProcessingStatus.incomingAnswering,
           );

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2028,13 +2028,27 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         }),
       );
 
-      final localStream = await userMediaBuilder.build(video: offer.hasVideo, frontCamera: call.frontCamera);
+      late final MediaStream localStream;
+      var resolvedVideo = offer.hasVideo;
+      try {
+        localStream = await userMediaBuilder.build(video: offer.hasVideo, frontCamera: call.frontCamera);
+      } on UserMediaError {
+        if (!offer.hasVideo) rethrow;
+        _logger.warning('__onCallPerformEventAnswered: camera unavailable, falling back to audio-only');
+        localStream = await userMediaBuilder.build(video: false);
+        resolvedVideo = false;
+      }
+
       final peerConnection = await _createPeerConnection(event.callId, call.line);
       await Future.forEach(localStream.getTracks(), (t) => peerConnection.addTrack(t, localStream));
 
       emit(
         state.copyWithMappedActiveCall(event.callId, (call) {
-          return call.copyWith(localStream: localStream, processingStatus: CallProcessingStatus.incomingAnswering);
+          return call.copyWith(
+            video: resolvedVideo,
+            localStream: localStream,
+            processingStatus: CallProcessingStatus.incomingAnswering,
+          );
         }),
       );
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2028,19 +2028,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         }),
       );
 
-      final videoEnabled = offer.hasVideo && await userMediaBuilder.isVideoAvailable();
-      if (offer.hasVideo && !videoEnabled) {
-        _logger.info('__onCallPerformEventAnswered: camera permission not granted, answering audio-only');
-      }
-
-      final localStream = await userMediaBuilder.build(video: videoEnabled, frontCamera: call.frontCamera);
+      final localStream = await userMediaBuilder.build(video: offer.hasVideo, frontCamera: call.frontCamera);
       final peerConnection = await _createPeerConnection(event.callId, call.line);
       await Future.forEach(localStream.getTracks(), (t) => peerConnection.addTrack(t, localStream));
 
       emit(
         state.copyWithMappedActiveCall(event.callId, (call) {
           return call.copyWith(
-            video: videoEnabled,
+            video: localStream.getVideoTracks().isNotEmpty,
             localStream: localStream,
             processingStatus: CallProcessingStatus.incomingAnswering,
           );

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2028,7 +2028,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         }),
       );
 
-      final localStream = await userMediaBuilder.build(video: offer.hasVideo, frontCamera: call.frontCamera);
+      final localStream = await userMediaBuilder.build(
+        video: offer.hasVideo,
+        frontCamera: call.frontCamera,
+        allowAudioFallback: true,
+      );
       final peerConnection = await _createPeerConnection(event.callId, call.line);
       await Future.forEach(localStream.getTracks(), (t) => peerConnection.addTrack(t, localStream));
 

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -39,6 +39,10 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   /// permission is checked first via [isCameraPermissionGranted]. If denied,
   /// the stream is acquired without video rather than throwing.
   ///
+  /// If the pre-check passes but [getUserMedia] still fails (e.g. permission
+  /// revoked between check and call), the method retries with [video: false]
+  /// so the incoming call is answered audio-only rather than dropped.
+  ///
   /// When [allowAudioFallback] is [false] (default), any failure to acquire
   /// media throws [UserMediaError], preserving the original behaviour for
   /// callers that handle the error explicitly (e.g. camera-enable action).
@@ -49,6 +53,15 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   Future<MediaStream> build({required bool video, bool? frontCamera, bool allowAudioFallback = false}) async {
     final resolvedVideo = video && (!allowAudioFallback || await _isCameraAvailable());
 
+    try {
+      return await _acquireStream(resolvedVideo: resolvedVideo, frontCamera: frontCamera);
+    } catch (_) {
+      if (!allowAudioFallback || !resolvedVideo) rethrow;
+      return _acquireStream(resolvedVideo: false, frontCamera: frontCamera);
+    }
+  }
+
+  Future<MediaStream> _acquireStream({required bool resolvedVideo, bool? frontCamera}) async {
     final Map<String, dynamic> mediaConstraints = {
       'audio': _buildAudioConstraints(),
       'video': resolvedVideo ? _buildVideoConstraintsMap(frontCamera: frontCamera) : false,

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -6,7 +6,7 @@ import 'audio_constraints_builder.dart';
 import 'video_constraints_builder.dart';
 
 abstract class UserMediaBuilder {
-  Future<MediaStream> build({required bool video, bool? frontCamera});
+  Future<MediaStream> build({required bool video, bool? frontCamera, bool allowAudioFallback = false});
 }
 
 class DefaultUserMediaBuilder implements UserMediaBuilder {
@@ -27,15 +27,19 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
 
   /// Requests access to the user's media input devices (camera and/or microphone).
   ///
-  /// When [video] is [true] and [isCameraPermissionGranted] is provided, the
-  /// camera permission is checked first. If denied, the stream is acquired
-  /// without video to allow audio-only fallback.
+  /// When [allowAudioFallback] is [true] and [video] is [true], the camera
+  /// permission is checked first via [isCameraPermissionGranted]. If denied,
+  /// the stream is acquired without video rather than throwing.
+  ///
+  /// When [allowAudioFallback] is [false] (default), any failure to acquire
+  /// media throws [UserMediaError], preserving the original behaviour for
+  /// callers that handle the error explicitly (e.g. camera-enable action).
   ///
   /// For more information on constraints structure, see:
   /// https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
   @override
-  Future<MediaStream> build({required bool video, bool? frontCamera}) async {
-    final resolvedVideo = video && await _isCameraAvailable();
+  Future<MediaStream> build({required bool video, bool? frontCamera, bool allowAudioFallback = false}) async {
+    final resolvedVideo = video && (!allowAudioFallback || await _isCameraAvailable());
 
     final Map<String, dynamic> mediaConstraints = {
       'audio': _buildAudioConstraints(),

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -14,6 +14,7 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     this.audioConstraintsBuilder,
     this.videoConstraintsBuilder,
     this.isCameraPermissionGranted,
+    this.getUserMedia,
   });
 
   final AudioConstraintsBuilder? audioConstraintsBuilder;
@@ -24,6 +25,13 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   /// When [null], video availability is assumed to be [true] — the platform
   /// itself (OS / browser) will handle the permission prompt.
   final Future<bool> Function()? isCameraPermissionGranted;
+
+  /// Injectable override for [navigator.mediaDevices.getUserMedia].
+  ///
+  /// Defaults to the real platform API when [null].
+  /// Intended for use in tests only.
+  @visibleForTesting
+  final Future<MediaStream> Function(Map<String, dynamic>)? getUserMedia;
 
   /// Requests access to the user's media input devices (camera and/or microphone).
   ///
@@ -47,7 +55,7 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     };
 
     try {
-      final localStream = await navigator.mediaDevices.getUserMedia(mediaConstraints);
+      final localStream = await (getUserMedia ?? navigator.mediaDevices.getUserMedia)(mediaConstraints);
 
       if (!kIsWeb) {
         await Helper.setAppleAudioConfiguration(

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import 'audio_constraints_builder.dart';
 import 'video_constraints_builder.dart';
 
 abstract class UserMediaBuilder {
   Future<MediaStream> build({required bool video, bool? frontCamera});
+
+  Future<bool> isVideoAvailable();
 }
 
 class DefaultUserMediaBuilder implements UserMediaBuilder {
@@ -14,6 +17,16 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
 
   final AudioConstraintsBuilder? audioConstraintsBuilder;
   final VideoConstraintsBuilder? videoConstraintsBuilder;
+
+  /// Returns [true] when the camera permission is granted on the current platform.
+  ///
+  /// On web, where permission_handler is not applicable, always returns [true]
+  /// and lets the browser prompt handle access.
+  @override
+  Future<bool> isVideoAvailable() async {
+    if (kIsWeb) return true;
+    return (await Permission.camera.status).isGranted;
+  }
 
   /// Requests access to the user's media input devices (camera and/or microphone).
   ///

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 import 'audio_constraints_builder.dart';
 import 'video_constraints_builder.dart';
@@ -13,19 +12,29 @@ abstract class UserMediaBuilder {
 }
 
 class DefaultUserMediaBuilder implements UserMediaBuilder {
-  const DefaultUserMediaBuilder({this.audioConstraintsBuilder, this.videoConstraintsBuilder});
+  const DefaultUserMediaBuilder({
+    this.audioConstraintsBuilder,
+    this.videoConstraintsBuilder,
+    this.isCameraPermissionGranted,
+  });
 
   final AudioConstraintsBuilder? audioConstraintsBuilder;
   final VideoConstraintsBuilder? videoConstraintsBuilder;
 
-  /// Returns [true] when the camera permission is granted on the current platform.
+  /// Optional callback to check whether camera permission is granted.
   ///
-  /// On web, where permission_handler is not applicable, always returns [true]
-  /// and lets the browser prompt handle access.
+  /// When [null], video availability is assumed to be [true] — the platform
+  /// itself (OS / browser) will handle the permission prompt.
+  final Future<bool> Function()? isCameraPermissionGranted;
+
+  /// Returns [true] when camera permission is granted.
+  ///
+  /// Delegates to [isCameraPermissionGranted] when provided; otherwise
+  /// returns [true] and lets the platform handle access.
   @override
   Future<bool> isVideoAvailable() async {
     if (kIsWeb) return true;
-    return (await Permission.camera.status).isGranted;
+    return isCameraPermissionGranted == null || await isCameraPermissionGranted!();
   }
 
   /// Requests access to the user's media input devices (camera and/or microphone).

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -7,8 +7,6 @@ import 'video_constraints_builder.dart';
 
 abstract class UserMediaBuilder {
   Future<MediaStream> build({required bool video, bool? frontCamera});
-
-  Future<bool> isVideoAvailable();
 }
 
 class DefaultUserMediaBuilder implements UserMediaBuilder {
@@ -27,25 +25,21 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   /// itself (OS / browser) will handle the permission prompt.
   final Future<bool> Function()? isCameraPermissionGranted;
 
-  /// Returns [true] when camera permission is granted.
-  ///
-  /// Delegates to [isCameraPermissionGranted] when provided; otherwise
-  /// returns [true] and lets the platform handle access.
-  @override
-  Future<bool> isVideoAvailable() async {
-    if (kIsWeb) return true;
-    return isCameraPermissionGranted == null || await isCameraPermissionGranted!();
-  }
-
   /// Requests access to the user's media input devices (camera and/or microphone).
+  ///
+  /// When [video] is [true] and [isCameraPermissionGranted] is provided, the
+  /// camera permission is checked first. If denied, the stream is acquired
+  /// without video to allow audio-only fallback.
   ///
   /// For more information on constraints structure, see:
   /// https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
   @override
   Future<MediaStream> build({required bool video, bool? frontCamera}) async {
+    final resolvedVideo = video && await _isCameraAvailable();
+
     final Map<String, dynamic> mediaConstraints = {
       'audio': _buildAudioConstraints(),
-      'video': video ? _buildVideoConstraintsMap(frontCamera: frontCamera) : false,
+      'video': resolvedVideo ? _buildVideoConstraintsMap(frontCamera: frontCamera) : false,
     };
 
     try {
@@ -53,7 +47,7 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
 
       if (!kIsWeb) {
         await Helper.setAppleAudioConfiguration(
-          AppleAudioConfiguration(appleAudioMode: video ? AppleAudioMode.videoChat : AppleAudioMode.voiceChat),
+          AppleAudioConfiguration(appleAudioMode: resolvedVideo ? AppleAudioMode.videoChat : AppleAudioMode.voiceChat),
         );
       }
 
@@ -61,6 +55,11 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     } catch (e) {
       throw UserMediaError(e.toString());
     }
+  }
+
+  Future<bool> _isCameraAvailable() async {
+    if (kIsWeb || isCameraPermissionGranted == null) return true;
+    return isCameraPermissionGranted!();
   }
 
   /// Constructs the map structure for audio constraints.

--- a/test/features/call/utils/user_media_builder_test.dart
+++ b/test/features/call/utils/user_media_builder_test.dart
@@ -98,6 +98,61 @@ void main() {
     });
   });
 
+  group('DefaultUserMediaBuilder — allowAudioFallback: true, getUserMedia retry', () {
+    test('retries with video: false when getUserMedia fails on first video attempt', () async {
+      final capturedAttempts = <bool>[];
+      final subject = DefaultUserMediaBuilder(
+        isCameraPermissionGranted: () async => true,
+        getUserMedia: (constraints) async {
+          final hasVideo = constraints['video'] != false;
+          capturedAttempts.add(hasVideo);
+          if (hasVideo) throw Exception('NotAllowedError');
+          return mockStream;
+        },
+      );
+
+      final result = await subject.build(video: true, allowAudioFallback: true);
+
+      expect(capturedAttempts, [true, false]);
+      expect(result, mockStream);
+    });
+
+    test('does not retry when allowAudioFallback is false', () async {
+      var callCount = 0;
+      final subject = DefaultUserMediaBuilder(
+        getUserMedia: (_) async {
+          callCount++;
+          throw Exception('NotAllowedError');
+        },
+      );
+
+      await expectLater(subject.build(video: true), throwsA(isA<UserMediaError>()));
+      expect(callCount, 1);
+    });
+
+    test('does not retry when video was already false', () async {
+      var callCount = 0;
+      final subject = DefaultUserMediaBuilder(
+        getUserMedia: (_) async {
+          callCount++;
+          throw Exception('device error');
+        },
+      );
+
+      await expectLater(subject.build(video: false, allowAudioFallback: true), throwsA(isA<UserMediaError>()));
+      expect(callCount, 1);
+    });
+
+    test('throws UserMediaError when retry also fails', () async {
+      final subject = DefaultUserMediaBuilder(
+        isCameraPermissionGranted: () async => true,
+        getUserMedia: (_) async => throw Exception('no mic'),
+      );
+
+      await expectLater(subject.build(video: true, allowAudioFallback: true), throwsA(isA<UserMediaError>()));
+    });
+  });
+
   group('DefaultUserMediaBuilder — error handling', () {
     test('wraps getUserMedia exception in UserMediaError', () async {
       final subject = DefaultUserMediaBuilder(getUserMedia: (_) async => throw Exception('device not found'));

--- a/test/features/call/utils/user_media_builder_test.dart
+++ b/test/features/call/utils/user_media_builder_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/features/call/utils/user_media_builder.dart';
+
+class MockMediaStream extends Mock implements MediaStream {}
+
+void main() {
+  late MockMediaStream mockStream;
+  late Map<String, dynamic> capturedConstraints;
+  late Future<MediaStream> Function(Map<String, dynamic>) fakeGetUserMedia;
+
+  setUp(() {
+    mockStream = MockMediaStream();
+    capturedConstraints = {};
+
+    fakeGetUserMedia = (constraints) async {
+      capturedConstraints = constraints;
+      return mockStream;
+    };
+  });
+
+  DefaultUserMediaBuilder builder({Future<bool> Function()? isCameraPermissionGranted}) =>
+      DefaultUserMediaBuilder(isCameraPermissionGranted: isCameraPermissionGranted, getUserMedia: fakeGetUserMedia);
+
+  group('DefaultUserMediaBuilder — audio/video constraints', () {
+    test('passes video: false to getUserMedia when video is false', () async {
+      await builder().build(video: false);
+      expect(capturedConstraints['video'], isFalse);
+    });
+
+    test('passes video map to getUserMedia when video is true', () async {
+      await builder().build(video: true);
+      expect(capturedConstraints['video'], isA<Map>());
+    });
+
+    test('passes audio constraints to getUserMedia', () async {
+      await builder().build(video: false);
+      expect(capturedConstraints['audio'], isNotNull);
+    });
+  });
+
+  group('DefaultUserMediaBuilder — allowAudioFallback: false (default)', () {
+    test('does not call isCameraPermissionGranted when allowAudioFallback is false', () async {
+      var permissionCalled = false;
+      await builder(
+        isCameraPermissionGranted: () async {
+          permissionCalled = true;
+          return false;
+        },
+      ).build(video: true);
+
+      expect(permissionCalled, isFalse);
+      expect(capturedConstraints['video'], isA<Map>());
+    });
+
+    test('passes video: true regardless of camera permission when allowAudioFallback is false', () async {
+      await builder(isCameraPermissionGranted: () async => false).build(video: true);
+      expect(capturedConstraints['video'], isA<Map>());
+    });
+  });
+
+  group('DefaultUserMediaBuilder — allowAudioFallback: true', () {
+    test('passes video: true when camera permission is granted', () async {
+      await builder(isCameraPermissionGranted: () async => true).build(video: true, allowAudioFallback: true);
+
+      expect(capturedConstraints['video'], isA<Map>());
+    });
+
+    test('passes video: false when camera permission is denied', () async {
+      await builder(isCameraPermissionGranted: () async => false).build(video: true, allowAudioFallback: true);
+
+      expect(capturedConstraints['video'], isFalse);
+    });
+
+    test('passes video: false when video is false regardless of camera permission', () async {
+      await builder(isCameraPermissionGranted: () async => true).build(video: false, allowAudioFallback: true);
+
+      expect(capturedConstraints['video'], isFalse);
+    });
+
+    test('passes video: true when isCameraPermissionGranted is null', () async {
+      await builder().build(video: true, allowAudioFallback: true);
+      expect(capturedConstraints['video'], isA<Map>());
+    });
+
+    test('calls isCameraPermissionGranted exactly once per build call', () async {
+      var callCount = 0;
+      await builder(
+        isCameraPermissionGranted: () async {
+          callCount++;
+          return true;
+        },
+      ).build(video: true, allowAudioFallback: true);
+
+      expect(callCount, 1);
+    });
+  });
+
+  group('DefaultUserMediaBuilder — error handling', () {
+    test('wraps getUserMedia exception in UserMediaError', () async {
+      final subject = DefaultUserMediaBuilder(getUserMedia: (_) async => throw Exception('device not found'));
+
+      await expectLater(subject.build(video: false), throwsA(isA<UserMediaError>()));
+    });
+
+    test('UserMediaError message contains original error', () async {
+      final subject = DefaultUserMediaBuilder(getUserMedia: (_) async => throw Exception('device not found'));
+
+      UserMediaError? captured;
+      await subject.build(video: false).catchError((Object e) {
+        captured = e as UserMediaError;
+        return mockStream as MediaStream;
+      });
+      expect(captured?.message, contains('device not found'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- When answering an incoming video call without camera permission the app previously dropped the call with a `UserMediaError`
- `DefaultUserMediaBuilder.build()` now accepts an `allowAudioFallback` flag; when `true` it checks camera permission via the injected `isCameraPermissionGranted` callback and silently falls back to audio-only if denied
- All existing callers use the default `allowAudioFallback: false` — original error-throw behaviour is fully preserved (camera-enable action still shows `CallUserMediaErrorNotification` on failure)
- `__onCallPerformEventAnswered` passes `allowAudioFallback: true`; `ActiveCall.video` is resolved from actual stream tracks after `build()`

## Changes

**`lib/features/call/utils/user_media_builder.dart`**
- Added optional `isCameraPermissionGranted: Future<bool> Function()?` callback to `DefaultUserMediaBuilder`
- Added `allowAudioFallback: bool = false` parameter to `build()`; when `true`, resolves effective video flag via `_isCameraAvailable()` before calling `getUserMedia`

**`lib/features/call/bloc/call_bloc.dart` — `__onCallPerformEventAnswered`**
- Calls `build(video: offer.hasVideo, ..., allowAudioFallback: true)`
- Sets `ActiveCall.video` from `localStream.getVideoTracks().isNotEmpty` (actual result, not intent)

**`lib/app/router/main_shell.dart`**
- Injects `() => appPermissions.isPermissionGranted(Permission.camera)` as the permission callback at construction time

## Test plan

- [ ] Answer an incoming video call with camera permission denied → call connects in audio-only mode, camera button shows as disabled
- [ ] Answer an incoming audio call with microphone permission denied → call is still declined (error path unchanged)
- [ ] Answer an incoming video call with both camera and microphone granted → video call works as before
- [ ] During an active call, tap camera enable with camera permission denied → `CallUserMediaErrorNotification` shown, video state unchanged (regression guard)

## Linked issue

WT-1049