### PR TITLE
fix(signaling): parallelize Pigeon IPC calls in _startService() to reduce FGS delay

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -225,17 +225,27 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       );
     }
 
-    await _hostApi.initializeServiceCallback(
-      dispatcherHandle.toRawHandle(),
-      // onSync handle is not used directly by Kotlin -- the background isolate
-      // calls onSignalingServiceSync via PSignalingServiceFlutterApi.setUp.
-      // Pass 0 as a placeholder.
-      0,
-    );
-
-    await _hostApi.saveConnectionConfig(config.coreUrl, config.tenantId, config.token);
-    await _hostApi.saveTrustedCertificates(_encodeTrustedCertificates(config.trustedCertificates));
-    await _hostApi.startService(signalingModeToNative(mode));
+    // All four writes go through the same BinaryMessenger, so they are
+    // delivered to the Kotlin main-thread Looper in FIFO order regardless
+    // of parallelism. startService() is therefore always processed after
+    // the credential writes, so the background isolate receives correct
+    // data on the first synchronizeIsolate() attempt.
+    // Running them concurrently removes three sequential Binder round-trips
+    // (~300–900 ms under memory pressure) before startForegroundService()
+    // is called, giving the OS more time to run onCreate() within the
+    // vendor-specific FGS promotion window.
+    await Future.wait([
+      _hostApi.initializeServiceCallback(
+        dispatcherHandle.toRawHandle(),
+        // onSync handle is not used directly by Kotlin -- the background isolate
+        // calls onSignalingServiceSync via PSignalingServiceFlutterApi.setUp.
+        // Pass 0 as a placeholder.
+        0,
+      ),
+      _hostApi.saveConnectionConfig(config.coreUrl, config.tenantId, config.token),
+      _hostApi.saveTrustedCertificates(_encodeTrustedCertificates(config.trustedCertificates)),
+      _hostApi.startService(signalingModeToNative(mode)),
+    ]);
 
     // Do NOT clear the hub port here.
     //

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -225,15 +225,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       );
     }
 
-    // All four writes go through the same BinaryMessenger, so they are
-    // delivered to the Kotlin main-thread Looper in FIFO order regardless
-    // of parallelism. startService() is therefore always processed after
-    // the credential writes, so the background isolate receives correct
-    // data on the first synchronizeIsolate() attempt.
-    // Running them concurrently removes three sequential Binder round-trips
-    // (~300–900 ms under memory pressure) before startForegroundService()
-    // is called, giving the OS more time to run onCreate() within the
-    // vendor-specific FGS promotion window.
+    // Persist all credentials concurrently — they write to independent
+    // SharedPreferences keys and have no ordering dependency between them.
+    // Running them in parallel removes two sequential Binder round-trips
+    // (~200–600 ms under memory pressure) before startForegroundService()
+    // is called.
     await Future.wait([
       _hostApi.initializeServiceCallback(
         dispatcherHandle.toRawHandle(),
@@ -244,8 +240,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       ),
       _hostApi.saveConnectionConfig(config.coreUrl, config.tenantId, config.token),
       _hostApi.saveTrustedCertificates(_encodeTrustedCertificates(config.trustedCertificates)),
-      _hostApi.startService(signalingModeToNative(mode)),
     ]);
+
+    // Start the service only after all credentials are persisted so that
+    // synchronizeIsolate() reads correct data on the first attempt.
+    await _hostApi.startService(signalingModeToNative(mode));
 
     // Do NOT clear the hub port here.
     //


### PR DESCRIPTION
## Problem

`_startService()` in `plugin.dart` called `startForegroundService()` (via `_hostApi.startService()`) only after completing three sequential Pigeon `await` calls. Each `await` is a full Binder round-trip: Dart → BinaryMessenger → Kotlin main thread → Binder reply → Dart resumes.

Under Xiaomi HyperOS memory pressure, each round-trip adds ~100–300 ms. Three sequential calls add ~300–900 ms before `startForegroundService()` is even called — consuming a significant portion of Xiaomi's aggressive ~1.2s FGS promotion window.

```dart
// Before — each await blocks until Kotlin replies
await _hostApi.initializeServiceCallback(...);  // +100–300 ms
await _hostApi.saveConnectionConfig(...);        // +100–300 ms
await _hostApi.saveTrustedCertificates(...);     // +100–300 ms
await _hostApi.startService(...);                // ← startForegroundService() here
```

## Fix

The three credential writes are independent — they write to separate SharedPreferences keys with no ordering dependency between them. They are parallelized via `Future.wait()`. `startService()` remains a separate sequential `await` after `Future.wait()` resolves, preserving the guarantee that credentials are persisted before the service starts.

```dart
// After — credential writes run concurrently
await Future.wait([
    _hostApi.initializeServiceCallback(...),
    _hostApi.saveConnectionConfig(...),
    _hostApi.saveTrustedCertificates(...),
]);
// startService() only dispatched after all credentials are written
await _hostApi.startService(...);
```

## Result

- Removes two sequential Binder round-trips (~200–600 ms under memory pressure) before `startForegroundService()` is called
- `startService()` is explicitly sequenced after `Future.wait()` — no cross-channel ordering assumption
- A failure in any credential write prevents `startService()` from being dispatched, preserving the original error-isolation behavior

## Part of

Umbrella: #1099