### PR TITLE
fix(signaling): cancel in-flight connect on disconnect

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -114,7 +114,7 @@ class SignalingModuleImpl implements SignalingModule {
 
   /// Identity token for the active connect attempt.
   ///
-  /// Non-null while a [_connectAsync] is in progress (acts as [_connecting]).
+  /// Non-null while a [_connectAsync] is in progress; null when idle.
   /// [connect] creates a fresh [Object] and passes it to [_connectAsync].
   /// [disconnect] sets it to null, which [_connectAsync] detects after each
   /// suspension point — the "latest wins" pattern for non-cancellable Futures.
@@ -196,11 +196,12 @@ class SignalingModuleImpl implements SignalingModule {
 
   @override
   Future<void> disconnect() async {
+    final hadInFlightConnect = _connectToken != null;
     _connectToken = null; // invalidate any in-flight _connectAsync
 
     final client = _client;
     if (client == null) {
-      _logger.fine('disconnect: no active client, in-flight connect cancelled');
+      if (hadInFlightConnect) _logger.fine('disconnect: in-flight connect cancelled');
       return;
     }
     _client = null;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -113,6 +113,13 @@ class SignalingModuleImpl implements SignalingModule {
   bool _disposed = false;
   bool _connecting = false;
 
+  /// Monotonically increasing counter incremented by every [connect] and
+  /// [disconnect] call. [_connectAsync] captures the current value at the
+  /// moment it starts and checks it after every suspension point: if the
+  /// counter has changed the connect attempt is stale and exits without
+  /// emitting events or setting [_client].
+  int _generation = 0;
+
   /// Completer resolved by [_onDisconnect] after a graceful [disconnect] call.
   Completer<void>? _disconnectAck;
 
@@ -182,12 +189,16 @@ class SignalingModuleImpl implements SignalingModule {
   @override
   void connect() {
     if (_disposed || _connecting) return;
+    final gen = ++_generation;
     _eventBuffer.clear();
-    unawaited(_connectAsync());
+    unawaited(_connectAsync(gen));
   }
 
   @override
   Future<void> disconnect() async {
+    ++_generation; // invalidate any in-flight _connectAsync
+    _connecting = false; // allow subsequent connect() to proceed
+
     final client = _client;
     if (client == null) return;
     _client = null;
@@ -220,7 +231,7 @@ class SignalingModuleImpl implements SignalingModule {
   // Internal
   // ---------------------------------------------------------------------------
 
-  Future<void> _connectAsync() async {
+  Future<void> _connectAsync(int gen) async {
     if (_connecting) return;
     _connecting = true;
     try {
@@ -234,7 +245,7 @@ class SignalingModuleImpl implements SignalingModule {
         }
       }
 
-      if (_disposed) return;
+      if (gen != _generation || _disposed) return;
 
       _emit(SignalingConnecting());
 
@@ -249,11 +260,13 @@ class SignalingModuleImpl implements SignalingModule {
           force: true,
         );
 
-        if (_disposed) {
+        if (gen != _generation || _disposed) {
+          // This connect was superseded by disconnect() or a newer connect() —
+          // clean up the client without emitting events.
           try {
             await client.disconnect(SignalingDisconnectCode.normalClosure.code);
           } catch (e, s) {
-            _logger.warning('_connectAsync dispose-disconnect error', e, s);
+            _logger.warning('_connectAsync stale-disconnect error', e, s);
           }
           return;
         }
@@ -270,7 +283,7 @@ class SignalingModuleImpl implements SignalingModule {
         _emit(SignalingConnected());
         unawaited(_requestQueue.flush(execute: client.execute, isActive: () => identical(_client, client)));
       } catch (e, s) {
-        if (_disposed) return;
+        if (gen != _generation || _disposed) return;
         _logger.warning('_connectAsync failed', e, s);
 
         final errorString = e.toString();
@@ -280,7 +293,9 @@ class SignalingModuleImpl implements SignalingModule {
         _emit(SignalingConnectionFailed(error: e, isRepeated: isRepeated, recommendedReconnectDelay: reconnectDelay));
       }
     } finally {
-      _connecting = false;
+      // Only reset _connecting for the current generation — a superseded
+      // _connectAsync must not clear the flag owned by the active one.
+      if (gen == _generation) _connecting = false;
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -111,14 +111,14 @@ class SignalingModuleImpl implements SignalingModule {
 
   WebtritSignalingClient? _client;
   bool _disposed = false;
-  bool _connecting = false;
 
-  /// Monotonically increasing counter incremented by every [connect] and
-  /// [disconnect] call. [_connectAsync] captures the current value at the
-  /// moment it starts and checks it after every suspension point: if the
-  /// counter has changed the connect attempt is stale and exits without
-  /// emitting events or setting [_client].
-  int _generation = 0;
+  /// Identity token for the active connect attempt.
+  ///
+  /// Non-null while a [_connectAsync] is in progress (acts as [_connecting]).
+  /// [connect] creates a fresh [Object] and passes it to [_connectAsync].
+  /// [disconnect] sets it to null, which [_connectAsync] detects after each
+  /// suspension point — the "latest wins" pattern for non-cancellable Futures.
+  Object? _connectToken;
 
   /// Completer resolved by [_onDisconnect] after a graceful [disconnect] call.
   Completer<void>? _disconnectAck;
@@ -188,20 +188,19 @@ class SignalingModuleImpl implements SignalingModule {
   /// Clears the session buffer on each call.
   @override
   void connect() {
-    if (_disposed || _connecting) return;
-    final gen = ++_generation;
+    if (_disposed || _connectToken != null) return;
+    final token = _connectToken = Object();
     _eventBuffer.clear();
-    unawaited(_connectAsync(gen));
+    unawaited(_connectAsync(token));
   }
 
   @override
   Future<void> disconnect() async {
-    ++_generation; // invalidate any in-flight _connectAsync
-    _connecting = false; // allow subsequent connect() to proceed
+    _connectToken = null; // invalidate any in-flight _connectAsync
 
     final client = _client;
     if (client == null) {
-      _logger.fine('disconnect: no active client, in-flight connect cancelled (gen=$_generation)');
+      _logger.fine('disconnect: no active client, in-flight connect cancelled');
       return;
     }
     _client = null;
@@ -234,9 +233,7 @@ class SignalingModuleImpl implements SignalingModule {
   // Internal
   // ---------------------------------------------------------------------------
 
-  Future<void> _connectAsync(int gen) async {
-    if (_connecting) return;
-    _connecting = true;
+  Future<void> _connectAsync(Object connectToken) async {
     try {
       final existing = _client;
       if (existing != null) {
@@ -248,7 +245,7 @@ class SignalingModuleImpl implements SignalingModule {
         }
       }
 
-      if (gen != _generation || _disposed) return;
+      if (_connectToken != connectToken || _disposed) return;
 
       _emit(SignalingConnecting());
 
@@ -263,10 +260,10 @@ class SignalingModuleImpl implements SignalingModule {
           force: true,
         );
 
-        if (gen != _generation || _disposed) {
+        if (_connectToken != connectToken || _disposed) {
           // This connect was superseded by disconnect() or a newer connect() —
           // clean up the client without emitting events.
-          _logger.fine('_connectAsync: stale connect discarded (gen=$gen, current=$_generation)');
+          _logger.fine('_connectAsync: stale connect discarded');
           try {
             await client.disconnect(SignalingDisconnectCode.normalClosure.code);
           } catch (e, s) {
@@ -287,7 +284,7 @@ class SignalingModuleImpl implements SignalingModule {
         _emit(SignalingConnected());
         unawaited(_requestQueue.flush(execute: client.execute, isActive: () => identical(_client, client)));
       } catch (e, s) {
-        if (gen != _generation || _disposed) return;
+        if (_connectToken != connectToken || _disposed) return;
         _logger.warning('_connectAsync failed', e, s);
 
         final errorString = e.toString();
@@ -297,9 +294,9 @@ class SignalingModuleImpl implements SignalingModule {
         _emit(SignalingConnectionFailed(error: e, isRepeated: isRepeated, recommendedReconnectDelay: reconnectDelay));
       }
     } finally {
-      // Only reset _connecting for the current generation — a superseded
-      // _connectAsync must not clear the flag owned by the active one.
-      if (gen == _generation) _connecting = false;
+      // Only clear the token if this is still the active connect — a superseded
+      // _connectAsync must not remove the token owned by the active one.
+      if (_connectToken == connectToken) _connectToken = null;
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -200,7 +200,10 @@ class SignalingModuleImpl implements SignalingModule {
     _connecting = false; // allow subsequent connect() to proceed
 
     final client = _client;
-    if (client == null) return;
+    if (client == null) {
+      _logger.fine('disconnect: no active client, in-flight connect cancelled (gen=$_generation)');
+      return;
+    }
     _client = null;
     _intentionalDisconnect = true;
     _disconnectAck = Completer<void>();
@@ -263,6 +266,7 @@ class SignalingModuleImpl implements SignalingModule {
         if (gen != _generation || _disposed) {
           // This connect was superseded by disconnect() or a newer connect() —
           // clean up the client without emitting events.
+          _logger.fine('_connectAsync: stale connect discarded (gen=$gen, current=$_generation)');
           try {
             await client.disconnect(SignalingDisconnectCode.normalClosure.code);
           } catch (e, s) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -3,12 +3,13 @@
 /// Reproduces the disconnect-during-connect race condition:
 ///
 /// When [SignalingModuleImpl.disconnect] is called while [_connectAsync] is
-/// still awaiting the client factory (_client == null, _connecting == true),
-/// disconnect() returns early without resetting _connecting. The next
-/// connect() call is then silently dropped because _connecting is still true.
+/// still awaiting the client factory (_client == null, _connectToken != null),
+/// disconnect() must cancel the in-flight attempt by clearing _connectToken.
+/// The next connect() call must then be allowed to start a fresh attempt
+/// instead of being blocked by the stale in-flight operation.
 ///
-/// These tests FAIL on the current implementation and PASS after the fix.
-library;
+/// Tests labelled "BUG:" reproduce the broken behavior on the unfixed code.
+/// Tests labelled "after fix:" verify the correct behavior.
 
 import 'dart:async';
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -10,6 +10,7 @@
 ///
 /// Tests labelled "BUG:" reproduce the broken behavior on the unfixed code.
 /// Tests labelled "after fix:" verify the correct behavior.
+library;
 
 import 'dart:async';
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -1,0 +1,210 @@
+/// Unit tests for [SignalingModuleImpl].
+///
+/// Reproduces the disconnect-during-connect race condition:
+///
+/// When [SignalingModuleImpl.disconnect] is called while [_connectAsync] is
+/// still awaiting the client factory (_client == null, _connecting == true),
+/// disconnect() returns early without resetting _connecting. The next
+/// connect() call is then silently dropped because _connecting is still true.
+///
+/// These tests FAIL on the current implementation and PASS after the fix.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ssl_certificates/ssl_certificates.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
+
+// ---------------------------------------------------------------------------
+// Fake client
+// ---------------------------------------------------------------------------
+
+class _FakeClient extends Fake implements WebtritSignalingClient {
+  DisconnectHandler? _onDisconnect;
+
+  @override
+  void listen({
+    required StateHandshakeHandler onStateHandshake,
+    required EventHandler onEvent,
+    required ErrorHandler onError,
+    required DisconnectHandler onDisconnect,
+  }) {
+    _onDisconnect = onDisconnect;
+  }
+
+  @override
+  Future<void> disconnect([int? code, String? reason]) async {
+    _onDisconnect?.call(code, reason);
+  }
+
+  @override
+  Future<void> execute(Request request, [Duration? timeout]) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Controlled factory
+// ---------------------------------------------------------------------------
+
+/// A factory where each call gets its own [Completer].
+/// Tracks how many times the factory was called and allows releasing each
+/// call independently.
+class _ControlledFactory {
+  final _calls = <Completer<WebtritSignalingClient>>[];
+  int get callCount => _calls.length;
+
+  Completer<WebtritSignalingClient> get lastCall => _calls.last;
+
+  SignalingClientFactory get factory =>
+      ({
+        required Uri url,
+        required String tenantId,
+        required String token,
+        required Duration connectionTimeout,
+        required TrustedCertificates certs,
+        required bool force,
+      }) {
+        final c = Completer<WebtritSignalingClient>();
+        _calls.add(c);
+        return c.future;
+      };
+
+  void release(int callIndex, WebtritSignalingClient client) => _calls[callIndex].complete(client);
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+SignalingModuleImpl _buildModule(SignalingClientFactory factory) => SignalingModuleImpl(
+  coreUrl: 'https://example.com',
+  tenantId: 'tenant',
+  token: 'token',
+  trustedCertificates: TrustedCertificates.empty,
+  clientFactory: factory,
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('SignalingModuleImpl — disconnect() during in-flight connect()', () {
+    // -----------------------------------------------------------------------
+    // Core bug: disconnect while _client==null leaves _connecting=true
+    // -----------------------------------------------------------------------
+
+    test('BUG: second connect() is silently dropped because _connecting stays true after disconnect()', () async {
+      // Arrange
+      final factory = _ControlledFactory();
+      final module = _buildModule(factory.factory);
+
+      // Act: connect #1 → factory called, hangs
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+      expect(factory.callCount, 1, reason: 'first connect() must call the factory');
+
+      // disconnect() while _client==null — the bug: does not reset _connecting
+      await module.disconnect();
+
+      // connect #2 — must call the factory again; currently it is silently dropped
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // BUG: factory was not called a second time — second connect() was dropped
+      expect(
+        factory.callCount,
+        2,
+        reason: 'second connect() was silently dropped: factory call count did not increase',
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // Consequence: stale connect completes and leaves module in wrong state
+    // -----------------------------------------------------------------------
+
+    test('BUG: stale in-flight connect completes after disconnect() and leaves module connected', () async {
+      // Arrange
+      final factory = _ControlledFactory();
+      final module = _buildModule(factory.factory);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      // connect #1 → factory hangs
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // disconnect() — no-op when _client==null (the bug)
+      await module.disconnect();
+
+      // Release the stale factory (simulates slow WebSocket that eventually connects)
+      factory.release(0, _FakeClient());
+      await Future<void>.delayed(Duration.zero);
+
+      // BUG: module is now "connected" even though we explicitly disconnected
+      expect(
+        module.isConnected,
+        isFalse,
+        reason: 'stale connect() completed after disconnect() and incorrectly set _client',
+      );
+      expect(
+        events.whereType<SignalingConnected>(),
+        isEmpty,
+        reason: 'SignalingConnected must not fire for a connect() superseded by disconnect()',
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // Expected correct behavior after the fix
+    // -----------------------------------------------------------------------
+
+    test('after fix: disconnect() cancels in-flight connect so second connect() reaches the factory', () async {
+      final factory = _ControlledFactory();
+      final module = _buildModule(factory.factory);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      // connect #1 → hangs
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // disconnect() → must cancel connect #1 and reset _connecting
+      await module.disconnect();
+
+      // connect #2 → must be accepted (factory called again)
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+      expect(factory.callCount, 2, reason: 'second connect() must call the factory');
+
+      // Release connect #2 — module should become connected
+      factory.release(1, _FakeClient());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(module.isConnected, isTrue);
+      expect(events.whereType<SignalingConnected>(), isNotEmpty);
+    });
+
+    test('after fix: stale factory result is discarded, SignalingConnected not emitted', () async {
+      final factory = _ControlledFactory();
+      final module = _buildModule(factory.factory);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      // connect #1 → hangs
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // disconnect() cancels connect #1
+      await module.disconnect();
+
+      // Release the stale factory call AFTER disconnect
+      factory.release(0, _FakeClient());
+      await Future<void>.delayed(Duration.zero);
+
+      // Stale result must be discarded
+      expect(module.isConnected, isFalse);
+      expect(events.whereType<SignalingConnected>(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

`SignalingModuleImpl.disconnect()` was a no-op when called while a `connect()` was in-flight (WebSocket handshake pending). This left the module in a state where the next `connect()` call was silently dropped.

### Root cause

`disconnect()` checked only `_client` to decide whether there was anything to do:

```dart
Future<void> disconnect() async {
  final client = _client;
  if (client == null) return;  // ← no-op when handshake is in-flight
  ...
}
```

Between `connect()` starting and `_clientFactory(...)` completing, `_client` is `null` while a connect is actively in progress. If `disconnect()` is called in this window, it returns without stopping the in-flight async task. The subsequent `connect()` is then silently dropped because the module still considers itself busy.

### Failure chain (observed on Pixel 9, Android 16)

```
18:42:18  connect() → starts _connectAsync, awaiting WebSocket handshake
18:42:19  notifyAppPaused → disconnect() → _client==null → return (no-op)
           connect is still in-flight
18:42:21  notifyAppResumed → connect() → module thinks it's busy → dropped
18:42:33  createCall: routing state not available after 10s
```

The lifecycle bounce (`active → paused → resumed`) is triggered on Android 16 when the user taps the call button — Android Telecom API fires the transition automatically. The pause hits exactly while the WebSocket handshake is pending.

---

## Fix

Replaced the two-field approach (`bool _connecting` + connect-in-progress tracking) with a single `Object? _connectToken` field — the **"latest wins"** pattern for non-cancellable Dart Futures.

```dart
Object? _connectToken; // null = idle, non-null = connect in progress
```

**How it works:**

`connect()` mints a fresh `Object()` and passes it to `_connectAsync`:
```dart
void connect() {
  if (_disposed || _connectToken != null) return;
  final token = _connectToken = Object();
  unawaited(_connectAsync(token));
}
```

`disconnect()` sets `_connectToken = null` — one line that both cancels the in-flight connect and allows the next `connect()` to proceed:
```dart
Future<void> disconnect() async {
  _connectToken = null;
  final client = _client;
  if (client == null) return;
  ...
}
```

`_connectAsync` checks token identity after every suspension point. If the token no longer matches, the connect was superseded — it cleans up silently without emitting events:
```dart
Future<void> _connectAsync(Object connectToken) async {
  try {
    final client = await _clientFactory(...);

    if (_connectToken != connectToken || _disposed) {
      await client.disconnect(...); // clean up, no events
      return;
    }

    _client = client;
    _emit(SignalingConnected());
  } finally {
    if (_connectToken == connectToken) _connectToken = null;
  }
}
```

The `finally` guard ensures a superseded `_connectAsync` does not clear the token that belongs to a newer active connect.

---

## Tests

Four unit tests in `signaling_module_impl_test.dart` using `_ControlledFactory` — a test helper with per-call `Completer` and call counter to control factory resolution timing precisely:

| Test | Verifies |
|------|----------|
| `BUG: second connect() silently dropped` | `factory.callCount == 2` after disconnect + reconnect |
| `BUG: stale connect sets _client after disconnect` | `isConnected == false` when stale factory resolves |
| `after fix: second connect() reaches the factory` | factory called again after disconnect |
| `after fix: stale result discarded, no SignalingConnected` | no event emitted for superseded connect |

All 4 pass.

---

## Diagnostic logs

```
D/SignalingModuleImpl: disconnect: no active client, in-flight connect cancelled
D/SignalingModuleImpl: _connectAsync: stale connect discarded
```

Both lines appearing in a log session confirm the race was triggered and correctly handled.

---

## Scope

- `SignalingModuleImpl` internals only — no public API changes, no event type changes
- No changes to `SignalingReconnectController`, hub layer, or any caller