### PR TITLE
fix(android): minimize app instead of destroying Activity when back pressed at root

### DIFF
--- a/android/app/src/main/kotlin/com/webtrit/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/MainActivity.kt
@@ -3,11 +3,12 @@ package com.webtrit.app
 import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity : FlutterActivity() {
-    // Move the app to background instead of destroying the Activity when
-    // the user presses Back on the root screen. This prevents the Flutter
-    // engine (and any active WebRTC call) from being torn down on back press.
-    @Suppress("DEPRECATION")
-    override fun onBackPressed() {
+    // Called by Flutter only after its own navigation stack is fully exhausted.
+    // Returning true prevents the default finish() call and moves the app to
+    // background instead, keeping the Flutter engine (and any active WebRTC
+    // call) alive.
+    override fun popSystemNavigator(): Boolean {
         moveTaskToBack(true)
+        return true
     }
 }

--- a/android/app/src/main/kotlin/com/webtrit/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/MainActivity.kt
@@ -3,12 +3,23 @@ package com.webtrit.app
 import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity : FlutterActivity() {
-    // Called by Flutter only after its own navigation stack is fully exhausted.
-    // Returning true prevents the default finish() call and moves the app to
-    // background instead, keeping the Flutter engine (and any active WebRTC
-    // call) alive.
+    /**
+     * Overrides the default back-press behavior when Flutter's navigation stack is fully exhausted.
+     *
+     * By default, [FlutterActivity] calls [finish] at this point, which destroys the Activity and
+     * tears down the Flutter engine — including any active WebRTC peer connections. This causes
+     * in-progress calls to drop immediately.
+     *
+     * This override intentionally minimizes the app for **all** cases (not only during active calls).
+     * This is the standard VoIP app pattern: the app maintains background signaling connections and
+     * must stay alive to receive incoming calls, so "exit via Back" is replaced with "move to
+     * background". Users can still fully close the app through the recent-apps screen.
+     *
+     * Falls back to [super.popSystemNavigator] if [moveTaskToBack] reports that the task could not
+     * be moved (e.g. the activity is not part of a root task), preserving correct behavior in that
+     * edge case.
+     */
     override fun popSystemNavigator(): Boolean {
-        moveTaskToBack(true)
-        return true
+        return if (moveTaskToBack(true)) true else super.popSystemNavigator()
     }
 }

--- a/android/app/src/main/kotlin/com/webtrit/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/MainActivity.kt
@@ -2,5 +2,12 @@ package com.webtrit.app
 
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity: FlutterActivity() {
+class MainActivity : FlutterActivity() {
+    // Move the app to background instead of destroying the Activity when
+    // the user presses Back on the root screen. This prevents the Flutter
+    // engine (and any active WebRTC call) from being torn down on back press.
+    @Suppress("DEPRECATION")
+    override fun onBackPressed() {
+        moveTaskToBack(true)
+    }
 }


### PR DESCRIPTION
## Problem

When a user presses Back on the root screen while an active call is in progress, Android destroys `MainActivity` instead of moving it to the background. This tears down the Flutter engine and the entire WebRTC stack, causing the call to drop.

Observed sequence in logcat:
1. `onKeyDown(KEYCODE_BACK)` on root screen
2. `DestroyActivityItem.execute` + `FlutterActivity.onDestroy` — Activity destroyed
3. `AppLifecycleState.detached` — Flutter engine gone
4. `ice_hangup` with `reason: DTLS alert` — WebRTC torn down
5. Server sends `hangup` with `reason: to BYE` — call ended

## Fix

Override `popSystemNavigator()` in `MainActivity`. This method is called by Flutter **only after its own navigation stack is fully exhausted** — meaning Flutter has already handled all internal back presses. At that point, instead of the default `finish()`, we call `moveTaskToBack(true)` to minimize the app.

```kotlin
override fun popSystemNavigator(): Boolean {
    moveTaskToBack(true)
    return true
}
```

## Behavior

| Situation | Result |
|---|---|
| Flutter has routes in stack | Flutter pops route normally, `popSystemNavigator` not called |
| Flutter stack is empty (root screen) | `moveTaskToBack(true)` — app minimizes, engine stays alive |