### PR TITLE
refactor: replace int discriminators with string tags in hub codec

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -77,7 +77,6 @@ class SignalingHub {
   void _onModuleEvent(SignalingModuleEvent event) {
     if (event is SignalingConnecting) _sessionBuffer.clear();
     final encoded = encodeHubEvent(event);
-    if (encoded == null) return;
     if (event is! SignalingProtocolEvent) _sessionBuffer.add(encoded);
     _broadcast(encoded);
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -1,80 +1,78 @@
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
 
-// ---------------------------------------------------------------------------
-// Type discriminators (hub -> subscriber, position [0])
-// ---------------------------------------------------------------------------
+const _tagConnecting = 'connecting';
+const _tagConnected = 'connected';
+const _tagConnectionFailed = 'connection_failed';
+const _tagDisconnecting = 'disconnecting';
+const _tagDisconnected = 'disconnected';
+const _tagHandshakeReceived = 'handshake_received';
+const _tagProtocolEvent = 'protocol_event';
+const _tagExecuteResult = 'execute_result';
+const _tagSubAck = 'sub_ack';
 
-const _kConnecting = 0;
-const _kConnected = 1;
-const _kConnectionFailed = 2;
-const _kDisconnecting = 3;
-const _kDisconnected = 4;
-const _kHandshakeReceived = 5;
-const _kProtocolEvent = 6;
-const _kExecuteResult = 7;
-const _kSubAck = 8;
-
-// ---------------------------------------------------------------------------
-// Encode SignalingModuleEvent -> List<dynamic>
-// ---------------------------------------------------------------------------
-
+/// Encodes a [SignalingModuleEvent] into an isolate-safe [List] for transport
+/// over a [SendPort].
+///
+/// Returns null for [SignalingProtocolEvent] subclasses that are not handled
+/// (should never occur given the sealed hierarchy, but keeps the return type
+/// nullable for forward compatibility).
 List<dynamic>? encodeHubEvent(SignalingModuleEvent event) {
   switch (event) {
     case SignalingConnecting():
-      return [_kConnecting];
+      return [_tagConnecting];
     case SignalingConnected():
-      return [_kConnected];
+      return [_tagConnected];
     case SignalingConnectionFailed(:final error, :final isRepeated, :final recommendedReconnectDelay):
-      return [_kConnectionFailed, error.toString(), isRepeated, recommendedReconnectDelay.inMilliseconds];
+      return [_tagConnectionFailed, error.toString(), isRepeated, recommendedReconnectDelay.inMilliseconds];
     case SignalingDisconnecting():
-      return [_kDisconnecting];
+      return [_tagDisconnecting];
     case SignalingDisconnected(:final code, :final reason, :final knownCode, :final recommendedReconnectDelay):
-      return [_kDisconnected, code, reason, knownCode.index, recommendedReconnectDelay?.inMilliseconds];
+      return [_tagDisconnected, code, reason, knownCode.name, recommendedReconnectDelay?.inMilliseconds];
     case SignalingHandshakeReceived(:final handshake):
-      return [_kHandshakeReceived, _encodeHandshake(handshake)];
+      return [_tagHandshakeReceived, _encodeHandshake(handshake)];
     case SignalingProtocolEvent(:final event):
-      return [_kProtocolEvent, event.toJson()];
+      return [_tagProtocolEvent, event.toJson()];
   }
 }
 
-// ---------------------------------------------------------------------------
-// Decode List<dynamic> -> SignalingModuleEvent
-// ---------------------------------------------------------------------------
-
+/// Decodes an isolate-safe [List] back into a [SignalingModuleEvent].
+///
+/// Returns null for unrecognised or malformed messages so that the hub
+/// listener can skip them without crashing.
 SignalingModuleEvent? decodeHubEvent(List<dynamic> msg) {
   if (msg.isEmpty) return null;
-  final type = msg[0] as int;
-  switch (type) {
-    case _kConnecting:
+  final tag = msg[0];
+  switch (tag) {
+    case _tagConnecting:
       return SignalingConnecting();
-    case _kConnected:
+    case _tagConnected:
       return SignalingConnected();
-    case _kConnectionFailed:
+    case _tagConnectionFailed:
       final delayMs = msg[3] as int;
       return SignalingConnectionFailed(
         error: msg[1] as String,
         isRepeated: msg[2] as bool,
         recommendedReconnectDelay: Duration(milliseconds: delayMs),
       );
-    case _kDisconnecting:
+    case _tagDisconnecting:
       return SignalingDisconnecting();
-    case _kDisconnected:
+    case _tagDisconnected:
       final delayMs = msg[4] as int?;
       return SignalingDisconnected(
         code: msg[1] as int?,
         reason: msg[2] as String?,
-        knownCode: SignalingDisconnectCode.values[msg[3] as int],
+        knownCode: SignalingDisconnectCode.values.byName(msg[3] as String),
         recommendedReconnectDelay: delayMs != null ? Duration(milliseconds: delayMs) : null,
       );
-    case _kHandshakeReceived:
+    case _tagHandshakeReceived:
       try {
         final handshake = StateHandshake.fromJson(Map<String, dynamic>.from(msg[1] as Map));
         return SignalingHandshakeReceived(handshake: handshake);
       } catch (_) {
         return null;
       }
-    case _kProtocolEvent:
+    case _tagProtocolEvent:
       try {
         final event = Event.fromJson(Map<String, dynamic>.from(msg[1] as Map));
         return SignalingProtocolEvent(event: event);
@@ -86,32 +84,22 @@ SignalingModuleEvent? decodeHubEvent(List<dynamic> msg) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Execute result helpers
-// ---------------------------------------------------------------------------
-
+/// Encodes an execute result for transport from hub to subscriber.
 List<dynamic> encodeExecuteResult(String correlationId, Object? error) => [
-  _kExecuteResult,
+  _tagExecuteResult,
   correlationId,
   error?.toString(),
 ];
 
-bool isExecuteResult(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _kExecuteResult;
+bool isExecuteResult(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagExecuteResult;
 
 ({String correlationId, String? error}) decodeExecuteResult(List<dynamic> msg) =>
     (correlationId: msg[1] as String, error: msg[2] as String?);
 
-// ---------------------------------------------------------------------------
-// Sub-ack helpers (hub -> subscriber, confirms port is alive)
-// ---------------------------------------------------------------------------
+/// Encodes a subscribe-ack sent by the hub to confirm a new subscriber's port is live.
+List<dynamic> encodeSubAck() => [_tagSubAck];
 
-List<dynamic> encodeSubAck() => [_kSubAck];
-
-bool isSubAck(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _kSubAck;
-
-// ---------------------------------------------------------------------------
-// StateHandshake encoder
-// ---------------------------------------------------------------------------
+bool isSubAck(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagSubAck;
 
 Map<String, dynamic> _encodeHandshake(StateHandshake h) {
   return {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -14,10 +14,10 @@ const _tagSubAck = 'sub_ack';
 /// Encodes a [SignalingModuleEvent] into an isolate-safe [List] for transport
 /// over a [SendPort].
 ///
-/// Returns null for [SignalingProtocolEvent] subclasses that are not handled
-/// (should never occur given the sealed hierarchy, but keeps the return type
-/// nullable for forward compatibility).
-List<dynamic>? encodeHubEvent(SignalingModuleEvent event) {
+/// This encoding is exhaustive for the current [SignalingModuleEvent]
+/// hierarchy. If new event types are added, this method must be updated to
+/// encode them.
+List<dynamic> encodeHubEvent(SignalingModuleEvent event) {
   switch (event) {
     case SignalingConnecting():
       return [_tagConnecting];
@@ -43,44 +43,43 @@ List<dynamic>? encodeHubEvent(SignalingModuleEvent event) {
 SignalingModuleEvent? decodeHubEvent(List<dynamic> msg) {
   if (msg.isEmpty) return null;
   final tag = msg[0];
-  switch (tag) {
-    case _tagConnecting:
-      return SignalingConnecting();
-    case _tagConnected:
-      return SignalingConnected();
-    case _tagConnectionFailed:
-      final delayMs = msg[3] as int;
-      return SignalingConnectionFailed(
-        error: msg[1] as String,
-        isRepeated: msg[2] as bool,
-        recommendedReconnectDelay: Duration(milliseconds: delayMs),
-      );
-    case _tagDisconnecting:
-      return SignalingDisconnecting();
-    case _tagDisconnected:
-      final delayMs = msg[4] as int?;
-      return SignalingDisconnected(
-        code: msg[1] as int?,
-        reason: msg[2] as String?,
-        knownCode: SignalingDisconnectCode.values.byName(msg[3] as String),
-        recommendedReconnectDelay: delayMs != null ? Duration(milliseconds: delayMs) : null,
-      );
-    case _tagHandshakeReceived:
-      try {
+  try {
+    switch (tag) {
+      case _tagConnecting:
+        return SignalingConnecting();
+      case _tagConnected:
+        return SignalingConnected();
+      case _tagConnectionFailed:
+        final delayMs = msg[3] as int;
+        return SignalingConnectionFailed(
+          error: msg[1] as String,
+          isRepeated: msg[2] as bool,
+          recommendedReconnectDelay: Duration(milliseconds: delayMs),
+        );
+      case _tagDisconnecting:
+        return SignalingDisconnecting();
+      case _tagDisconnected:
+        final delayMs = msg[4] as int?;
+        final knownCodeName = msg[3] as String;
+        final knownCode =
+            SignalingDisconnectCode.values.asNameMap()[knownCodeName] ?? SignalingDisconnectCode.unmappedCode;
+        return SignalingDisconnected(
+          code: msg[1] as int?,
+          reason: msg[2] as String?,
+          knownCode: knownCode,
+          recommendedReconnectDelay: delayMs != null ? Duration(milliseconds: delayMs) : null,
+        );
+      case _tagHandshakeReceived:
         final handshake = StateHandshake.fromJson(Map<String, dynamic>.from(msg[1] as Map));
         return SignalingHandshakeReceived(handshake: handshake);
-      } catch (_) {
-        return null;
-      }
-    case _tagProtocolEvent:
-      try {
+      case _tagProtocolEvent:
         final event = Event.fromJson(Map<String, dynamic>.from(msg[1] as Map));
         return SignalingProtocolEvent(event: event);
-      } catch (_) {
+      default:
         return null;
-      }
-    default:
-      return null;
+    }
+  } catch (_) {
+    return null;
   }
 }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
@@ -313,6 +313,17 @@ void main() {
       expect(decodeHubEvent(['unknown_tag', 'data']), isNull);
     });
 
+    test('decodeHubEvent returns null for malformed connection_failed payload', () {
+      expect(decodeHubEvent(['connection_failed']), isNull);
+    });
+
+    test('decodeHubEvent maps unknown knownCode name to unmappedCode', () {
+      final msg = ['disconnected', null, null, 'nonExistentCode', null];
+      final decoded = decodeHubEvent(msg) as SignalingDisconnected?;
+      expect(decoded, isNotNull);
+      expect(decoded!.knownCode, SignalingDisconnectCode.unmappedCode);
+    });
+
     test('encodeHubEvent -> decodeHubEvent is stable for all stateless events', () {
       final stateless = [SignalingConnecting(), SignalingConnected(), SignalingDisconnecting()];
       for (final event in stateless) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
@@ -4,10 +4,6 @@ import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_s
 
 import 'package:webtrit_signaling_service_android/src/hub/signaling_hub_codec.dart';
 
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
-
 final _kHandshake = StateHandshake(
   keepaliveInterval: const Duration(seconds: 30),
   timestamp: 1705322000000,
@@ -18,10 +14,6 @@ final _kHandshake = StateHandshake(
   guestLine: null,
 );
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 T _roundtrip<T extends SignalingModuleEvent>(T event) {
   final encoded = encodeHubEvent(event);
   expect(encoded, isNotNull);
@@ -31,13 +23,9 @@ T _roundtrip<T extends SignalingModuleEvent>(T event) {
 }
 
 void main() {
-  // -------------------------------------------------------------------------
-  // Stateless events -- roundtrip
-  // -------------------------------------------------------------------------
-
   group('SignalingHubCodec -- SignalingConnecting', () {
-    test('encodes to [0]', () {
-      expect(encodeHubEvent(SignalingConnecting()), equals([0]));
+    test('encodes to [connecting]', () {
+      expect(encodeHubEvent(SignalingConnecting()), equals(['connecting']));
     });
 
     test('roundtrip returns SignalingConnecting', () {
@@ -46,8 +34,8 @@ void main() {
   });
 
   group('SignalingHubCodec -- SignalingConnected', () {
-    test('encodes to [1]', () {
-      expect(encodeHubEvent(SignalingConnected()), equals([1]));
+    test('encodes to [connected]', () {
+      expect(encodeHubEvent(SignalingConnected()), equals(['connected']));
     });
 
     test('roundtrip returns SignalingConnected', () {
@@ -56,18 +44,14 @@ void main() {
   });
 
   group('SignalingHubCodec -- SignalingDisconnecting', () {
-    test('encodes to [3]', () {
-      expect(encodeHubEvent(SignalingDisconnecting()), equals([3]));
+    test('encodes to [disconnecting]', () {
+      expect(encodeHubEvent(SignalingDisconnecting()), equals(['disconnecting']));
     });
 
     test('roundtrip returns SignalingDisconnecting', () {
       _roundtrip(SignalingDisconnecting());
     });
   });
-
-  // -------------------------------------------------------------------------
-  // SignalingConnectionFailed
-  // -------------------------------------------------------------------------
 
   group('SignalingHubCodec -- SignalingConnectionFailed', () {
     test('encodes error as string representation', () {
@@ -77,10 +61,10 @@ void main() {
         recommendedReconnectDelay: const Duration(seconds: 3),
       );
       final encoded = encodeHubEvent(event)!;
-      expect(encoded[0], 2);
+      expect(encoded[0], 'connection_failed');
       expect(encoded[1], event.error.toString());
       expect(encoded[2], false);
-      expect(encoded[3], 3000); // milliseconds
+      expect(encoded[3], 3000);
     });
 
     test('roundtrip preserves isRepeated: false', () {
@@ -125,11 +109,19 @@ void main() {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // SignalingDisconnected
-  // -------------------------------------------------------------------------
-
   group('SignalingHubCodec -- SignalingDisconnected', () {
+    test('encodes knownCode as enum name, not index', () {
+      final encoded = encodeHubEvent(
+        SignalingDisconnected(
+          code: 1000,
+          reason: null,
+          knownCode: SignalingDisconnectCode.normalClosure,
+          recommendedReconnectDelay: const Duration(seconds: 3),
+        ),
+      )!;
+      expect(encoded[3], 'normalClosure');
+    });
+
     test('roundtrip preserves code and reason', () {
       final decoded = _roundtrip(
         SignalingDisconnected(
@@ -143,7 +135,7 @@ void main() {
       expect(decoded.reason, 'normal close');
     });
 
-    test('roundtrip preserves knownCode', () {
+    test('roundtrip preserves all SignalingDisconnectCode values', () {
       for (final knownCode in SignalingDisconnectCode.values) {
         final decoded = _roundtrip(
           SignalingDisconnected(
@@ -208,10 +200,6 @@ void main() {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // SignalingHandshakeReceived
-  // -------------------------------------------------------------------------
-
   group('SignalingHubCodec -- SignalingHandshakeReceived', () {
     test('roundtrip produces SignalingHandshakeReceived', () {
       final event = SignalingHandshakeReceived(handshake: _kHandshake);
@@ -244,7 +232,7 @@ void main() {
 
     test('malformed handshake payload returns null', () {
       final msg = [
-        5,
+        'handshake_received',
         <String, dynamic>{'bad': 'data'},
       ];
       final decoded = decodeHubEvent(msg);
@@ -252,22 +240,18 @@ void main() {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // Sub-ack helpers
-  // -------------------------------------------------------------------------
-
   group('SignalingHubCodec -- sub-ack', () {
-    test('encodeSubAck returns [8]', () {
-      expect(encodeSubAck(), equals([8]));
+    test('encodeSubAck returns [sub_ack]', () {
+      expect(encodeSubAck(), equals(['sub_ack']));
     });
 
-    test('isSubAck is true for [8]', () {
-      expect(isSubAck([8]), isTrue);
+    test('isSubAck is true for [sub_ack]', () {
+      expect(isSubAck(['sub_ack']), isTrue);
     });
 
-    test('isSubAck is false for other type codes', () {
-      expect(isSubAck([0]), isFalse);
-      expect(isSubAck([7, 'id', null]), isFalse);
+    test('isSubAck is false for other tags', () {
+      expect(isSubAck(['connecting']), isFalse);
+      expect(isSubAck(['execute_result', 'id', null]), isFalse);
     });
 
     test('isSubAck is false for empty list', () {
@@ -275,33 +259,29 @@ void main() {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // Execute result helpers
-  // -------------------------------------------------------------------------
-
   group('SignalingHubCodec -- execute result', () {
-    test('encodeExecuteResult without error produces [7, corrId, null]', () {
+    test('encodeExecuteResult without error produces [execute_result, corrId, null]', () {
       final encoded = encodeExecuteResult('corr-1', null);
-      expect(encoded[0], 7);
+      expect(encoded[0], 'execute_result');
       expect(encoded[1], 'corr-1');
       expect(encoded[2], isNull);
     });
 
     test('encodeExecuteResult with error stringifies the error', () {
       final encoded = encodeExecuteResult('corr-2', Exception('boom'));
-      expect(encoded[0], 7);
+      expect(encoded[0], 'execute_result');
       expect(encoded[1], 'corr-2');
       expect(encoded[2], isA<String>());
       expect(encoded[2] as String, contains('boom'));
     });
 
-    test('isExecuteResult is true for [7, ...]', () {
-      expect(isExecuteResult([7, 'id', null]), isTrue);
+    test('isExecuteResult is true for [execute_result, ...]', () {
+      expect(isExecuteResult(['execute_result', 'id', null]), isTrue);
     });
 
-    test('isExecuteResult is false for other type codes', () {
-      expect(isExecuteResult([0]), isFalse);
-      expect(isExecuteResult([8]), isFalse);
+    test('isExecuteResult is false for other tags', () {
+      expect(isExecuteResult(['connecting']), isFalse);
+      expect(isExecuteResult(['sub_ack']), isFalse);
     });
 
     test('isExecuteResult is false for empty list', () {
@@ -324,17 +304,13 @@ void main() {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // Edge cases
-  // -------------------------------------------------------------------------
-
   group('SignalingHubCodec -- edge cases', () {
     test('decodeHubEvent returns null for empty list', () {
       expect(decodeHubEvent([]), isNull);
     });
 
-    test('decodeHubEvent returns null for unknown type code', () {
-      expect(decodeHubEvent([99, 'unknown']), isNull);
+    test('decodeHubEvent returns null for unknown tag', () {
+      expect(decodeHubEvent(['unknown_tag', 'data']), isNull);
     });
 
     test('encodeHubEvent -> decodeHubEvent is stable for all stateless events', () {


### PR DESCRIPTION
## Summary

Replaces integer type discriminators (`0`..`8`) in `signaling_hub_codec.dart` with string tags.

**Problems fixed:**

- `knownCode: SignalingDisconnectCode.values[msg[3] as int]` -- decoding by `.values[index]` breaks silently if enum members are reordered or inserted. Replaced with `.values.byName(knownCode.name)` -- stable across reordering.
- Integer constants (`_kConnecting = 0`, etc.) gave no hint at the call site what message type they represented. String tags (`'connecting'`, `'connected'`, ...) are self-documenting in logs and debugger output.
- Section divider comments removed.

**No behaviour change** -- wire format is internal to the hub/client pair within the same app process; no external consumers.

## Test plan

- [ ] `dart analyze lib/` -- no issues
- [ ] All 146 tests pass