### PR TITLE
chore: misc cleanup

### DIFF
--- a/lib/features/login/cubit/login_cubit.freezed.dart
+++ b/lib/features/login/cubit/login_cubit.freezed.dart
@@ -45,7 +45,7 @@ abstract mixin class $LoginStateCopyWith<$Res>  {
   factory $LoginStateCopyWith(LoginState value, $Res Function(LoginState) _then) = _$LoginStateCopyWithImpl;
 @useResult
 $Res call({
- bool processing, LoginMode? mode, String? coreUrl, String? tenantId, WebtritSystemInfo? systemInfo, List<LoginType>? supportedLoginTypes, (SessionOtpProvisional, DateTime)? otpSigninSessionOtpProvisionalWithDateTime, bool passwordSigninPasswordInputObscureText, (SessionOtpProvisional, DateTime)? signupSessionOtpProvisionalWithDateTime, String? token, String? userId, EmbeddedData? embedded, Map<String, dynamic>? embeddedExtras, Map<String, dynamic>? embeddedCallbackData, Object? embeddedRequestError, UrlInput coreUrlInput, UserRefInput otpSigninUserRefInput, CodeInput otpSigninCodeInput, UserRefInput passwordSigninUserRefInput, PasswordInput passwordSigninPasswordInput, EmailInput signupEmailInput, CodeInput signupCodeInput
+ bool processing, LoginMode? mode, String? coreUrl, String? tenantId, WebtritSystemInfo? systemInfo, List<LoginType>? supportedLoginTypes, (InvalidType, DateTime)? otpSigninSessionOtpProvisionalWithDateTime, bool passwordSigninPasswordInputObscureText, (InvalidType, DateTime)? signupSessionOtpProvisionalWithDateTime, String? token, String? userId, EmbeddedData? embedded, Map<String, dynamic>? embeddedExtras, Map<String, dynamic>? embeddedCallbackData, Object? embeddedRequestError, UrlInput coreUrlInput, UserRefInput otpSigninUserRefInput, CodeInput otpSigninCodeInput, UserRefInput passwordSigninUserRefInput, PasswordInput passwordSigninPasswordInput, EmailInput signupEmailInput, CodeInput signupCodeInput
 });
 
 
@@ -71,9 +71,9 @@ as String?,tenantId: freezed == tenantId ? _self.tenantId : tenantId // ignore: 
 as String?,systemInfo: freezed == systemInfo ? _self.systemInfo : systemInfo // ignore: cast_nullable_to_non_nullable
 as WebtritSystemInfo?,supportedLoginTypes: freezed == supportedLoginTypes ? _self.supportedLoginTypes : supportedLoginTypes // ignore: cast_nullable_to_non_nullable
 as List<LoginType>?,otpSigninSessionOtpProvisionalWithDateTime: freezed == otpSigninSessionOtpProvisionalWithDateTime ? _self.otpSigninSessionOtpProvisionalWithDateTime : otpSigninSessionOtpProvisionalWithDateTime // ignore: cast_nullable_to_non_nullable
-as (SessionOtpProvisional, DateTime)?,passwordSigninPasswordInputObscureText: null == passwordSigninPasswordInputObscureText ? _self.passwordSigninPasswordInputObscureText : passwordSigninPasswordInputObscureText // ignore: cast_nullable_to_non_nullable
+as (InvalidType, DateTime)?,passwordSigninPasswordInputObscureText: null == passwordSigninPasswordInputObscureText ? _self.passwordSigninPasswordInputObscureText : passwordSigninPasswordInputObscureText // ignore: cast_nullable_to_non_nullable
 as bool,signupSessionOtpProvisionalWithDateTime: freezed == signupSessionOtpProvisionalWithDateTime ? _self.signupSessionOtpProvisionalWithDateTime : signupSessionOtpProvisionalWithDateTime // ignore: cast_nullable_to_non_nullable
-as (SessionOtpProvisional, DateTime)?,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as (InvalidType, DateTime)?,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
 as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
 as String?,embedded: freezed == embedded ? _self.embedded : embedded // ignore: cast_nullable_to_non_nullable
 as EmbeddedData?,embeddedExtras: freezed == embeddedExtras ? _self.embeddedExtras : embeddedExtras // ignore: cast_nullable_to_non_nullable

--- a/packages/device_auto_rotate/example/pubspec.lock
+++ b/packages/device_auto_rotate/example/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -242,10 +242,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   vector_math:
     dependency: transitive
     description:

--- a/screenshots/lib/data/favorites.dart
+++ b/screenshots/lib/data/favorites.dart
@@ -2,13 +2,7 @@ import 'package:webtrit_phone/models/models.dart';
 
 final dFavorites = <FavoriteWithContact>[
   (
-    favorite: Favorite(
-      number: '1234',
-      sourceType: FavoriteSourceType.device,
-      sourceId: '1',
-      label: 'ext',
-      position: 0,
-    ),
+    favorite: Favorite(number: '1234', sourceType: FavoriteSourceType.device, sourceId: '1', label: 'ext', position: 0),
     contact: Contact(
       id: 0,
       sourceType: ContactSourceType.external,
@@ -19,13 +13,7 @@ final dFavorites = <FavoriteWithContact>[
     ),
   ),
   (
-    favorite: Favorite(
-      number: '2345',
-      sourceType: FavoriteSourceType.device,
-      sourceId: '2',
-      label: 'ext',
-      position: 1,
-    ),
+    favorite: Favorite(number: '2345', sourceType: FavoriteSourceType.device, sourceId: '2', label: 'ext', position: 1),
     contact: Contact(
       id: 0,
       sourceType: ContactSourceType.external,
@@ -36,13 +24,7 @@ final dFavorites = <FavoriteWithContact>[
     ),
   ),
   (
-    favorite: Favorite(
-      number: '3456',
-      sourceType: FavoriteSourceType.device,
-      sourceId: '3',
-      label: 'ext',
-      position: 2,
-    ),
+    favorite: Favorite(number: '3456', sourceType: FavoriteSourceType.device, sourceId: '3', label: 'ext', position: 2),
     contact: Contact(
       id: 0,
       sourceType: ContactSourceType.external,
@@ -53,13 +35,7 @@ final dFavorites = <FavoriteWithContact>[
     ),
   ),
   (
-    favorite: Favorite(
-      number: '4567',
-      sourceType: FavoriteSourceType.device,
-      sourceId: '4',
-      label: 'ext',
-      position: 3,
-    ),
+    favorite: Favorite(number: '4567', sourceType: FavoriteSourceType.device, sourceId: '4', label: 'ext', position: 3),
     contact: Contact(
       id: 0,
       sourceType: ContactSourceType.external,
@@ -70,13 +46,7 @@ final dFavorites = <FavoriteWithContact>[
     ),
   ),
   (
-    favorite: Favorite(
-      number: '5678',
-      sourceType: FavoriteSourceType.device,
-      sourceId: '5',
-      label: 'ext',
-      position: 4,
-    ),
+    favorite: Favorite(number: '5678', sourceType: FavoriteSourceType.device, sourceId: '5', label: 'ext', position: 4),
     contact: Contact(
       id: 0,
       sourceType: ContactSourceType.external,
@@ -87,13 +57,7 @@ final dFavorites = <FavoriteWithContact>[
     ),
   ),
   (
-    favorite: Favorite(
-      number: '6789',
-      sourceType: FavoriteSourceType.device,
-      sourceId: '6',
-      label: 'ext',
-      position: 5,
-    ),
+    favorite: Favorite(number: '6789', sourceType: FavoriteSourceType.device, sourceId: '6', label: 'ext', position: 5),
     contact: Contact(
       id: 0,
       sourceType: ContactSourceType.external,


### PR DESCRIPTION
## Summary
- Reformat `screenshots/lib/data/favorites.dart` — collapse multi-line `Favorite(...)` constructors to single-line
- Downgrade `matcher` → 0.12.18 and `test_api` → 0.7.9 in `device_auto_rotate` example lock file
- Regenerate `login_cubit.freezed.dart`