### PR TITLE
fix(signaling): bidirectional hub protocol + persistent-mode reconnect

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -30,12 +30,12 @@ class SignalingHub {
   /// consumerId -> subscriber SendPort
   final Map<String, SendPort> _subscribers = {};
 
-  /// True when at least one main-isolate subscriber is connected.
+  /// True when at least one subscriber (from any isolate) is connected.
   ///
   /// Used by [SignalingForegroundIsolateManager] to decide whether reconnect
-  /// decisions should be delegated to [SignalingReconnectController] in the
-  /// main isolate (subscribers present) or handled locally in the background
-  /// isolate (no subscribers — app is closed, persistent-service mode).
+  /// decisions should be delegated (subscribers present — at least one isolate
+  /// can drive reconnects) or handled locally in the background isolate
+  /// (no subscribers — app is closed, persistent-service mode).
   bool get hasSubscribers => _subscribers.isNotEmpty;
 
   /// Encoded events since the last [SignalingConnecting] event.
@@ -104,9 +104,17 @@ class SignalingHub {
       case SignalingHubExecuteCommand():
         _handleExecute(cmd);
       case SignalingHubConnectCommand():
+        if (!_subscribers.containsKey(cmd.consumerId)) {
+          _logger.warning('Hub connect: unknown subscriber ${cmd.consumerId}');
+          return;
+        }
         _logger.fine('Hub received connect command from ${cmd.consumerId}');
         _signalingModule.connect();
       case SignalingHubDisconnectCommand():
+        if (!_subscribers.containsKey(cmd.consumerId)) {
+          _logger.warning('Hub disconnect: unknown subscriber ${cmd.consumerId}');
+          return;
+        }
         _logger.fine('Hub received disconnect command from ${cmd.consumerId}');
         unawaited(_signalingModule.disconnect());
     }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -30,6 +30,14 @@ class SignalingHub {
   /// consumerId -> subscriber SendPort
   final Map<String, SendPort> _subscribers = {};
 
+  /// True when at least one main-isolate subscriber is connected.
+  ///
+  /// Used by [SignalingForegroundIsolateManager] to decide whether reconnect
+  /// decisions should be delegated to [SignalingReconnectController] in the
+  /// main isolate (subscribers present) or handled locally in the background
+  /// isolate (no subscribers — app is closed, persistent-service mode).
+  bool get hasSubscribers => _subscribers.isNotEmpty;
+
   /// Encoded events since the last [SignalingConnecting] event.
   /// Replayed to late subscribers so they receive the current session state.
   final List<List<dynamic>> _sessionBuffer = [];

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -95,6 +95,12 @@ class SignalingHub {
         _handleUnsubscribe(cmd);
       case SignalingHubExecuteCommand():
         _handleExecute(cmd);
+      case SignalingHubConnectCommand():
+        _logger.fine('Hub received connect command from ${cmd.consumerId}');
+        _signalingModule.connect();
+      case SignalingHubDisconnectCommand():
+        _logger.fine('Hub received disconnect command from ${cmd.consumerId}');
+        unawaited(_signalingModule.disconnect());
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -95,6 +95,24 @@ class SignalingHubClient {
     );
   }
 
+  /// Asks the hub to connect the background WebSocket.
+  ///
+  /// Fire-and-forget: the hub will call [SignalingModule.connect] in the
+  /// background isolate. The resulting [SignalingConnected] event will arrive
+  /// on [events] once the connection is established.
+  void sendConnect() {
+    _hubPort.send(SignalingHubConnectCommand(consumerId: consumerId).encode());
+  }
+
+  /// Asks the hub to disconnect the background WebSocket.
+  ///
+  /// Fire-and-forget: the hub will call [SignalingModule.disconnect] in the
+  /// background isolate. The resulting [SignalingDisconnected] event will arrive
+  /// on [events] once the connection is closed.
+  void sendDisconnect() {
+    _hubPort.send(SignalingHubDisconnectCommand(consumerId: consumerId).encode());
+  }
+
   /// Sends the unsubscribe command and closes all resources.
   Future<void> dispose() async {
     _hubPort.send(SignalingHubUnsubscribeCommand(consumerId: consumerId).encode());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
@@ -41,6 +41,12 @@ sealed class SignalingHubCommand {
             correlationId: wire[2] as String,
             request: Map<String, dynamic>.from(wire[3] as Map),
           );
+        case _tagConnect:
+          if (wire.length < 2) return null;
+          return SignalingHubConnectCommand(consumerId: wire[1] as String);
+        case _tagDisconnect:
+          if (wire.length < 2) return null;
+          return SignalingHubDisconnectCommand(consumerId: wire[1] as String);
         default:
           return null;
       }
@@ -58,6 +64,12 @@ const _tagUnsubscribe = 'unsub';
 
 /// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubExecuteCommand].
 const _tagExecute = 'exec';
+
+/// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubConnectCommand].
+const _tagConnect = 'connect';
+
+/// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubDisconnectCommand].
+const _tagDisconnect = 'disconnect';
 
 /// Registers [replyPort] as a subscriber in the hub.
 ///
@@ -102,4 +114,28 @@ class SignalingHubExecuteCommand extends SignalingHubCommand {
 
   @override
   List<Object?> encode() => [_tagExecute, consumerId, correlationId, request];
+}
+
+/// Asks the hub to call [SignalingModule.connect] on the background WebSocket.
+///
+/// Sent by [SignalingHubModule.connect] so the main isolate can trigger a
+/// connection attempt without owning the WebSocket directly.
+class SignalingHubConnectCommand extends SignalingHubCommand {
+  const SignalingHubConnectCommand({required String consumerId}) : super(consumerId);
+
+  @override
+  List<Object?> encode() => [_tagConnect, consumerId];
+}
+
+/// Asks the hub to call [SignalingModule.disconnect] on the background WebSocket.
+///
+/// Sent by [SignalingHubModule.disconnect] so the main isolate can close the
+/// connection. The background isolate will no longer schedule an auto-reconnect
+/// after this — reconnect decisions belong to [SignalingReconnectController] in
+/// the main isolate.
+class SignalingHubDisconnectCommand extends SignalingHubCommand {
+  const SignalingHubDisconnectCommand({required String consumerId}) : super(consumerId);
+
+  @override
+  List<Object?> encode() => [_tagDisconnect, consumerId];
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
@@ -14,8 +14,10 @@ final _logger = Logger('SignalingHubModule');
 /// foreground-service isolate. Routes all execute calls through the hub's
 /// WebSocket rather than opening an additional connection.
 ///
-/// [connect] and [disconnect] are no-ops -- the hub owns the connection
-/// lifecycle. [dispose] unsubscribes from the hub and releases resources.
+/// [connect] sends a [SignalingHubConnectCommand] to the foreground-service
+/// isolate, which calls [SignalingModule.connect] on the real WebSocket module.
+/// [disconnect] sends a [SignalingHubDisconnectCommand] similarly.
+/// [dispose] unsubscribes from the hub and releases resources.
 ///
 /// ## Two-level buffering
 ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
@@ -64,13 +64,22 @@ class SignalingHubModule implements SignalingModule {
     return _hubClient.execute(request);
   }
 
-  /// No-op -- the hub owns the WebSocket connection lifecycle.
+  /// Asks the hub to connect the background WebSocket.
+  ///
+  /// Sends a [SignalingHubConnectCommand] to the foreground-service isolate,
+  /// which calls [SignalingModule.connect] on the real WebSocket module.
+  /// The resulting [SignalingConnected] event arrives on [events] once the
+  /// connection is established.
   @override
-  void connect() {}
+  void connect() => _hubClient.sendConnect();
 
-  /// No-op -- the hub owns the WebSocket connection lifecycle.
+  /// Asks the hub to disconnect the background WebSocket.
+  ///
+  /// Sends a [SignalingHubDisconnectCommand] to the foreground-service isolate,
+  /// which calls [SignalingModule.disconnect] on the real WebSocket module.
+  /// The resulting [SignalingDisconnected] event arrives on [events].
   @override
-  Future<void> disconnect() async {}
+  Future<void> disconnect() async => _hubClient.sendDisconnect();
 
   @override
   Future<void> dispose() async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -79,6 +79,7 @@ class SignalingForegroundIsolateManager {
   SignalingHub? _hub;
 
   StreamSubscription<SignalingModuleEvent>? _eventsSubscription;
+  Timer? _reconnectTimer;
 
   bool _started = false;
 
@@ -93,9 +94,11 @@ class SignalingForegroundIsolateManager {
 
   Future<void> _start() async {
     if (_started) {
-      // Hub and module are already initialized. If the module lost its
-      // connection (e.g. a code-1002 close that does not auto-reconnect),
-      // reconnect it now so the external start() call is not silently ignored.
+      // Hub and module are already initialized. Cancel any pending
+      // persistent-mode auto-reconnect timer — the caller (main isolate or
+      // network-restore handler) takes responsibility for the connection now.
+      _reconnectTimer?.cancel();
+      _reconnectTimer = null;
       if (!(_signalingModule?.isConnected ?? false)) {
         _logger.info('SignalingForegroundIsolateManager already started but not connected, reconnecting');
         _signalingModule?.connect();
@@ -133,6 +136,8 @@ class SignalingForegroundIsolateManager {
 
     _logger.info('SignalingForegroundIsolateManager stopping');
 
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
     await _eventsSubscription?.cancel();
     await _hub?.dispose();
     await _signalingModule?.dispose();
@@ -167,11 +172,15 @@ class SignalingForegroundIsolateManager {
         _logger.info('IsolateManager: connecting...');
       case SignalingConnected():
         _logger.info('IsolateManager: connected');
-      case SignalingConnectionFailed(:final error):
-        // Reconnect decisions are delegated to SignalingReconnectController in
-        // the main isolate, which sends a SignalingHubConnectCommand via the hub
-        // when appropriate. This isolate only logs.
+      case SignalingConnectionFailed(:final error, :final recommendedReconnectDelay):
         _logger.warning('IsolateManager: connection failed -- $error');
+        if (!(_hub?.hasSubscribers ?? false)) {
+          // No main-isolate subscriber — app is closed (persistent-service mode).
+          // Reconnect locally; when the app opens and subscribes, the main isolate
+          // takes over reconnect decisions via SignalingReconnectController.
+          _scheduleReconnect(recommendedReconnectDelay);
+        }
+      // else: delegated to SignalingReconnectController in the main isolate.
       case SignalingHandshakeReceived(:final handshake):
         _logger.info('IsolateManager: handshake lines=${handshake.lines}');
       case SignalingProtocolEvent(:final event):
@@ -179,13 +188,37 @@ class SignalingForegroundIsolateManager {
         if (event is IncomingCallEvent) {
           _dispatchIncomingCall(event);
         }
-      case SignalingDisconnected(:final code, :final reason):
-        // Reconnect decisions are delegated to SignalingReconnectController in
-        // the main isolate. This isolate only logs.
+      case SignalingDisconnected(:final code, :final reason, :final recommendedReconnectDelay):
         _logger.info('IsolateManager: disconnected code=$code reason=$reason');
+        if (!(_hub?.hasSubscribers ?? false)) {
+          // No main-isolate subscriber — app is closed (persistent-service mode).
+          _scheduleReconnect(recommendedReconnectDelay);
+        }
+      // else: delegated to SignalingReconnectController in the main isolate.
       default:
         break;
     }
+  }
+
+  /// Schedules an auto-reconnect for persistent-service mode (no hub subscribers).
+  ///
+  /// Called only when [SignalingHub.hasSubscribers] is false — i.e. the app is
+  /// closed and there is no [SignalingReconnectController] in the main isolate
+  /// to drive reconnect decisions. When [delay] is null the server signalled
+  /// that reconnecting is not appropriate (e.g. code 1002 protocol error), so
+  /// no timer is scheduled.
+  void _scheduleReconnect(Duration? delay) {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    if (delay == null) return;
+    _logger.info('IsolateManager: scheduling reconnect in ${delay.inMilliseconds} ms (persistent mode)');
+    _reconnectTimer = Timer(delay, () {
+      _reconnectTimer = null;
+      if (_started && !(_signalingModule?.isConnected ?? false)) {
+        _logger.info('IsolateManager: auto-reconnecting (persistent mode)');
+        _signalingModule?.connect();
+      }
+    });
   }
 
   /// Invokes the app-registered incoming call callback in this background isolate.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -79,7 +79,6 @@ class SignalingForegroundIsolateManager {
   SignalingHub? _hub;
 
   StreamSubscription<SignalingModuleEvent>? _eventsSubscription;
-  Timer? _reconnectTimer;
 
   bool _started = false;
 
@@ -99,8 +98,6 @@ class SignalingForegroundIsolateManager {
       // reconnect it now so the external start() call is not silently ignored.
       if (!(_signalingModule?.isConnected ?? false)) {
         _logger.info('SignalingForegroundIsolateManager already started but not connected, reconnecting');
-        _reconnectTimer?.cancel();
-        _reconnectTimer = null;
         _signalingModule?.connect();
       }
       return;
@@ -136,9 +133,6 @@ class SignalingForegroundIsolateManager {
 
     _logger.info('SignalingForegroundIsolateManager stopping');
 
-    _reconnectTimer?.cancel();
-    _reconnectTimer = null;
-
     await _eventsSubscription?.cancel();
     await _hub?.dispose();
     await _signalingModule?.dispose();
@@ -173,9 +167,11 @@ class SignalingForegroundIsolateManager {
         _logger.info('IsolateManager: connecting...');
       case SignalingConnected():
         _logger.info('IsolateManager: connected');
-      case SignalingConnectionFailed(:final error, :final recommendedReconnectDelay):
-        _logger.warning('IsolateManager: connection failed -- $error, reconnect in $recommendedReconnectDelay');
-        _scheduleReconnect(recommendedReconnectDelay);
+      case SignalingConnectionFailed(:final error):
+        // Reconnect decisions are delegated to SignalingReconnectController in
+        // the main isolate, which sends a SignalingHubConnectCommand via the hub
+        // when appropriate. This isolate only logs.
+        _logger.warning('IsolateManager: connection failed -- $error');
       case SignalingHandshakeReceived(:final handshake):
         _logger.info('IsolateManager: handshake lines=${handshake.lines}');
       case SignalingProtocolEvent(:final event):
@@ -183,11 +179,10 @@ class SignalingForegroundIsolateManager {
         if (event is IncomingCallEvent) {
           _dispatchIncomingCall(event);
         }
-      case SignalingDisconnected(:final code, :final reason, :final recommendedReconnectDelay):
+      case SignalingDisconnected(:final code, :final reason):
+        // Reconnect decisions are delegated to SignalingReconnectController in
+        // the main isolate. This isolate only logs.
         _logger.info('IsolateManager: disconnected code=$code reason=$reason');
-        if (recommendedReconnectDelay != null) {
-          _scheduleReconnect(recommendedReconnectDelay);
-        }
       default:
         break;
     }
@@ -225,17 +220,6 @@ class SignalingForegroundIsolateManager {
     } catch (e, st) {
       _logger.severe('IsolateManager: incoming call handler threw', e, st);
     }
-  }
-
-  void _scheduleReconnect(Duration? delay) {
-    if (delay == null) return;
-    _reconnectTimer?.cancel();
-    _reconnectTimer = Timer(delay, () {
-      if (_started) {
-        _logger.info('SignalingForegroundIsolateManager reconnecting after $delay');
-        _signalingModule?.connect();
-      }
-    });
   }
 }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_module_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_module_test.dart
@@ -16,6 +16,8 @@ class _FakeHubClient extends Fake implements SignalingHubClient {
 
   bool started = false;
   bool disposed = false;
+  bool connectSent = false;
+  bool disconnectSent = false;
   final List<Request> executedRequests = [];
 
   @override
@@ -26,6 +28,12 @@ class _FakeHubClient extends Fake implements SignalingHubClient {
 
   @override
   void start() => started = true;
+
+  @override
+  void sendConnect() => connectSent = true;
+
+  @override
+  void sendDisconnect() => disconnectSent = true;
 
   @override
   Future<void> execute(Request request) async {
@@ -245,40 +253,28 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // connect / disconnect are no-ops
+  // connect / disconnect forward commands to hub client
   // -------------------------------------------------------------------------
 
-  group('SignalingHubModule -- connect/disconnect are no-ops', () {
-    test('connect() does not throw or emit events', () async {
+  group('SignalingHubModule -- connect/disconnect forward to hub client', () {
+    test('connect() sends connect command to hub client', () {
       final hub = _FakeHubClient();
       final module = SignalingHubModule(hub);
       addTearDown(module.dispose);
-
-      final events = <SignalingModuleEvent>[];
-      module.events.listen(events.add);
 
       module.connect();
-      await Future<void>.delayed(Duration.zero);
 
-      expect(events, isEmpty);
+      expect(hub.connectSent, isTrue);
     });
 
-    test('disconnect() does not throw or emit events', () async {
+    test('disconnect() sends disconnect command to hub client', () async {
       final hub = _FakeHubClient();
       final module = SignalingHubModule(hub);
       addTearDown(module.dispose);
 
-      hub.inject(SignalingConnected());
-      await Future<void>.delayed(Duration.zero);
-
-      final events = <SignalingModuleEvent>[];
-      module.events.listen(events.add);
-
       await module.disconnect();
-      await Future<void>.delayed(Duration.zero);
 
-      expect(events.whereType<SignalingDisconnecting>(), isEmpty);
-      expect(events.whereType<SignalingDisconnected>(), isEmpty);
+      expect(hub.disconnectSent, isTrue);
     });
   });
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
@@ -198,69 +198,46 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // Manual reconnect cancels pending timer
+  // No auto-reconnect — delegated to main isolate
   // -------------------------------------------------------------------------
 
-  group('SignalingForegroundIsolateManager -- manual reconnect cancels pending timer', () {
-    test('pending auto-reconnect timer does not fire after manual reconnect via handleStatus(enabled: true)', () async {
+  // Reconnect decisions belong exclusively to SignalingReconnectController in
+  // the main isolate. It sends SignalingHubConnectCommand via the hub when it
+  // decides to reconnect. The foreground-service isolate must NOT reconnect on
+  // its own — doing so would bypass lifecycle guards (e.g. app paused, no
+  // active calls) and cause spurious 4502 reconnect loops.
+
+  group('SignalingForegroundIsolateManager -- no auto-reconnect on disconnect', () {
+    test('does NOT reconnect when disconnect carries a non-null delay hint', () async {
       final module = _FakeSignalingModule();
       final manager = _makeManager(module);
       addTearDown(() => manager.handleStatus(enabled: false));
 
       await manager.handleStatus(enabled: true);
-      await Future<void>.delayed(Duration.zero);
-
-      // Disconnect with a delay hint — schedules a 100 ms auto-reconnect timer.
-      module.simulateDisconnectWithDelay(const Duration(milliseconds: 100));
       await Future<void>.delayed(Duration.zero);
       expect(module.connectCount, 1);
-
-      // Before the timer fires, the main isolate triggers a manual reconnect.
-      await manager.handleStatus(enabled: true);
-      await Future<void>.delayed(Duration.zero);
-      expect(module.connectCount, 2); // reconnected once manually
-
-      // Wait past the timer deadline — it must have been cancelled.
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(module.connectCount, 2); // still 2, timer did not fire
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Auto-reconnect via delay hint
-  // -------------------------------------------------------------------------
-
-  group('SignalingForegroundIsolateManager -- auto-reconnect via delay hint', () {
-    test('schedules reconnect when disconnect carries a non-null delay', () async {
-      final module = _FakeSignalingModule();
-      final manager = _makeManager(module);
-      addTearDown(() => manager.handleStatus(enabled: false));
-
-      await manager.handleStatus(enabled: true);
-      await Future<void>.delayed(Duration.zero);
 
       module.simulateDisconnectWithDelay(const Duration(milliseconds: 50));
       await Future<void>.delayed(Duration.zero);
-      expect(module.connectCount, 1); // not yet
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(module.connectCount, 2); // reconnected via timer
+      // Wait well past the old reconnect deadline — no reconnect must fire.
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(module.connectCount, 1, reason: 'isolate must not auto-reconnect; only main isolate may reconnect');
     });
 
-    test('schedules reconnect when connection fails with a delay hint', () async {
+    test('does NOT reconnect when connection fails with a delay hint', () async {
       final module = _FakeSignalingModule();
       final manager = _makeManager(module);
       addTearDown(() => manager.handleStatus(enabled: false));
 
       await manager.handleStatus(enabled: true);
       await Future<void>.delayed(Duration.zero);
-
-      module.simulateConnectionFailed(const Duration(milliseconds: 50));
-      await Future<void>.delayed(Duration.zero);
       expect(module.connectCount, 1);
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(module.connectCount, 2);
+      module.simulateConnectionFailed(const Duration(milliseconds: 50));
+
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(module.connectCount, 1, reason: 'isolate must not auto-reconnect; only main isolate may reconnect');
     });
   });
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
@@ -90,6 +90,14 @@ class _FakeSignalingHub extends Fake implements SignalingHub {
   // ignore: avoid_unused_constructor_parameters
   _FakeSignalingHub(SignalingModule _);
 
+  /// Controls whether the hub reports active subscribers.
+  ///
+  /// Default [true] simulates the normal case where the app is open and the
+  /// main isolate is subscribed. Set to [false] to simulate persistent-service
+  /// mode where the app is closed and there are no subscribers.
+  @override
+  bool hasSubscribers = true;
+
   @override
   void start() {}
 
@@ -101,6 +109,10 @@ class _FakeSignalingHub extends Fake implements SignalingHub {
 // Helper
 // ---------------------------------------------------------------------------
 
+/// Creates a manager where the hub reports active subscribers (app is open).
+///
+/// Reconnect decisions are delegated to the main isolate; the background
+/// isolate must not auto-reconnect in this configuration.
 SignalingForegroundIsolateManager _makeManager(_FakeSignalingModule module) {
   return SignalingForegroundIsolateManager(
     coreUrl: 'wss://example.com',
@@ -109,7 +121,20 @@ SignalingForegroundIsolateManager _makeManager(_FakeSignalingModule module) {
     // moduleFactoryHandle is 0 by default, but _testModuleFactory overrides
     // the handle-resolution path, so 0 does not trigger the "no factory" guard.
     moduleFactory: (_) => module,
-    hubFactory: _FakeSignalingHub.new,
+    hubFactory: _FakeSignalingHub.new, // hasSubscribers defaults to true
+  );
+}
+
+/// Creates a manager where the hub reports NO subscribers (app is closed —
+/// persistent-service mode). The background isolate must auto-reconnect
+/// independently in this configuration.
+SignalingForegroundIsolateManager _makeManagerPersistentMode(_FakeSignalingModule module) {
+  return SignalingForegroundIsolateManager(
+    coreUrl: 'wss://example.com',
+    tenantId: 'tenant',
+    token: 'tok',
+    moduleFactory: (_) => module,
+    hubFactory: (m) => _FakeSignalingHub(m)..hasSubscribers = false,
   );
 }
 
@@ -198,16 +223,17 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // No auto-reconnect — delegated to main isolate
+  // No auto-reconnect when subscribers present — delegated to main isolate
   // -------------------------------------------------------------------------
 
-  // Reconnect decisions belong exclusively to SignalingReconnectController in
-  // the main isolate. It sends SignalingHubConnectCommand via the hub when it
-  // decides to reconnect. The foreground-service isolate must NOT reconnect on
-  // its own — doing so would bypass lifecycle guards (e.g. app paused, no
-  // active calls) and cause spurious 4502 reconnect loops.
+  // When the main isolate is subscribed to the hub (app is open), reconnect
+  // decisions belong exclusively to SignalingReconnectController. It sends
+  // SignalingHubConnectCommand via the hub when it decides to reconnect.
+  // The foreground-service isolate must NOT reconnect on its own — doing so
+  // would bypass lifecycle guards (e.g. app paused, no active calls) and
+  // cause spurious 4502 reconnect loops.
 
-  group('SignalingForegroundIsolateManager -- no auto-reconnect on disconnect', () {
+  group('SignalingForegroundIsolateManager -- no auto-reconnect when main isolate is subscribed', () {
     test('does NOT reconnect when disconnect carries a non-null delay hint', () async {
       final module = _FakeSignalingModule();
       final manager = _makeManager(module);
@@ -238,6 +264,81 @@ void main() {
 
       await Future<void>.delayed(const Duration(milliseconds: 150));
       expect(module.connectCount, 1, reason: 'isolate must not auto-reconnect; only main isolate may reconnect');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Persistent-service mode — auto-reconnect when no subscribers (app closed)
+  // -------------------------------------------------------------------------
+
+  // In persistent signaling mode the foreground service outlives the app.
+  // When the app is closed there are no hub subscribers, so
+  // SignalingReconnectController is not running. The background isolate must
+  // therefore manage reconnects locally until the app reopens and the main
+  // isolate subscribes again.
+
+  group('SignalingForegroundIsolateManager -- persistent mode auto-reconnect (no subscribers)', () {
+    test('reconnects after disconnect when no subscribers and delay is provided', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerPersistentMode(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      module.simulateDisconnectWithDelay(const Duration(milliseconds: 50));
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(module.connectCount, 2, reason: 'isolate must auto-reconnect in persistent mode when no subscribers');
+    });
+
+    test('reconnects after connection failed when no subscribers and delay is provided', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerPersistentMode(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      module.simulateConnectionFailed(const Duration(milliseconds: 50));
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(module.connectCount, 2, reason: 'isolate must auto-reconnect in persistent mode when no subscribers');
+    });
+
+    test('does NOT reconnect when delay is null (e.g. code 1002) even with no subscribers', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerPersistentMode(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      // code 1002 → recommendedReconnectDelay == null → no reconnect
+      module.simulateDisconnect1002();
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(module.connectCount, 1, reason: 'null delay means server rejected reconnect');
+    });
+
+    test('stop() cancels a pending persistent-mode reconnect timer', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerPersistentMode(module);
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      module.simulateDisconnectWithDelay(const Duration(milliseconds: 50));
+
+      // Stop before the timer fires.
+      await manager.handleStatus(enabled: false);
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(module.connectCount, 1, reason: 'timer cancelled by stop() — no reconnect after dispose');
     });
   });
 


### PR DESCRIPTION
## Root cause

`SignalingHubModule.connect()`/`disconnect()` were no-ops — the hub owned
the connection lifecycle but had no way to receive commands from the main
isolate. The background foreground-service isolate reconnected independently
via its own `_reconnectTimer`, bypassing all lifecycle guards in
`SignalingReconnectController` (app paused, active call, etc.).

This caused the **\"green status + error toast\"** bug: background reconnects
while the phone was locked → `SignalingConnected` → `_wasConnected = true` →
next disconnect → error toast queued → visible on unlock.

The same independent timer also caused a regression in **persistent-service
mode** (app closed): without it the background isolate had no way to keep
the connection alive when the main isolate is not running.

---

## Fix

### 1. Bidirectional hub protocol (`connect`/`disconnect` commands)

Extended the hub IPC with two new commands so the main isolate can drive
the WebSocket lifecycle instead of the background isolate doing it alone.

| File | Change |
|------|--------|
| `signaling_hub_command.dart` | Add `SignalingHubConnectCommand` / `SignalingHubDisconnectCommand` |
| `signaling_hub_client.dart` | Add `sendConnect()` / `sendDisconnect()` |
| `signaling_hub.dart` | Handle new commands, forward to `SignalingModule`; add `hasSubscribers` getter |
| `signaling_hub_module.dart` | `connect()`/`disconnect()` now forward commands to hub client |

### 2. Conditional reconnect in the background isolate

The reconnect timer is restored but gated on `SignalingHub.hasSubscribers`:

| State | `hasSubscribers` | Who reconnects |
|-------|-----------------|----------------|
| App open | `true` | `SignalingReconnectController` in main isolate |
| App closed (persistent mode) | `false` | `SignalingForegroundIsolateManager` locally |
| `recommendedReconnectDelay == null` (e.g. code 1002) | any | nobody — server rejected reconnect |

`signaling_foreground_isolate_manager.dart`:
- `_scheduleReconnect()` is called only when `!hub.hasSubscribers`
- When `handleStatus(enabled: true)` arrives while a timer is pending, the timer is cancelled (caller takes over)
- `_stop()` always cancels the timer

---

## Tests

All **162 tests pass** (`flutter test` in `webtrit_signaling_service_android`).

New/updated test groups:
- `SignalingHubModule -- connect/disconnect forward to hub client`
- `SignalingForegroundIsolateManager -- no auto-reconnect when main isolate is subscribed`
- `SignalingForegroundIsolateManager -- persistent mode auto-reconnect (no subscribers)` — 4 new tests:
  - reconnects on disconnect with delay
  - reconnects on connection failed with delay
  - does NOT reconnect when delay is null (code 1002)
  - stop() cancels a pending timer

---

## Test plan

- [ ] **Unit**: `flutter test` in `webtrit_signaling_service_android` — all 162 pass
- [ ] **Device (normal mode)**: lock phone during active session → no reconnect in background → unlock → no error toast
- [ ] **Device (normal mode)**: WiFi restored → `SignalingReconnectController` sends connect command → reconnects cleanly
- [ ] **Device (persistent mode)**: close app → drop connection → background isolate reconnects automatically
- [ ] **Device (persistent mode)**: open app after background reconnect → main isolate subscribes → takes over reconnect decisions