### PR TITLE
fix(session): resolve stuck 'No internet' status after network restore

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -627,7 +627,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       state.copyWith(
         callServiceState: state.callServiceState.copyWith(
           signalingClientStatus: SignalingClientStatus.connecting,
+          lastSignalingClientConnectError: null,
           lastSignalingClientDisconnectError: null,
+          lastSignalingDisconnectCode: null,
         ),
       ),
     );


### PR DESCRIPTION
## Problem

After turning internet off and back on, the app status gets stuck on "Connection error" or "Connection issue" even though a fresh reconnect attempt is already in progress.

**Observed on:** Samsung SM-M325FV, Android 13
**Log:** `samsung-SM-M325FV-Android-13_2026-04-10_130044.logcat`

---

## Root Cause

`__onSignalingClientEventConnecting` in `call_bloc.dart` cleared only `lastSignalingClientDisconnectError` but left `lastSignalingClientConnectError` and `lastSignalingDisconnectCode` from the previous failed session:

```dart
// BEFORE — stale errors survive into the reconnect window
signalingClientStatus: SignalingClientStatus.connecting,
lastSignalingClientDisconnectError: null,
// lastSignalingClientConnectError ← NOT cleared
// lastSignalingDisconnectCode     ← NOT cleared
```

`CallServiceState.get status` evaluates these fields in priority order:

```dart
if (networkStatus == NetworkStatus.none)          → connectivityNone
else if (lastSignalingClientConnectError != null) → connectError   // ← stale error wins
else if (lastSignalingDisconnectCode != null)     → connectIssue   // ← stale code wins
...
else                                              → inProgress
```

So even when a fresh `SignalingConnecting` fires and the module is actively reconnecting, the UI shows "Connection error" or "Connection issue" until `SignalingConnected` clears them.

---

## Fix

Clear all stale error fields in `__onSignalingClientEventConnecting`:

```dart
// AFTER
signalingClientStatus: SignalingClientStatus.connecting,
lastSignalingClientConnectError: null,    // ← added
lastSignalingClientDisconnectError: null,
lastSignalingDisconnectCode: null,        // ← added
```

As soon as a new connect attempt starts, the status correctly reflects `inProgress` ("Connection in progress") for the entire reconnect window.

---

## Scope

- One handler in `call_bloc.dart`
- No model or API changes
- `SignalingConnected` already clears these fields — this fix mirrors that behavior one step earlier (at `Connecting`)