### PR TITLE
refactor: extract HubConnectionManager from WebtritSignalingServiceAndroid

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -46,6 +46,10 @@ class HubConnectionManager {
   int _generation = 0;
   Future<void>? _initTask;
 
+  // Set by tearDown() to prevent the whenComplete restart from calling begin()
+  // while teardown is in progress. Reset by begin() so the cycle can restart.
+  bool _tearingDown = false;
+
   bool get isConnected => _module?.isConnected ?? false;
 
   Future<void>? execute(Request request) => _module?.execute(request);
@@ -56,12 +60,13 @@ class HubConnectionManager {
   /// any concurrent in-progress loop exits on its next iteration.
   void begin() {
     if (_module != null) return;
+    _tearingDown = false;
     _generation++;
     final generation = _generation;
     _logger.fine('begin generation=$generation taskRunning=${_initTask != null}');
     _initTask ??= _initLoop(generation).whenComplete(() {
       _initTask = null;
-      if (_module == null && _isActive()) {
+      if (!_tearingDown && _module == null && _isActive()) {
         _logger.fine('begin restarting loop after gen-mismatch exit (gen=$_generation)');
         begin();
       }
@@ -69,8 +74,13 @@ class HubConnectionManager {
   }
 
   /// Cancels any in-progress init loop and tears down the current module.
+  ///
+  /// Sets [_tearingDown] before bumping the generation so the [whenComplete]
+  /// restart guard in [begin] sees the flag and does not start a new polling
+  /// loop while teardown is still running.
   Future<void> tearDown() async {
     _logger.fine('tearDown generation=$_generation');
+    _tearingDown = true;
     _generation++;
     await _initTask;
     _initTask = null;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -16,6 +16,15 @@ final _logger = Logger('HubConnectionManager');
 ///
 /// Generation-based cancellation prevents stale polling loops from completing
 /// after a concurrent [begin] or [tearDown] call.
+///
+/// TODO(hub-discovery): Replace polling with a push-based discovery mechanism.
+/// Current approach polls [IsolateNameServer] every 100 ms because the background
+/// isolate starts asynchronously and there is no signal for when it is ready.
+/// A cleaner alternative: pass a [SendPort] from the main isolate to the
+/// background isolate at startup (via Pigeon or [RootIsolateToken]), so the
+/// background isolate notifies the main isolate directly when the hub is ready.
+/// This eliminates the polling delay and the 500 ms ack timeout, but requires
+/// changes to the Kotlin bootstrap flow in [FlutterEngineHelper].
 class HubConnectionManager {
   HubConnectionManager({
     required void Function(SignalingModuleEvent) onEvent,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
+
+import 'hub/signaling_hub_client.dart';
+import 'hub/signaling_hub_module.dart';
+
+final _logger = Logger('HubConnectionManager');
+
+/// Manages the lifecycle of a [SignalingHubModule] connection.
+///
+/// Polls [IsolateNameServer] for the hub port, wires up a [SignalingHubModule]
+/// when the port becomes available, and tears it down on demand.
+///
+/// Generation-based cancellation prevents stale polling loops from completing
+/// after a concurrent [begin] or [tearDown] call.
+class HubConnectionManager {
+  HubConnectionManager({
+    required void Function(SignalingModuleEvent) onEvent,
+    required void Function(Object, StackTrace) onError,
+    required bool Function() isActive,
+    required String consumerId,
+  }) : _onEvent = onEvent,
+       _onError = onError,
+       _isActive = isActive,
+       _consumerId = consumerId;
+
+  final void Function(SignalingModuleEvent) _onEvent;
+  final void Function(Object, StackTrace) _onError;
+  final bool Function() _isActive;
+  final String _consumerId;
+
+  SignalingHubModule? _module;
+  StreamSubscription<SignalingModuleEvent>? _moduleSub;
+  int _generation = 0;
+  Future<void>? _initTask;
+
+  bool get isConnected => _module?.isConnected ?? false;
+
+  Future<void>? execute(Request request) => _module?.execute(request);
+
+  /// Starts or restarts the hub-init polling loop.
+  ///
+  /// No-op if a module is already wired up. Increments the generation so
+  /// any concurrent in-progress loop exits on its next iteration.
+  void begin() {
+    if (_module != null) return;
+    _generation++;
+    final generation = _generation;
+    _logger.fine('begin generation=$generation taskRunning=${_initTask != null}');
+    _initTask ??= _initLoop(generation).whenComplete(() {
+      _initTask = null;
+      if (_module == null && _isActive()) {
+        _logger.fine('begin restarting loop after gen-mismatch exit (gen=$_generation)');
+        begin();
+      }
+    });
+  }
+
+  /// Cancels any in-progress init loop and tears down the current module.
+  Future<void> tearDown() async {
+    _logger.fine('tearDown generation=$_generation');
+    _generation++;
+    await _initTask;
+    _initTask = null;
+
+    await _moduleSub?.cancel();
+    _moduleSub = null;
+    await _module?.dispose();
+    _module = null;
+    _logger.fine('tearDown complete');
+  }
+
+  Future<void> _initLoop(int generation) async {
+    const retryDelay = Duration(milliseconds: 100);
+    const ackTimeout = Duration(milliseconds: 500);
+
+    _logger.fine('_initLoop started gen=$generation');
+    var attempts = 0;
+
+    while (true) {
+      if (_generation != generation || !_isActive()) {
+        _logger.fine(
+          '_initLoop gen=$generation exiting (currentGen=$_generation active=${_isActive()}) after $attempts attempts',
+        );
+        return;
+      }
+
+      final client = SignalingHubClient.tryConnect(_consumerId);
+      if (client != null) {
+        _logger.fine('_initLoop gen=$generation hub port found after $attempts attempts, awaiting ack');
+        // awaitAck MUST be called before SignalingHubModule is constructed so the
+        // internal Completer is in place before the hub's sub-ack can arrive.
+        final ackFuture = client.awaitAck(timeout: ackTimeout);
+        final module = SignalingHubModule(client);
+        final ackReceived = await ackFuture;
+
+        if (ackReceived) {
+          if (_generation != generation || !_isActive()) {
+            _logger.fine('_initLoop gen=$generation ack received but generation changed, disposing stale module');
+            await module.dispose();
+            return;
+          }
+          _module = module;
+          _logger.info('_initLoop gen=$generation hub connected (consumerId=${client.consumerId})');
+          _moduleSub = _module!.events.listen(_onEvent, onError: _onError);
+          return;
+        }
+
+        _logger.fine('_initLoop gen=$generation ack timeout -- stale port, retrying');
+        await module.dispose();
+      }
+
+      attempts++;
+      await Future<void>.delayed(retryDelay);
+    }
+  }
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -1,14 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'dart:ui' show IsolateNameServer, PluginUtilities;
+import 'dart:ui' show PluginUtilities;
 import 'package:logging/logging.dart';
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
 
-import 'hub/signaling_hub_client.dart';
-import 'hub/signaling_hub_module.dart';
+import 'hub_connection_manager.dart';
 import 'isolate/entry_point.dart' show signalingServiceCallbackDispatcher;
 import 'messages.g.dart';
 import 'mode_mapping.dart';
@@ -60,24 +59,24 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   final _hostApi = PSignalingServiceHostApi();
 
   // ---------------------------------------------------------------------------
-  // Hub mode (persistent) state
-  // ---------------------------------------------------------------------------
-
-  SignalingHubModule? _hubModule;
-  StreamSubscription<SignalingModuleEvent>? _hubModuleSub;
-
-  // Hub init background loop state.
-  // Incremented on every teardown or new init to invalidate in-progress loops.
-  int _hubInitGeneration = 0;
-  Future<void>? _hubInitTask;
-
-  // ---------------------------------------------------------------------------
   // Shared state
   // ---------------------------------------------------------------------------
 
   StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
 
   final _eventBuffer = SignalingEventBuffer();
+
+  late final _hubManager = HubConnectionManager(
+    consumerId: 'android_plugin_$hashCode',
+    onEvent: (event) {
+      _eventBuffer.onEvent(event);
+      if (!_eventsController.isClosed) _eventsController.add(event);
+    },
+    onError: (e, st) {
+      if (!_eventsController.isClosed) _eventsController.addError(e, st);
+    },
+    isActive: () => !_eventsController.isClosed,
+  );
 
   /// Last config passed to [start] -- reused when switching modes via [updateMode].
   SignalingServiceConfig? _currentConfig;
@@ -126,21 +125,20 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       _eventsController = StreamController<SignalingModuleEvent>.broadcast();
     }
 
-    await _startHubMode(config, effectiveMode);
+    await _startService(config, effectiveMode);
   }
 
   @override
   Future<void> attach() async {
     _logger.info('attach');
-    _beginHubInit();
+    _hubManager.begin();
   }
 
   @override
   Future<void> execute(Request request) async {
-    final hub = _hubModule;
-    if (hub != null && hub.isConnected) {
+    if (_hubManager.isConnected) {
       _logger.fine('execute ${request.runtimeType}');
-      await hub.execute(request)!;
+      await _hubManager.execute(request)!;
       return;
     }
     _logger.warning('execute called but not connected (${request.runtimeType})');
@@ -165,16 +163,13 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     }
 
     _eventBuffer.clear();
-    await _startHubMode(config, mode);
+    await _startService(config, mode);
   }
 
   @override
   Future<void> dispose() async {
     _logger.info('dispose');
-    _hubInitGeneration++;
-    await _hubInitTask;
-
-    await _tearDownHubMode();
+    await _hubManager.tearDown();
 
     // NOTE: stopService() is intentionally NOT called here.
     // The Android service lifecycle is managed by the Kotlin side:
@@ -228,11 +223,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   }
 
   // ---------------------------------------------------------------------------
-  // Hub mode internals
+  // Service start internals
   // ---------------------------------------------------------------------------
 
-  Future<void> _startHubMode(SignalingServiceConfig config, SignalingServiceMode mode) async {
-    _logger.fine('_startHubMode mode=$mode generation=$_hubInitGeneration');
+  Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
+    _logger.fine('_startService mode=$mode');
     final dispatcherHandle = PluginUtilities.getCallbackHandle(signalingServiceCallbackDispatcher);
     if (dispatcherHandle == null) {
       throw StateError(
@@ -260,111 +255,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     // source. Clearing here causes a different failure: when the foreground
     // service is already running (persistent mode), its background isolate's
     // _started guard prevents _hub.start() from being called again, so the
-    // port would never be re-registered after being cleared -- _hubInitLoop
+    // port would never be re-registered after being cleared -- HubConnectionManager
     // would poll forever and the signaling status would be stuck on
-    // "connecting". If a stale port does reach _hubInitLoop, the 500 ms ack
+    // "connecting". If a stale port does reach the init loop, the 500 ms ack
     // timeout causes a safe retry without blocking the happy path.
-    _beginHubInit();
-  }
-
-  Future<void> _tearDownHubMode() async {
-    _logger.fine('_tearDownHubMode generation=$_hubInitGeneration');
-    _hubInitGeneration++;
-    await _hubInitTask;
-    _hubInitTask = null;
-
-    await _hubModuleSub?.cancel();
-    _hubModuleSub = null;
-    await _hubModule?.dispose();
-    _hubModule = null;
-    _logger.fine('_tearDownHubMode complete');
-  }
-
-  // ---------------------------------------------------------------------------
-  // Hub module init
-  // ---------------------------------------------------------------------------
-
-  /// Starts the hub-init background loop if it is not already running and
-  /// no hub module is wired up yet.
-  ///
-  /// Increments [_hubInitGeneration] so any concurrent in-progress loop exits
-  /// on its next iteration check, preventing two concurrent loops.
-  ///
-  /// When an in-progress loop exits due to a generation mismatch (caused by a
-  /// concurrent [_beginHubInit] call), the [whenComplete] callback restarts the
-  /// loop so polling continues with the latest generation instead of stopping.
-  void _beginHubInit() {
-    if (_hubModule != null) return;
-    _hubInitGeneration++;
-    final generation = _hubInitGeneration;
-    _logger.fine('_beginHubInit generation=$generation taskRunning=${_hubInitTask != null}');
-    _hubInitTask ??= _hubInitLoop(generation).whenComplete(() {
-      _hubInitTask = null;
-      if (_hubModule == null && !_eventsController.isClosed) {
-        _logger.fine('_beginHubInit restarting loop after gen-mismatch exit (gen=$_hubInitGeneration)');
-        _beginHubInit();
-      }
-    });
-  }
-
-  /// Polls [IsolateNameServer] indefinitely until the hub port is registered,
-  /// then wires up [SignalingHubModule] and forwards its events to
-  /// [_eventsController].
-  ///
-  /// The loop exits when [_hubInitGeneration] no longer matches [generation]
-  /// (i.e. a newer [_beginHubInit] or [_tearDownHubMode] was called) or the
-  /// events controller is closed.
-  Future<void> _hubInitLoop(int generation) async {
-    const retryDelay = Duration(milliseconds: 100);
-    const ackTimeout = Duration(milliseconds: 500);
-
-    _logger.fine('_hubInitLoop started gen=$generation');
-    var attempts = 0;
-
-    while (true) {
-      if (_hubInitGeneration != generation || _eventsController.isClosed) {
-        _logger.fine(
-          '_hubInitLoop gen=$generation exiting (currentGen=$_hubInitGeneration closed=${_eventsController.isClosed}) after $attempts attempts',
-        );
-        return;
-      }
-
-      final client = SignalingHubClient.tryConnect('android_plugin_$hashCode');
-      if (client != null) {
-        _logger.fine('_hubInitLoop gen=$generation hub port found after $attempts attempts, awaiting ack');
-        // awaitAck MUST be called before start() so the internal Completer
-        // is in place before the hub's sub-ack can arrive.
-        final ackFuture = client.awaitAck(timeout: ackTimeout);
-        final module = SignalingHubModule(client); // subscribes, then calls client.start()
-        final ackReceived = await ackFuture;
-
-        if (ackReceived) {
-          if (_hubInitGeneration != generation || _eventsController.isClosed) {
-            _logger.fine('_hubInitLoop gen=$generation ack received but generation changed, disposing stale module');
-            await module.dispose();
-            return;
-          }
-          _hubModule = module;
-          _logger.info('_hubInitLoop gen=$generation hub connected (consumerId=${client.consumerId})');
-          _hubModuleSub = _hubModule!.events.listen(
-            (event) {
-              _eventBuffer.onEvent(event);
-              if (!_eventsController.isClosed) _eventsController.add(event);
-            },
-            onError: (Object e, StackTrace st) {
-              if (!_eventsController.isClosed) _eventsController.addError(e, st);
-            },
-          );
-          return;
-        }
-
-        _logger.fine('_hubInitLoop gen=$generation ack timeout -- stale port, retrying');
-        await module.dispose();
-      }
-
-      attempts++;
-      await Future<void>.delayed(retryDelay);
-    }
+    _hubManager.begin();
   }
 }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -298,6 +298,28 @@ void main() {
       expect(connectedEvents.length, equals(1));
     });
 
+    test('tearDown() does not allow whenComplete to restart polling', () async {
+      // Regression: whenComplete inside begin() could call begin() again while
+      // tearDown() was still running, creating an untracked polling loop.
+      // This test verifies that tearDown() fully stops the manager and no
+      // reconnection happens unless begin() is explicitly called again.
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+
+      manager.begin();
+      await _waitFor(() => manager.isConnected);
+
+      await manager.tearDown();
+      expect(manager.isConnected, isFalse);
+
+      // Give the event loop time to run any unexpected restarted polling loops.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(manager.isConnected, isFalse);
+    });
+
     test('reconnects after tearDown() and begin() cycle', () async {
       _module = _FakeSignalingModule();
       _hub = _startHub(_module!);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -1,0 +1,324 @@
+/// Integration tests for [HubConnectionManager].
+///
+/// Tests run in a single Dart isolate using real [ReceivePort]/[SendPort] and
+/// [IsolateNameServer]. No background isolate or Android service is involved.
+///
+/// Each test disposes the hub in tearDown so the port name is free for the next
+/// test. All tests are sequential to avoid IsolateNameServer conflicts.
+library;
+
+import 'dart:async';
+import 'dart:ui' show IsolateNameServer;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
+
+import 'package:webtrit_signaling_service_android/src/constants.dart';
+import 'package:webtrit_signaling_service_android/src/hub/signaling_hub.dart';
+import 'package:webtrit_signaling_service_android/src/hub_connection_manager.dart';
+
+// ---------------------------------------------------------------------------
+// Minimal fake SignalingModule
+// ---------------------------------------------------------------------------
+
+class _FakeSignalingModule implements SignalingModule {
+  final _controller = StreamController<SignalingModuleEvent>.broadcast();
+  final List<SignalingModuleEvent> _buffer = [];
+  bool _connected = false;
+  bool _disposed = false;
+
+  @override
+  Stream<SignalingModuleEvent> get events {
+    return Stream.multi((sink) {
+      final sub = _controller.stream.listen(sink.add, onError: sink.addError, onDone: sink.close);
+      sink.onCancel = sub.cancel;
+      for (final e in List<SignalingModuleEvent>.of(_buffer)) {
+        sink.add(e);
+      }
+    }, isBroadcast: true);
+  }
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  void connect() {
+    _connected = true;
+    _emit(SignalingConnecting());
+    _emit(SignalingConnected());
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+    _emit(SignalingDisconnecting());
+    _emit(
+      SignalingDisconnected(
+        code: null,
+        reason: null,
+        knownCode: SignalingDisconnectCode.unmappedCode,
+        recommendedReconnectDelay: null,
+      ),
+    );
+  }
+
+  @override
+  Future<void>? execute(Request request) => Future<void>.value();
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _buffer.clear();
+    await _controller.close();
+  }
+
+  void inject(SignalingModuleEvent event) => _emit(event);
+
+  void _emit(SignalingModuleEvent event) {
+    if (_controller.isClosed) return;
+    _buffer.add(event);
+    _controller.add(event);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Builds and starts a [SignalingHub] backed by [module], then connects the
+/// module so [SignalingConnected] is in the hub's session buffer.
+///
+/// New subscribers immediately receive the session buffer replay and see
+/// [SignalingHubModule.isConnected] as true after the ack round-trip.
+SignalingHub _startHub(_FakeSignalingModule module) {
+  final hub = SignalingHub(module);
+  hub.start();
+  // Emit SignalingConnecting + SignalingConnected into the hub's session buffer
+  // so late-subscribing [SignalingHubModule] instances become connected after
+  // the hub replays the buffer on subscribe.
+  module.connect();
+  return hub;
+}
+
+/// Waits up to [timeout] for [condition] to become true, polling every 50 ms.
+Future<void> _waitFor(bool Function() condition, {Duration timeout = const Duration(seconds: 2)}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test setup helper
+// ---------------------------------------------------------------------------
+
+/// Wraps [HubConnectionManager] construction and captures forwarded events.
+({HubConnectionManager manager, List<SignalingModuleEvent> received}) _buildManager({bool Function()? isActive}) {
+  final received = <SignalingModuleEvent>[];
+  bool active = true;
+  final manager = HubConnectionManager(
+    consumerId: 'test_consumer',
+    onEvent: received.add,
+    onError: (e, st) => fail('Unexpected error: $e'),
+    isActive: isActive ?? () => active,
+  );
+  return (manager: manager, received: received);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  SignalingHub? _hub;
+  _FakeSignalingModule? _module;
+
+  tearDown(() async {
+    await _hub?.dispose();
+    await _module?.dispose();
+    _hub = null;
+    _module = null;
+    IsolateNameServer.removePortNameMapping(kSignalingHubPortName);
+  });
+
+  group('HubConnectionManager', () {
+    test('connects when hub is already running before begin()', () async {
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+      addTearDown(manager.tearDown);
+
+      manager.begin();
+
+      await _waitFor(() => manager.isConnected);
+      expect(manager.isConnected, isTrue);
+    });
+
+    test('polls and connects when hub starts after begin()', () async {
+      final (:manager, :received) = _buildManager();
+      addTearDown(manager.tearDown);
+
+      manager.begin();
+      expect(manager.isConnected, isFalse);
+
+      // Start hub after a delay — manager should find it via polling.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      await _waitFor(() => manager.isConnected);
+      expect(manager.isConnected, isTrue);
+    });
+
+    test('second begin() call is a no-op when already connected', () async {
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+      addTearDown(manager.tearDown);
+
+      manager.begin();
+      await _waitFor(() => manager.isConnected);
+
+      final receivedBefore = received.length;
+      manager.begin();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // No extra events should be emitted from a second connection attempt.
+      expect(received.length, equals(receivedBefore));
+      expect(manager.isConnected, isTrue);
+    });
+
+    test('forwards events from hub to onEvent callback', () async {
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+      addTearDown(manager.tearDown);
+
+      manager.begin();
+      await _waitFor(() => manager.isConnected);
+
+      _module!.inject(SignalingConnecting());
+
+      await _waitFor(() => received.whereType<SignalingConnecting>().isNotEmpty);
+      expect(received.whereType<SignalingConnecting>(), isNotEmpty);
+    });
+
+    test('tearDown() while polling (no hub) stops cleanly', () async {
+      final (:manager, :received) = _buildManager();
+
+      manager.begin();
+      expect(manager.isConnected, isFalse);
+
+      // tearDown while still polling — should complete without error.
+      await expectLater(manager.tearDown(), completes);
+      expect(manager.isConnected, isFalse);
+    });
+
+    test('tearDown() after connected disposes the module', () async {
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+
+      manager.begin();
+      await _waitFor(() => manager.isConnected);
+
+      await manager.tearDown();
+
+      expect(manager.isConnected, isFalse);
+    });
+
+    test('events stop arriving after tearDown()', () async {
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+
+      manager.begin();
+      await _waitFor(() => manager.isConnected);
+      await manager.tearDown();
+
+      final countAfterTearDown = received.length;
+      _module!.inject(SignalingConnecting());
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(received.length, equals(countAfterTearDown));
+    });
+
+    test('isActive() returning false causes polling loop to exit', () async {
+      bool active = true;
+      final received = <SignalingModuleEvent>[];
+      final manager = HubConnectionManager(
+        consumerId: 'test_consumer_inactive',
+        onEvent: received.add,
+        onError: (e, st) => fail('Unexpected error: $e'),
+        isActive: () => active,
+      );
+      addTearDown(manager.tearDown);
+
+      manager.begin();
+      expect(manager.isConnected, isFalse);
+
+      // Deactivate before hub appears — loop should exit on its next iteration.
+      active = false;
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      // Hub starts now, but the loop has already exited.
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(manager.isConnected, isFalse);
+    });
+
+    test('concurrent begin() calls result in exactly one connection', () async {
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+      addTearDown(manager.tearDown);
+
+      // Call begin() multiple times before polling completes.
+      for (var i = 0; i < 5; i++) {
+        manager.begin();
+      }
+
+      await _waitFor(() => manager.isConnected);
+
+      // Only one SignalingConnected should have been forwarded.
+      final connectedEvents = received.whereType<SignalingConnected>().toList();
+      expect(connectedEvents.length, equals(1));
+    });
+
+    test('reconnects after tearDown() and begin() cycle', () async {
+      _module = _FakeSignalingModule();
+      _hub = _startHub(_module!);
+
+      final (:manager, :received) = _buildManager();
+      addTearDown(manager.tearDown);
+
+      manager.begin();
+      await _waitFor(() => manager.isConnected);
+
+      await manager.tearDown();
+      expect(manager.isConnected, isFalse);
+
+      // Second begin() should reconnect to the same hub.
+      manager.begin();
+      await _waitFor(() => manager.isConnected);
+      expect(manager.isConnected, isTrue);
+    });
+  });
+}
+
+extension<T> on Iterable<T> {
+  Iterable<S> whereType<S>() => where((e) => e is S).cast<S>();
+}


### PR DESCRIPTION
## Summary

- Extracts hub-init polling loop, generation-based cancellation, and `SignalingHubModule` lifecycle from `WebtritSignalingServiceAndroid` into a new `HubConnectionManager` class (`hub_connection_manager.dart`)
- `plugin.dart` is reduced from 386 → ~230 lines; its single responsibility is now Android service lifecycle coordination via `_hostApi` calls
- No behaviour changes — only structural decomposition

## Changes

| File | Before | After |
|------|--------|-------|
| `src/plugin.dart` | 386 lines, 5+ responsibilities | ~230 lines, 1 responsibility |
| `src/hub_connection_manager.dart` | — | new, ~120 lines |

## Test plan

- [ ] `dart analyze lib/` passes with no issues
- [ ] Existing Android hub integration tests pass unchanged
- [ ] Verify `start` → `attach` → `dispose` cycle behaviour is identical