### PR TITLE
fix: avoid Vulkan/Impeller init in signaling background engine

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -1,6 +1,6 @@
 import 'dart:ui' show RootIsolateToken;
 
-import 'package:flutter/services.dart' show BackgroundIsolateBinaryMessenger;
+import 'package:flutter/services.dart' show BackgroundIsolateBinaryMessenger, BinaryMessenger;
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
 import 'package:logging_appenders/logging_appenders.dart';
@@ -27,34 +27,39 @@ void signalingServiceCallbackDispatcher() {
   PrintAppender(formatter: const ColorFormatter()).attachToLogger(Logger.root);
 
   _logger.info('signalingServiceCallbackDispatcher: background isolate starting');
-  _ensureBindingInitialized();
-  PSignalingServiceFlutterApi.setUp(_SignalingFlutterApiHandler());
+  final messenger = _ensureBinaryMessengerInitialized();
+  PSignalingServiceFlutterApi.setUp(_SignalingFlutterApiHandler(), binaryMessenger: messenger);
   // Notify Kotlin that the Dart isolate has registered its handler and is ready
   // to receive onSynchronize calls. This resolves the race where Kotlin calls
   // synchronizeIsolate() before the Dart handler is registered
   // (executeDartCallback is async -- the Dart isolate starts after Kotlin has
   // already tried to call onSynchronize).
-  PSignalingServiceHostApi().notifyIsolateReady();
+  PSignalingServiceHostApi(binaryMessenger: messenger).notifyIsolateReady();
   _logger.info('signalingServiceCallbackDispatcher: notifyIsolateReady sent, waiting for onSynchronize');
 }
 
 /// Initialises a [BinaryMessenger] for platform channels in this background
 /// isolate without touching the full Flutter rendering stack.
 ///
