### PR TITLE
fix: regenerate login_cubit.freezed.dart and update pubspec.lock

### DIFF
--- a/lib/features/login/cubit/login_cubit.freezed.dart
+++ b/lib/features/login/cubit/login_cubit.freezed.dart
@@ -45,7 +45,7 @@ abstract mixin class $LoginStateCopyWith<$Res>  {
   factory $LoginStateCopyWith(LoginState value, $Res Function(LoginState) _then) = _$LoginStateCopyWithImpl;
 @useResult
 $Res call({
- bool processing, LoginMode? mode, String? coreUrl, String? tenantId, WebtritSystemInfo? systemInfo, List<LoginType>? supportedLoginTypes, (InvalidType, DateTime)? otpSigninSessionOtpProvisionalWithDateTime, bool passwordSigninPasswordInputObscureText, (InvalidType, DateTime)? signupSessionOtpProvisionalWithDateTime, String? token, String? userId, EmbeddedData? embedded, Map<String, dynamic>? embeddedExtras, Map<String, dynamic>? embeddedCallbackData, Object? embeddedRequestError, UrlInput coreUrlInput, UserRefInput otpSigninUserRefInput, CodeInput otpSigninCodeInput, UserRefInput passwordSigninUserRefInput, PasswordInput passwordSigninPasswordInput, EmailInput signupEmailInput, CodeInput signupCodeInput
+ bool processing, LoginMode? mode, String? coreUrl, String? tenantId, WebtritSystemInfo? systemInfo, List<LoginType>? supportedLoginTypes, (SessionOtpProvisional, DateTime)? otpSigninSessionOtpProvisionalWithDateTime, bool passwordSigninPasswordInputObscureText, (SessionOtpProvisional, DateTime)? signupSessionOtpProvisionalWithDateTime, String? token, String? userId, EmbeddedData? embedded, Map<String, dynamic>? embeddedExtras, Map<String, dynamic>? embeddedCallbackData, Object? embeddedRequestError, UrlInput coreUrlInput, UserRefInput otpSigninUserRefInput, CodeInput otpSigninCodeInput, UserRefInput passwordSigninUserRefInput, PasswordInput passwordSigninPasswordInput, EmailInput signupEmailInput, CodeInput signupCodeInput
 });
 
 
@@ -71,9 +71,9 @@ as String?,tenantId: freezed == tenantId ? _self.tenantId : tenantId // ignore: 
 as String?,systemInfo: freezed == systemInfo ? _self.systemInfo : systemInfo // ignore: cast_nullable_to_non_nullable
 as WebtritSystemInfo?,supportedLoginTypes: freezed == supportedLoginTypes ? _self.supportedLoginTypes : supportedLoginTypes // ignore: cast_nullable_to_non_nullable
 as List<LoginType>?,otpSigninSessionOtpProvisionalWithDateTime: freezed == otpSigninSessionOtpProvisionalWithDateTime ? _self.otpSigninSessionOtpProvisionalWithDateTime : otpSigninSessionOtpProvisionalWithDateTime // ignore: cast_nullable_to_non_nullable
-as (InvalidType, DateTime)?,passwordSigninPasswordInputObscureText: null == passwordSigninPasswordInputObscureText ? _self.passwordSigninPasswordInputObscureText : passwordSigninPasswordInputObscureText // ignore: cast_nullable_to_non_nullable
+as (SessionOtpProvisional, DateTime)?,passwordSigninPasswordInputObscureText: null == passwordSigninPasswordInputObscureText ? _self.passwordSigninPasswordInputObscureText : passwordSigninPasswordInputObscureText // ignore: cast_nullable_to_non_nullable
 as bool,signupSessionOtpProvisionalWithDateTime: freezed == signupSessionOtpProvisionalWithDateTime ? _self.signupSessionOtpProvisionalWithDateTime : signupSessionOtpProvisionalWithDateTime // ignore: cast_nullable_to_non_nullable
-as (InvalidType, DateTime)?,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as (SessionOtpProvisional, DateTime)?,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
 as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
 as String?,embedded: freezed == embedded ? _self.embedded : embedded // ignore: cast_nullable_to_non_nullable
 as EmbeddedData?,embeddedExtras: freezed == embeddedExtras ? _self.embeddedExtras : embeddedExtras // ignore: cast_nullable_to_non_nullable

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1153,10 +1153,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: "direct main"
     description:
@@ -1774,26 +1774,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- Regenerate `login_cubit.freezed.dart` — replaces stale `InvalidType` references with correct `SessionOtpProvisional` type for OTP session fields
- Update `pubspec.lock` with minor transitive dependency bumps (matcher, test, test_api, test_core)

## Test plan

- [ ] App builds without errors
- [ ] Login flow works as expected (OTP and password signin)