### PR TITLE
fix: initialize logging in signaling background isolate

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -1,7 +1,6 @@
-import 'dart:developer' as developer;
-
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
+import 'package:logging_appenders/logging_appenders.dart';
 
 import '../messages.g.dart';
 import 'signaling_sync_handler.dart';
@@ -19,16 +18,9 @@ final _logger = Logger('SignalingEntryPoint');
 /// [PSignalingServiceHostApi.initializeServiceCallback].
 @pragma('vm:entry-point')
 void signalingServiceCallbackDispatcher() {
+  hierarchicalLoggingEnabled = true;
   Logger.root.level = Level.ALL;
-  Logger.root.onRecord.listen((record) {
-    developer.log(
-      record.message,
-      name: record.loggerName,
-      level: record.level.value,
-      error: record.error,
-      stackTrace: record.stackTrace,
-    );
-  });
+  PrintAppender(formatter: const ColorFormatter()).attachToLogger(Logger.root);
 
   _logger.info('signalingServiceCallbackDispatcher: background isolate starting');
   WidgetsFlutterBinding.ensureInitialized();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
 
@@ -17,6 +19,17 @@ final _logger = Logger('SignalingEntryPoint');
 /// [PSignalingServiceHostApi.initializeServiceCallback].
 @pragma('vm:entry-point')
 void signalingServiceCallbackDispatcher() {
+  Logger.root.level = Level.ALL;
+  Logger.root.onRecord.listen((record) {
+    developer.log(
+      record.message,
+      name: record.loggerName,
+      level: record.level.value,
+      error: record.error,
+      stackTrace: record.stackTrace,
+    );
+  });
+
   _logger.info('signalingServiceCallbackDispatcher: background isolate starting');
   WidgetsFlutterBinding.ensureInitialized();
   PSignalingServiceFlutterApi.setUp(_SignalingFlutterApiHandler());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   logging: ^1.3.0
+  logging_appenders: ^1.4.0+1
   connectivity_plus: ^7.0.0
   webtrit_signaling:
     path: ../../webtrit_signaling


### PR DESCRIPTION
## Summary

- The signaling foreground service runs in a separate Dart isolate (`signalingServiceCallbackDispatcher`). Dart isolates do not share memory, so `Logger.root` in that isolate had no listeners — all log records from `WebtritSignalingClient`, `SignalingForegroundIsolateManager`, `SignalingHub`, and related classes were silently dropped.
- Initial fix used `dart:developer` log() — but that only posts to the Dart VM service protocol and is not visible in logcat.
- Replaced with `PrintAppender(formatter: const ColorFormatter())` — the same setup used by `AppLogger` in the main isolate — so all background isolate logs appear in logcat under the `flutter` tag.
- Added `logging_appenders: ^1.4.0+1` dependency to `webtrit_signaling_service_android`.

## Test plan

- [x] Run the app on Android and verify `WebtritSignalingClient` / `SignalingForegroundIsolateManager` / `SignalingHub` logs appear in logcat under their logger names
- [x] Confirm no regression in signaling connect/disconnect flow