### PR TITLE
fix(signaling): eliminate 1s call-setup delay in notifyForceReconnect (WT-1239)

### DIFF
--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -123,7 +123,7 @@ class SignalingReconnectController {
   /// WebSocket ready as fast as possible; any delay here directly adds latency
   /// before the SDP offer reaches the server.
   ///
-  /// Note: spurious "connection failed" toast suppression (WT-1221) is handled
+  /// Spurious "connection failed" toasts on transient failures are suppressed
   /// by the consecutive-failure threshold, not by this delay, so reducing the
   /// delay here is safe.
   void notifyForceReconnect() {

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -117,9 +117,18 @@ class SignalingReconnectController {
   /// Call when the app needs an immediate reconnect regardless of lifecycle
   /// state - e.g. when a new active call appears while the app is in the
   /// background and the signaling client is not connected.
+  ///
+  /// Uses [Duration.zero] so the reconnect fires in the next event-loop tick.
+  /// Callers (outgoing call start, incoming call answer from push) need the
+  /// WebSocket ready as fast as possible; any delay here directly adds latency
+  /// before the SDP offer reaches the server.
+  ///
+  /// Note: spurious "connection failed" toast suppression (WT-1221) is handled
+  /// by the consecutive-failure threshold, not by this delay, so reducing the
+  /// delay here is safe.
   void notifyForceReconnect() {
     _logger.fine('notifyForceReconnect');
-    _scheduleReconnect(kSignalingClientFastReconnectDelay, force: true);
+    _scheduleReconnect(Duration.zero, force: true);
   }
 
   /// Call when active-call presence changes while the app may be in the

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -450,7 +450,8 @@ void main() {
         controller.notifyAppPaused(hasActiveCalls: false);
         controller.notifyForceReconnect();
 
-        async.elapse(kSignalingClientFastReconnectDelay);
+        // Must fire immediately, not after kSignalingClientFastReconnectDelay.
+        async.elapse(Duration.zero);
         expect(module.connectCalls, 1);
       });
     });
@@ -466,8 +467,115 @@ void main() {
         controller.notifyNetworkUnavailable();
         controller.notifyForceReconnect();
 
-        async.elapse(kSignalingClientFastReconnectDelay);
+        // Must fire immediately, not after kSignalingClientFastReconnectDelay.
+        async.elapse(Duration.zero);
         expect(module.connectCalls, 1);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Force reconnect — timing (WT-1239)
+  //
+  // notifyForceReconnect is called when an active call needs signaling urgently
+  // (outgoing call start, incoming call answer from push). A 1-second delay
+  // before reconnect makes calls placed immediately after screen unlock appear
+  // to hang for ~2 s before the server receives the SDP offer.
+  //
+  // Expected fix: notifyForceReconnect uses Duration.zero so connect() fires
+  // in the next event-loop tick, not after kSignalingClientFastReconnectDelay.
+  // -------------------------------------------------------------------------
+
+  group('SignalingReconnectController - notifyForceReconnect timing (WT-1239)', () {
+    // Regression test — currently FAILS, passes after the fix.
+    test('reconnects immediately (Duration.zero), not after kSignalingClientFastReconnectDelay', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = false;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyForceReconnect();
+
+        // connect() must fire in the current event-loop tick (Duration.zero timer),
+        // not after the full kSignalingClientFastReconnectDelay = 1 s.
+        expect(module.connectCalls, 0, reason: 'timer not yet fired synchronously');
+        async.elapse(Duration.zero);
+        expect(module.connectCalls, 1);
+      });
+    });
+
+    // Full screen-unlock → immediate-call scenario (WT-1239).
+    //
+    // Reproduces the sequence from the bug log:
+    //   screen lock  → signaling intentionally disconnected
+    //   screen unlock → notifyAppResumed schedules 1 s reconnect timer
+    //   user taps    → notifyForceReconnect must NOT reset the timer to another
+    //                   full second; it must connect NOW.
+    test('screen unlock → immediate call: connect fires before kSignalingClientFastReconnectDelay', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = false;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        // Screen locked — signaling disconnects intentionally (code 1000, no reconnect).
+        controller.notifyAppPaused(hasActiveCalls: false);
+
+        // Screen unlocked — schedules fast reconnect in kSignalingClientFastReconnectDelay.
+        controller.notifyAppResumed();
+
+        // User taps a recent call ~200 ms after unlock,
+        // well before the notifyAppResumed timer would fire.
+        async.elapse(const Duration(milliseconds: 200));
+        expect(module.connectCalls, 0, reason: 'notifyAppResumed 1 s timer not yet elapsed');
+
+        // Outgoing call started — signaling needed urgently.
+        controller.notifyForceReconnect();
+
+        // connect() must fire immediately, not after another full second.
+        async.elapse(Duration.zero);
+        expect(module.connectCalls, 1, reason: 'force reconnect for an outgoing call must be immediate');
+
+        // The notifyAppResumed timer was cancelled by notifyForceReconnect;
+        // no second connect() call should happen when that duration elapses.
+        async.elapse(kSignalingClientFastReconnectDelay);
+        expect(module.connectCalls, 1, reason: 'cancelled notifyAppResumed timer must not fire separately');
+      });
+    });
+
+    // Verifies that reducing the delay to Duration.zero does NOT re-introduce
+    // the spurious "Connecting to the core failed" toast fixed in WT-1221.
+    //
+    // The toast is suppressed by the consecutive-failure threshold (≥ 2),
+    // which is independent of the reconnect delay.
+    test('first connect failure after immediate reconnect does not trigger toast (WT-1221 guard)', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = false;
+        int notifyCount = 0;
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: () => notifyCount++,
+          notifyAfterConsecutiveFailures: 2,
+        );
+        addTearDown(controller.dispose);
+
+        // Screen unlock + immediate outgoing call.
+        controller.notifyAppPaused(hasActiveCalls: false);
+        controller.notifyAppResumed();
+        controller.notifyForceReconnect();
+        async.elapse(Duration.zero);
+        expect(module.connectCalls, 1);
+
+        // Transient DNS failure on the first attempt (e.g. post-unlock glitch).
+        module.emit(_failed());
+
+        // Toast must NOT appear — only 1 failure, threshold is 2.
+        expect(notifyCount, 0, reason: 'WT-1221: spurious toast must be suppressed on first failure');
       });
     });
   });

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -475,19 +475,16 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // Force reconnect — timing (WT-1239)
+  // Force reconnect — timing
   //
   // notifyForceReconnect is called when an active call needs signaling urgently
   // (outgoing call start, incoming call answer from push). A 1-second delay
   // before reconnect makes calls placed immediately after screen unlock appear
   // to hang for ~2 s before the server receives the SDP offer.
   //
