### PR TITLE
refactor(WT-1221): centralize disconnect notification decisions in SignalingReconnectController

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -127,7 +127,23 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     _reconnectController = SignalingReconnectController(
       signalingModule: signalingModule,
-      onConnectionFailed: () => submitNotification(const SignalingConnectFailedNotification()),
+      onConnectionFailed: (knownCode) {
+        final Notification notification;
+        switch (knownCode) {
+          case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
+          case SignalingDisconnectCode.controllerForceAttachClose:
+            // Silent reconnect — these codes are expected during background/lock-screen
+            // scenarios or duplicate-session cleanup. Don't disturb the user.
+            return;
+          case SignalingDisconnectCode.sessionMissedError:
+            notification = const SignalingSessionMissedNotification();
+          case null:
+            notification = const SignalingConnectFailedNotification();
+          default:
+            notification = SignalingDisconnectNotification(knownCode: knownCode);
+        }
+        submitNotification(notification);
+      },
       onConnectionPresenceChanged: (isAvailable) =>
           _logger.info('signaling presence changed: isAvailable=$isAvailable'),
     );
@@ -665,7 +681,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     Emitter<CallState> emit,
   ) async {
     final code = SignalingDisconnectCode.values.byCode(event.code ?? -1);
-    final repeated = event.code == state.callServiceState.lastSignalingDisconnectCode;
+
+    // Notification decisions are handled by [_reconnectController.onConnectionFailed].
+    // This method only updates [CallState].
 
     CallState newState = state.copyWith(
       callServiceState: state.callServiceState.copyWith(
@@ -673,17 +691,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         lastSignalingDisconnectCode: event.code,
       ),
     );
-    Notification? notificationToShow;
 
     if (code == SignalingDisconnectCode.appUnregisteredError) {
       add(const _CallSignalingEvent.registration(RegistrationStatus.unregistered));
-
-      newState = state.copyWith(
-        callServiceState: state.callServiceState.copyWith(
-          signalingClientStatus: SignalingClientStatus.disconnect,
-          lastSignalingDisconnectCode: event.code,
-        ),
-      );
     } else if (code == SignalingDisconnectCode.requestCallIdError) {
       state.activeCalls.where((e) => e.wasHungUp).forEach((e) => add(_ResetStateEvent.completeCall(e.callId)));
     } else if (code == SignalingDisconnectCode.controllerExitError) {
@@ -691,11 +701,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     } else if (code == SignalingDisconnectCode.controllerForceAttachClose) {
       // Server closed the connection because a duplicate signaling session was detected
       // (e.g. background push isolate still connected when main engine reconnects).
-      // Reconnect silently: don't set lastSignalingDisconnectCode so connectIssue is never shown.
+      // Keep lastSignalingDisconnectCode null so connectIssue is never shown.
       _logger.warning(
         '__onSignalingClientEventDisconnected: signaling race detected - '
-        'server force-closed duplicate session (code=${event.code}, reason="${event.reason}"). '
-        'Reconnecting silently without showing connectIssue.',
+        'server force-closed duplicate session (code=${event.code}, reason="${event.reason}").',
       );
       newState = state.copyWith(
         callServiceState: state.callServiceState.copyWith(
@@ -703,31 +712,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           lastSignalingDisconnectCode: null,
         ),
       );
-    } else if (code == SignalingDisconnectCode.sessionMissedError) {
-      notificationToShow = const SignalingSessionMissedNotification();
     } else if (code.type == SignalingDisconnectCodeType.auxiliary) {
-      _logger.info('__onSignalingClientEventDisconnected: socket goes down');
-
       /// Fun facts
       /// - in case of network disconnection on android this section is evaluating faster than [_onConnectivityResultChanged].
       /// - also in case of network disconnection error code is protocolError instead of normalClosure by unknown reason
       /// so we need to handle it here as regular disconnection
-      if (code != SignalingDisconnectCode.protocolError) {
-        notificationToShow = SignalingDisconnectNotification(
-          knownCode: code,
-          systemCode: event.code,
-          systemReason: event.reason,
-        );
-      }
-    } else {
-      notificationToShow = SignalingDisconnectNotification(
-        knownCode: code,
-        systemCode: event.code,
-        systemReason: event.reason,
-      );
+      _logger.info('__onSignalingClientEventDisconnected: socket goes down');
     }
+
     emit(newState);
-    if (notificationToShow != null && !repeated) submitNotification(notificationToShow);
   }
 
   // processing call push events

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -132,6 +132,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         switch (knownCode) {
           case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
           case SignalingDisconnectCode.controllerForceAttachClose:
+            // Expected silent reconnect: keepalive timeout on lock-screen or duplicate-session cleanup.
             _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
             return;
           case SignalingDisconnectCode.sessionMissedError:

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -127,21 +127,26 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     _reconnectController = SignalingReconnectController(
       signalingModule: signalingModule,
-      onConnectionFailed: (knownCode) {
-        final Notification notification;
+      onConnectionFailed: (failure) {
+        final (:knownCode, :systemCode, :systemReason) = failure;
         switch (knownCode) {
           case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
           case SignalingDisconnectCode.controllerForceAttachClose:
             // Expected silent reconnect: keepalive timeout on lock-screen or duplicate-session cleanup.
             _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
             return;
-          case SignalingDisconnectCode.sessionMissedError:
-            notification = const SignalingSessionMissedNotification();
-          case null:
-            notification = const SignalingConnectFailedNotification();
           default:
-            notification = SignalingDisconnectNotification(knownCode: knownCode);
+            break;
         }
+        final notification = switch (knownCode) {
+          SignalingDisconnectCode.sessionMissedError => const SignalingSessionMissedNotification(),
+          null => const SignalingConnectFailedNotification(),
+          _ => SignalingDisconnectNotification(
+            knownCode: knownCode,
+            systemCode: systemCode,
+            systemReason: systemReason,
+          ),
+        };
         submitNotification(notification);
       },
       onConnectionPresenceChanged: (isAvailable) =>
@@ -682,8 +687,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   ) async {
     final code = SignalingDisconnectCode.values.byCode(event.code ?? -1);
 
-    // Notification decisions are handled by [_reconnectController.onConnectionFailed].
-    // This method only updates [CallState].
+    // Notification decisions are handled by SignalingReconnectController via its
+    // onConnectionFailed callback. This method only updates [CallState].
 
     CallState newState = state.copyWith(
       callServiceState: state.callServiceState.copyWith(
@@ -698,6 +703,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       state.activeCalls.where((e) => e.wasHungUp).forEach((e) => add(_ResetStateEvent.completeCall(e.callId)));
     } else if (code == SignalingDisconnectCode.controllerExitError) {
       _logger.info('__onSignalingClientEventDisconnected: skipping expected system unregistration notification');
+    } else if (code == SignalingDisconnectCode.signalingKeepaliveTimeoutError) {
+      // Keepalive timeout while backgrounded (Android network restrictions).
+      // Keep lastSignalingDisconnectCode null so connectIssue is never shown.
+      newState = state.copyWith(
+        callServiceState: state.callServiceState.copyWith(
+          signalingClientStatus: SignalingClientStatus.disconnect,
+          lastSignalingDisconnectCode: null,
+        ),
+      );
     } else if (code == SignalingDisconnectCode.controllerForceAttachClose) {
       // Server closed the connection because a duplicate signaling session was detected
       // (e.g. background push isolate still connected when main engine reconnects).

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -132,8 +132,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         switch (knownCode) {
           case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
           case SignalingDisconnectCode.controllerForceAttachClose:
-            // Silent reconnect — these codes are expected during background/lock-screen
-            // scenarios or duplicate-session cleanup. Don't disturb the user.
+            _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
             return;
           case SignalingDisconnectCode.sessionMissedError:
             notification = const SignalingSessionMissedNotification();

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -9,6 +9,15 @@ import 'package:webtrit_phone/app/constants.dart';
 
 final _logger = Logger('SignalingReconnectController');
 
+/// Carries the full context of a connection failure passed to
+/// [SignalingReconnectController.onConnectionFailed].
+///
+/// - [knownCode] is `null` for initial-connect failures ([SignalingConnectionFailed]),
+///   or the decoded [SignalingDisconnectCode] for unexpected disconnects.
+/// - [systemCode] and [systemReason] are the raw WebSocket close code and reason
+///   from the server, useful for detailed error display.
+typedef SignalingFailureInfo = ({SignalingDisconnectCode? knownCode, int? systemCode, String? systemReason});
+
 /// Centralizes all signaling reconnect logic and connection-failure notification
 /// decisions for both the foreground [CallBloc] and background [IsolateManager].
 ///
@@ -38,7 +47,7 @@ final _logger = Logger('SignalingReconnectController');
 /// ```dart
 /// final controller = SignalingReconnectController(
 ///   signalingModule: module,
-///   onConnectionFailed: () => submitNotification(SignalingConnectFailedNotification()),
+///   onConnectionFailed: (failure) => submitNotification(SignalingConnectFailedNotification()),
 ///   onConnectionPresenceChanged: (isAvailable) => add(_SignalingPresenceChanged(isAvailable)),
 /// );
 ///
@@ -53,7 +62,7 @@ final _logger = Logger('SignalingReconnectController');
 class SignalingReconnectController {
   SignalingReconnectController({
     required SignalingModule signalingModule,
-    void Function(SignalingDisconnectCode? knownCode)? onConnectionFailed,
+    void Function(SignalingFailureInfo)? onConnectionFailed,
     void Function(bool isAvailable)? onConnectionPresenceChanged,
     int notifyAfterConsecutiveFailures = 2,
     bool reconnectEnabled = true,
@@ -67,7 +76,7 @@ class SignalingReconnectController {
   }
 
   final SignalingModule _module;
-  final void Function(SignalingDisconnectCode? knownCode)? _onConnectionFailed;
+  final void Function(SignalingFailureInfo)? _onConnectionFailed;
   final void Function(bool isAvailable)? _onConnectionPresenceChanged;
   final int _notifyThreshold;
   final bool _reconnectEnabled;
@@ -187,14 +196,14 @@ class SignalingReconnectController {
           _logger.fine('_onEvent: connection lost after established session - notifying immediately');
           _wasConnected = false;
           _consecutiveFailures = 0;
-          _onConnectionFailed?.call(null);
+          _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
           _emitPresence(false);
         } else {
           _consecutiveFailures++;
           _logger.fine('_onEvent: connection failed (consecutive=$_consecutiveFailures)');
           if (_consecutiveFailures == _notifyThreshold) {
             _logger.info('_onEvent: notifying - consecutive failures reached threshold ($_notifyThreshold)');
-            _onConnectionFailed?.call(null);
+            _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
             _emitPresence(false);
           }
         }
@@ -202,12 +211,12 @@ class SignalingReconnectController {
 
       // Unexpected TCP-level close without a preceding error event.
       // Notify immediately - an established session was lost.
-      case SignalingDisconnected(:final recommendedReconnectDelay, :final knownCode)
+      case SignalingDisconnected(:final recommendedReconnectDelay, :final knownCode, :final code, :final reason)
           when recommendedReconnectDelay != null:
         _logger.fine('_onEvent: unexpected disconnect - notifying immediately');
         _wasConnected = false;
         _consecutiveFailures = 0;
-        _onConnectionFailed?.call(knownCode);
+        _onConnectionFailed?.call((knownCode: knownCode, systemCode: code, systemReason: reason));
         _emitPresence(false);
         _scheduleReconnect(recommendedReconnectDelay);
 

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -115,7 +115,15 @@ class SignalingReconnectController {
   void notifyAppResumed() {
     _logger.fine('notifyAppResumed');
     _appActive = true;
-    _wasConnected = false;
+    // Reset only when there are no active calls. During an active call
+    // _wasConnected must stay true so a subsequent SignalingConnectionFailed
+    // is treated as an established-session drop and notifies immediately.
+    // Without active calls this reset prevents a persistent-mode background
+    // reconnect (replayed via hub session buffer) from skipping the
+    // consecutive-failure threshold on the first post-resume failure.
+    if (!_hasActiveCalls) {
+      _wasConnected = false;
+    }
     _consecutiveFailures = 0;
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
   }

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 
+import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
@@ -52,7 +53,7 @@ final _logger = Logger('SignalingReconnectController');
 class SignalingReconnectController {
   SignalingReconnectController({
     required SignalingModule signalingModule,
-    void Function()? onConnectionFailed,
+    void Function(SignalingDisconnectCode? knownCode)? onConnectionFailed,
     void Function(bool isAvailable)? onConnectionPresenceChanged,
     int notifyAfterConsecutiveFailures = 2,
     bool reconnectEnabled = true,
@@ -66,7 +67,7 @@ class SignalingReconnectController {
   }
 
   final SignalingModule _module;
-  final void Function()? _onConnectionFailed;
+  final void Function(SignalingDisconnectCode? knownCode)? _onConnectionFailed;
   final void Function(bool isAvailable)? _onConnectionPresenceChanged;
   final int _notifyThreshold;
   final bool _reconnectEnabled;
@@ -186,14 +187,14 @@ class SignalingReconnectController {
           _logger.fine('_onEvent: connection lost after established session - notifying immediately');
           _wasConnected = false;
           _consecutiveFailures = 0;
-          _onConnectionFailed?.call();
+          _onConnectionFailed?.call(null);
           _emitPresence(false);
         } else {
           _consecutiveFailures++;
           _logger.fine('_onEvent: connection failed (consecutive=$_consecutiveFailures)');
           if (_consecutiveFailures == _notifyThreshold) {
             _logger.info('_onEvent: notifying - consecutive failures reached threshold ($_notifyThreshold)');
-            _onConnectionFailed?.call();
+            _onConnectionFailed?.call(null);
             _emitPresence(false);
           }
         }
@@ -201,11 +202,12 @@ class SignalingReconnectController {
 
       // Unexpected TCP-level close without a preceding error event.
       // Notify immediately - an established session was lost.
-      case SignalingDisconnected(:final recommendedReconnectDelay) when recommendedReconnectDelay != null:
+      case SignalingDisconnected(:final recommendedReconnectDelay, :final knownCode)
+          when recommendedReconnectDelay != null:
         _logger.fine('_onEvent: unexpected disconnect - notifying immediately');
         _wasConnected = false;
         _consecutiveFailures = 0;
-        _onConnectionFailed?.call();
+        _onConnectionFailed?.call(knownCode);
         _emitPresence(false);
         _scheduleReconnect(recommendedReconnectDelay);
 

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -120,6 +120,11 @@ class SignalingReconnectController {
     _logger.fine('notifyAppPaused hasActiveCalls=$hasActiveCalls');
     if (!hasActiveCalls) {
       _appActive = false;
+      // Intentional disconnect on app pause — treat the next reconnect as a
+      // fresh attempt, not a "session lost" event. Without this reset the
+      // first post-unlock connect failure would bypass the consecutive-failure
+      // threshold and immediately fire onConnectionFailed (WT-1221).
+      _wasConnected = false;
       _disconnect();
     }
   }

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -104,9 +104,16 @@ class SignalingReconnectController {
   // ---------------------------------------------------------------------------
 
   /// Call when [AppLifecycleState.resumed] fires.
+  ///
+  /// Resets [_wasConnected] and [_consecutiveFailures] so that background
+  /// reconnects (which the hub module handles independently via the foreground
+  /// service isolate) do not leave stale state that skips the
+  /// consecutive-failure threshold on the first post-unlock attempt.
   void notifyAppResumed() {
     _logger.fine('notifyAppResumed');
     _appActive = true;
+    _wasConnected = false;
+    _consecutiveFailures = 0;
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
   }
 
@@ -196,19 +203,33 @@ class SignalingReconnectController {
       //    may be transient, notify only after [_notifyThreshold] consecutive failures.
       // 2. An error fired on an already-established WebSocket connection -
       //    always notify immediately because the user-visible session was lost.
+      //
+      // On Android the hub module's connect()/disconnect() are no-ops — the
+      // foreground-service isolate owns the WebSocket lifecycle and reconnects
+      // independently. Its reconnects can set [_wasConnected] = true while the
+      // app is backgrounded. Notifying while backgrounded (no active calls)
+      // would queue a toast that surfaces incorrectly when the app resumes.
       case SignalingConnectionFailed(:final recommendedReconnectDelay):
         if (_wasConnected) {
           _logger.fine('_onEvent: connection lost after established session - notifying immediately');
           _wasConnected = false;
           _consecutiveFailures = 0;
-          _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
+          if (_appActive || _hasActiveCalls) {
+            _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
+          } else {
+            _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
+          }
           _emitPresence(false);
         } else {
           _consecutiveFailures++;
           _logger.fine('_onEvent: connection failed (consecutive=$_consecutiveFailures)');
           if (_consecutiveFailures == _notifyThreshold) {
             _logger.info('_onEvent: notifying - consecutive failures reached threshold ($_notifyThreshold)');
-            _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
+            if (_appActive || _hasActiveCalls) {
+              _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
+            } else {
+              _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
+            }
             _emitPresence(false);
           }
         }
@@ -221,7 +242,11 @@ class SignalingReconnectController {
         _logger.fine('_onEvent: unexpected disconnect - notifying immediately');
         _wasConnected = false;
         _consecutiveFailures = 0;
-        _onConnectionFailed?.call((knownCode: knownCode, systemCode: code, systemReason: reason));
+        if (_appActive || _hasActiveCalls) {
+          _onConnectionFailed?.call((knownCode: knownCode, systemCode: code, systemReason: reason));
+        } else {
+          _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
+        }
         _emitPresence(false);
         _scheduleReconnect(recommendedReconnectDelay);
 

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -105,10 +105,13 @@ class SignalingReconnectController {
 
   /// Call when [AppLifecycleState.resumed] fires.
   ///
-  /// Resets [_wasConnected] and [_consecutiveFailures] so that background
-  /// reconnects (which the hub module handles independently via the foreground
-  /// service isolate) do not leave stale state that skips the
-  /// consecutive-failure threshold on the first post-unlock attempt.
+  /// Resets [_wasConnected] and [_consecutiveFailures] to treat the first
+  /// post-resume attempt as a fresh session. In persistent-service mode the
+  /// background isolate may have reconnected while the app was closed; when
+  /// the app reopens the hub replays [SignalingConnected] from its session
+  /// buffer, setting [_wasConnected] to true. Without the reset here the
+  /// first post-resume connection failure would bypass the
+  /// consecutive-failure threshold and fire [onConnectionFailed] immediately.
   void notifyAppResumed() {
     _logger.fine('notifyAppResumed');
     _appActive = true;
@@ -204,11 +207,10 @@ class SignalingReconnectController {
       // 2. An error fired on an already-established WebSocket connection -
       //    always notify immediately because the user-visible session was lost.
       //
-      // On Android the hub module's connect()/disconnect() are no-ops — the
-      // foreground-service isolate owns the WebSocket lifecycle and reconnects
-      // independently. Its reconnects can set [_wasConnected] = true while the
-      // app is backgrounded. Notifying while backgrounded (no active calls)
-      // would queue a toast that surfaces incorrectly when the app resumes.
+      // Notifications are suppressed when the app is inactive and there are no
+      // active calls: in persistent-service mode the background isolate can
+      // reconnect while the app is closed, and notifying at that point would
+      // queue a toast that surfaces incorrectly when the app resumes.
       case SignalingConnectionFailed(:final recommendedReconnectDelay):
         if (_wasConnected) {
           _logger.fine('_onEvent: connection lost after established session - notifying immediately');

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -462,6 +462,45 @@ void main() {
         expect(module.connectCalls, 1);
       });
     });
+
+    // WT-1221: "Connecting to the core failed" toast on screen unlock.
+    //
+    // Scenario: user had an active session (_wasConnected = true), locked the
+    // screen, then unlocked. The first post-unlock connect failure must go
+    // through the consecutive-failure threshold — not fire onConnectionFailed
+    // immediately as if an established session was lost.
+    test('notifyAppPaused resets _wasConnected — post-unlock failure respects threshold (WT-1221)', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        int notifyCount = 0;
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: (_) => notifyCount++,
+          notifyAfterConsecutiveFailures: 2,
+          reconnectEnabled: false,
+        );
+        addTearDown(controller.dispose);
+
+        // Establish a session so _wasConnected = true.
+        module.emit(SignalingConnected());
+        expect(notifyCount, 0);
+
+        // Screen lock — intentional disconnect.
+        controller.notifyAppPaused(hasActiveCalls: false);
+
+        // Screen unlock — first post-unlock connect failure.
+        controller.notifyAppResumed();
+        module.emit(_failed());
+
+        // Must NOT fire immediately (would be wrong: no session was lost).
+        expect(notifyCount, 0, reason: 'first post-unlock failure must not trigger toast immediately');
+
+        // Second failure reaches threshold — now it is appropriate to notify.
+        module.emit(_failed());
+        expect(notifyCount, 1);
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -502,6 +502,44 @@ void main() {
       });
     });
 
+    // Copilot review: notifyAppResumed must NOT reset _wasConnected when there
+    // is an active call. If it did, a subsequent SignalingConnectionFailed would
+    // be misclassified as an initial connect attempt (going through the
+    // consecutive-failure threshold) instead of an established-session drop
+    // that notifies immediately.
+    test('notifyAppResumed during active call preserves _wasConnected — failure notifies immediately', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        int notifyCount = 0;
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: (_) => notifyCount++,
+          notifyAfterConsecutiveFailures: 3,
+          reconnectEnabled: false,
+        );
+        addTearDown(controller.dispose);
+
+        // Session established — _wasConnected = true.
+        module.emit(SignalingConnected());
+
+        // Brief background while a call is active (e.g. user swipes away and back).
+        controller.notifyAppPaused(hasActiveCalls: true);
+        controller.notifyHasActiveCalls(hasActiveCalls: true);
+
+        // App comes back to foreground during the call.
+        controller.notifyAppResumed();
+
+        // Connection drops — must notify immediately because _wasConnected is still true.
+        module.emit(_failed());
+        expect(
+          notifyCount,
+          1,
+          reason: 'established-session drop during active call must notify immediately, not wait for threshold',
+        );
+      });
+    });
+
     // Background reconnect race: on Android the hub module's connect/disconnect
     // are no-ops, so the background isolate can reconnect while the app is
     // paused and set _wasConnected = true. A subsequent failure must NOT queue

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -57,6 +57,14 @@ SignalingDisconnected _lost() => SignalingDisconnected(
   recommendedReconnectDelay: kSignalingClientReconnectDelay,
 );
 
+// Simulates a server-side keepalive timeout (backgrounded app, Android network restrictions).
+SignalingDisconnected _keepaliveTimeout() => SignalingDisconnected(
+  code: 4502,
+  reason: 'signaling keepalive timeout error',
+  knownCode: SignalingDisconnectCode.signalingKeepaliveTimeoutError,
+  recommendedReconnectDelay: kSignalingClientReconnectDelay,
+);
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -110,7 +118,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 3,
           reconnectEnabled: false,
         );
@@ -130,7 +138,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 2,
           reconnectEnabled: false,
         );
@@ -150,7 +158,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 2,
           reconnectEnabled: false,
         );
@@ -172,7 +180,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 2,
           reconnectEnabled: false,
         );
@@ -195,6 +203,67 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // onConnectionFailed — knownCode forwarding
+  // -------------------------------------------------------------------------
+
+  group('SignalingReconnectController - onConnectionFailed knownCode', () {
+    test('passes null knownCode on SignalingConnectionFailed', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        SignalingDisconnectCode? receivedCode = SignalingDisconnectCode.unmappedCode; // sentinel
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: (knownCode) => receivedCode = knownCode,
+          notifyAfterConsecutiveFailures: 1,
+          reconnectEnabled: false,
+        );
+        addTearDown(controller.dispose);
+
+        module.emit(_failed());
+
+        expect(receivedCode, isNull);
+      });
+    });
+
+    test('passes knownCode on SignalingDisconnected (unexpected)', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        SignalingDisconnectCode? receivedCode;
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: (knownCode) => receivedCode = knownCode,
+          reconnectEnabled: false,
+        );
+        addTearDown(controller.dispose);
+
+        module.emit(_lost());
+
+        expect(receivedCode, SignalingDisconnectCode.unmappedCode);
+      });
+    });
+
+    test('passes signalingKeepaliveTimeoutError knownCode on keepalive disconnect', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        SignalingDisconnectCode? receivedCode;
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: (knownCode) => receivedCode = knownCode,
+          reconnectEnabled: false,
+        );
+        addTearDown(controller.dispose);
+
+        module.emit(_keepaliveTimeout());
+
+        expect(receivedCode, SignalingDisconnectCode.signalingKeepaliveTimeoutError);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // SignalingDisconnected (unexpected) — immediate notification
   // -------------------------------------------------------------------------
 
@@ -206,7 +275,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 5,
           reconnectEnabled: false,
         );
@@ -225,7 +294,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 2,
           reconnectEnabled: false,
         );
