### PR TITLE
refactor: split entry_point.dart into bootstrap and sync handler

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -10,7 +10,8 @@ final _logger = Logger('SignalingEntryPoint');
 /// background engine first starts.
 ///
 /// Initialises Flutter bindings and registers the [PSignalingServiceFlutterApi]
-/// handler so Kotlin can send [onSignalingServiceSync] calls into this isolate.
+/// handler so Kotlin can send [onSynchronize] calls into this isolate, which
+/// are then queued to [onSignalingServiceSync] internally.
 ///
 /// The raw handle for this function is stored in [StorageDelegate] and obtained
 /// in the main isolate via [PluginUtilities.getCallbackHandle] before calling
@@ -19,7 +20,7 @@ final _logger = Logger('SignalingEntryPoint');
 void signalingServiceCallbackDispatcher() {
   _logger.info('signalingServiceCallbackDispatcher: background isolate starting');
   WidgetsFlutterBinding.ensureInitialized();
-  PSignalingServiceFlutterApi.setUp(_SignalingFlutterApiHandler());
+  PSignalingServiceFlutterApi.setUp(SignalingFlutterApiHandler());
   // Notify Kotlin that the Dart isolate has registered its handler and is ready
   // to receive onSynchronize calls. This resolves the race where Kotlin calls
   // synchronizeIsolate() before the Dart handler is registered
@@ -27,18 +28,4 @@ void signalingServiceCallbackDispatcher() {
   // already tried to call onSynchronize).
   PSignalingServiceHostApi().notifyIsolateReady();
   _logger.info('signalingServiceCallbackDispatcher: notifyIsolateReady sent, waiting for onSynchronize');
-}
-
-/// Kotlin -> Dart Pigeon bridge for the signaling foreground service.
-///
-/// Receives [onSynchronize] calls from Kotlin and serialises them through
-/// [pendingSync] so that rapid stop+start sequences never interleave.
-class _SignalingFlutterApiHandler extends PSignalingServiceFlutterApi {
-  @override
-  void onSynchronize(PSignalingServiceStatus status) {
-    _logger.fine('onSynchronize received from Kotlin, queuing sync');
-    pendingSync = pendingSync.then((_) => onSignalingServiceSync(status)).catchError((Object e, StackTrace s) {
-      _logger.severe('onSignalingServiceSync failed - sync chain kept alive', e, s);
-    });
-  }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -1,103 +1,44 @@
-import 'dart:async';
-
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
 
 import '../messages.g.dart';
-import 'signaling_foreground_isolate_manager.dart';
+import 'signaling_sync_handler.dart';
 
 final _logger = Logger('SignalingEntryPoint');
-
-SignalingForegroundIsolateManager? _manager;
-
-// Serialises concurrent onSynchronize calls so that a rapid stop+start
-// sequence cannot interleave _stop() and _start().
-Future<void> _pendingSync = Future.value();
-
-// ---------------------------------------------------------------------------
-// Background isolate entry points
-// ---------------------------------------------------------------------------
 
 /// Step 1 -- Dart callback executed by [FlutterEngineHelper] when the
 /// background engine first starts.
 ///
-/// Responsibility: initialise Flutter bindings and register the
-/// [PSignalingServiceFlutterApi] handler so Kotlin can send [onSynchronize]
-/// calls into this isolate.
+/// Initialises Flutter bindings and registers the [PSignalingServiceFlutterApi]
+/// handler so Kotlin can send [onSignalingServiceSync] calls into this isolate.
 ///
-/// [callbackDispatcherHandle] stored in [StorageDelegate] is the raw handle
-/// for THIS function (obtained via [PluginUtilities.getCallbackHandle] in the
-/// main isolate before calling [PSignalingServiceHostApi.initializeServiceCallback]).
+/// The raw handle for this function is stored in [StorageDelegate] and obtained
+/// in the main isolate via [PluginUtilities.getCallbackHandle] before calling
+/// [PSignalingServiceHostApi.initializeServiceCallback].
 @pragma('vm:entry-point')
 void signalingServiceCallbackDispatcher() {
   _logger.info('signalingServiceCallbackDispatcher: background isolate starting');
   WidgetsFlutterBinding.ensureInitialized();
   PSignalingServiceFlutterApi.setUp(_SignalingFlutterApiHandler());
-  // Notify Kotlin that the Dart isolate has registered its PSignalingServiceFlutterApi
-  // handler and is now ready to receive onSynchronize calls.
-  // This resolves the race where Kotlin calls synchronizeIsolate() before the Dart
-  // handler is registered (executeDartCallback is async -- the Dart isolate starts
-  // after Kotlin has already tried to call onSynchronize).
+  // Notify Kotlin that the Dart isolate has registered its handler and is ready
+  // to receive onSynchronize calls. This resolves the race where Kotlin calls
+  // synchronizeIsolate() before the Dart handler is registered
+  // (executeDartCallback is async -- the Dart isolate starts after Kotlin has
+  // already tried to call onSynchronize).
   PSignalingServiceHostApi().notifyIsolateReady();
   _logger.info('signalingServiceCallbackDispatcher: notifyIsolateReady sent, waiting for onSynchronize');
 }
 
-/// Step 2 -- called by [_SignalingFlutterApiHandler.onSynchronize] (Kotlin ->
-/// Dart via Pigeon) whenever the service status changes.
+/// Kotlin -> Dart Pigeon bridge for the signaling foreground service.
 ///
-/// Re-creates the manager when connection params change so that a token
-/// refresh or re-login always starts a fresh connection.
-@pragma('vm:entry-point')
-Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
-  _logger.info(
-    'onSignalingServiceSync enabled=${status.enabled} tenantId=${status.tenantId} '
-    'hasIncomingCallHandler=${status.incomingCallHandlerHandle != 0} '
-    'hasModuleFactory=${status.moduleFactoryHandle != 0}',
-  );
-  if (status.enabled) {
-    // Re-create manager when credentials or factory handle change (e.g. after re-login).
-    final existing = _manager;
-    if (existing != null) {
-      final configChanged =
-          existing.coreUrl != status.coreUrl ||
-          existing.tenantId != status.tenantId ||
-          existing.token != status.token ||
-          existing.trustedCertificatesJson != status.trustedCertificatesJson ||
-          existing.incomingCallHandlerHandle != status.incomingCallHandlerHandle ||
-          existing.moduleFactoryHandle != status.moduleFactoryHandle;
-      if (configChanged) {
-        _logger.info('onSignalingServiceSync config changed, recreating manager');
-        await existing.handleStatus(enabled: false);
-        _manager = null;
-      }
-    }
-    if (_manager == null) {
-      _logger.info('onSignalingServiceSync creating new SignalingForegroundIsolateManager');
-    }
-    _manager ??= SignalingForegroundIsolateManager(
-      coreUrl: status.coreUrl,
-      tenantId: status.tenantId,
-      token: status.token,
-      trustedCertificatesJson: status.trustedCertificatesJson,
-      incomingCallHandlerHandle: status.incomingCallHandlerHandle,
-      moduleFactoryHandle: status.moduleFactoryHandle,
-    );
-  }
-  await _manager?.handleStatus(enabled: status.enabled);
-}
-
-// ---------------------------------------------------------------------------
-// PSignalingServiceFlutterApi handler (Kotlin -> Dart bridge)
-// ---------------------------------------------------------------------------
-
+/// Receives [onSynchronize] calls from Kotlin and serialises them through
+/// [pendingSync] so that rapid stop+start sequences never interleave.
 class _SignalingFlutterApiHandler extends PSignalingServiceFlutterApi {
   @override
   void onSynchronize(PSignalingServiceStatus status) {
     _logger.fine('onSynchronize received from Kotlin, queuing sync');
-    // Chain each call so rapid stop+start sequences are serialised and never
-    // interleave _stop() with _start().
-    _pendingSync = _pendingSync.then((_) => onSignalingServiceSync(status)).catchError((Object e, StackTrace s) {
-      _logger.severe('onSignalingServiceSync failed — sync chain kept alive', e, s);
+    pendingSync = pendingSync.then((_) => onSignalingServiceSync(status)).catchError((Object e, StackTrace s) {
+      _logger.severe('onSignalingServiceSync failed - sync chain kept alive', e, s);
     });
   }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
@@ -9,7 +9,21 @@ SignalingForegroundIsolateManager? _manager;
 
 /// Serialises concurrent [onSignalingServiceSync] calls so that a rapid
 /// stop+start sequence cannot interleave stop and start operations.
-Future<void> pendingSync = Future.value();
+Future<void> _pendingSync = Future.value();
+
+/// Kotlin -> Dart Pigeon bridge for the signaling foreground service.
+///
+/// Receives [onSynchronize] calls from Kotlin and serialises them through
+/// [_pendingSync] so that rapid stop+start sequences never interleave.
+class SignalingFlutterApiHandler extends PSignalingServiceFlutterApi {
+  @override
+  void onSynchronize(PSignalingServiceStatus status) {
+    _logger.fine('onSynchronize received from Kotlin, queuing sync');
+    _pendingSync = _pendingSync.then((_) => onSignalingServiceSync(status)).catchError((Object e, StackTrace s) {
+      _logger.severe('onSignalingServiceSync failed - sync chain kept alive', e, s);
+    });
+  }
+}
 
 /// Called by the [PSignalingServiceFlutterApi] handler whenever Kotlin sends a
 /// status update (service enabled/disabled, config changed).

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
@@ -1,0 +1,59 @@
+import 'package:logging/logging.dart';
+
+import '../messages.g.dart';
+import 'signaling_foreground_isolate_manager.dart';
+
+final _logger = Logger('SignalingSyncHandler');
+
+SignalingForegroundIsolateManager? _manager;
+
+/// Serialises concurrent [onSignalingServiceSync] calls so that a rapid
+/// stop+start sequence cannot interleave stop and start operations.
+Future<void> pendingSync = Future.value();
+
+/// Called by the [PSignalingServiceFlutterApi] handler whenever Kotlin sends a
+/// status update (service enabled/disabled, config changed).
+///
+/// Re-creates [SignalingForegroundIsolateManager] when connection params change
+/// so that a token refresh or re-login always starts a fresh connection.
+///
+/// Must be annotated with [@pragma('vm:entry-point')] to survive tree-shaking
+/// because its handle is resolved at runtime via [PluginUtilities].
+@pragma('vm:entry-point')
+Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
+  _logger.info(
+    'onSignalingServiceSync enabled=${status.enabled} tenantId=${status.tenantId} '
+    'hasIncomingCallHandler=${status.incomingCallHandlerHandle != 0} '
+    'hasModuleFactory=${status.moduleFactoryHandle != 0}',
+  );
+  if (status.enabled) {
+    // Re-create manager when credentials or factory handle change (e.g. after re-login).
+    final existing = _manager;
+    if (existing != null) {
+      final configChanged =
+          existing.coreUrl != status.coreUrl ||
+          existing.tenantId != status.tenantId ||
+          existing.token != status.token ||
+          existing.trustedCertificatesJson != status.trustedCertificatesJson ||
+          existing.incomingCallHandlerHandle != status.incomingCallHandlerHandle ||
+          existing.moduleFactoryHandle != status.moduleFactoryHandle;
+      if (configChanged) {
+        _logger.info('onSignalingServiceSync config changed, recreating manager');
+        await existing.handleStatus(enabled: false);
+        _manager = null;
+      }
+    }
+    if (_manager == null) {
+      _logger.info('onSignalingServiceSync creating new SignalingForegroundIsolateManager');
+    }
+    _manager ??= SignalingForegroundIsolateManager(
+      coreUrl: status.coreUrl,
+      tenantId: status.tenantId,
+      token: status.token,
+      trustedCertificatesJson: status.trustedCertificatesJson,
+      incomingCallHandlerHandle: status.incomingCallHandlerHandle,
+      moduleFactoryHandle: status.moduleFactoryHandle,
+    );
+  }
+  await _manager?.handleStatus(enabled: status.enabled);
+}


### PR DESCRIPTION
## Summary

Splits `entry_point.dart` (104 lines, 3 concerns) into two focused files:

| File | Responsibility |
|------|---------------|
| `entry_point.dart` | Bootstrap only: initialises Flutter bindings, registers Pigeon handler, notifies Kotlin the isolate is ready |
| `signaling_sync_handler.dart` | Sync logic: `_manager` lifecycle, config-change detection, `onSignalingServiceSync` |

`_pendingSync` moves to `signaling_sync_handler.dart` as `pendingSync` (package-visible) since `_SignalingFlutterApiHandler` in `entry_point.dart` chains onto it.

No behaviour changes — identical logic, different file layout.

## Test plan

- [ ] `dart analyze lib/` — no issues
- [ ] All 145 tests pass unchanged