### PR TITLE
fix: janus video stub sanitizing

### DIFF
--- a/lib/features/call/utils/sdp_mod_builder.dart
+++ b/lib/features/call/utils/sdp_mod_builder.dart
@@ -341,6 +341,20 @@ class SDPModBuilder {
     final media = _getMedia(kind);
     if (media == null) return;
 
+    if (kind == RTPCodecKind.video) {
+      final mid = media['mid'];
+      final payloads = media['payloads'];
+      final port = media['port'];
+      final direction = media['direction'];
+      if (mid == 1 || payloads == 0 || port == 0 || direction == 'inactive') {
+        // Special condition for janus video stub.
+        // If for example user call by video to voicemail service that does not support video, janus creates video m-line with mid=1, payloads=0, port=0 and direction=inactive;
+        //
+        // TODO: if it happens again maybe will be enough to check only payloads=0 and direction=inactive without checking mid and port
+        return;
+      }
+    }
+
     final originalPayloads = [];
     final originalRtpMaps = [];
     final originalFmtps = [];


### PR DESCRIPTION
This pull request adds a safeguard to the SDP modification logic to handle a specific edge case involving Janus video stubs. When a video call is made to a service (like voicemail) that doesn't support video, Janus may generate a video media line with certain values indicating it is inactive. The new logic detects this scenario and skips further processing for such video lines.

**SDP modification improvements:**

* Updated `SDPModBuilder` in `sdp_mod_builder.dart` to skip processing video media lines with `mid=1`, `payloads=0`, `port=0`, and `direction=inactive`, which are used by Janus as stubs for unsupported video calls. This prevents unnecessary handling of inactive video lines.