### PR TITLE
fix: stop voicemail polling after server responds with unsupported (WT-1107)

### DIFF
--- a/lib/common/refreshable.dart
+++ b/lib/common/refreshable.dart
@@ -2,4 +2,11 @@ abstract class Refreshable {
   /// Called when data needs to be refreshed.
   /// For example, after network reconnection or during polling.
   Future<void> refresh();
+
+  /// Returns `false` when this refreshable has permanently stopped needing updates
+  /// (e.g. the remote feature is not configured) and should be skipped or unregistered
+  /// by polling and connectivity services.
+  ///
+  /// Defaults to `true`. Override to opt out of further refresh calls.
+  bool get isActive => true;
 }

--- a/lib/repositories/caller_id_settings/caller_id_settings_repository.dart
+++ b/lib/repositories/caller_id_settings/caller_id_settings_repository.dart
@@ -86,7 +86,6 @@ class CallerIdSettingsRepositoryRemoteImpl
   }
 
   @override
-  @override
   bool get isActive => true;
 
   @override

--- a/lib/repositories/caller_id_settings/caller_id_settings_repository.dart
+++ b/lib/repositories/caller_id_settings/caller_id_settings_repository.dart
@@ -86,6 +86,10 @@ class CallerIdSettingsRepositoryRemoteImpl
   }
 
   @override
+  @override
+  bool get isActive => true;
+
+  @override
   Future<void> refresh() => sync();
 
   @override

--- a/lib/repositories/contacts/external_contacts_repository.dart
+++ b/lib/repositories/contacts/external_contacts_repository.dart
@@ -64,6 +64,10 @@ class ExternalContactsRepository with ExternalContactApiMapper implements Refres
   }
 
   @override
+  @override
+  bool get isActive => true;
+
+  @override
   Future<void> refresh() async {
     return _gatherListContacts();
   }

--- a/lib/repositories/contacts/external_contacts_repository.dart
+++ b/lib/repositories/contacts/external_contacts_repository.dart
@@ -64,7 +64,6 @@ class ExternalContactsRepository with ExternalContactApiMapper implements Refres
   }
 
   @override
-  @override
   bool get isActive => true;
 
   @override

--- a/lib/repositories/favorites/favorites_repository.dart
+++ b/lib/repositories/favorites/favorites_repository.dart
@@ -147,6 +147,10 @@ class FavoritesRepositorySyncableImpl implements FavoritesRepository, Refreshabl
   }
 
   @override
+  @override
+  bool get isActive => true;
+
+  @override
   Future<void> refresh() => _maybeSync();
 
   FavoriteSourceType _favoriteSourceTypeFromContact(ContactSourceType sourceType) {

--- a/lib/repositories/favorites/favorites_repository.dart
+++ b/lib/repositories/favorites/favorites_repository.dart
@@ -147,7 +147,6 @@ class FavoritesRepositorySyncableImpl implements FavoritesRepository, Refreshabl
   }
 
   @override
-  @override
   bool get isActive => true;
 
   @override

--- a/lib/repositories/system_info/system_info_repository.dart
+++ b/lib/repositories/system_info/system_info_repository.dart
@@ -182,7 +182,6 @@ class SystemInfoRepositoryImpl implements SystemInfoRepository {
   }
 
   @override
-  @override
   bool get isActive => true;
 
   @override

--- a/lib/repositories/system_info/system_info_repository.dart
+++ b/lib/repositories/system_info/system_info_repository.dart
@@ -182,6 +182,10 @@ class SystemInfoRepositoryImpl implements SystemInfoRepository {
   }
 
   @override