-/// Uses [BackgroundIsolateBinaryMessenger] when [RootIsolateToken.instance] is
-/// available (background engine root isolate) to avoid initialising
-/// RendererBinding / Impeller / Vulkan. The full [WidgetsFlutterBinding] is
-/// kept as a fallback for environments where the token is unexpectedly absent.
-void _ensureBindingInitialized() {
+/// Returns [BackgroundIsolateBinaryMessenger.instance] when
+/// [RootIsolateToken.instance] is available (background engine root isolate),
+/// avoiding RendererBinding / Impeller / Vulkan initialisation. Falls back to
+/// [WidgetsFlutterBinding] and returns `null` (Pigeon uses the binding's
+/// default messenger) when the token is unexpectedly absent.
+BinaryMessenger? _ensureBinaryMessengerInitialized() {
   final token = RootIsolateToken.instance;
   if (token != null) {
     BackgroundIsolateBinaryMessenger.ensureInitialized(token);
-    _logger.info('_ensureBindingInitialized: BackgroundIsolateBinaryMessenger initialised');
+    _logger.info('_ensureBinaryMessengerInitialized: BackgroundIsolateBinaryMessenger initialised');
+    return BackgroundIsolateBinaryMessenger.instance;
   } else {
     // Fallback: token is unexpectedly absent. Full binding initialization
     // includes Vulkan/Impeller and may be slow after device inactivity.
-    _logger.warning('_ensureBindingInitialized: RootIsolateToken unavailable, falling back to WidgetsFlutterBinding');
+    _logger.warning(
+      '_ensureBinaryMessengerInitialized: RootIsolateToken unavailable, falling back to WidgetsFlutterBinding',
+    );
     WidgetsFlutterBinding.ensureInitialized();
+    return null;
   }
 }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -17,12 +17,6 @@ final _logger = Logger('SignalingEntryPoint');
 /// registers the [PSignalingServiceFlutterApi] handler so Kotlin can send
 /// [onSynchronize] calls into this isolate.
 ///
-/// Uses [BackgroundIsolateBinaryMessenger] when [RootIsolateToken.instance] is
-/// available (background engine root isolate) to avoid initialising the full
-/// Flutter rendering stack (Vulkan / Impeller). The full
-/// [WidgetsFlutterBinding] is kept as a fallback for environments where the
-/// token is unexpectedly absent.
-///
 /// The raw handle for this function is stored in [StorageDelegate] and obtained
 /// in the main isolate via [PluginUtilities.getCallbackHandle] before calling
 /// [PSignalingServiceHostApi.initializeServiceCallback].
@@ -33,22 +27,7 @@ void signalingServiceCallbackDispatcher() {
   PrintAppender(formatter: const ColorFormatter()).attachToLogger(Logger.root);
 
   _logger.info('signalingServiceCallbackDispatcher: background isolate starting');
-
-  final token = RootIsolateToken.instance;
-  if (token != null) {
-    // Lightweight path: sets up a BinaryMessenger for platform channels
-    // without initialising RendererBinding / Impeller / Vulkan.
-    BackgroundIsolateBinaryMessenger.ensureInitialized(token);
-    _logger.info('signalingServiceCallbackDispatcher: BackgroundIsolateBinaryMessenger initialised');
-  } else {
-    // Fallback: token is unexpectedly absent. Full binding initialization
-    // includes Vulkan/Impeller and may be slow after device inactivity.
-    _logger.warning(
-      'signalingServiceCallbackDispatcher: RootIsolateToken unavailable, falling back to WidgetsFlutterBinding',
-    );
-    WidgetsFlutterBinding.ensureInitialized();
-  }
-
+  _ensureBindingInitialized();
   PSignalingServiceFlutterApi.setUp(_SignalingFlutterApiHandler());
   // Notify Kotlin that the Dart isolate has registered its handler and is ready
   // to receive onSynchronize calls. This resolves the race where Kotlin calls
@@ -57,6 +36,26 @@ void signalingServiceCallbackDispatcher() {
   // already tried to call onSynchronize).
   PSignalingServiceHostApi().notifyIsolateReady();
   _logger.info('signalingServiceCallbackDispatcher: notifyIsolateReady sent, waiting for onSynchronize');
+}
+
+/// Initialises a [BinaryMessenger] for platform channels in this background
+/// isolate without touching the full Flutter rendering stack.
+///
+/// Uses [BackgroundIsolateBinaryMessenger] when [RootIsolateToken.instance] is
+/// available (background engine root isolate) to avoid initialising
+/// RendererBinding / Impeller / Vulkan. The full [WidgetsFlutterBinding] is
+/// kept as a fallback for environments where the token is unexpectedly absent.
+void _ensureBindingInitialized() {
+  final token = RootIsolateToken.instance;
+  if (token != null) {
+    BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+    _logger.info('_ensureBindingInitialized: BackgroundIsolateBinaryMessenger initialised');
+  } else {
+    // Fallback: token is unexpectedly absent. Full binding initialization
+    // includes Vulkan/Impeller and may be slow after device inactivity.
+    _logger.warning('_ensureBindingInitialized: RootIsolateToken unavailable, falling back to WidgetsFlutterBinding');
+    WidgetsFlutterBinding.ensureInitialized();
+  }
 }
 
 /// Kotlin -> Dart Pigeon bridge for the signaling foreground service.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -1,3 +1,6 @@
+import 'dart:ui' show RootIsolateToken;
+
+import 'package:flutter/services.dart' show BackgroundIsolateBinaryMessenger;
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
 import 'package:logging_appenders/logging_appenders.dart';
@@ -10,8 +13,15 @@ final _logger = Logger('SignalingEntryPoint');
 /// Step 1 -- Dart callback executed by [FlutterEngineHelper] when the
 /// background engine first starts.
 ///
-/// Initialises Flutter bindings and registers the [PSignalingServiceFlutterApi]
-/// handler so Kotlin can send [onSignalingServiceSync] calls into this isolate.
+/// Initialises a binary messenger so that Pigeon platform channels work, then
+/// registers the [PSignalingServiceFlutterApi] handler so Kotlin can send
+/// [onSynchronize] calls into this isolate.
+///
+/// Uses [BackgroundIsolateBinaryMessenger] when [RootIsolateToken.instance] is
+/// available (background engine root isolate) to avoid initialising the full
+/// Flutter rendering stack (Vulkan / Impeller). The full
+/// [WidgetsFlutterBinding] is kept as a fallback for environments where the
+/// token is unexpectedly absent.
 ///
 /// The raw handle for this function is stored in [StorageDelegate] and obtained
 /// in the main isolate via [PluginUtilities.getCallbackHandle] before calling
@@ -23,7 +33,22 @@ void signalingServiceCallbackDispatcher() {
   PrintAppender(formatter: const ColorFormatter()).attachToLogger(Logger.root);
 
   _logger.info('signalingServiceCallbackDispatcher: background isolate starting');
-  WidgetsFlutterBinding.ensureInitialized();
+
+  final token = RootIsolateToken.instance;
+  if (token != null) {
+    // Lightweight path: sets up a BinaryMessenger for platform channels
+    // without initialising RendererBinding / Impeller / Vulkan.
+    BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+    _logger.info('signalingServiceCallbackDispatcher: BackgroundIsolateBinaryMessenger initialised');
+  } else {
+    // Fallback: token is unexpectedly absent. Full binding initialization
+    // includes Vulkan/Impeller and may be slow after device inactivity.
+    _logger.warning(
+      'signalingServiceCallbackDispatcher: RootIsolateToken unavailable, falling back to WidgetsFlutterBinding',
+    );
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
   PSignalingServiceFlutterApi.setUp(_SignalingFlutterApiHandler());
   // Notify Kotlin that the Dart isolate has registered its handler and is ready
   // to receive onSynchronize calls. This resolves the race where Kotlin calls


### PR DESCRIPTION
## Overview

In `pushBound` mode the signaling WebSocket runs inside an Android foreground service that starts a separate Flutter engine (background isolate). The Dart entry point of that engine — `signalingServiceCallbackDispatcher` — used `WidgetsFlutterBinding.ensureInitialized()` to set up platform channels required by Pigeon.

`WidgetsFlutterBinding` initialises the full rendering stack (`RendererBinding` → Impeller → Vulkan). A background Flutter engine has no rendering surface and does not need any of that — it only needs a `BinaryMessenger` to communicate over platform channels.

## Changes

**Replace binding initialisation:**
`WidgetsFlutterBinding.ensureInitialized()` → `BackgroundIsolateBinaryMessenger.ensureInitialized(token)`, which sets up only a `BinaryMessenger` without touching the rendering stack. `WidgetsFlutterBinding` is retained as a fallback when the token is unexpectedly absent.

**Extract helper and pass messenger explicitly:**
The initialisation is extracted into `_ensureBinaryMessengerInitialized()` which returns `BinaryMessenger?`. The result is passed explicitly to both `PSignalingServiceFlutterApi.setUp(binaryMessenger: ...)` and `PSignalingServiceHostApi(binaryMessenger: ...)`, removing the implicit dependency on `ServicesBinding.defaultBinaryMessenger`.

The helper name reflects what it actually does — sets up a `BinaryMessenger`, not a Flutter binding.

## Files changed

- `packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart`

## Test plan

- [ ] Build and install a debug APK
- [ ] Log in, make a call to confirm signaling works normally
- [ ] Confirm logcat shows `BackgroundIsolateBinaryMessenger initialised` from the background isolate thread (no Impeller/Vulkan init)
- [ ] Confirm `synchronizeIsolate succeeded` appears in logcat within 1–2 s of service start