### PR TITLE
refactor: replace raw Map hub commands with SignalingHubCommand sealed class

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -53,7 +53,7 @@ class SignalingHub {
     _logger.fine('Hub started and registered as $kSignalingHubPortName');
 
     _moduleSubscription = _signalingModule.events.listen(_onModuleEvent);
-    _receivePort.listen(_onCommand);
+    _receivePort.listen((msg) => _onCommand(msg as SignalingHubCommand));
   }
 
   /// Removes the hub from [IsolateNameServer], cancels all subscriptions,
@@ -81,15 +81,14 @@ class SignalingHub {
     }
   }
 
-  void _onCommand(dynamic msg) {
-    if (msg is! SignalingHubCommand) return;
-    switch (msg) {
+  void _onCommand(SignalingHubCommand cmd) {
+    switch (cmd) {
       case SignalingHubSubscribeCommand():
-        _handleSubscribe(msg);
+        _handleSubscribe(cmd);
       case SignalingHubUnsubscribeCommand():
-        _handleUnsubscribe(msg);
+        _handleUnsubscribe(cmd);
       case SignalingHubExecuteCommand():
-        _handleExecute(msg);
+        _handleExecute(cmd);
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -8,6 +8,7 @@ import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_s
 
 import '../constants.dart';
 import 'signaling_hub_codec.dart';
+import 'signaling_hub_command.dart';
 
 final _logger = Logger('SignalingHub');
 
@@ -95,52 +96,45 @@ class SignalingHub {
   // ---------------------------------------------------------------------------
 
   void _onCommand(dynamic msg) {
-    if (msg is! Map) return;
-    final cmd = msg['cmd'] as String?;
-    switch (cmd) {
-      case 'sub':
+    if (msg is! SignalingHubCommand) return;
+    switch (msg) {
+      case SignalingHubSubscribeCommand():
         _handleSubscribe(msg);
-      case 'unsub':
+      case SignalingHubUnsubscribeCommand():
         _handleUnsubscribe(msg);
-      case 'exec':
+      case SignalingHubExecuteCommand():
         _handleExecute(msg);
     }
   }
 
-  void _handleSubscribe(Map<dynamic, dynamic> msg) {
-    final id = msg['id'] as String;
-    final port = msg['port'] as SendPort;
-    _subscribers[id] = port;
-    _logger.fine('Hub subscriber added: $id (total: ${_subscribers.length})');
+  void _handleSubscribe(SignalingHubSubscribeCommand cmd) {
+    _subscribers[cmd.consumerId] = cmd.replyPort;
+    _logger.fine('Hub subscriber added: ${cmd.consumerId} (total: ${_subscribers.length})');
     // Ack first so the subscriber knows the hub port is alive (not stale).
-    port.send(encodeSubAck());
+    cmd.replyPort.send(encodeSubAck());
     // Replay current session buffer so the new subscriber gets the full state.
     for (final event in List<List<dynamic>>.from(_sessionBuffer)) {
-      port.send(event);
+      cmd.replyPort.send(event);
     }
   }
 
-  void _handleUnsubscribe(Map<dynamic, dynamic> msg) {
-    final id = msg['id'] as String;
-    _subscribers.remove(id);
-    _logger.fine('Hub subscriber removed: $id (total: ${_subscribers.length})');
+  void _handleUnsubscribe(SignalingHubUnsubscribeCommand cmd) {
+    _subscribers.remove(cmd.consumerId);
+    _logger.fine('Hub subscriber removed: ${cmd.consumerId} (total: ${_subscribers.length})');
   }
 
-  void _handleExecute(Map<dynamic, dynamic> msg) {
-    final id = msg['id'] as String;
-    final corr = msg['corr'] as String;
-    final reqMap = msg['req'] as Map;
-    final port = _subscribers[id];
+  void _handleExecute(SignalingHubExecuteCommand cmd) {
+    final port = _subscribers[cmd.consumerId];
     if (port == null) {
-      _logger.warning('Hub execute: unknown subscriber $id, corr=$corr');
+      _logger.warning('Hub execute: unknown subscriber ${cmd.consumerId}, corr=${cmd.correlationId}');
       return;
     }
-    unawaited(_executeAndReply(port, corr, reqMap));
+    unawaited(_executeAndReply(port, cmd.correlationId, cmd.request));
   }
 
-  Future<void> _executeAndReply(SendPort replyPort, String correlationId, Map<dynamic, dynamic> reqMap) async {
+  Future<void> _executeAndReply(SendPort replyPort, String correlationId, Map<String, dynamic> reqMap) async {
     try {
-      final request = Request.fromJson(Map<String, dynamic>.from(reqMap));
+      final request = Request.fromJson(reqMap);
       if (!_signalingModule.isConnected) throw StateError('Signaling not connected');
       await _signalingModule.execute(request)!;
       replyPort.send(encodeExecuteResult(correlationId, null));

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -19,7 +19,7 @@ final _logger = Logger('SignalingHub');
 /// Any isolate (e.g. push notification isolate) can subscribe by looking up
 /// [kSignalingHubPortName] via [IsolateNameServer].
 ///
-/// Protocol -- subscriber -> hub: [SignalingHubCommand] subtypes.
+/// Protocol -- subscriber -> hub: [SignalingHubCommand.encode] / [SignalingHubCommand.decode].
 /// Protocol -- hub -> subscriber (List): see [encodeHubEvent] / [decodeHubEvent].
 class SignalingHub {
   SignalingHub(this._signalingModule);
@@ -53,7 +53,14 @@ class SignalingHub {
     _logger.fine('Hub started and registered as $kSignalingHubPortName');
 
     _moduleSubscription = _signalingModule.events.listen(_onModuleEvent);
-    _receivePort.listen((msg) => _onCommand(msg as SignalingHubCommand));
+    _receivePort.listen((msg) {
+      final cmd = SignalingHubCommand.decode(msg);
+      if (cmd == null) {
+        _logger.warning('Hub ignoring unrecognised message: $msg');
+        return;
+      }
+      _onCommand(cmd);
+    });
   }
 
   /// Removes the hub from [IsolateNameServer], cancels all subscriptions,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -19,14 +19,8 @@ final _logger = Logger('SignalingHub');
 /// Any isolate (e.g. push notification isolate) can subscribe by looking up
 /// [kSignalingHubPortName] via [IsolateNameServer].
 ///
-/// Protocol -- subscriber -> hub (Map):
-///   {cmd:'sub',  id:consumerId, port:SendPort}
-///   {cmd:'unsub', id:consumerId}
-///   {cmd:'exec',  id:consumerId, corr:correlationId, req:Map}
-///
-/// Protocol -- hub -> subscriber (List):
-///   See [encodeHubEvent] / [decodeHubEvent] in signaling_hub_codec.dart.
-///   Execute results use [encodeExecuteResult].
+/// Protocol -- subscriber -> hub: [SignalingHubCommand] subtypes.
+/// Protocol -- hub -> subscriber (List): see [encodeHubEvent] / [decodeHubEvent].
 class SignalingHub {
   SignalingHub(this._signalingModule);
 
@@ -73,10 +67,6 @@ class SignalingHub {
     _logger.fine('Hub disposed');
   }
 
-  // ---------------------------------------------------------------------------
-  // Module event forwarding
-  // ---------------------------------------------------------------------------
-
   void _onModuleEvent(SignalingModuleEvent event) {
     if (event is SignalingConnecting) _sessionBuffer.clear();
     final encoded = encodeHubEvent(event);
@@ -90,10 +80,6 @@ class SignalingHub {
       port.send(encoded);
     }
   }
-
-  // ---------------------------------------------------------------------------
-  // Command handling
-  // ---------------------------------------------------------------------------
 
   void _onCommand(dynamic msg) {
     if (msg is! SignalingHubCommand) return;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -8,6 +8,7 @@ import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_s
 
 import '../constants.dart';
 import 'signaling_hub_codec.dart';
+import 'signaling_hub_command.dart';
 
 final _logger = Logger('SignalingHubClient');
 
@@ -55,7 +56,7 @@ class SignalingHubClient {
     if (_started) return;
     _started = true;
     _subscription = _receivePort.listen(_onMessage);
-    _hubPort.send({'cmd': 'sub', 'id': consumerId, 'port': _receivePort.sendPort});
+    _hubPort.send(SignalingHubSubscribeCommand(consumerId: consumerId, replyPort: _receivePort.sendPort));
     _logger.fine('Hub client $consumerId subscribed');
   }
 
@@ -82,7 +83,7 @@ class SignalingHubClient {
     final corrId = _generateId();
     final completer = Completer<void>();
     _pendingExecutions[corrId] = completer;
-    _hubPort.send({'cmd': 'exec', 'id': consumerId, 'corr': corrId, 'req': request.toJson()});
+    _hubPort.send(SignalingHubExecuteCommand(consumerId: consumerId, correlationId: corrId, request: request.toJson()));
     return completer.future.timeout(
       _executeTimeout,
       onTimeout: () {
@@ -94,7 +95,7 @@ class SignalingHubClient {
 
   /// Sends the unsubscribe command and closes all resources.
   Future<void> dispose() async {
-    _hubPort.send({'cmd': 'unsub', 'id': consumerId});
+    _hubPort.send(SignalingHubUnsubscribeCommand(consumerId: consumerId));
     await _subscription?.cancel();
     _receivePort.close();
     for (final c in _pendingExecutions.values) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -106,10 +106,6 @@ class SignalingHubClient {
     _logger.fine('Hub client $consumerId disposed');
   }
 
-  // ---------------------------------------------------------------------------
-  // Internal
-  // ---------------------------------------------------------------------------
-
   void _onMessage(dynamic msg) {
     if (msg is! List || msg.isEmpty) return;
     if (isSubAck(msg)) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -24,7 +24,7 @@ final _logger = Logger('SignalingHubClient');
 /// final client = SignalingHubClient.tryConnect('push_${hashCode}');
 /// if (client != null) {
 ///   final ackFuture = client.awaitAck(); // get future BEFORE start()
-///   client.start();                      // sends 'sub' -> hub replies with ack
+///   client.start();                      // sends SignalingHubSubscribeCommand -> hub replies with ack
 ///   final ackReceived = await ackFuture;
 ///   if (!ackReceived) await client.dispose();
 /// }
@@ -56,7 +56,7 @@ class SignalingHubClient {
     if (_started) return;
     _started = true;
     _subscription = _receivePort.listen((msg) => _onMessage(msg as List<Object?>));
-    _hubPort.send(SignalingHubSubscribeCommand(consumerId: consumerId, replyPort: _receivePort.sendPort));
+    _hubPort.send(SignalingHubSubscribeCommand(consumerId: consumerId, replyPort: _receivePort.sendPort).encode());
     _logger.fine('Hub client $consumerId subscribed');
   }
 
@@ -83,7 +83,9 @@ class SignalingHubClient {
     final corrId = _generateId();
     final completer = Completer<void>();
     _pendingExecutions[corrId] = completer;
-    _hubPort.send(SignalingHubExecuteCommand(consumerId: consumerId, correlationId: corrId, request: request.toJson()));
+    _hubPort.send(
+      SignalingHubExecuteCommand(consumerId: consumerId, correlationId: corrId, request: request.toJson()).encode(),
+    );
     return completer.future.timeout(
       _executeTimeout,
       onTimeout: () {
@@ -95,7 +97,7 @@ class SignalingHubClient {
 
   /// Sends the unsubscribe command and closes all resources.
   Future<void> dispose() async {
-    _hubPort.send(SignalingHubUnsubscribeCommand(consumerId: consumerId));
+    _hubPort.send(SignalingHubUnsubscribeCommand(consumerId: consumerId).encode());
     await _subscription?.cancel();
     _receivePort.close();
     for (final c in _pendingExecutions.values) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -46,7 +46,7 @@ class SignalingHubClient {
   final _controller = StreamController<SignalingModuleEvent>.broadcast();
   final Map<String, Completer<void>> _pendingExecutions = {};
 
-  StreamSubscription<dynamic>? _subscription;
+  StreamSubscription<Object?>? _subscription;
   bool _started = false;
   Completer<bool>? _subAckCompleter;
 
@@ -55,7 +55,7 @@ class SignalingHubClient {
   void start() {
     if (_started) return;
     _started = true;
-    _subscription = _receivePort.listen(_onMessage);
+    _subscription = _receivePort.listen((msg) => _onMessage(msg as List<Object?>));
     _hubPort.send(SignalingHubSubscribeCommand(consumerId: consumerId, replyPort: _receivePort.sendPort));
     _logger.fine('Hub client $consumerId subscribed');
   }
@@ -106,8 +106,8 @@ class SignalingHubClient {
     _logger.fine('Hub client $consumerId disposed');
   }
 
-  void _onMessage(dynamic msg) {
-    if (msg is! List || msg.isEmpty) return;
+  void _onMessage(List<Object?> msg) {
+    if (msg.isEmpty) return;
     if (isSubAck(msg)) {
       final completer = _subAckCompleter;
       _subAckCompleter = null;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
@@ -1,17 +1,51 @@
 import 'dart:isolate';
 
-/// Commands sent from a subscriber isolate to [SignalingHub].
+/// Typed commands sent from a subscriber to [SignalingHub].
 ///
-/// All inter-isolate communication from subscriber to hub goes through one of
-/// these three commands. Using a sealed class instead of raw
-/// [Map<dynamic, dynamic>] makes the protocol explicit and exhaustively checked
-/// by the compiler.
+/// Instances are NOT sent directly across isolate boundaries — only
+/// isolate-safe primitives, [SendPort], [List], and [Map] values can cross
+/// a [SendPort]. Use [SignalingHubCommand.encode] before sending and
+/// [SignalingHubCommand.decode] on the receiving side to convert between
+/// the typed API and the wire payload.
 sealed class SignalingHubCommand {
   const SignalingHubCommand(this.consumerId);
 
   /// Identifies the subscriber sending this command.
   final String consumerId;
+
+  /// Encodes this command to an isolate-safe [List] payload for [SendPort.send].
+  List<Object?> encode();
+
+  /// Decodes an isolate-safe [List] payload back to a typed [SignalingHubCommand].
+  ///
+  /// Returns null when [wire] is not a recognised command payload so the hub
+  /// can log and ignore unexpected messages safely.
+  static SignalingHubCommand? decode(Object? wire) {
+    if (wire is! List || wire.isEmpty) return null;
+    final tag = wire[0];
+    switch (tag) {
+      case _tagSubscribe:
+        if (wire.length < 3) return null;
+        return SignalingHubSubscribeCommand(consumerId: wire[1] as String, replyPort: wire[2] as SendPort);
+      case _tagUnsubscribe:
+        if (wire.length < 2) return null;
+        return SignalingHubUnsubscribeCommand(consumerId: wire[1] as String);
+      case _tagExecute:
+        if (wire.length < 4) return null;
+        return SignalingHubExecuteCommand(
+          consumerId: wire[1] as String,
+          correlationId: wire[2] as String,
+          request: Map<String, dynamic>.from(wire[3] as Map),
+        );
+      default:
+        return null;
+    }
+  }
 }
+
+const _tagSubscribe = 'sub';
+const _tagUnsubscribe = 'unsub';
+const _tagExecute = 'exec';
 
 /// Registers [replyPort] as a subscriber in the hub.
 ///
@@ -23,6 +57,9 @@ class SignalingHubSubscribeCommand extends SignalingHubCommand {
   /// The port the hub uses to deliver events and execute results back to this
   /// subscriber.
   final SendPort replyPort;
+
+  @override
+  List<Object?> encode() => [_tagSubscribe, consumerId, replyPort];
 }
 
 /// Removes the subscriber from the hub.
@@ -31,6 +68,9 @@ class SignalingHubSubscribeCommand extends SignalingHubCommand {
 /// receiving this command.
 class SignalingHubUnsubscribeCommand extends SignalingHubCommand {
   const SignalingHubUnsubscribeCommand({required String consumerId}) : super(consumerId);
+
+  @override
+  List<Object?> encode() => [_tagUnsubscribe, consumerId];
 }
 
 /// Asks the hub to execute [request] on the active WebSocket connection and
@@ -47,4 +87,7 @@ class SignalingHubExecuteCommand extends SignalingHubCommand {
 
   /// JSON-serialised request payload forwarded to [WebtritSignalingClient].
   final Map<String, dynamic> request;
+
+  @override
+  List<Object?> encode() => [_tagExecute, consumerId, correlationId, request];
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
@@ -20,25 +20,32 @@ sealed class SignalingHubCommand {
   ///
   /// Returns null when [wire] is not a recognised command payload so the hub
   /// can log and ignore unexpected messages safely.
+  ///
+  /// Returns null (rather than throwing) on any malformed payload — wrong tag,
+  /// missing fields, or unexpected field types.
   static SignalingHubCommand? decode(Object? wire) {
     if (wire is! List || wire.isEmpty) return null;
-    final tag = wire[0];
-    switch (tag) {
-      case _tagSubscribe:
-        if (wire.length < 3) return null;
-        return SignalingHubSubscribeCommand(consumerId: wire[1] as String, replyPort: wire[2] as SendPort);
-      case _tagUnsubscribe:
-        if (wire.length < 2) return null;
-        return SignalingHubUnsubscribeCommand(consumerId: wire[1] as String);
-      case _tagExecute:
-        if (wire.length < 4) return null;
-        return SignalingHubExecuteCommand(
-          consumerId: wire[1] as String,
-          correlationId: wire[2] as String,
-          request: Map<String, dynamic>.from(wire[3] as Map),
-        );
-      default:
-        return null;
+    try {
+      final tag = wire[0];
+      switch (tag) {
+        case _tagSubscribe:
+          if (wire.length < 3) return null;
+          return SignalingHubSubscribeCommand(consumerId: wire[1] as String, replyPort: wire[2] as SendPort);
+        case _tagUnsubscribe:
+          if (wire.length < 2) return null;
+          return SignalingHubUnsubscribeCommand(consumerId: wire[1] as String);
+        case _tagExecute:
+          if (wire.length < 4) return null;
+          return SignalingHubExecuteCommand(
+            consumerId: wire[1] as String,
+            correlationId: wire[2] as String,
+            request: Map<String, dynamic>.from(wire[3] as Map),
+          );
+        default:
+          return null;
+      }
+    } on TypeError {
+      return null;
     }
   }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
@@ -1,0 +1,50 @@
+import 'dart:isolate';
+
+/// Commands sent from a subscriber isolate to [SignalingHub].
+///
+/// All inter-isolate communication from subscriber to hub goes through one of
+/// these three commands. Using a sealed class instead of raw
+/// [Map<dynamic, dynamic>] makes the protocol explicit and exhaustively checked
+/// by the compiler.
+sealed class SignalingHubCommand {
+  const SignalingHubCommand(this.consumerId);
+
+  /// Identifies the subscriber sending this command.
+  final String consumerId;
+}
+
+/// Registers [replyPort] as a subscriber in the hub.
+///
+/// The hub responds with a sub-ack followed by a session buffer replay so the
+/// new subscriber receives the current connection state immediately.
+class SignalingHubSubscribeCommand extends SignalingHubCommand {
+  const SignalingHubSubscribeCommand({required String consumerId, required this.replyPort}) : super(consumerId);
+
+  /// The port the hub uses to deliver events and execute results back to this
+  /// subscriber.
+  final SendPort replyPort;
+}
+
+/// Removes the subscriber from the hub.
+///
+/// The hub stops forwarding events to the subscriber's [SendPort] after
+/// receiving this command.
+class SignalingHubUnsubscribeCommand extends SignalingHubCommand {
+  const SignalingHubUnsubscribeCommand({required String consumerId}) : super(consumerId);
+}
+
+/// Asks the hub to execute [request] on the active WebSocket connection and
+/// reply with the result identified by [correlationId].
+///
+/// The hub sends an execute-result message back to the subscriber's [SendPort]
+/// when the request completes or fails.
+class SignalingHubExecuteCommand extends SignalingHubCommand {
+  const SignalingHubExecuteCommand({required String consumerId, required this.correlationId, required this.request})
+    : super(consumerId);
+
+  /// Opaque ID used to match the execute result back to the pending completer.
+  final String correlationId;
+
+  /// JSON-serialised request payload forwarded to [WebtritSignalingClient].
+  final Map<String, dynamic> request;
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
@@ -50,8 +50,13 @@ sealed class SignalingHubCommand {
   }
 }
 
+/// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubSubscribeCommand].
 const _tagSubscribe = 'sub';
+
+/// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubUnsubscribeCommand].
 const _tagUnsubscribe = 'unsub';
+
+/// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubExecuteCommand].
 const _tagExecute = 'exec';
 
 /// Registers [replyPort] as a subscriber in the hub.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -58,10 +58,6 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
   final _hostApi = PSignalingServiceHostApi();
 
-  // ---------------------------------------------------------------------------
-  // Shared state
-  // ---------------------------------------------------------------------------
-
   StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
 
   final _eventBuffer = SignalingEventBuffer();
@@ -88,10 +84,6 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   /// chosen mode is used instead of reverting to the stale parameter.
   SignalingServiceMode? _currentMode;
 
-  // ---------------------------------------------------------------------------
-  // SignalingServicePlatform -- events
-  // ---------------------------------------------------------------------------
-
   @override
   Stream<SignalingModuleEvent> get events {
     return Stream.multi((sink) {
@@ -102,10 +94,6 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       }
     }, isBroadcast: true);
   }
-
-  // ---------------------------------------------------------------------------
-  // SignalingServicePlatform -- start / attach / execute / updateMode / dispose
-  // ---------------------------------------------------------------------------
 
   @override
   Future<void> start(
@@ -222,10 +210,6 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     await _hostApi.stopService();
   }
 
-  // ---------------------------------------------------------------------------
-  // Service start internals
-  // ---------------------------------------------------------------------------
-
   Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
     _logger.fine('_startService mode=$mode');
     final dispatcherHandle = PluginUtilities.getCallbackHandle(signalingServiceCallbackDispatcher);
@@ -262,10 +246,6 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     _hubManager.begin();
   }
 }
-
-// ---------------------------------------------------------------------------
-// Trusted certificates serialization
-// ---------------------------------------------------------------------------
 
 /// Encodes [TrustedCertificates] to a JSON string for cross-isolate transport.
 ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -135,21 +135,21 @@ Future<void> _waitFor(bool Function() condition, {Duration timeout = const Durat
 // ---------------------------------------------------------------------------
 
 void main() {
-  SignalingHub? _hub;
-  _FakeSignalingModule? _module;
+  SignalingHub? hub;
+  _FakeSignalingModule? module;
 
   tearDown(() async {
-    await _hub?.dispose();
-    await _module?.dispose();
-    _hub = null;
-    _module = null;
+    await hub?.dispose();
+    await module?.dispose();
+    hub = null;
+    module = null;
     IsolateNameServer.removePortNameMapping(kSignalingHubPortName);
   });
 
   group('HubConnectionManager', () {
     test('connects when hub is already running before begin()', () async {
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
       addTearDown(manager.tearDown);
@@ -169,16 +169,16 @@ void main() {
 
       // Start hub after a delay — manager should find it via polling.
       await Future<void>.delayed(const Duration(milliseconds: 200));
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       await _waitFor(() => manager.isConnected);
       expect(manager.isConnected, isTrue);
     });
 
     test('second begin() call is a no-op when already connected', () async {
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
       addTearDown(manager.tearDown);
@@ -196,8 +196,8 @@ void main() {
     });
 
     test('forwards events from hub to onEvent callback', () async {
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
       addTearDown(manager.tearDown);
@@ -205,7 +205,7 @@ void main() {
       manager.begin();
       await _waitFor(() => manager.isConnected);
 
-      _module!.inject(SignalingConnecting());
+      module!.inject(SignalingConnecting());
 
       await _waitFor(() => received.whereType<SignalingConnecting>().isNotEmpty);
       expect(received.whereType<SignalingConnecting>(), isNotEmpty);
@@ -223,8 +223,8 @@ void main() {
     });
 
     test('tearDown() after connected disposes the module', () async {
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
 
@@ -237,8 +237,8 @@ void main() {
     });
 
     test('events stop arriving after tearDown()', () async {
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
 
@@ -247,7 +247,7 @@ void main() {
       await manager.tearDown();
 
       final countAfterTearDown = received.length;
-      _module!.inject(SignalingConnecting());
+      module!.inject(SignalingConnecting());
       await Future<void>.delayed(const Duration(milliseconds: 200));
 
       expect(received.length, equals(countAfterTearDown));
@@ -272,16 +272,16 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 300));
 
       // Hub starts now, but the loop has already exited.
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
       await Future<void>.delayed(const Duration(milliseconds: 300));
 
       expect(manager.isConnected, isFalse);
     });
 
     test('concurrent begin() calls result in exactly one connection', () async {
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
       addTearDown(manager.tearDown);
@@ -303,8 +303,8 @@ void main() {
       // tearDown() was still running, creating an untracked polling loop.
       // This test verifies that tearDown() fully stops the manager and no
       // reconnection happens unless begin() is explicitly called again.
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
 
@@ -321,8 +321,8 @@ void main() {
     });
 
     test('reconnects after tearDown() and begin() cycle', () async {
-      _module = _FakeSignalingModule();
-      _hub = _startHub(_module!);
+      module = _FakeSignalingModule();
+      hub = _startHub(module!);
 
       final (:manager, :received) = _buildManager();
       addTearDown(manager.tearDown);
@@ -339,8 +339,4 @@ void main() {
       expect(manager.isConnected, isTrue);
     });
   });
-}
-
-extension<T> on Iterable<T> {
-  Iterable<S> whereType<S>() => where((e) => e is S).cast<S>();
 }


### PR DESCRIPTION
## Summary

- Introduces `SignalingHubCommand` sealed class with three subtypes: `SignalingHubSubscribeCommand`, `SignalingHubUnsubscribeCommand`, `SignalingHubExecuteCommand`
- Replaces `Map<dynamic, dynamic>` with string keys in the subscriber → hub direction with typed commands
- `SignalingHub._onCommand` is now an exhaustive switch — compiler catches missing cases
- `SignalingHubClient` sends typed commands instead of raw maps; field names are now compile-time checked
- `_executeAndReply` receives `Map<String, dynamic>` instead of `Map<dynamic, dynamic>` — removes the `Map.from()` cast

## Motivation

The subscriber → hub wire-protocol was expressed as raw `Map<dynamic, dynamic>` with string keys (`'cmd'`, `'id'`, `'port'`, `'req'`). A typo in any key produced a silent no-op or a runtime cast exception with no indication of which field was wrong.

## Test plan

- [ ] All 145 existing tests pass unchanged
- [ ] `dart analyze lib/` — no issues