+  @override
+  bool get isActive => true;
+
+  @override
   Future<void> refresh() async {
     _logger.info('Background refresh started');
     try {

--- a/lib/repositories/user_info/user_repository.dart
+++ b/lib/repositories/user_info/user_repository.dart
@@ -50,6 +50,10 @@ class UserRepository implements Refreshable {
   }
 
   @override
+  @override
+  bool get isActive => true;
+
+  @override
   Future<void> refresh() async {
     try {
       final oldInfo = localDatasource.getInfo();

--- a/lib/repositories/user_info/user_repository.dart
+++ b/lib/repositories/user_info/user_repository.dart
@@ -50,7 +50,6 @@ class UserRepository implements Refreshable {
   }
 
   @override
-  @override
   bool get isActive => true;
 
   @override

--- a/lib/repositories/voicemail/voicemail_repository.dart
+++ b/lib/repositories/voicemail/voicemail_repository.dart
@@ -101,6 +101,9 @@ class VoicemailRepositoryImpl
   @override
   bool get isFeatureSupported => _featureSupported;
 
+  @override
+  bool get isActive => _featureSupported;
+
   void _initialize() {
     _updatesController = StreamController<List<Voicemail>>.broadcast(onListen: _onListen, onCancel: _onCancel);
 
@@ -370,6 +373,9 @@ class VoicemailRepositoryImpl
 
 class EmptyVoicemailRepository implements VoicemailRepository {
   const EmptyVoicemailRepository();
+
+  @override
+  bool get isActive => false;
 
   @override
   Future<void> fetchVoicemails({String? localeCode}) => Future.value();

--- a/lib/services/connectivity_lifecycle_service.dart
+++ b/lib/services/connectivity_lifecycle_service.dart
@@ -172,7 +172,7 @@ class ConnectivityLifecycleService implements Disposable {
   Future<void> refreshAll() async {
     if (_isDisposed || _refreshables.isEmpty) return;
 
-    final snapshot = List<Refreshable>.unmodifiable(_refreshables);
+    final snapshot = List<Refreshable>.unmodifiable(_refreshables.where((r) => r.isActive));
 
     if (options.parallelism == Parallelism.concurrent) {
       await _runConcurrent<Refreshable>(snapshot, (r) => r.refresh());

--- a/lib/services/polling_service.dart
+++ b/lib/services/polling_service.dart
@@ -239,6 +239,11 @@ class PollingService implements Disposable {
       final reachable = await _isReachable();
       if (_disposed) return _nextDelay(config);
 
+      if (!listener.isActive) {
+        unregister(listener);
+        return _nextDelay(config);
+      }
+
       if (reachable && !config.isRefreshing) {
         config.isRefreshing = true;
         try {

--- a/lib/services/polling_service.dart
+++ b/lib/services/polling_service.dart
@@ -281,6 +281,10 @@ class PollingService implements Disposable {
       if (_disposed) return;
       try {
         if (_shouldRunTimers && reachable) {
+          if (!listener.isActive) {
+            unregister(listener);
+            return;
+          }
           await listener.refresh();
           _logger.finest('PollingService: leading refresh succeeded for $listener');
           config.consecutiveErrors = 0;

--- a/test/mocks/mock_refreshable_repository.dart
+++ b/test/mocks/mock_refreshable_repository.dart
@@ -22,8 +22,10 @@ class MockRefreshableRepository implements Refreshable {
 
   Completer<void>? _neverCompleter;
 
+  bool active = true;
+
   @override
-  bool get isActive => true;
+  bool get isActive => active;
 
   @override
   Future<void> refresh() async {

--- a/test/mocks/mock_refreshable_repository.dart
+++ b/test/mocks/mock_refreshable_repository.dart
@@ -23,6 +23,9 @@ class MockRefreshableRepository implements Refreshable {
   Completer<void>? _neverCompleter;
 
   @override
+  bool get isActive => true;
+
+  @override
   Future<void> refresh() async {
     onStart?.call();
     calls++;

--- a/test/services/connectivity_lifecycle_service_test.dart
+++ b/test/services/connectivity_lifecycle_service_test.dart
@@ -305,6 +305,29 @@ void main() {
       });
     });
 
+    // Ensures inactive refreshables are skipped during refreshAll() triggered
+    // on reconnect, while active ones are still called normally.
+    test('inactive refreshable is skipped on reconnect', () {
+      fakeAsync((async) {
+        final active = MockRefreshableRepository();
+        final inactive = MockRefreshableRepository()..active = false;
+
+        service = ConnectivityLifecycleService(
+          connectivity: connectivity,
+          options: const ConnectivityLifecycleOptions(debounce: Duration.zero, jitterMaxMs: 0),
+        );
+
+        service.register(ConnectivityRecoveryRegistration.refreshable(active));
+        service.register(ConnectivityRecoveryRegistration.refreshable(inactive));
+
+        connectivity.push(true);
+        async.elapse(Duration.zero);
+
+        expect(active.calls, 1, reason: 'Active refreshable should be called');
+        expect(inactive.calls, 0, reason: 'Inactive refreshable must be skipped');
+      });
+    });
+
     // Ensures no events are processed after dispose(),
     // i.e., timers and subscriptions are cleaned up.
     test('ignores events after dispose', () async {

--- a/test/services/polling_service_test.dart
+++ b/test/services/polling_service_test.dart
@@ -184,6 +184,61 @@ void main() {
       });
     });
 
+    // Verifies that when a listener becomes inactive (isActive = false) it is
+    // automatically unregistered on the next polling tick and never called again.
+    test('listener becoming inactive is unregistered on next tick', () {
+      fakeAsync((async) {
+        connectivity.setConnected(true);
+
+        final task = MockRefreshableRepository();
+        service = PollingService(
+          connectivityService: connectivity,
+          registrations: [PollingRegistration(listener: task, interval: const Duration(seconds: 5))],
+          options: const PollingOptions(jitterMaxMs: 0),
+        );
+
+        async.flushMicrotasks();
+        expect(task.callCount, 1, reason: 'Leading refresh on boot');
+
+        // Listener becomes inactive after the leading call.
+        task.active = false;
+
+        // Next tick — isActive check unregisters the listener, no refresh call.
+        async.elapse(const Duration(seconds: 5, milliseconds: 600));
+        expect(task.callCount, 1, reason: 'No more calls after listener became inactive');
+
+        // Further ticks — still no calls and no crash.
+        async.elapse(const Duration(seconds: 10));
+        expect(task.callCount, 1);
+      });
+    });
+
+    // Verifies that an inactive listener is also skipped during the leading
+    // refresh triggered on reconnect or app resume.
+    test('inactive listener is skipped on leading refresh (resume/reconnect)', () {
+      fakeAsync((async) {
+        connectivity.setConnected(true);
+
+        final task = MockRefreshableRepository();
+        service = PollingService(
+          connectivityService: connectivity,
+          registrations: [PollingRegistration(listener: task, interval: const Duration(seconds: 60))],
+          options: const PollingOptions(pauseInBackground: true, jitterMaxMs: 0),
+        );
+
+        async.flushMicrotasks();
+        expect(task.callCount, 1);
+
+        task.active = false;
+
+        // Resume triggers a leading refresh — inactive listener must be skipped.
+        service.didChangeAppLifecycleState(AppLifecycleState.paused);
+        service.didChangeAppLifecycleState(AppLifecycleState.resumed);
+        async.flushMicrotasks();
+        expect(task.callCount, 1, reason: 'Inactive listener not refreshed on resume');
+      });
+    });
+
     // Confirms that after service.dispose() is called, all timers are canceled
     // and no further refresh calls are executed.
     test('dispose cancels timers — no further refresh calls', () async {


### PR DESCRIPTION
## Problem

After the server returns `voicemail_not_configured` (HTTP 422) or `endpoint_not_supported`, `VoicemailRepositoryImpl` correctly sets `_featureSupported = false` and stops making API calls. However, `PollingService` and `ConnectivityLifecycleService` kept the repository registered and continued invoking `refresh()` on every tick and reconnect — each call was a no-op but wasted CPU and timer cycles for the rest of the session.

## Changes

- **`Refreshable.isActive`** — new getter with default `true`; signals to polling infrastructure that a listener no longer needs refresh calls
- **`VoicemailRepositoryImpl.isActive`** — returns `_featureSupported`; becomes `false` after the first 422 / unsupported response
- **`EmptyVoicemailRepository.isActive`** — returns `false` (no-op implementation is never active)
- **`PollingService`** — checks `isActive` on each tick; unregisters the listener immediately if inactive
- **`ConnectivityLifecycleService`** — filters out inactive refreshables before each reconnect cycle
- All other `Refreshable` implementors — explicitly override `isActive => true` (required by `implements`)

## Test plan

- [ ] Configure account without voicemail — confirm polling stops after first 422 (check logs: no further `PollingService: refresh() succeeded for VoicemailRepository` entries)
- [ ] Verify other repositories (User, SystemInfo, Contacts, etc.) continue polling normally
- [ ] Reconnect to network after 422 — voicemail repo is not refreshed on reconnect