### PR TITLE
fix: stop signaling service on logout to prevent stale token reconnects

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -139,12 +139,17 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     // TODO(testability): extract this conditional into a SignalingCleanupCoordinator
     // class that takes a SignalingModule and an AppBloc so the logout vs. OS-kill
     // distinction can be unit-tested without building a full widget tree.
+    //
+    // Capture synchronously before any await: AppBloc may transition to
+    // unauthenticated while dispose() is in progress, so checking the status
+    // after the await would give a false negative.
+    final isLogout = _appBloc.state.status == AppLifecycleStatus.teardown;
     try {
       await _signalingModule.dispose();
     } catch (e, st) {
       _logger.warning('_tearDownSignaling: signalingModule.dispose() failed', e, st);
     } finally {
-      if (_appBloc.state.status == AppLifecycleStatus.teardown) {
+      if (isLogout) {
         try {
           await WebtritSignalingService.stopService();
         } catch (e, st) {

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -27,6 +28,8 @@ import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/services/services.dart';
 import 'package:webtrit_phone/utils/utils.dart';
+
+final _logger = Logger('MainShell');
 
 @RoutePage()
 class MainShell extends StatefulWidget {
@@ -136,9 +139,18 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     // TODO(testability): extract this conditional into a SignalingCleanupCoordinator
     // class that takes a SignalingModule and an AppBloc so the logout vs. OS-kill
     // distinction can be unit-tested without building a full widget tree.
-    await _signalingModule.dispose();
-    if (_appBloc.state.status == AppLifecycleStatus.teardown) {
-      await WebtritSignalingService.stopService();
+    try {
+      await _signalingModule.dispose();
+    } catch (e, st) {
+      _logger.warning('_tearDownSignaling: signalingModule.dispose() failed', e, st);
+    } finally {
+      if (_appBloc.state.status == AppLifecycleStatus.teardown) {
+        try {
+          await WebtritSignalingService.stopService();
+        } catch (e, st) {
+          _logger.warning('_tearDownSignaling: stopService() failed', e, st);
+        }
+      }
     }
   }
 

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -133,6 +133,9 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   }
 
   Future<void> _tearDownSignaling() async {
+    // TODO(testability): extract this conditional into a SignalingCleanupCoordinator
+    // class that takes a SignalingModule and an AppBloc so the logout vs. OS-kill
+    // distinction can be unit-tested without building a full widget tree.
     await _signalingModule.dispose();
     if (_appBloc.state.status == AppLifecycleStatus.teardown) {
       await WebtritSignalingService.stopService();

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -136,26 +136,10 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   }
 
   Future<void> _tearDownSignaling() async {
-    // TODO(testability): extract this conditional into a SignalingCleanupCoordinator
-    // class that takes a SignalingModule and an AppBloc so the logout vs. OS-kill
-    // distinction can be unit-tested without building a full widget tree.
-    //
-    // Capture synchronously before any await: AppBloc may transition to
-    // unauthenticated while dispose() is in progress, so checking the status
-    // after the await would give a false negative.
-    final isLogout = _appBloc.state.status == AppLifecycleStatus.teardown;
     try {
       await _signalingModule.dispose();
     } catch (e, st) {
       _logger.warning('_tearDownSignaling: signalingModule.dispose() failed', e, st);
-    } finally {
-      if (isLogout) {
-        try {
-          await WebtritSignalingService.stopService();
-        } catch (e, st) {
-          _logger.warning('_tearDownSignaling: stopService() failed', e, st);
-        }
-      }
     }
   }
 

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -43,6 +43,10 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// The [SessionGuard] instance that handles session expiration and logout.
   late final SessionGuard _sessionGuard;
 
+  /// Stored in [initState] so it remains accessible during [dispose] without
+  /// reading from a potentially deactivated [BuildContext].
+  late final AppBloc _appBloc;
+
   /// Created and connected in [initState] so that the WebSocket handshake
   /// runs in parallel while the widget tree and [CallBloc] are being built.
   /// Late subscribers (including [CallBloc]) receive all buffered session
@@ -88,7 +92,8 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
     // After authentication, regenerate the labels to include core URL and tenant ID in remote logging labels
     context.read<AppLogger>().updateRemoteLabels();
 
-    final session = context.read<AppBloc>().state.session;
+    _appBloc = context.read<AppBloc>();
+    final session = _appBloc.state.session;
     _signalingModule = WebtritSignalingService(
       config: SignalingServiceConfig(
         coreUrl: session.coreUrl!,
@@ -99,12 +104,11 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
       mode: context.read<IncomingCallTypeRepository>().getIncomingCallType().toSignalingServiceMode(),
     )..connect();
 
-    final appBloc = context.read<AppBloc>();
     final notificationsBloc = context.read<NotificationsBloc>();
 
     _sessionGuard = RouterLogoutSessionGuard(
       performLogout: () {
-        appBloc.add(const AppLogoutRequested(reason: AppLogoutReason.serverRejection));
+        _appBloc.add(const AppLogoutRequested(reason: AppLogoutReason.serverRejection));
       },
       onPreLogout: () {
         final notification = ErrorMessageNotification(_sessionExpiredMessage);
@@ -123,9 +127,16 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   void dispose() {
     _disposeSessionGuard();
     _callkeep.tearDown();
-    unawaited(_signalingModule.dispose());
+    unawaited(_tearDownSignaling());
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  Future<void> _tearDownSignaling() async {
+    await _signalingModule.dispose();
+    if (_appBloc.state.status == AppLifecycleStatus.teardown) {
+      await WebtritSignalingService.stopService();
+    }
   }
 
   @override

--- a/lib/features/session_status/view/teardown_screen.dart
+++ b/lib/features/session_status/view/teardown_screen.dart
@@ -27,7 +27,11 @@ class _TeardownScreenState extends State<TeardownScreen> {
     // Stop the native signaling service before session cleanup begins so it
     // stops reconnecting with the stale token immediately. TeardownScreen is
     // only rendered during explicit logout, so no status check is needed here.
-    unawaited(WebtritSignalingService.stopService());
+    unawaited(
+      WebtritSignalingService.stopService().catchError((Object e, StackTrace st) {
+        _logger.warning('stopService failed', e, st);
+      }),
+    );
 
     // Schedule the cleanup event after the widget is mounted.
     // Using addPostFrameCallback ensures the navigation transition

--- a/lib/features/session_status/view/teardown_screen.dart
+++ b/lib/features/session_status/view/teardown_screen.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
+import 'package:webtrit_signaling_service/webtrit_signaling_service.dart' show WebtritSignalingService;
 
 import 'package:webtrit_phone/blocs/app/app_bloc.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
@@ -20,6 +23,11 @@ class _TeardownScreenState extends State<TeardownScreen> {
   void initState() {
     super.initState();
     _logger.fine('TeardownScreen.initState');
+
+    // Stop the native signaling service before session cleanup begins so it
+    // stops reconnecting with the stale token immediately. TeardownScreen is
+    // only rendered during explicit logout, so no status check is needed here.
+    unawaited(WebtritSignalingService.stopService());
 
     // Schedule the cleanup event after the widget is mounted.
     // Using addPostFrameCallback ensures the navigation transition

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -161,4 +161,10 @@ class WebtritSignalingService implements SignalingModule {
 
   /// Switches the service lifecycle mode without restarting the connection.
   static Future<void> updateMode(SignalingServiceMode mode) => SignalingServicePlatform.instance.updateMode(mode);
+
+  /// Stops the native signaling service and clears stored credentials.
+  ///
+  /// Call on explicit user logout to prevent the service from reconnecting
+  /// with a stale token after the session ends. No-op on iOS.
+  static Future<void> stopService() => SignalingServicePlatform.instance.stopService();
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -22,6 +22,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   final List<Function> incomingCallHandles = [];
   final List<SignalingModuleFactory> moduleFactories = [];
   int disposeCount = 0;
+  int stopServiceCount = 0;
 
   void inject(SignalingModuleEvent event) => _eventsController.add(event);
 
@@ -57,6 +58,9 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
     disposeCount++;
     await _eventsController.close();
   }
+
+  @override
+  Future<void> stopService() async => stopServiceCount++;
 }
 
 class _VerifiedFakePlatform extends _FakePlatform with MockPlatformInterfaceMixin {}
@@ -302,6 +306,11 @@ void main() {
     test('updateMode pushBound delegates to platform', () async {
       await WebtritSignalingService.updateMode(SignalingServiceMode.pushBound);
       expect(platform.updatedModes, [SignalingServiceMode.pushBound]);
+    });
+
+    test('stopService delegates to platform', () async {
+      await WebtritSignalingService.stopService();
+      expect(platform.stopServiceCount, 1);
     });
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -113,7 +113,7 @@ class SignalingForegroundService : Service() {
         Log.d(TAG, "onTaskRemoved")
         if (StorageDelegate.isPushBound(applicationContext)) {
             Log.d(TAG, "pushBound mode -- stopping service on task removal")
-            stopSelf()
+            gracefulStop { stopSelf() }
         }
     }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -160,6 +160,61 @@ class SignalingForegroundService : Service() {
     }
 
     // ---------------------------------------------------------------------------
+    // Graceful stop
+    // ---------------------------------------------------------------------------
+
+    /// Sends [PSignalingServiceStatus] with [enabled]=false to the background
+    /// isolate so it can disconnect the WebSocket cleanly before the service
+    /// is destroyed. [onComplete] is invoked once the isolate ACKs the signal
+    /// or after [_gracefulStopTimeoutMs] if no ACK arrives.
+    ///
+    /// If no isolate API is wired up (service not yet started or already torn
+    /// down) [onComplete] is called immediately.
+    internal fun gracefulStop(onComplete: () -> Unit) {
+        val api = _isolateFlutterApi
+        if (api == null) {
+            Log.d(TAG, "gracefulStop: no isolate API, stopping immediately")
+            onComplete()
+            return
+        }
+
+        Log.d(TAG, "gracefulStop: signalling isolate to stop")
+
+        var settled = false
+        val mainHandler = Handler(Looper.getMainLooper())
+
+        fun settle(reason: String) {
+            if (settled) return
+            settled = true
+            Log.d(TAG, "gracefulStop: $reason")
+            onComplete()
+        }
+
+        mainHandler.postDelayed(
+            { settle("timeout after ${_gracefulStopTimeoutMs}ms -- forcing stop") },
+            _gracefulStopTimeoutMs,
+        )
+
+        api.onSynchronize(
+            PSignalingServiceStatus(
+                enabled = false,
+                coreUrl = "",
+                tenantId = "",
+                token = "",
+                trustedCertificatesJson = null,
+                incomingCallHandlerHandle = 0L,
+                moduleFactoryHandle = 0L,
+            ),
+        ) { result ->
+            result.onSuccess { settle("isolate ACKed stop signal") }
+            result.onFailure { e ->
+                Log.w(TAG, "gracefulStop: stop signal failed: $e")
+                settle("isolate stop signal failed")
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
     // Synchronize isolate with retry
     // ---------------------------------------------------------------------------
 
@@ -221,6 +276,9 @@ class SignalingForegroundService : Service() {
         /// Base delay between retries (ms). Actual delay = base * (retryCount + 1).
         /// Attempts fire at ~500ms, ~1000ms, ~1500ms, ~2000ms, ~2500ms.
         private const val _syncRetryBaseDelayMs = 500L
+
+        /// How long [gracefulStop] waits for an isolate ACK before forcing the stop.
+        private const val _gracefulStopTimeoutMs = 3000L
 
         var isRunning = false
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -84,7 +84,12 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
     override fun stopService() {
         Log.d(TAG, "stopService")
         StorageDelegate.clearConnectionConfig(context)
-        SignalingForegroundService.stop(context)
+        val service = SignalingForegroundService.instance
+        if (service != null) {
+            service.gracefulStop { SignalingForegroundService.stop(context) }
+        } else {
+            SignalingForegroundService.stop(context)
+        }
     }
 
     override fun notifyIsolateReady() {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'dart:ui' show PluginUtilities;
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart' show BinaryMessenger;
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -211,6 +211,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
   @override
   Future<void> stopService() async {
+    _logger.info('stopService');
     await _hostApi.stopService();
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'dart:ui' show PluginUtilities;
+import 'package:flutter/services.dart' show BinaryMessenger;
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
@@ -46,7 +48,12 @@ final _logger = Logger('WebtritSignalingServiceAndroid');
 ///        - pushBound: onTaskRemoved -> stopSelf()
 ///        - persistent: service keeps running; BootReceiver restarts after reboot.
 class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
-  WebtritSignalingServiceAndroid._();
+  WebtritSignalingServiceAndroid._({BinaryMessenger? binaryMessenger})
+    : _hostApi = PSignalingServiceHostApi(binaryMessenger: binaryMessenger);
+
+  @visibleForTesting
+  WebtritSignalingServiceAndroid.forTesting({BinaryMessenger? binaryMessenger})
+    : _hostApi = PSignalingServiceHostApi(binaryMessenger: binaryMessenger);
 
   static WebtritSignalingServiceAndroid? _instance;
 
@@ -56,7 +63,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     SignalingServicePlatform.instance = _instance!;
   }
 
-  final _hostApi = PSignalingServiceHostApi();
+  final PSignalingServiceHostApi _hostApi;
 
   StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -202,10 +202,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     await _hostApi.saveModuleFactory(handle.toRawHandle());
   }
 
-  /// Stops the foreground service and clears stored credentials.
-  ///
-  /// Call this on explicit user logout so the service does not keep
-  /// reconnecting with stale tokens after the session ends.
+  @override
   Future<void> stopService() async {
     await _hostApi.stopService();
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   flutter:
     sdk: flutter
   logging: ^1.3.0
-  meta: ^1.16.0
   logging_appenders: ^1.4.0+1
   connectivity_plus: ^7.0.0
   webtrit_signaling:

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   logging: ^1.3.0
+  meta: ^1.16.0
   logging_appenders: ^1.4.0+1
   connectivity_plus: ^7.0.0
   webtrit_signaling:

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_signaling_service_android/src/plugin.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const _stopServiceChannel =
+      'dev.flutter.pigeon.webtrit_signaling_service_android'
+      '.PSignalingServiceHostApi.stopService';
+
+  group('WebtritSignalingServiceAndroid -- stopService()', () {
+    late WebtritSignalingServiceAndroid plugin;
+
+    setUp(() {
+      plugin = WebtritSignalingServiceAndroid.forTesting();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        _stopServiceChannel,
+        null,
+      );
+    });
+
+    test('calls the host API stopService channel', () async {
+      var called = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(_stopServiceChannel, (
+        message,
+      ) async {
+        called = true;
+        return const StandardMessageCodec().encodeMessage(<Object?>[null]);
+      });
+
+      await plugin.stopService();
+
+      expect(called, isTrue);
+    });
+
+    test('does not call stopService channel on dispose', () async {
+      var stopCalled = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(_stopServiceChannel, (
+        message,
+      ) async {
+        stopCalled = true;
+        return const StandardMessageCodec().encodeMessage(<Object?>[null]);
+      });
+
+      await plugin.dispose();
+
+      expect(stopCalled, isFalse);
+    });
+  });
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -6,7 +6,7 @@ import 'package:webtrit_signaling_service_android/src/plugin.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  const _stopServiceChannel =
+  const stopServiceChannel =
       'dev.flutter.pigeon.webtrit_signaling_service_android'
       '.PSignalingServiceHostApi.stopService';
 
@@ -18,15 +18,12 @@ void main() {
     });
 
     tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
-        _stopServiceChannel,
-        null,
-      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(stopServiceChannel, null);
     });
 
     test('calls the host API stopService channel', () async {
       var called = false;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(_stopServiceChannel, (
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(stopServiceChannel, (
         message,
       ) async {
         called = true;
@@ -40,7 +37,7 @@ void main() {
 
     test('does not call stopService channel on dispose', () async {
       var stopCalled = false;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(_stopServiceChannel, (
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(stopServiceChannel, (
         message,
       ) async {
         stopCalled = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -78,4 +78,11 @@ abstract class SignalingServicePlatform extends PlatformInterface {
 
   /// Stops the service and releases all resources.
   Future<void> dispose();
+
+  /// Stops the native signaling service and clears stored credentials.
+  ///
+  /// Call on explicit user logout to prevent the service from reconnecting
+  /// with a stale token after the session ends. No-op on platforms that
+  /// do not run a persistent background service (e.g. iOS).
+  Future<void> stopService() async {}
 }

--- a/test/features/session_status/view/teardown_screen_test.dart
+++ b/test/features/session_status/view/teardown_screen_test.dart
@@ -1,0 +1,89 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+// ignore: depend_on_referenced_packages
+import 'package:plugin_platform_interface/plugin_platform_interface.dart' show MockPlatformInterfaceMixin;
+// ignore: depend_on_referenced_packages
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart'
+    show SignalingServicePlatform;
+
+import 'package:webtrit_phone/blocs/app/app_bloc.dart';
+import 'package:webtrit_phone/features/session_status/view/teardown_screen.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes / Mocks
+// ---------------------------------------------------------------------------
+
+class _MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {}
+
+/// Fake platform that records the order in which operations are invoked.
+/// Shared [callLog] lets tests verify ordering across stopService and add().
+class _FakePlatform extends Fake with MockPlatformInterfaceMixin implements SignalingServicePlatform {
+  final List<String> callLog = [];
+
+  @override
+  Future<void> stopService() async => callLog.add('stopService');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Widget _buildSubject(_MockAppBloc appBloc) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: BlocProvider<AppBloc>.value(value: appBloc, child: const TeardownScreen()),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late _MockAppBloc appBloc;
+  late _FakePlatform platform;
+
+  setUpAll(() {
+    registerFallbackValue(const AppCleanupRequested());
+  });
+
+  setUp(() {
+    appBloc = _MockAppBloc();
+    platform = _FakePlatform();
+    SignalingServicePlatform.instance = platform;
+  });
+
+  group('TeardownScreen', () {
+    testWidgets('calls stopService() during initState', (tester) async {
+      await tester.pumpWidget(_buildSubject(appBloc));
+
+      expect(platform.callLog, contains('stopService'));
+    });
+
+    testWidgets('dispatches AppCleanupRequested on the first frame', (tester) async {
+      await tester.pumpWidget(_buildSubject(appBloc));
+      await tester.pump(); // flush addPostFrameCallback
+
+      verify(() => appBloc.add(const AppCleanupRequested())).called(1);
+    });
+
+    testWidgets('stopService() is called before AppCleanupRequested', (tester) async {
+      when(() => appBloc.add(any())).thenAnswer((invocation) {
+        if (invocation.positionalArguments.first is AppCleanupRequested) {
+          platform.callLog.add('AppCleanupRequested');
+        }
+      });
+
+      await tester.pumpWidget(_buildSubject(appBloc));
+      await tester.pump();
+
+      expect(platform.callLog, ['stopService', 'AppCleanupRequested']);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On Android the Kotlin foreground signaling service kept reconnecting with an expired token after logout. Root cause: `dispose()` only tore down the Dart-side hub — the native service stayed alive and its background isolate kept retrying the WebSocket with the stale token. The same issue caused delayed FCM push delivery after swiping the app in pushBound mode (server did not receive a clean WebSocket close).

## How it works

The WebSocket lives exclusively in a background Dart isolate inside the Kotlin foreground service. The main isolate connects to it via `HubConnectionManager` / `IsolateNameServer` — calling `dispose()` only closes that Dart-side listener, it does not touch the isolate or the socket.

To stop the service and disconnect cleanly:
1. Kotlin sends `onSynchronize(enabled=false)` to the background isolate via Pigeon.
2. The isolate runs `_stop()` → `signalingModule.dispose()` → `client.disconnect()` → WebSocket close frame.
3. Only after the ACK (or a 3 s timeout) does Kotlin call `stopSelf()`.

## Cases fixed

| Case | Trigger | Fix |
|---|---|---|
| Logout — stale token reconnects | `TeardownScreen.initState()` | Calls `WebtritSignalingService.stopService()` synchronously before `AppCleanupRequested` is dispatched |
| Swipe app (pushBound mode) — dirty disconnect | `onTaskRemoved()` | Calls `gracefulStop { stopSelf() }` instead of bare `stopSelf()` |

## Changes

- `SignalingServicePlatform` — add `stopService()` default no-op (safe for iOS / other platforms)
- `WebtritSignalingService` — expose `static stopService()` helper
- `WebtritSignalingServiceAndroid.stopService()` — add `@override` + log line
- `SignalingForegroundService` — add `gracefulStop(onComplete)`: sends `enabled=false` to isolate, waits for ACK up to 3 s, then calls `onComplete`; used in both `stopService()` plugin method and `onTaskRemoved()`
- `WebtritSignalingServicePlugin.stopService()` — delegate to `gracefulStop { stop(context) }` instead of stopping immediately
- `SignalingForegroundService.onTaskRemoved()` — replace `stopSelf()` with `gracefulStop { stopSelf() }` (pushBound mode)
- `TeardownScreen.initState()` — call `unawaited(WebtritSignalingService.stopService())` before scheduling `AppCleanupRequested`; `TeardownScreen` is rendered exclusively during logout so no status check needed
- `MainShell._tearDownSignaling()` — simplified to only `signalingModule.dispose()`; `stopService` responsibility moved to `TeardownScreen`

## Tests

- `signaling_service_test.dart` — `stopService` delegates to platform
- `plugin_test.dart` — `stopService` calls Pigeon channel; `dispose` does NOT call it
- `teardown_screen_test.dart` — `stopService` called during `initState`; `AppCleanupRequested` dispatched on first frame; `stopService` precedes `AppCleanupRequested` (ordering)

## Test plan

- [ ] Login → logout → verify no further reconnect attempts in logcat after teardown
- [ ] Login → logout → login to a different server → signaling connects with the new token
- [ ] Swipe app from recents (pushBound mode) → verify "disconnected" appears in logcat
- [ ] Swipe app from recents (persistent mode) → service keeps running, incoming calls still arrive
- [ ] Session expiry logout (`serverRejection`) → same behaviour as explicit logout