-  // Expected fix: notifyForceReconnect uses Duration.zero so connect() fires
-  // in the next event-loop tick, not after kSignalingClientFastReconnectDelay.
   // -------------------------------------------------------------------------
 
-  group('SignalingReconnectController - notifyForceReconnect timing (WT-1239)', () {
-    // Regression test — currently FAILS, passes after the fix.
+  group('SignalingReconnectController - notifyForceReconnect timing', () {
     test('reconnects immediately (Duration.zero), not after kSignalingClientFastReconnectDelay', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
@@ -498,15 +495,15 @@ void main() {
 
         controller.notifyForceReconnect();
 
-        // connect() must fire in the current event-loop tick (Duration.zero timer),
-        // not after the full kSignalingClientFastReconnectDelay = 1 s.
+        // connect() must be scheduled for the next event-loop iteration via a
+        // Duration.zero timer, not after the full kSignalingClientFastReconnectDelay = 1 s.
         expect(module.connectCalls, 0, reason: 'timer not yet fired synchronously');
         async.elapse(Duration.zero);
         expect(module.connectCalls, 1);
       });
     });
 
-    // Full screen-unlock → immediate-call scenario (WT-1239).
+    // Full screen-unlock → immediate-call scenario.
     //
     // Reproduces the sequence from the bug log:
     //   screen lock  → signaling intentionally disconnected
@@ -547,11 +544,11 @@ void main() {
     });
 
     // Verifies that reducing the delay to Duration.zero does NOT re-introduce
-    // the spurious "Connecting to the core failed" toast fixed in WT-1221.
+    // spurious "connection failed" toasts on transient failures.
     //
-    // The toast is suppressed by the consecutive-failure threshold (≥ 2),
+    // Toasts are suppressed by the consecutive-failure threshold (≥ 2),
     // which is independent of the reconnect delay.
-    test('first connect failure after immediate reconnect does not trigger toast (WT-1221 guard)', () {
+    test('first connect failure after immediate reconnect does not trigger toast', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -575,7 +572,7 @@ void main() {
         module.emit(_failed());
 
         // Toast must NOT appear — only 1 failure, threshold is 2.
-        expect(notifyCount, 0, reason: 'WT-1221: spurious toast must be suppressed on first failure');
+        expect(notifyCount, 0, reason: 'spurious toast must be suppressed on first failure');
       });
     });
   });


### PR DESCRIPTION
## Problem

When the user locks the screen mid-session, the signaling WebSocket is intentionally disconnected (code 1000). On the next unlock + tap-to-call sequence, `notifyForceReconnect()` scheduled the reconnect with `kSignalingClientFastReconnectDelay` (1 s). This caused a visible **~1 s "Connecting to signaling" spinner** before the SDP offer could be sent to the server — degrading call-setup latency every time the device was unlocked.

Root cause tracked in WT-1239.

## Fix

`notifyForceReconnect()` now passes `Duration.zero` to `_scheduleReconnect`, so the WebSocket reconnect is scheduled in the next event-loop tick instead of after 1 s.

**Why this is safe (WT-1221):**
The spurious "connection failed" toast suppression added in WT-1221 is controlled by the *consecutive-failure threshold* (`notifyAfterConsecutiveFailures`), not by the reconnect delay. The 1 s delay was a copy-paste of the value used by `notifyAppResumed` (a proactive, non-urgent reconnect). Force-reconnect callers (outgoing call start, push-answer) need the socket ready as fast as possible.

`notifyAppResumed()` keeps its 1 s delay — it is a proactive background reconnect with no urgency.

## Tests

Three regression tests added in `signaling_reconnect_controller_test.dart` (`notifyForceReconnect timing (WT-1239)` group):

1. **Timing regression** — `notifyForceReconnect` fires on `Duration.zero`, not `kSignalingClientFastReconnectDelay`
2. **Screen-unlock → call scenario** — full pause/resume/force-reconnect sequence; confirms cancelled `notifyAppResumed` timer does not fire a second `connect()`
3. **WT-1221 guard** — first failure after immediate reconnect does not trigger a toast

TDD cycle: 5 tests failed (RED) before fix, all 33 tests pass (GREEN) after.

## Checklist

- [x] Unit tests added / updated
- [x] No change to `notifyAppResumed` delay (proactive reconnect, not urgent)
- [x] WT-1221 toast suppression verified still intact