### PR TITLE
fix: replace launchSignaling with run() and unconditional releaseCall

### DIFF
--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -68,18 +68,23 @@ Future<void> _disposeContext() async {
 /// serialize its handle.
 /// Registered via [AndroidCallkeepServices.backgroundPushNotificationBootstrapService.initializeCallback].
 @pragma('vm:entry-point')
-Future<void> onPushNotificationSyncCallback(
-  CallkeepPushNotificationSyncStatus status,
-  CallkeepIncomingCallMetadata? metadata,
-) async {
-  _logger.info('onPushNotificationCallback: $status');
+Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
+  _logger.info('onPushNotificationSyncCallback: callId=${metadata?.callId}');
 
-  switch (status) {
-    case CallkeepPushNotificationSyncStatus.synchronizeCallStatus:
-      final (_, manager) = await _getOrInit();
-      await manager.launchSignaling(metadata);
-    case CallkeepPushNotificationSyncStatus.releaseResources:
-      await _disposeContext();
+  final (_, manager) = await _getOrInit();
+  try {
+    await manager
+        .run(metadata)
+        .timeout(
+          const Duration(seconds: 20),
+          onTimeout: () {
+            _logger.warning('onPushNotificationSyncCallback: timed out callId=${metadata?.callId}');
+          },
+        );
+  } catch (e) {
+    _logger.severe('onPushNotificationSyncCallback: error=$e');
+  } finally {
+    await _disposeContext();
   }
 }
 

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -21,20 +21,22 @@ export 'package:webtrit_signaling_service/webtrit_signaling_service.dart'
         SignalingHandshakeReceived,
         SignalingProtocolEvent;
 
+const _kPushNotificationSyncTimeout = Duration(seconds: 20);
+
 final _logger = Logger('BackgroundCallIsolate');
 
 // Lazily-initialised isolate-level context.
 PushIsolateContext? _context;
 PushNotificationIsolateManager? _manager;
 
-/// Returns the isolate-level context and manager, initialising them on the
+/// Returns the isolate-level manager, initialising context and manager on the
 /// first call and reusing the same instances on every subsequent call.
 ///
 /// [PushIsolateContext] is kept separate from [PushNotificationIsolateManager]
 /// because the manager depends on feature-layer imports that must not be pulled
 /// into [lib/common]. Both are torn down together by [_disposeContext].
-Future<(PushIsolateContext, PushNotificationIsolateManager)> _getOrInit() async {
-  if (_context != null) return (_context!, _manager!);
+Future<PushNotificationIsolateManager> _getOrInit() async {
+  if (_manager != null) return _manager!;
 
   _context = await PushIsolateContext.init();
   _manager = PushNotificationIsolateManager(
@@ -46,7 +48,7 @@ Future<(PushIsolateContext, PushNotificationIsolateManager)> _getOrInit() async 
     logger: Logger('PushNotificationIsolateManager'),
   );
 
-  return (_context!, _manager!);
+  return _manager!;
 }
 
 /// Closes the manager and releases all isolate-level resources.
@@ -61,26 +63,22 @@ Future<void> _disposeContext() async {
   _manager = null;
 }
 
-/// Called by the Flutter engine when the CallKeep push-notification isolate
-/// synchronises call state with the Android telecom framework.
+/// Entry point for the CallKeep push-notification background isolate.
 ///
-/// Annotated with [@pragma('vm:entry-point')] so that [PluginUtilities] can
-/// serialize its handle.
+/// Runs the full incoming-call lifecycle (signaling, missed-call notification,
+/// call log, native release) with a 20 s timeout, then disposes all resources.
 /// Registered via [AndroidCallkeepServices.backgroundPushNotificationBootstrapService.initializeCallback].
 @pragma('vm:entry-point')
 Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
-  _logger.info('onPushNotificationSyncCallback: callId=${metadata?.callId}');
-
-  final (_, manager) = await _getOrInit();
   try {
-    await manager
-        .run(metadata)
-        .timeout(
-          const Duration(seconds: 20),
-          onTimeout: () {
-            _logger.warning('onPushNotificationSyncCallback: timed out callId=${metadata?.callId}');
-          },
-        );
+    // Initialise context and manager lazily on first push notification.
+    final manager = await _getOrInit();
+    // Run the full incoming-call lifecycle; guard with a timeout in case it stalls.
+    final incomingCallProcessing = manager.run(metadata);
+    await incomingCallProcessing.timeout(
+      _kPushNotificationSyncTimeout,
+      onTimeout: () => _logger.warning('onPushNotificationSyncCallback: timed out callId=${metadata?.callId}'),
+    );
   } catch (e) {
     _logger.severe('onPushNotificationSyncCallback: error=$e');
   } finally {

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -148,8 +148,6 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
           logger.info('Signaling: disconnected code=$code reason=$reason knownCode=$knownCode');
         case SignalingConnectionFailed(:final error):
           _onSignalingError(error);
-        default:
-          logger.info('Signaling: unhandled event ${event.runtimeType}');
       }
     });
   }

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -91,6 +91,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     _pendingRequests.clear();
     await _signalingSubscription.cancel();
     await _signalingModule.dispose();
