### PR TITLE
refactor: move session buffer from SignalingHubModule to SignalingHubClient

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -44,11 +44,20 @@ class SignalingHubClient {
   final SendPort _hubPort;
   final ReceivePort _receivePort = ReceivePort();
   final _controller = StreamController<SignalingModuleEvent>.broadcast();
+  final _eventBuffer = SignalingEventBuffer();
   final Map<String, Completer<void>> _pendingExecutions = {};
 
   StreamSubscription<Object?>? _subscription;
   bool _started = false;
   Completer<bool>? _subAckCompleter;
+
+  /// Snapshot of buffered events from the current session.
+  ///
+  /// Applies the same rules as [SignalingHub]'s session buffer: cleared on
+  /// [SignalingConnecting], [SignalingProtocolEvent] items are never included.
+  /// Consumers such as [SignalingHubModule] use this to replay state to
+  /// late subscribers of their own event streams.
+  List<SignalingModuleEvent> get snapshot => _eventBuffer.snapshot;
 
   /// Sends the subscribe command and begins forwarding hub events to [events].
   /// Safe to call more than once -- subsequent calls are no-ops.
@@ -104,6 +113,7 @@ class SignalingHubClient {
       if (!c.isCompleted) c.completeError(StateError('Hub client disposed'));
     }
     _pendingExecutions.clear();
+    _eventBuffer.clear();
     await _controller.close();
     _logger.fine('Hub client $consumerId disposed');
   }
@@ -129,6 +139,7 @@ class SignalingHubClient {
     }
     final event = decodeHubEvent(msg);
     if (event != null && !_controller.isClosed) {
+      _eventBuffer.onEvent(event);
       _controller.add(event);
     }
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
@@ -16,6 +16,10 @@ final _logger = Logger('SignalingHubModule');
 ///
 /// [connect] and [disconnect] are no-ops -- the hub owns the connection
 /// lifecycle. [dispose] unsubscribes from the hub and releases resources.
+///
+/// Late subscribers to [events] receive the current session state via
+/// [SignalingHubClient.snapshot], which accumulates events as the hub
+/// replays and broadcasts them through the client.
 class SignalingHubModule implements SignalingModule {
   SignalingHubModule(this._hubClient) {
     _sub = _hubClient.events.listen(_onHubEvent);
@@ -28,7 +32,6 @@ class SignalingHubModule implements SignalingModule {
   bool _connected = false;
   StreamSubscription<SignalingModuleEvent>? _sub;
 
-  final _eventBuffer = SignalingEventBuffer();
   final _controller = StreamController<SignalingModuleEvent>.broadcast();
 
   @override
@@ -36,7 +39,7 @@ class SignalingHubModule implements SignalingModule {
     return Stream.multi((sink) {
       final sub = _controller.stream.listen(sink.add, onError: sink.addError, onDone: sink.close);
       sink.onCancel = sub.cancel;
-      for (final event in _eventBuffer.snapshot) {
+      for (final event in _hubClient.snapshot) {
         sink.add(event);
       }
     }, isBroadcast: true);
@@ -64,13 +67,8 @@ class SignalingHubModule implements SignalingModule {
     await _sub?.cancel();
     await _hubClient.dispose();
     await _controller.close();
-    _eventBuffer.clear();
     _logger.fine('SignalingHubModule disposed');
   }
-
-  // ---------------------------------------------------------------------------
-  // Internal
-  // ---------------------------------------------------------------------------
 
   void _onHubEvent(SignalingModuleEvent event) {
     switch (event) {
@@ -92,7 +90,6 @@ class SignalingHubModule implements SignalingModule {
     }
 
     if (_controller.isClosed) return;
-    _eventBuffer.onEvent(event);
     _controller.add(event);
   }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_module_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_module_test.dart
@@ -6,6 +6,8 @@ import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_s
 
 import 'package:webtrit_signaling_service_android/src/hub/signaling_hub_client.dart';
 import 'package:webtrit_signaling_service_android/src/hub/signaling_hub_module.dart';
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart'
+    show SignalingEventBuffer;
 
 // ---------------------------------------------------------------------------
 // Fake hub client
@@ -13,6 +15,7 @@ import 'package:webtrit_signaling_service_android/src/hub/signaling_hub_module.d
 
 class _FakeHubClient extends Fake implements SignalingHubClient {
   final _controller = StreamController<SignalingModuleEvent>.broadcast();
+  final _buffer = SignalingEventBuffer();
 
   bool started = false;
   bool disposed = false;
@@ -25,6 +28,9 @@ class _FakeHubClient extends Fake implements SignalingHubClient {
   Stream<SignalingModuleEvent> get events => _controller.stream;
 
   @override
+  List<SignalingModuleEvent> get snapshot => _buffer.snapshot;
+
+  @override
   void start() => started = true;
 
   @override
@@ -34,11 +40,15 @@ class _FakeHubClient extends Fake implements SignalingHubClient {
 
   @override
   Future<void> dispose() async {
+    _buffer.clear();
     await _controller.close();
     disposed = true;
   }
 
-  void inject(SignalingModuleEvent event) => _controller.add(event);
+  void inject(SignalingModuleEvent event) {
+    _buffer.onEvent(event);
+    _controller.add(event);
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Eliminates the duplicate `SignalingEventBuffer` in `SignalingHubModule` by moving it one level down into `SignalingHubClient`.

**Before:** two independent buffers in the pipeline:
- `SignalingHub._sessionBuffer` -- replay for new hub subscribers (cross-isolate)
- `SignalingHubModule._eventBuffer` -- replay for late `hubModule.events` subscribers

**After:** one buffer per pipeline level:
- `SignalingHub._sessionBuffer` -- replay for new hub subscribers (cross-isolate, unchanged)
- `SignalingHubClient._eventBuffer` + `snapshot` -- accumulates decoded events; `SignalingHubModule.events` replays from `_hubClient.snapshot` instead of maintaining its own buffer

`SignalingHubModule` no longer owns any buffering logic -- it delegates replay entirely to the client layer.

## Test plan

- [ ] `dart analyze lib/` -- no issues
- [ ] All 145 tests pass