### PR TITLE
fix: reconnect signaling when background isolate is already started but disconnected

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -77,7 +77,16 @@ class SignalingForegroundIsolateManager {
   }
 
   Future<void> _start() async {
-    if (_started) return;
+    if (_started) {
+      // Hub and module are already initialized. If the module lost its
+      // connection (e.g. a code-1002 close that does not auto-reconnect),
+      // reconnect it now so the external start() call is not silently ignored.
+      if (!(_signalingModule?.isConnected ?? false)) {
+        _logger.info('SignalingForegroundIsolateManager already started but not connected, reconnecting');
+        _signalingModule?.connect();
+      }
+      return;
+    }
 
     _logger.info('SignalingForegroundIsolateManager starting (incomingCallHandler=${incomingCallHandlerHandle != 0})');
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -99,6 +99,8 @@ class SignalingForegroundIsolateManager {
       // reconnect it now so the external start() call is not silently ignored.
       if (!(_signalingModule?.isConnected ?? false)) {
         _logger.info('SignalingForegroundIsolateManager already started but not connected, reconnecting');
+        _reconnectTimer?.cancel();
+        _reconnectTimer = null;
         _signalingModule?.connect();
       }
       return;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -12,6 +12,12 @@ import '../hub/signaling_hub.dart';
 
 final _logger = Logger('SignalingForegroundIsolateManager');
 
+/// Factory that wraps a [SignalingModule] in a [SignalingHub].
+///
+/// The default implementation is [SignalingHub.new]. Overridable in tests
+/// to avoid [IsolateNameServer] usage.
+typedef SignalingHubFactory = SignalingHub Function(SignalingModule module);
+
 /// Manages the [SignalingModule] + [SignalingHub] lifecycle inside the
 /// foreground-service background isolate.
 ///
@@ -37,7 +43,7 @@ class SignalingForegroundIsolateManager {
     this.incomingCallHandlerHandle = 0,
     this.moduleFactoryHandle = 0,
     @visibleForTesting SignalingModuleFactory? moduleFactory,
-    @visibleForTesting SignalingHub Function(SignalingModule)? hubFactory,
+    @visibleForTesting SignalingHubFactory? hubFactory,
   }) : _testModuleFactory = moduleFactory,
        _testHubFactory = hubFactory;
 
@@ -67,7 +73,7 @@ class SignalingForegroundIsolateManager {
   final SignalingModuleFactory? _testModuleFactory;
 
   /// Overrides [SignalingHub] construction in tests to avoid [IsolateNameServer].
-  final SignalingHub Function(SignalingModule)? _testHubFactory;
+  final SignalingHubFactory? _testHubFactory;
 
   SignalingModule? _signalingModule;
   SignalingHub? _hub;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'dart:ui' show CallbackHandle, PluginUtilities;
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
@@ -35,7 +36,10 @@ class SignalingForegroundIsolateManager {
     this.trustedCertificatesJson,
     this.incomingCallHandlerHandle = 0,
     this.moduleFactoryHandle = 0,
-  });
+    @visibleForTesting SignalingModuleFactory? moduleFactory,
+    @visibleForTesting SignalingHub Function(SignalingModule)? hubFactory,
+  }) : _testModuleFactory = moduleFactory,
+       _testHubFactory = hubFactory;
 
   final String coreUrl;
   final String tenantId;