@@ -556,7 +625,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 2,
         );
         addTearDown(controller.dispose);
@@ -604,7 +673,7 @@ void main() {
         int notifyCount = 0;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: () => notifyCount++,
+          onConnectionFailed: (_) => notifyCount++,
           notifyAfterConsecutiveFailures: 1,
           reconnectEnabled: false,
         );

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -501,6 +501,74 @@ void main() {
         expect(notifyCount, 1);
       });
     });
+
+    // Background reconnect race: on Android the hub module's connect/disconnect
+    // are no-ops, so the background isolate can reconnect while the app is
+    // paused and set _wasConnected = true. A subsequent failure must NOT queue
+    // a notification (it would appear incorrectly when the app resumes).
+    test('background reconnect while paused — failure does not fire onConnectionFailed', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        int notifyCount = 0;
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: (_) => notifyCount++,
+          notifyAfterConsecutiveFailures: 2,
+          reconnectEnabled: false,
+        );
+        addTearDown(controller.dispose);
+
+        // App goes background.
+        controller.notifyAppPaused(hasActiveCalls: false);
+
+        // Background isolate reconnects independently (hub broadcasts SignalingConnected).
+        module.emit(SignalingConnected());
+
+        // Connection fails while still paused (e.g. 4502 or generic error).
+        module.emit(_failed());
+        module.emit(_keepaliveTimeout());
+
+        // No notifications must have been queued — user is not watching.
+        expect(notifyCount, 0, reason: 'backgrounded without calls — no toast must be queued');
+      });
+    });
+
+    // notifyAppResumed resets _consecutiveFailures so that many background
+    // failures do not push the counter past the threshold, preventing
+    // notifications from appearing on the first post-unlock failures.
+    test('notifyAppResumed resets consecutiveFailures — threshold works correctly after unlock', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        int notifyCount = 0;
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          onConnectionFailed: (_) => notifyCount++,
+          notifyAfterConsecutiveFailures: 2,
+          reconnectEnabled: false,
+        );
+        addTearDown(controller.dispose);
+
+        // App goes background and accumulates many failures (counter climbs past threshold).
+        controller.notifyAppPaused(hasActiveCalls: false);
+        for (var i = 0; i < 10; i++) {
+          module.emit(_failed());
+        }
+        expect(notifyCount, 0, reason: 'no notifications while backgrounded');
+
+        // Unlock — state is reset.
+        controller.notifyAppResumed();
+
+        // First post-unlock failure: counter is 1, below threshold — no toast.
+        module.emit(_failed());
+        expect(notifyCount, 0, reason: 'first post-unlock failure must not notify');
+
+        // Second post-unlock failure: counter reaches threshold — toast is correct here.
+        module.emit(_failed());
+        expect(notifyCount, 1);
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -214,7 +214,7 @@ void main() {
         SignalingDisconnectCode? receivedCode = SignalingDisconnectCode.unmappedCode; // sentinel
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: (knownCode) => receivedCode = knownCode,
+          onConnectionFailed: (failure) => receivedCode = failure.knownCode,
           notifyAfterConsecutiveFailures: 1,
           reconnectEnabled: false,
         );
