### PR TITLE
docs(signaling): add remoteMessaging FGS type rationale

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/AndroidManifest.xml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/AndroidManifest.xml
@@ -8,6 +8,40 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
+        <!--
+            foregroundServiceType="remoteMessaging" is the correct type for SignalingForegroundService.
+
+            This service maintains a persistent WebSocket connection to the WebTrit signaling server
+            to send and receive call-signaling messages (SDP offers/answers, ICE candidates, call
+            state events). It never accesses the microphone, camera, or location — it is purely a
+            messaging transport layer that runs before, during, and after a call.
+
+            Why NOT phoneCall:
+              The phoneCall type is reserved for services that actively manage a call via the Android
+              Telecom API (audio focus, in-call UI, connection state). That responsibility belongs to
+              webtrit_callkeep running in the callkeep_core process via PhoneConnectionService.
+              SignalingForegroundService sits below that layer: it delivers the signaling payloads
+              that allow the Telecom layer to set up and tear down calls, but it does not manage
+              calls itself. Using phoneCall here would require MANAGE_OWN_CALLS or default-dialer
+              privileges and would be semantically incorrect.
+
+            Why NOT microphone / camera:
+              This service does not capture any media. WebRTC media is handled by a separate
+              component (flutter-webrtc) that runs in the main app process.
+
+            Why NOT dataSync:
+              dataSync is for periodic background sync tasks. This service holds a continuous
+              real-time connection — not a periodic one.
+
+            Android documentation for remoteMessaging:
+              "Use this type if the app needs to be kept running on-device so that a remote
+              service can send messages to the device."
+            This matches exactly: the WebSocket is kept alive so the signaling server can push
+            call events to the device at any time, without relying solely on FCM.
+
+            Required permission: FOREGROUND_SERVICE_REMOTE_MESSAGING (declared above).
+            Applies on Android 14+ (API 34, UPSIDE_DOWN_CAKE); older versions use type=0.
+        -->
         <service
             android:name=".SignalingForegroundService"
             android:foregroundServiceType="remoteMessaging"

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/AndroidManifest.xml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/AndroidManifest.xml
@@ -9,38 +9,16 @@
 
     <application>
         <!--
-            foregroundServiceType="remoteMessaging" is the correct type for SignalingForegroundService.
+            SignalingForegroundService uses foregroundServiceType="remoteMessaging".
 
-            This service maintains a persistent WebSocket connection to the WebTrit signaling server
-            to send and receive call-signaling messages (SDP offers/answers, ICE candidates, call
-            state events). It never accesses the microphone, camera, or location — it is purely a
-            messaging transport layer that runs before, during, and after a call.
-
-            Why NOT phoneCall:
-              The phoneCall type is reserved for services that actively manage a call via the Android
-              Telecom API (audio focus, in-call UI, connection state). That responsibility belongs to
-              webtrit_callkeep running in the callkeep_core process via PhoneConnectionService.
-              SignalingForegroundService sits below that layer: it delivers the signaling payloads
-              that allow the Telecom layer to set up and tear down calls, but it does not manage
-              calls itself. Using phoneCall here would require MANAGE_OWN_CALLS or default-dialer
-              privileges and would be semantically incorrect.
-
-            Why NOT microphone / camera:
-              This service does not capture any media. WebRTC media is handled by a separate
-              component (flutter-webrtc) that runs in the main app process.
-
-            Why NOT dataSync:
-              dataSync is for periodic background sync tasks. This service holds a continuous
-              real-time connection — not a periodic one.
-
-            Android documentation for remoteMessaging:
-              "Use this type if the app needs to be kept running on-device so that a remote
-              service can send messages to the device."
-            This matches exactly: the WebSocket is kept alive so the signaling server can push
-            call events to the device at any time, without relying solely on FCM.
+            This service maintains a persistent WebSocket connection to the WebTrit signaling
+            server to exchange call-signaling messages (SDP, ICE candidates, call state events).
+            The remoteMessaging type is defined by Android as the appropriate type for services
+            that keep a long-running connection alive so a remote server can deliver messages to
+            the device at any time — which is exactly what this service does.
 
             Required permission: FOREGROUND_SERVICE_REMOTE_MESSAGING (declared above).