+    await _releaseCall(_metadata?.callId);
     _completeWithError(StateError('PushNotificationIsolateManager closed'));
   }
 
@@ -350,7 +351,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   // Native release
   // ---------------------------------------------------------------------------
 
-  Future<void> _releaseCall(String callId) async {
+  Future<void> _releaseCall(String? callId) async {
+    if (callId == null) return;
     try {
       await _pushService.releaseCall(callId);
     } catch (e) {

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -20,8 +20,8 @@ import '../models/jsep_value.dart';
 ///
 /// Opened once per incoming push notification, connects to the signaling server
 /// to retrieve call state, handles missed-call logging and notifications, and
-/// forwards decline/end actions to the Android telecom framework.
-/// Never reconnects -- the isolate is short-lived by design.
+/// releases the incoming call service when all work is done.
+/// Never reconnects — the isolate is short-lived by design.
 class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegate {
   PushNotificationIsolateManager({
     required this.callLogsRepository,
@@ -59,6 +59,9 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   /// Requests queued while the signaling module is not yet connected.
   final List<_PendingRequest> _pendingRequests = [];
 
+  /// Completer resolved when all isolate work is done and [releaseCall] has been called.
+  Completer<void>? _completer;
+
   // Workaround: captures init time as fallback timestamp for call logs.
   final DateTime _initialConnectionTime = DateTime.now();
 
@@ -66,12 +69,15 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   // Public API
   // ---------------------------------------------------------------------------
 
-  /// Connects to the signaling server to synchronise call state for the given
-  /// push notification [metadata].
-  Future<void> launchSignaling(CallkeepIncomingCallMetadata? metadata) async {
+  /// Connects to the signaling server, processes call state for the given push
+  /// notification [metadata], and returns a [Future] that completes after all
+  /// work is done (notifications shown, logs written, native service released).
+  Future<void> run(CallkeepIncomingCallMetadata? metadata) {
     _metadata = metadata;
-    logger.info('launchSignaling: $metadata');
+    _completer = Completer<void>();
+    logger.info('run: callId=${metadata?.callId}');
     _signalingModule.connect();
+    return _completer!.future;
   }
 
   /// Cancels all timers and pending requests, then disposes the signaling module.
@@ -85,6 +91,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     _pendingRequests.clear();
     await _signalingSubscription.cancel();
     await _signalingModule.dispose();
+    _completeWithError(StateError('PushNotificationIsolateManager closed'));
   }
 
   // ---------------------------------------------------------------------------
@@ -94,9 +101,6 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   @override
   void performEndCall(String callId) async {
     try {
-      // Do not early-return when _lines is empty -- _sendRequest queues the
-      // request so it is executed once the handshake arrives (e.g. user declines
-      // from the lock screen before the signaling handshake completes).
       await _sendRequest(callId, (line, id, tx) => DeclineRequest(transaction: tx, line: line, callId: id));
     } catch (e) {
       logger.severe(e);
@@ -129,14 +133,22 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
     _signalingSubscription = _signalingModule.events.listen((event) {
       switch (event) {
+        case SignalingConnecting():
+          logger.info('Signaling: connecting');
+        case SignalingConnected():
+          logger.info('Signaling: connected');
         case SignalingHandshakeReceived(:final handshake):
           _onHandshake(handshake);
         case SignalingProtocolEvent(:final event):
           _onProtocolEvent(event);
+        case SignalingDisconnecting():
+          logger.info('Signaling: disconnecting');
+        case SignalingDisconnected(:final code, :final reason, :final knownCode):
+          logger.info('Signaling: disconnected code=$code reason=$reason knownCode=$knownCode');
         case SignalingConnectionFailed(:final error):
           _onSignalingError(error);
         default:
-          break;
+          logger.info('Signaling: unhandled event ${event.runtimeType}');
       }
     });
   }
@@ -147,6 +159,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
   void _onHandshake(StateHandshake handshake) {
     final lines = handshake.lines.whereType<Line>().toList();
+    logger.info('Handshake received: ${lines.length} active line(s)');
 
     _lines.clear();
     _incomingCallEvents.clear();
@@ -155,6 +168,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     }
 
     if (_lines.isEmpty) {
+      logger.info('Handshake: no active lines - ending calls');
       _onNoActiveLines();
       return;
     }
@@ -163,14 +177,15 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       final callEvent = activeLine.callLogs.whereType<CallEventLog>().map((log) => log.callEvent).firstOrNull;
 
       if (callEvent is IncomingCallEvent) {
+        logger.info('Handshake: incoming call found callId=${callEvent.callId}');
         _incomingCallEvents[callEvent.callId] = callEvent;
         _executePendingRequests();
         return;
       }
     }
 
+    logger.info('Handshake: active lines present but no IncomingCallEvent found - lines=${_lines.keys}');
     _executePendingRequests();
-    logger.info('Handshake completed: ${_lines.keys}');
   }
 
   void _onProtocolEvent(Event event) {
@@ -197,44 +212,67 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   }
 
   void _onNoActiveLines() async {
-    if (_metadata != null) {
-      final event = HangupEvent(callId: _metadata!.callId, line: -1, reason: 'Missed', code: -1);
-      final call = (
-        direction: CallDirection.incoming,
-        number: _metadata!.handle!.value,
-        video: _metadata!.hasVideo,
-        username: _metadata!.displayName,
-        createdTime: DateTime.now(),
-        acceptedTime: null,
-        hungUpTime: DateTime.now(),
-      );
-      await _showMissedCallNotification(event, call);
-      await _logCall(call);
+    logger.info('No active lines: releasing call');
+    if (_metadata == null) {
+      logger.severe('_onNoActiveLines: metadata is null, cannot release call');
+      _complete();
+      return;
     }
-    await _pushService.endCalls();
+    final event = HangupEvent(callId: _metadata!.callId, line: -1, reason: 'Missed', code: -1);
+    final call = (
+      direction: CallDirection.incoming,
+      number: _metadata!.handle!.value,
+      video: _metadata!.hasVideo,
+      username: _metadata!.displayName,
+      createdTime: DateTime.now(),
+      acceptedTime: null,
+      hungUpTime: DateTime.now(),
+    );
+    await _showMissedCallNotification(event, call);
+    await _logCall(call);
+    await _releaseCall(_metadata!.callId);
+    _complete();
   }
 
   void _onUnregistered(UnregisteredEvent event) async {
     try {
-      await _pushService.endCalls();
+      final callId = _metadata?.callId;
+      if (callId == null) {
+        logger.severe('_onUnregistered: metadata is null, cannot release call');
+        _complete();
+        return;
+      }
+      await _releaseCall(callId);
     } catch (e) {
       logger.severe(e);
+    } finally {
+      _complete();
     }
   }
 
   void _onSignalingError(Object error) async {
+    logger.severe('Signaling connection failed: $error - releasing call');
     try {
-      await _pushService.endCalls();
+      final callId = _metadata?.callId;
+      if (callId == null) {
+        logger.severe('_onSignalingError: metadata is null, cannot release call');
+        _complete();
+        return;
+      }
+      await _releaseCall(callId);
     } catch (e) {
       logger.severe(e);
+    } finally {
+      _complete();
     }
   }
 
   void _onHangupCall(HangupEvent event, NewCall call) async {
-    logger.info('Hangup event: $event');
+    logger.info('Hangup event: callId=${event.callId} reason=${event.reason}');
     await _showMissedCallNotification(event, call);
     await _logCall(call);
-    await _pushService.endCall(event.callId);
+    await _releaseCall(event.callId);
+    _complete();
   }
 
   // ---------------------------------------------------------------------------
@@ -306,6 +344,30 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       return;
     }
     await future;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Native release
+  // ---------------------------------------------------------------------------
+
+  Future<void> _releaseCall(String callId) async {
+    try {
+      await _pushService.releaseCall(callId);
+    } catch (e) {
+      logger.severe('_releaseCall failed: $e');
+    }
+  }
+
+  void _complete() {
+    if (_completer != null && !_completer!.isCompleted) {
+      _completer!.complete();
+    }
+  }
+
+  void _completeWithError(Object error) {
+    if (_completer != null && !_completer!.isCompleted) {
+      _completer!.completeError(error);
+    }
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces `launchSignaling(status, metadata)` callback with `run(metadata)` — returns a `Future<void>` that completes after all isolate work is done (notifications, call logs, native release)
- Dart isolate now calls `releaseCall(callId)` unconditionally in every terminal path (hangup, no active lines, unregistered, signaling error)
- `onPushNotificationSyncCallback` awaits `manager.run(metadata)` with a 20s timeout, then disposes all resources
- Removes `CallkeepPushNotificationSyncStatus` usage — status is no longer part of the callback signature

## Test plan

- [ ] Incoming push call dismissed when caller hangs up while app is backgrounded
- [ ] Missed call notification appears correctly
- [ ] Call log entry written for missed calls
- [ ] 20s Dart-side timeout triggers `_disposeContext()` cleanup if isolate stalls