### PR TITLE
feat: signaling networking improvemets

### DIFF
--- a/lib/features/call/services/signaling_module.dart
+++ b/lib/features/call/services/signaling_module.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:logging/logging.dart';
 import 'package:ssl_certificates/ssl_certificates.dart';
@@ -8,6 +9,8 @@ import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 final _logger = Logger('SignalingModule');
+
+const _queuedRequestTimeout = Duration(seconds: 30);
 
 // ---------------------------------------------------------------------------
 // Events
@@ -150,7 +153,9 @@ abstract class SignalingModule implements SignalingReconnectable {
 
   /// Sends [request] via the active connection.
   ///
-  /// Returns `null` when not connected; callers must handle this case.
+  /// When connected, the request is sent immediately.
+  /// When not connected, the request is queued and sent on the next successful
+  /// connection, or fails with [NotConnectedException] after 30 seconds.
   /// Returns a [Future] that completes when the request has been written to
   /// the transport.
   Future<void>? execute(Request request);
@@ -201,6 +206,7 @@ class SignalingModuleIsolateImpl implements SignalingModule {
   /// Events buffered since the last [connect] call. Cleared on every [connect]
   /// so that late subscribers receive only the current session's events.
   final List<SignalingModuleEvent> _sessionBuffer = [];
+  final Queue<_QueuedRequest> _queuedRequests = Queue<_QueuedRequest>();
 
   WebtritSignalingClient? _client;
   bool _disposed = false;
@@ -287,7 +293,11 @@ class SignalingModuleIsolateImpl implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  Future<void>? execute(Request request) => _client?.execute(request);
+  Future<void>? execute(Request request) {
+    final client = _client;
+    if (client != null) return client.execute(request);
+    return _enqueueRequest(request);
+  }
 
   /// Initiates a connection. Fire-and-forget - returns immediately.
   /// The result arrives via [events] as [SignalingConnected] or
@@ -330,6 +340,7 @@ class SignalingModuleIsolateImpl implements SignalingModule {
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    _failAllQueuedRequests(NotConnectedException('Signaling module is disposed'));
     _sessionBuffer.clear();
     await disconnect();
     // Wait for _onDisconnect to fire so SignalingDisconnected is emitted before
@@ -392,6 +403,7 @@ class SignalingModuleIsolateImpl implements SignalingModule {
 
         _client = client;
         _emit(SignalingConnected());
+        unawaited(_flushQueuedRequests(client));
       } catch (e, s) {
         if (_disposed) return;
         _logger.warning('_connectAsync failed', e, s);
@@ -464,6 +476,51 @@ class SignalingModuleIsolateImpl implements SignalingModule {
     ack?.complete();
   }
 
+  Future<void> _enqueueRequest(Request request) {
+    final completer = Completer<void>();
+    late final _QueuedRequest queuedRequest;
+    final timer = Timer(_queuedRequestTimeout, () => _onQueuedRequestTimeout(queuedRequest));
+    queuedRequest = _QueuedRequest(request: request, completer: completer, timer: timer);
+    _queuedRequests.add(queuedRequest);
+    return completer.future;
+  }
+
+  Future<void> _flushQueuedRequests(WebtritSignalingClient client) async {
+    while (_queuedRequests.isNotEmpty && identical(_client, client)) {
+      final queuedRequest = _queuedRequests.first;
+      try {
+        await client.execute(queuedRequest.request);
+        _queuedRequests.removeFirst();
+        queuedRequest.timer.cancel();
+        if (!queuedRequest.completer.isCompleted) queuedRequest.completer.complete();
+      } catch (error, stackTrace) {
+        if (!identical(_client, client)) return;
+        _queuedRequests.removeFirst();
+        queuedRequest.timer.cancel();
+        if (!queuedRequest.completer.isCompleted) {
+          queuedRequest.completer.completeError(error, stackTrace);
+        }
+      }
+    }
+  }
+
+  void _onQueuedRequestTimeout(_QueuedRequest queuedRequest) {
+    if (!_queuedRequests.remove(queuedRequest)) return;
+    if (!queuedRequest.completer.isCompleted) {
+      queuedRequest.completer.completeError(
+        NotConnectedException('Timeout waiting for signaling connection to send request: ${queuedRequest.request}'),
+      );
+    }
+  }
+
+  void _failAllQueuedRequests(Object error) {
+    while (_queuedRequests.isNotEmpty) {
+      final queuedRequest = _queuedRequests.removeFirst();
+      queuedRequest.timer.cancel();
+      if (!queuedRequest.completer.isCompleted) queuedRequest.completer.completeError(error);
+    }
+  }
+
   /// Maps a disconnect code to the recommended reconnect delay.
   ///
   /// - [Duration.zero] - reconnect immediately (server evicted a duplicate session)
@@ -490,4 +547,21 @@ class SignalingModuleIsolateImpl implements SignalingModule {
     }
     _controller.add(event);
   }
+}
+
+class NotConnectedException implements Exception {
+  NotConnectedException([this.message = 'Signaling client is not connected']);
+
+  final String message;
+
+  @override
+  String toString() => 'NotConnectedException: $message';
+}
+
+class _QueuedRequest {
+  _QueuedRequest({required this.request, required this.completer, required this.timer});
+
+  final Request request;
+  final Completer<void> completer;
+  final Timer timer;
 }

--- a/lib/features/call/services/signaling_module.dart
+++ b/lib/features/call/services/signaling_module.dart
@@ -11,6 +11,7 @@ import 'package:webtrit_phone/utils/utils.dart';
 final _logger = Logger('SignalingModule');
 
 const _queuedRequestTimeout = Duration(seconds: 30);
+const _executeTimeoutRetryCount = 3;
 
 // ---------------------------------------------------------------------------
 // Events
@@ -154,6 +155,8 @@ abstract class SignalingModule implements SignalingReconnectable {
   /// Sends [request] via the active connection.
   ///
   /// When connected, the request is sent immediately.
+  /// If send fails with [WebtritSignalingTransactionTimeoutException],
+  /// it is retried up to 3 times.
   /// When not connected, the request is queued and sent on the next successful
   /// connection, or fails with [NotConnectedException] after 30 seconds.
   /// Returns a [Future] that completes when the request has been written to
@@ -295,7 +298,7 @@ class SignalingModuleIsolateImpl implements SignalingModule {
   @override
   Future<void>? execute(Request request) {
     final client = _client;
-    if (client != null) return client.execute(request);
+    if (client != null) return _executeWithRetry(client, request);
     return _enqueueRequest(request);
   }
 
@@ -489,7 +492,7 @@ class SignalingModuleIsolateImpl implements SignalingModule {
     while (_queuedRequests.isNotEmpty && identical(_client, client)) {
       final queuedRequest = _queuedRequests.first;
       try {
-        await client.execute(queuedRequest.request);
+        await _executeWithRetry(client, queuedRequest.request);
         _queuedRequests.removeFirst();
         queuedRequest.timer.cancel();
         if (!queuedRequest.completer.isCompleted) queuedRequest.completer.complete();
@@ -501,6 +504,18 @@ class SignalingModuleIsolateImpl implements SignalingModule {
           queuedRequest.completer.completeError(error, stackTrace);
         }
       }
+    }
+  }
+
+  Future<void> _executeWithRetry(WebtritSignalingClient client, Request request, [int timeoutRetry = 0]) async {
+    try {
+      await client.execute(request);
+    } on WebtritSignalingTransactionTimeoutException catch (error, stackTrace) {
+      if (!identical(_client, client) || timeoutRetry >= _executeTimeoutRetryCount) {
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+      _logger.warning('_executeWithRetry timeout, retrying... (retry #$timeoutRetry)', error, stackTrace);
+      return _executeWithRetry(client, request, timeoutRetry + 1);
     }
   }
 

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -74,7 +74,7 @@ class WebtritSignalingClient {
   late final ErrorHandler _onError;
   late final DisconnectHandler _onDisconnect;
 
-  late final Duration _keepaliveInterval;
+  Duration? _keepaliveInterval;
   Timer? _keepaliveTimer;
 
   final _transactions = <String, Transaction>{};
@@ -290,7 +290,7 @@ class WebtritSignalingClient {
   //
 
   void _startKeepaliveTimer() {
-    _keepaliveTimer = Timer(_keepaliveInterval, _onKeepalive);
+    _keepaliveTimer = Timer(_keepaliveInterval ?? Duration(seconds: 30), _onKeepalive);
   }
 
   void _stopKeepaliveTimer() {

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ssl_certificates/ssl_certificates.dart';
@@ -20,6 +21,8 @@ class _FakeSignalingClient extends Fake implements WebtritSignalingClient {
 
   bool disconnected = false;
   int? lastDisconnectCode;
+  int executeCallCount = 0;
+  final Queue<Object?> _executeResponses = Queue<Object?>();
 
   @override
   void listen({
@@ -41,13 +44,21 @@ class _FakeSignalingClient extends Fake implements WebtritSignalingClient {
   }
 
   @override
-  Future<void> execute(Request request, [Duration? timeout]) async {}
+  Future<void> execute(Request request, [Duration? timeout]) async {
+    executeCallCount += 1;
+    if (_executeResponses.isEmpty) return;
+    final response = _executeResponses.removeFirst();
+    if (response != null) throw response;
+  }
 
   // Helpers to inject server-side messages in tests.
   void injectHandshake(StateHandshake handshake) => _onStateHandshake?.call(handshake);
   void injectEvent(Event event) => _onEvent?.call(event);
   void injectError(Object error, [StackTrace? st]) => _onError?.call(error, st);
   void injectDisconnect(int? code, String? reason) => _onDisconnect?.call(code, reason);
+  void enqueueExecuteTimeout() => _executeResponses.add(WebtritSignalingTransactionTimeoutException(1, 'tx-timeout'));
+  void enqueueExecuteError(Object error) => _executeResponses.add(error);
+  void enqueueExecuteSuccess() => _executeResponses.add(null);
 }
 
 /// Variant of [_FakeSignalingClient] whose [disconnect] always throws.
@@ -145,6 +156,8 @@ SignalingModuleIsolateImpl _buildModule(SignalingClientFactory factory) => Signa
   trustedCertificates: TrustedCertificates.empty,
   signalingClientFactory: factory,
 );
+
+Request _buildRequest() => HangupRequest(transaction: 'tx-1', line: 0, callId: 'call-1');
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -300,6 +313,72 @@ void main() {
       await module.disconnect();
 
       expect(events, isEmpty);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  group('SignalingModule - execute()', () {
+    test('retries timeout up to 3 times and succeeds on the next attempt', () async {
+      final client = _FakeSignalingClient()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteSuccess();
+      final module = _buildModule(_successFactory(client));
+      addTearDown(module.dispose);
+
+      module.connect();
+      await pumpEventQueue();
+
+      await expectLater(module.execute(_buildRequest()), completes);
+      expect(client.executeCallCount, equals(4));
+    });
+
+    test('throws timeout error after retry limit is exhausted', () async {
+      final client = _FakeSignalingClient()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteTimeout();
+      final module = _buildModule(_successFactory(client));
+      addTearDown(module.dispose);
+
+      module.connect();
+      await pumpEventQueue();
+
+      await expectLater(module.execute(_buildRequest()), throwsA(isA<WebtritSignalingTransactionTimeoutException>()));
+      expect(client.executeCallCount, equals(4));
+    });
+
+    test('does not retry non-timeout execute errors', () async {
+      final client = _FakeSignalingClient()..enqueueExecuteError(StateError('execute failed'));
+      final module = _buildModule(_successFactory(client));
+      addTearDown(module.dispose);
+
+      module.connect();
+      await pumpEventQueue();
+
+      await expectLater(module.execute(_buildRequest()), throwsA(isA<StateError>()));
+      expect(client.executeCallCount, equals(1));
+    });
+
+    test('queued execute is flushed on connect and uses timeout retries', () async {
+      final client = _FakeSignalingClient()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteTimeout()
+        ..enqueueExecuteSuccess();
+      final module = _buildModule(_successFactory(client));
+      addTearDown(module.dispose);
+
+      final pending = module.execute(_buildRequest());
+      expect(pending, isNotNull);
+
+      module.connect();
+      await pumpEventQueue();
+
+      await expectLater(pending, completes);
+      expect(client.executeCallCount, equals(3));
     });
   });
 


### PR DESCRIPTION
- fixed keepAlive lateinit error
- added requests queue to eliminate errors and state inconsistency when requests sended to nowhere if socket in reconnection state, even after timeout it will throw exception NotConnectedException instead of silencing.
- added retry mechanism for timeouted requests

Relative core improvement:
https://github.com/WebTrit/webtrit_core/pull/96