@@ -233,7 +233,7 @@ void main() {
         SignalingDisconnectCode? receivedCode;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: (knownCode) => receivedCode = knownCode,
+          onConnectionFailed: (failure) => receivedCode = failure.knownCode,
           reconnectEnabled: false,
         );
         addTearDown(controller.dispose);
@@ -251,7 +251,7 @@ void main() {
         SignalingDisconnectCode? receivedCode;
         final controller = SignalingReconnectController(
           signalingModule: module,
-          onConnectionFailed: (knownCode) => receivedCode = knownCode,
+          onConnectionFailed: (failure) => receivedCode = failure.knownCode,
           reconnectEnabled: false,
         );
         addTearDown(controller.dispose);


### PR DESCRIPTION
## Summary

Centralizes all connection-failure notification decisions in `SignalingReconnectController`, fixes two sources of spurious error toasts, and adds guards against incorrect notifications when the app is backgrounded.

---

## Changes

### 1. Centralize notification decisions (`onConnectionFailed` callback)

`onConnectionFailed` now receives `SignalingFailureInfo` (`knownCode`, `systemCode`, `systemReason`) so the consumer has full context. All notification routing moved out of `CallBloc.__onSignalingClientEventDisconnected` into one `onConnectionFailed` callback — aligns with the existing comment *"notification decisions are fully handled by _reconnectController"*.

| `knownCode` | Action |
|---|---|
| `signalingKeepaliveTimeoutError` | silent — background/lock-screen expected behavior |
| `controllerForceAttachClose` | silent — duplicate session cleanup |
| `sessionMissedError` | `SignalingSessionMissedNotification` |
| `null` (connect failure) | `SignalingConnectFailedNotification` |
| other | `SignalingDisconnectNotification(knownCode, systemCode, systemReason)` |

### 2. Fix: spurious toast on screen unlock (WT-1221)

`notifyAppPaused(hasActiveCalls: false)` now resets `_wasConnected = false`. Without this, the sequence `connect → lock → unlock → first failure` triggered an immediate toast (bypassing the consecutive-failure threshold) because `_wasConnected` was still `true` from the previous session.

### 3. Fix: suppress background notifications

`onConnectionFailed` now guards notifications with `_appActive || _hasActiveCalls`. In persistent-service mode the background isolate can reconnect while the app is closed; notifying at that point would queue a toast that appears incorrectly on next app open.

`notifyAppResumed()` resets `_wasConnected` and `_consecutiveFailures` (only when `!_hasActiveCalls`) to start fresh on unlock. This prevents a persistent-mode background reconnect (replayed via hub session buffer) from skipping the threshold on the first post-resume failure.

### 4. Fix: preserve `_wasConnected` during active-call resume

`notifyAppResumed()` no longer resets `_wasConnected` when `_hasActiveCalls == true`. If it did, a `SignalingConnectionFailed` after resume during an active call would be misclassified as an initial connect attempt (going through the threshold) instead of an established-session drop that notifies immediately.

---

## Tests

All **40 tests pass** (`flutter test test/features/call/services/signaling_reconnect_controller_test.dart`).

New tests added:
- `onConnectionFailed` passes correct `knownCode` for connect failure, unexpected disconnect, keepalive timeout
- `notifyAppPaused` resets `_wasConnected` — post-unlock failure respects threshold (WT-1221)
- Background reconnect while paused — failure does not fire `onConnectionFailed`
- `notifyAppResumed` resets `consecutiveFailures` — threshold works correctly after unlock
- `notifyAppResumed` during active call preserves `_wasConnected` — failure notifies immediately

---

## Test plan

- [x] All 40 `signaling_reconnect_controller_test.dart` tests pass
- [x] `flutter analyze` — no issues
- [x] Manual: lock screen → unlock → verify no error snackbar
- [ ] Manual: active call → brief background → resume → drop connection → verify immediate notification (not delayed by threshold)
- [ ] Manual: persistent mode — close app → background reconnect → open app → verify no spurious toast