### PR TITLE
fix: audio routing if only one device (e.g avd simulator) (WT-1097)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1676,7 +1676,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       final callBeingTransferred = state.retrieveActiveCall(callId);
 
       if (callBeingTransferred?.speakerOnBeforeMinimize == true) {
-        add(CallControlEvent.audioDeviceSet(callId, state.availableAudioDevices.getSpeaker));
+        final speakerDevice = state.availableAudioDevices.getSpeaker;
+        if (speakerDevice != null) {
+          add(CallControlEvent.audioDeviceSet(callId, speakerDevice));
+        }
       }
 
       // After request succesfully submitted, transfer flow will continue
@@ -2502,7 +2505,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       await callkeep.reportUpdateCall(currentCall.callId, proximityEnabled: state.shouldListenToProximity);
 
       if (currentCall.speakerOnBeforeMinimize == true) {
-        add(CallControlEvent.audioDeviceSet(currentCall.callId, state.availableAudioDevices.getSpeaker));
+        final speakerDevice = state.availableAudioDevices.getSpeaker;
+        if (speakerDevice != null) {
+          add(CallControlEvent.audioDeviceSet(currentCall.callId, speakerDevice));
+        }
       }
     } else {
       _logger.warning('__onCallScreenEventDidPush: activeCalls is empty');

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1679,6 +1679,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         final speakerDevice = state.availableAudioDevices.getSpeaker;
         if (speakerDevice != null) {
           add(CallControlEvent.audioDeviceSet(callId, speakerDevice));
+        } else {
+          _logger.warning(
+            '_onCallControlEventBlindTransferSubmitted: speaker was on before minimize but its not available now',
+          );
         }
       }
 
@@ -2508,6 +2512,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         final speakerDevice = state.availableAudioDevices.getSpeaker;
         if (speakerDevice != null) {
           add(CallControlEvent.audioDeviceSet(currentCall.callId, speakerDevice));
+        } else {
+          _logger.warning(
+            '_onCallControlEventBlindTransferSubmitted: speaker was on before minimize but its not available now',
+          );
         }
       }
     } else {

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -345,7 +345,7 @@ extension CallAudioDeviceIterableExtension<T extends CallAudioDevice> on Iterabl
   bool get onlyBuiltIn =>
       every((device) => device.type == CallAudioDeviceType.earpiece || device.type == CallAudioDeviceType.speaker);
 
-  T get getSpeaker => firstWhere((device) => device.type == CallAudioDeviceType.speaker);
+  T? get getSpeaker => firstWhereOrNull((device) => device.type == CallAudioDeviceType.speaker);
 
-  T get getEarpiece => firstWhere((device) => device.type == CallAudioDeviceType.earpiece);
+  T? get getEarpiece => firstWhereOrNull((device) => device.type == CallAudioDeviceType.earpiece);
 }

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -373,11 +373,15 @@ class _CallActionsState extends State<CallActions> {
                   ? context.l10n.call_CallActionsTooltip_disableSpeaker
                   : context.l10n.call_CallActionsTooltip_enableSpeaker,
               child: TextButton(
-                onPressed: () => onAudioDeviceChanged?.call(
-                  (speakerOn ?? false)
-                      ? widget.availableAudioDevices.getEarpiece
-                      : widget.availableAudioDevices.getSpeaker,
-                ),
+                onPressed: () {
+                  final speakerDevice = widget.availableAudioDevices.getSpeaker;
+                  final earpieceDevice = widget.availableAudioDevices.getEarpiece;
+                  if (speakerOn == true) {
+                    if (earpieceDevice != null) onAudioDeviceChanged?.call(earpieceDevice);
+                  } else {
+                    if (speakerDevice != null) onAudioDeviceChanged?.call(speakerDevice);
+                  }
+                },
                 statesController: _speakerStatesController..update(WidgetState.selected, speakerOn ?? false),
                 style: widget.style?.speaker,
                 child: Icon((speakerOn ?? false) ? Icons.volume_up : Icons.phone_in_talk, size: actionPadIconSize),

--- a/lib/features/call/widgets/call_actions.dart
+++ b/lib/features/call/widgets/call_actions.dart
@@ -1,8 +1,9 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:webtrit_phone/app/keys.dart';
+import 'package:logging/logging.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -11,6 +12,8 @@ import 'package:webtrit_phone/widgets/widgets.dart';
 
 export 'call_actions_style.dart';
 export 'call_actions_styles.dart';
+
+final _logger = Logger('CallActions');
 
 class CallActions extends StatefulWidget {
   const CallActions({
@@ -377,9 +380,17 @@ class _CallActionsState extends State<CallActions> {
                   final speakerDevice = widget.availableAudioDevices.getSpeaker;
                   final earpieceDevice = widget.availableAudioDevices.getEarpiece;
                   if (speakerOn == true) {
-                    if (earpieceDevice != null) onAudioDeviceChanged?.call(earpieceDevice);
+                    if (earpieceDevice != null) {
+                      onAudioDeviceChanged?.call(earpieceDevice);
+                    } else {
+                      _logger.warning('Earpiece device not found while trying to disable speakerphone');
+                    }
                   } else {
-                    if (speakerDevice != null) onAudioDeviceChanged?.call(speakerDevice);
+                    if (speakerDevice != null) {
+                      onAudioDeviceChanged?.call(speakerDevice);
+                    } else {
+                      _logger.warning('Speaker device not found while trying to enable speakerphone');
+                    }
                   }
                 },
                 statesController: _speakerStatesController..update(WidgetState.selected, speakerOn ?? false),


### PR DESCRIPTION
This pull request improves the handling of audio device selection for calls by making the retrieval of speaker and earpiece devices null-safe.
This prevents potential crashes if the desired device is not available and ensures that UI actions and call state transitions only attempt to use available devices.