### PR TITLE
fix(l10n): escape apostrophe in Italian ARB plural string

### DIFF
--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -883,7 +883,7 @@ class AppLocalizationsIt extends AppLocalizations {
       count,
       locale: localeName,
       other: 'Visualizzazione degli ultimi $count record. Usa Condividi per esportare il log completo.',
-      one: 'Visualizzazione dell\'ultimo $count record. Usa Condividi per esportare il log completo.',
+      one: 'Visualizzazione dell’ultimo $count record. Usa Condividi per esportare il log completo.',
     );
     return '$_temp0';
   }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -746,7 +746,7 @@
   "@logRecordsConsole_Text_failure": {
     "description": "Shown in the Log Console screen when an unexpected error occurs while loading or displaying log records."
   },
-  "logRecordsConsole_Text_recordsCountHint": "{count, plural, one{Visualizzazione dell''ultimo {count} record. Usa Condividi per esportare il log completo.} other{Visualizzazione degli ultimi {count} record. Usa Condividi per esportare il log completo.}}",
+  "logRecordsConsole_Text_recordsCountHint": "{count, plural, one{Visualizzazione dell\u2019ultimo {count} record. Usa Condividi per esportare il log completo.} other{Visualizzazione degli ultimi {count} record. Usa Condividi per esportare il log completo.}}",
   "@logRecordsConsole_Text_recordsCountHint": {
     "description": "Shown in the info dialog to inform the user that only the most recent records are displayed and the share button exports the complete log.",
     "placeholders": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -746,7 +746,7 @@
   "@logRecordsConsole_Text_failure": {
     "description": "Shown in the Log Console screen when an unexpected error occurs while loading or displaying log records."
   },
-  "logRecordsConsole_Text_recordsCountHint": "{count, plural, one{Visualizzazione dell'ultimo {count} record. Usa Condividi per esportare il log completo.} other{Visualizzazione degli ultimi {count} record. Usa Condividi per esportare il log completo.}}",
+  "logRecordsConsole_Text_recordsCountHint": "{count, plural, one{Visualizzazione dell''ultimo {count} record. Usa Condividi per esportare il log completo.} other{Visualizzazione degli ultimi {count} record. Usa Condividi per esportare il log completo.}}",
   "@logRecordsConsole_Text_recordsCountHint": {
     "description": "Shown in the info dialog to inform the user that only the most recent records are displayed and the share button exports the complete log.",
     "placeholders": {


### PR DESCRIPTION
## Summary
- Fixes ICU lexing error in `app_it.arb` that caused Android build failure in CI
- Single quote `'` in `dell'ultimo` was being parsed as an ICU escape character
- Fixed by escaping to `''` per ICU message format spec

## Root cause
```
[app_it.arb:logRecordsConsole_Text_recordsCountHint] ICU Lexing Error: Unexpected character.
    {one=Visualizzazione dell'ultimo {count} record...
                             ^
Target gen_localizations failed: Error: Found syntax errors.
```

## Test plan
- [ ] Run `flutter gen-l10n` locally — should complete without errors
- [ ] Trigger CI build — `gen_localizations` step should pass