### PR TITLE
fix(signaling): call startForeground() first in onCreate() to reduce FGS timeout risk

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -59,14 +59,12 @@ class SignalingForegroundService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        startForeground()
+
         Log.d(TAG, "SignalingForegroundService onCreate")
-
         instance = this
-
         val callbackHandle = StorageDelegate.getCallbackDispatcher(applicationContext)
         flutterEngineHelper = FlutterEngineHelper(applicationContext, callbackHandle, this)
-
-        startForeground()
         isRunning = true
     }
 


### PR DESCRIPTION
## Problem

`SignalingForegroundService.onCreate()` called `startForeground()` as the 5th operation, after a blocking SharedPreferences read (`StorageDelegate.getCallbackDispatcher()`).

Under Xiaomi HyperOS memory pressure, that SharedPrefs IPC blocks the main thread for 50–500ms. Combined with the main thread being busy during Flutter cold start, the total delay from `startForegroundService()` to `startForeground()` exceeded Xiaomi's aggressive ~1.2s window (vs the standard 10s), causing `ForegroundServiceDidNotStartInTimeException`.

From the crash log:
```
T+0.000s  startForegroundService()
T+1.205s  Xiaomi removes ServiceRecord
T+2.252s  startForeground() → rejected → crash
```

## Fix

Move `startForeground()` to be the first call after `super.onCreate()`, before any IPC.

```kotlin
// Before
override fun onCreate() {
    super.onCreate()
    Log.d(TAG, ...)
    instance = this
    val callbackHandle = StorageDelegate.getCallbackDispatcher(applicationContext)  // SharedPrefs IPC
    flutterEngineHelper = FlutterEngineHelper(...)
    startForeground()  // 5th — too late under pressure
    isRunning = true
}

// After
override fun onCreate() {
    super.onCreate()
    startForeground()  // first — no IPC before it

    Log.d(TAG, ...)
    instance = this
    val callbackHandle = StorageDelegate.getCallbackDispatcher(applicationContext)
    flutterEngineHelper = FlutterEngineHelper(...)
    isRunning = true
}
```

## Safety

- `startForeground()` has no dependency on `flutterEngineHelper` or `callbackHandle` — the engine starts in `onStartCommand()`, which runs after `onCreate()` completes
- `instance` is only read by `WebtritSignalingServicePlugin.notifyIsolateReady()`, which is called after `onStartCommand()` + Dart isolate ready — well after `onCreate()` completes
- `isRunning` placement at the end of `onCreate()` is unchanged in meaning

## Part of

Umbrella: #1099