@@ -58,6 +62,12 @@ class SignalingForegroundIsolateManager {
   /// Registered by the app via [WebtritSignalingService.setModuleFactory].
   /// 0 means no factory is registered -- the isolate will log an error and skip start.
   final int moduleFactoryHandle;
+
+  /// Overrides handle-based [SignalingModule] creation in tests.
+  final SignalingModuleFactory? _testModuleFactory;
+
+  /// Overrides [SignalingHub] construction in tests to avoid [IsolateNameServer].
+  final SignalingHub Function(SignalingModule)? _testHubFactory;
 
   SignalingModule? _signalingModule;
   SignalingHub? _hub;
@@ -90,20 +100,10 @@ class SignalingForegroundIsolateManager {
 
     _logger.info('SignalingForegroundIsolateManager starting (incomingCallHandler=${incomingCallHandlerHandle != 0})');
 
-    final rawHandle = moduleFactoryHandle;
-    if (rawHandle == 0) {
-      _logger.severe('No module factory registered -- call setModuleFactory() before start()');
-      return;
-    }
-
-    final factoryCallback = PluginUtilities.getCallbackFromHandle(CallbackHandle.fromRawHandle(rawHandle));
-    if (factoryCallback == null) {
-      _logger.severe('Could not resolve module factory from handle $rawHandle');
-      return;
-    }
+    final factory = _testModuleFactory ?? _resolveModuleFactory();
+    if (factory == null) return;
 
     _started = true;
-    final factory = factoryCallback as SignalingModuleFactory;
     final config = SignalingServiceConfig(
       coreUrl: coreUrl,
       tenantId: tenantId,
@@ -113,7 +113,7 @@ class SignalingForegroundIsolateManager {
 
     _signalingModule = factory(config);
 
-    _hub = SignalingHub(_signalingModule!);
+    _hub = (_testHubFactory ?? SignalingHub.new)(_signalingModule!);
     _hub!.start();
 
     _eventsSubscription = _signalingModule!.events.listen(_onEvent);
@@ -140,6 +140,22 @@ class SignalingForegroundIsolateManager {
     _signalingModule = null;
 
     _logger.info('SignalingForegroundIsolateManager stopped');
+  }
+
+  /// Resolves the [SignalingModuleFactory] from the raw [moduleFactoryHandle].
+  ///
+  /// Returns null and logs an error when the handle is 0 or cannot be resolved.
+  SignalingModuleFactory? _resolveModuleFactory() {
+    if (moduleFactoryHandle == 0) {
+      _logger.severe('No module factory registered -- call setModuleFactory() before start()');
+      return null;
+    }
+    final callback = PluginUtilities.getCallbackFromHandle(CallbackHandle.fromRawHandle(moduleFactoryHandle));
+    if (callback == null) {
+      _logger.severe('Could not resolve module factory from handle $moduleFactoryHandle');
+      return null;
+    }
+    return callback as SignalingModuleFactory;
   }
 
   void _onEvent(SignalingModuleEvent event) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
@@ -1,0 +1,287 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
+
+import 'package:webtrit_signaling_service_android/src/hub/signaling_hub.dart';
+import 'package:webtrit_signaling_service_android/src/isolate/signaling_foreground_isolate_manager.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/// Fake [SignalingModule] that tracks [connect] calls and lets tests control
+/// [isConnected] and the event stream directly.
+class _FakeSignalingModule extends Fake implements SignalingModule {
+  final _controller = StreamController<SignalingModuleEvent>.broadcast();
+
+  int connectCount = 0;
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Stream<SignalingModuleEvent> get events => _controller.stream;
+
+  @override
+  void connect() {
+    connectCount++;
+    _connected = true;
+    _controller.add(SignalingConnected());
+  }
+
+  @override
+  Future<void>? execute(Request request) => null;
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+  }
+
+  @override
+  Future<void> dispose() async {
+    _connected = false;
+    await _controller.close();
+  }
+
+  /// Simulates a WebSocket close with code 1002 (protocol error).
+  ///
+  /// [SignalingModuleImpl._reconnectDelay] maps 1002 to null, so the manager
+  /// does not schedule an auto-reconnect -- reproducing the exact scenario
+  /// that triggered the bug.
+  void simulateDisconnect1002() {
+    _connected = false;
+    _controller.add(
+      SignalingDisconnected(
+        code: 1002,
+        reason: null,
+        knownCode: SignalingDisconnectCode.protocolError,
+        recommendedReconnectDelay: null,
+      ),
+    );
+  }
+
+  /// Simulates a disconnect that includes a reconnect delay hint (e.g. code 1001).
+  void simulateDisconnectWithDelay(Duration delay) {
+    _connected = false;
+    _controller.add(
+      SignalingDisconnected(
+        code: 1001,
+        reason: null,
+        knownCode: SignalingDisconnectCode.goingAway,
+        recommendedReconnectDelay: delay,
+      ),
+    );
+  }
+
+  /// Simulates a connection failure with a delay hint.
+  void simulateConnectionFailed(Duration delay) {
+    _connected = false;
+    _controller.add(
+      SignalingConnectionFailed(error: Exception('timeout'), isRepeated: false, recommendedReconnectDelay: delay),
+    );
+  }
+}
+
+/// No-op [SignalingHub] that avoids [IsolateNameServer] and [ReceivePort] in tests.
+class _FakeSignalingHub extends Fake implements SignalingHub {
+  // ignore: avoid_unused_constructor_parameters
+  _FakeSignalingHub(SignalingModule _);
+
+  @override
+  void start() {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+SignalingForegroundIsolateManager _makeManager(_FakeSignalingModule module) {
+  return SignalingForegroundIsolateManager(
+    coreUrl: 'wss://example.com',
+    tenantId: 'tenant',
+    token: 'tok',
+    // moduleFactoryHandle is 0 by default, but _testModuleFactory overrides
+    // the handle-resolution path, so 0 does not trigger the "no factory" guard.
+    moduleFactory: (_) => module,
+    hubFactory: _FakeSignalingHub.new,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // -------------------------------------------------------------------------
+  // Initial start
+  // -------------------------------------------------------------------------
+
+  group('SignalingForegroundIsolateManager -- initial start', () {
+    test('calls connect() on the module on first handleStatus(enabled: true)', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(module.connectCount, 1);
+    });
+
+    test('is idempotent when already started and connected', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(module.connectCount, 1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reconnect after code-1002 disconnect (the bug scenario)
+  // -------------------------------------------------------------------------
+
+  group('SignalingForegroundIsolateManager -- reconnect after code-1002', () {
+    test('reconnects when handleStatus(enabled: true) is called after a 1002 disconnect '
+        'that did not schedule an auto-reconnect', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      // Initial start — module connects.
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+      expect(module.isConnected, isTrue);
+
+      // WebSocket closes with code 1002. recommendedReconnectDelay == null,
+      // so the manager does not schedule an auto-reconnect.
+      module.simulateDisconnect1002();
+      await Future<void>.delayed(Duration.zero);
+      expect(module.isConnected, isFalse);
+      expect(module.connectCount, 1); // still 1 — no auto-reconnect
+
+      // Main isolate detects WiFi restored and calls start() again.
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(module.connectCount, 2);
+    });
+
+    test('does not reconnect when module is still connected after handleStatus(enabled: true)', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.isConnected, isTrue);
+
+      // Trigger again while connected — should be a no-op.
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(module.connectCount, 1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Auto-reconnect via delay hint
+  // -------------------------------------------------------------------------
+
+  group('SignalingForegroundIsolateManager -- auto-reconnect via delay hint', () {
+    test('schedules reconnect when disconnect carries a non-null delay', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      module.simulateDisconnectWithDelay(const Duration(milliseconds: 50));
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1); // not yet
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(module.connectCount, 2); // reconnected via timer
+    });
+
+    test('schedules reconnect when connection fails with a delay hint', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      module.simulateConnectionFailed(const Duration(milliseconds: 50));
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(module.connectCount, 2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stop / restart cycle
+  // -------------------------------------------------------------------------
+
+  group('SignalingForegroundIsolateManager -- stop and restart', () {
+    test('disposes module on handleStatus(enabled: false)', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      await manager.handleStatus(enabled: false);
+
+      expect(module.isConnected, isFalse);
+    });
+
+    test('full restart creates a fresh module after stop', () async {
+      final modules = <_FakeSignalingModule>[];
+      int callCount = 0;
+      final manager = SignalingForegroundIsolateManager(
+        coreUrl: 'wss://example.com',
+        tenantId: 'tenant',
+        token: 'tok',
+        moduleFactory: (_) {
+          final m = _FakeSignalingModule();
+          modules.add(m);
+          callCount++;
+          return m;
+        },
+        hubFactory: _FakeSignalingHub.new,
+      );
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      await manager.handleStatus(enabled: false);
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Factory must have been called twice — once per start.
+      expect(callCount, 2);
+      expect(modules[0].connectCount, 1);
+      expect(modules[1].connectCount, 1);
+
+      await manager.handleStatus(enabled: false);
+    });
+  });
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
@@ -198,6 +198,35 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // Manual reconnect cancels pending timer
+  // -------------------------------------------------------------------------
+
+  group('SignalingForegroundIsolateManager -- manual reconnect cancels pending timer', () {
+    test('pending auto-reconnect timer does not fire after manual reconnect via handleStatus(enabled: true)', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Disconnect with a delay hint — schedules a 100 ms auto-reconnect timer.
+      module.simulateDisconnectWithDelay(const Duration(milliseconds: 100));
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      // Before the timer fires, the main isolate triggers a manual reconnect.
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 2); // reconnected once manually
+
+      // Wait past the timer deadline — it must have been cancelled.
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(module.connectCount, 2); // still 2, timer did not fire
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Auto-reconnect via delay hint
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

After turning WiFi off and back on, the signaling WebSocket did not reconnect.

**Root cause - failure chain:**

1. WiFi turns off -> WebSocket closes with code 1002 (protocol error)
2. _reconnectDelay(1002) == null -> background isolate emits SignalingDisconnected(delay: null) -> no auto-reconnect scheduled; _started stays true
3. Main isolate: notifyNetworkUnavailable() -> _module.disconnect() -> no-op by design (WebtritSignalingService.disconnect() keeps the service alive for background calls)
4. WiFi comes back -> notifyNetworkAvailable() -> timer -> _module.connect() -> WebtritSignalingServiceAndroid.start() -> Kotlin sends onSynchronize to background isolate
5. Background isolate: handleStatus(enabled: true) -> _start() -> if (_started) return -> silent no-op; WebSocket never reconnects

The _started flag in SignalingForegroundIsolateManager._start() was intended to prevent duplicate hub/module initialization, but it also blocked reconnection after an unintentional disconnect that does not auto-recover (code 1002).

## Changes

**Fix (_start reconnect):** When _start() is called on an already-initialized manager but the module is no longer connected, cancel any pending reconnect timer and call connect() on the existing module instead of returning silently.

```dart
if (_started) {
  if (!(_signalingModule?.isConnected ?? false)) {
    _reconnectTimer?.cancel();
    _reconnectTimer = null;
    _signalingModule?.connect();
  }
  return;
}
```

Cancelling the timer prevents a race where a pending auto-reconnect timer (from a prior disconnect-with-delay) fires after the manual reconnect and tears down an already-healthy connection.

**Refactor (testability):** Added @visibleForTesting moduleFactory and hubFactory parameters to bypass PluginUtilities handle resolution and IsolateNameServer in unit tests. Extracted _resolveModuleFactory() for readability. Added SignalingHubFactory typedef.

**Tests (9 cases):** initial start, idempotency while connected, reconnect after code-1002 (the bug scenario), pending timer cancelled by manual reconnect, auto-reconnect via delay hint, stop/restart lifecycle.