-            Applies on Android 14+ (API 34, UPSIDE_DOWN_CAKE); older versions use type=0.
+            Applies on Android 14+ (API 34+); older versions pass type=0.
         -->
         <service
             android:name=".SignalingForegroundService"

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -135,16 +135,11 @@ class SignalingForegroundService : Service() {
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
 
-        // FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING is the correct type for this service.
-        // It maintains a persistent WebSocket to the WebTrit signaling server and never
-        // accesses microphone, camera, or location.
-        //
-        // phoneCall type is not appropriate here: call management via the Telecom API
-        // (audio focus, in-call UI) is handled by webtrit_callkeep in the callkeep_core
-        // process. This service is the transport layer below the call.
-        //
-        // Type is only declared on API 34+ (Android 14 / UPSIDE_DOWN_CAKE); on older
-        // versions the OS does not enforce a type so 0 is passed.
+        // FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING: this service maintains a persistent
+        // WebSocket to the WebTrit signaling server so it can receive call-signaling
+        // messages (SDP, ICE candidates, call events) at any time. The remoteMessaging
+        // type is the Android-defined category for exactly this use case.
+        // Declared on API 34+ only; older versions do not enforce a type.
         ServiceCompat.startForeground(
             this,
             NOTIFICATION_ID,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -139,7 +139,8 @@ class SignalingForegroundService : Service() {
         // WebSocket to the WebTrit signaling server so it can receive call-signaling
         // messages (SDP, ICE candidates, call events) at any time. The remoteMessaging
         // type is the Android-defined category for exactly this use case.
-        // Declared on API 34+ only; older versions do not enforce a type.
+        // Passed to startForeground() on API 34+ only; older versions pass 0 and do
+        // not enforce a foreground service type here.
         ServiceCompat.startForeground(
             this,
             NOTIFICATION_ID,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -135,6 +135,16 @@ class SignalingForegroundService : Service() {
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
 
+        // FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING is the correct type for this service.
+        // It maintains a persistent WebSocket to the WebTrit signaling server and never
+        // accesses microphone, camera, or location.
+        //
+        // phoneCall type is not appropriate here: call management via the Telecom API
+        // (audio focus, in-call UI) is handled by webtrit_callkeep in the callkeep_core
+        // process. This service is the transport layer below the call.
+        //
+        // Type is only declared on API 34+ (Android 14 / UPSIDE_DOWN_CAKE); on older
+        // versions the OS does not enforce a type so 0 is passed.
         ServiceCompat.startForeground(
             this,
             NOTIFICATION_ID,


### PR DESCRIPTION
## Summary

Adds inline documentation explaining why `foregroundServiceType="remoteMessaging"` is used for `SignalingForegroundService`.

- XML comment in `AndroidManifest.xml` before the `<service>` declaration
- Inline comment in `SignalingForegroundService.kt` at the `startForeground()` call site

No logic changes — comments only.

---

## Context

`SignalingForegroundService` maintains a persistent WebSocket connection to the WebTrit
signaling server to exchange call-signaling messages (SDP, ICE candidates, call state events).

Android defines `remoteMessaging` as the type for services that keep a long-running connection
alive so a remote server can deliver messages to the device at any time — which is exactly
what this service does. The WebSocket stays open so the signaling server can push call events
to the device without relying solely on FCM.

Required permission: `FOREGROUND_SERVICE_REMOTE_MESSAGING` (already declared in the manifest).
The type is passed to `startForeground()` on API 34+ only; older versions receive `type=0`.

---

## Test plan

- [ ] No `MissingForegroundServiceTypeException` or `SecurityException` on Android 14+
- [ ] `foregroundServiceType: 512` (`REMOTE_MESSAGING`) visible in logcat on Android 14+
- [ ] `type=0` path taken on Android 13 and below