### PR TITLE
fix: session status stuck on Connection in progress on devices without GMS

### DIFF
--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -40,11 +40,11 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     _emitCombinedStatus();
   }
 
-  void _emitCombinedStatus([PushTokensState? initialPushTokens, CallState? initialCall]) {
+  void _emitCombinedStatus() {
     _logger.finest('emitCombinedStatus: $_lastPushTokensState, $_lastCallState');
 
-    final pushTokens = initialPushTokens ?? _lastPushTokensState;
-    final call = initialCall ?? _lastCallState;
+    final pushTokens = _lastPushTokensState;
+    final call = _lastCallState;
 
     if (pushTokens != null && call != null) {
       emit(state.copyWith(status: _mapCallStatusToSessionStatus(call.status, pushTokens)));

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -16,10 +16,12 @@ final _logger = Logger('SessionStatusCubit');
 class SessionStatusCubit extends Cubit<SessionStatusState> {
   SessionStatusCubit({required PushTokensBloc pushTokensBloc, required CallBloc callBloc})
     : super(const SessionStatusState()) {
+    _lastPushTokensState = pushTokensBloc.state;
+    _lastCallState = callBloc.state;
     _pushTokensSubscription = pushTokensBloc.stream.listen(_onPushTokensChanged);
     _callSubscription = callBloc.stream.listen(_onCallChanged);
 
-    _emitCombinedStatus(pushTokensBloc.state, callBloc.state);
+    _emitCombinedStatus();
   }
 
   late final StreamSubscription<PushTokensState> _pushTokensSubscription;


### PR DESCRIPTION
## Problem

On devices without Google Mobile Services (e.g. Huawei MAO-LX9N Android 12), the app shows **"Connection in progress"** permanently, even though the signaling connection and SIP registration complete successfully.

**Root cause (two-part):**

1. `PushTokensBloc` never emits after initialization on no-GMS devices — `_retrieveAndStoreFcmToken` checks GMS availability, gets a terminal status, and returns early without any `emit()` or `add()`.

2. `SessionStatusCubit` constructor called `_emitCombinedStatus(pushTokensBloc.state, callBloc.state)` passing initial states as *parameters*, but never stored them in `_lastPushTokensState` / `_lastCallState`. All subsequent calls from `_onCallChanged` used `_lastPushTokensState = null`, so the condition `pushTokens != null && call != null` was always `false` — the UI status was never updated from its initial `SessionStatus.inProgress`.

On GMS devices this goes unnoticed because `PushTokensBloc` emits when the FCM token arrives, which triggers `_onPushTokensChanged`, seeds `_lastPushTokensState`, and unblocks future `_onCallChanged` emissions.

## Fix

Seed `_lastPushTokensState` and `_lastCallState` directly from the blocs' current states in the constructor, before subscribing to their streams.

```dart
_lastPushTokensState = pushTokensBloc.state;
_lastCallState = callBloc.state;
```

This way, even if `PushTokensBloc` never emits (no GMS), `_onCallChanged` can still update the UI status correctly.

## Affected devices

Reproduces on any Android device without Google Play Services where `PushTokensBloc` stays in its initial state (`pushToken: null, errorMessage: null`).

Confirmed via logcat: `HUAWEI-MAO-LX9N-Android-12_2026-04-10_120728.logcat` — signaling reaches `registered` at 12:07:02 but `_lastPushTokensState` is `null` throughout the entire session.