### PR TITLE
fix(signaling): persistent mode FGS recovery after OS kill

### DIFF
--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -86,9 +86,6 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     try {
       await WebtritSignalingService.restoreService();
     } catch (e, st) {
-      // Unexpected Pigeon or platform error. ForegroundServiceStartNotAllowedException
-      // is handled natively (Kotlin schedules a WorkManager retry) and does not reach here.
-      // Log with stack trace for actionable diagnostics.
       _logger.warning('restoreService() after push failed', e, st);
     }
   }

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -85,10 +85,11 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     await _disposeContext();
     try {
       await WebtritSignalingService.restoreService();
-    } catch (e) {
-      // Android 12+: ForegroundServiceStartNotAllowedException if the BFGS window
-      // closed before this point. Log and swallow -- the WorkManager job will retry.
-      _logger.warning('restoreService() after push failed: $e');
+    } catch (e, st) {
+      // Unexpected Pigeon or platform error. ForegroundServiceStartNotAllowedException
+      // is handled natively (Kotlin schedules a WorkManager retry) and does not reach here.
+      // Log with stack trace for actionable diagnostics.
+      _logger.warning('restoreService() after push failed', e, st);
     }
   }
 }

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -83,6 +83,13 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     _logger.severe('onPushNotificationSyncCallback: error=$e');
   } finally {
     await _disposeContext();
+    try {
+      await WebtritSignalingService.restoreService();
+    } catch (e) {
+      // Android 12+: ForegroundServiceStartNotAllowedException if the BFGS window
+      // closed before this point. Log and swallow -- the WorkManager job will retry.
+      _logger.warning('restoreService() after push failed: $e');
+    }
   }
 }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -167,4 +167,11 @@ class WebtritSignalingService implements SignalingModule {
   /// Call on explicit user logout to prevent the service from reconnecting
   /// with a stale token after the session ends. No-op on iOS.
   static Future<void> stopService() => SignalingServicePlatform.instance.stopService();
+
+  /// Restores the persistent foreground service if it was killed by the OS.
+  ///
+  /// Call from the push-notification callback after the temporary push WebSocket
+  /// is disposed to bring back the persistent connection for future calls.
+  /// No-op on iOS and when push mode is active or the service is already running.
+  static Future<void> restoreService() => SignalingServicePlatform.instance.restoreService();
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -23,6 +23,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   final List<SignalingModuleFactory> moduleFactories = [];
   int disposeCount = 0;
   int stopServiceCount = 0;
+  int restoreServiceCount = 0;
 
   void inject(SignalingModuleEvent event) => _eventsController.add(event);
 
@@ -61,6 +62,9 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
 
   @override
   Future<void> stopService() async => stopServiceCount++;
+
+  @override
+  Future<void> restoreService() async => restoreServiceCount++;
 }
 
 class _VerifiedFakePlatform extends _FakePlatform with MockPlatformInterfaceMixin {}
@@ -311,6 +315,11 @@ void main() {
     test('stopService delegates to platform', () async {
       await WebtritSignalingService.stopService();
       expect(platform.stopServiceCount, 1);
+    });
+
+    test('restoreService delegates to platform', () async {
+      await WebtritSignalingService.restoreService();
+      expect(platform.restoreServiceCount, 1);
     });
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/build.gradle
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/build.gradle
@@ -60,6 +60,7 @@ kotlin {
 
 dependencies {
     implementation "androidx.core:core-ktx:1.16.0"
+    implementation "androidx.work:work-runtime-ktx:2.9.0"
 
     if (flutterSdkPath) {
         compileOnly files("$flutterSdkPath/bin/cache/artifacts/engine/android-x86/flutter.jar")

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/Messages.g.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/Messages.g.kt
@@ -371,6 +371,13 @@ interface PSignalingServiceHostApi {
    * the service delivers the current status to the freshly-initialised isolate.
    */
   fun notifyIsolateReady()
+  /**
+   * Restores the persistent foreground service if it was killed by the OS.
+   *
+   * No-op when push mode is active, the service is already running, credentials
+   * are missing (post-logout), or the callback dispatcher is not registered.
+   */
+  fun connect()
 
   companion object {
     /** The codec used by PSignalingServiceHostApi. */
@@ -533,6 +540,22 @@ interface PSignalingServiceHostApi {
           channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> = try {
               api.notifyIsolateReady()
+              listOf(null)
+            } catch (exception: Throwable) {
+              MessagesPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_signaling_service_android.PSignalingServiceHostApi.connect$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.connect()
               listOf(null)
             } catch (exception: Throwable) {
               MessagesPigeonUtils.wrapError(exception)

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -96,7 +96,12 @@ class SignalingForegroundService : Service() {
 
     override fun onDestroy() {
         // Enqueue restart before any teardown so the job is queued while the process is still valid.
-        if (!StorageDelegate.isPushBound(applicationContext)) {
+        // Credentials guard: stopService() calls clearConnectionConfig() before stopping the service,
+        // so after explicit logout coreUrl is already empty here and no job is scheduled.
+        if (!StorageDelegate.isPushBound(applicationContext) &&
+            StorageDelegate.getCoreUrl(applicationContext).isNotEmpty() &&
+            StorageDelegate.getCallbackDispatcher(applicationContext) != 0L
+        ) {
             SignalingRestartWorker.enqueue(applicationContext, delayMillis = 15_000)
         }
         Log.d(TAG, "SignalingForegroundService onDestroy")
@@ -116,7 +121,8 @@ class SignalingForegroundService : Service() {
         if (StorageDelegate.isPushBound(applicationContext)) {
             Log.d(TAG, "pushBound mode -- stopping service on task removal")
             gracefulStop { stopSelf() }
-        } else {
+        } else if (StorageDelegate.getCoreUrl(applicationContext).isNotEmpty() &&
+                   StorageDelegate.getCallbackDispatcher(applicationContext) != 0L) {
             // persistent mode -- enqueue a fast restart in case the OS doesn't honour START_STICKY
             SignalingRestartWorker.enqueue(applicationContext, delayMillis = 1_000)
         }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -95,6 +95,10 @@ class SignalingForegroundService : Service() {
     }
 
     override fun onDestroy() {
+        // Enqueue restart before any teardown so the job is queued while the process is still valid.
+        if (!StorageDelegate.isPushBound(applicationContext)) {
+            SignalingRestartWorker.enqueue(applicationContext, delayMillis = 15_000)
+        }
         Log.d(TAG, "SignalingForegroundService onDestroy")
         instance = null
         wakeLock?.let { if (it.isHeld) it.release() }
@@ -112,6 +116,9 @@ class SignalingForegroundService : Service() {
         if (StorageDelegate.isPushBound(applicationContext)) {
             Log.d(TAG, "pushBound mode -- stopping service on task removal")
             gracefulStop { stopSelf() }
+        } else {
+            // persistent mode -- enqueue a fast restart in case the OS doesn't honour START_STICKY
+            SignalingRestartWorker.enqueue(applicationContext, delayMillis = 1_000)
         }
     }
 
@@ -284,7 +291,7 @@ class SignalingForegroundService : Service() {
         /// How long [gracefulStop] waits for an isolate ACK before forcing the stop.
         private const val _gracefulStopTimeoutMs = 3000L
 
-        var isRunning = false
+        @Volatile var isRunning = false
 
         /// The currently running service instance, set in [onCreate] and cleared in [onDestroy].
         /// Used by [WebtritSignalingServicePlugin.notifyIsolateReady] so the plugin can trigger

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -100,6 +100,8 @@ class SignalingForegroundService : Service() {
         // so after explicit logout coreUrl is already empty here and no job is scheduled.
         if (!StorageDelegate.isPushBound(applicationContext) &&
             StorageDelegate.getCoreUrl(applicationContext).isNotEmpty() &&
+            StorageDelegate.getTenantId(applicationContext).isNotEmpty() &&
+            StorageDelegate.getToken(applicationContext).isNotEmpty() &&
             StorageDelegate.getCallbackDispatcher(applicationContext) != 0L
         ) {
             SignalingRestartWorker.enqueue(applicationContext, delayMillis = 15_000)
@@ -122,6 +124,8 @@ class SignalingForegroundService : Service() {
             Log.d(TAG, "pushBound mode -- stopping service on task removal")
             gracefulStop { stopSelf() }
         } else if (StorageDelegate.getCoreUrl(applicationContext).isNotEmpty() &&
+                   StorageDelegate.getTenantId(applicationContext).isNotEmpty() &&
+                   StorageDelegate.getToken(applicationContext).isNotEmpty() &&
                    StorageDelegate.getCallbackDispatcher(applicationContext) != 0L) {
             // persistent mode -- enqueue a fast restart in case the OS doesn't honour START_STICKY
             SignalingRestartWorker.enqueue(applicationContext, delayMillis = 1_000)

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
@@ -1,0 +1,61 @@
+package com.webtrit.signaling_service
+
+import android.content.Context
+import android.util.Log
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+/// WorkManager worker that restarts [SignalingForegroundService] after it is killed.
+///
+/// Enqueued by [SignalingForegroundService.onDestroy] (15 s delay) and
+/// [SignalingForegroundService.onTaskRemoved] (1 s delay) when in persistent mode.
+/// The [ExistingWorkPolicy.REPLACE] policy resets the timer if both triggers fire
+/// close together, preventing duplicate restarts.
+///
+/// [Result.retry] is returned on [Exception] so WorkManager retries with
+/// exponential back-off. On Android 12+ this handles the case where
+/// [startForegroundService] throws [ForegroundServiceStartNotAllowedException]
+/// because the process has left the BFGS window — the next retry happens when the
+/// user opens the app or another foreground service becomes active.
+class SignalingRestartWorker(
+    context: Context,
+    workerParams: WorkerParameters,
+) : Worker(context, workerParams) {
+
+    override fun doWork(): Result = try {
+        if (!SignalingForegroundService.isRunning &&
+            !StorageDelegate.isPushBound(applicationContext) &&
+            StorageDelegate.getCoreUrl(applicationContext).isNotEmpty() &&
+            StorageDelegate.getCallbackDispatcher(applicationContext) != 0L
+        ) {
+            Log.w(TAG, "SignalingRestartWorker: restarting persistent FGS")
+            SignalingForegroundService.start(applicationContext)
+        }
+        Result.success()
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to restart FGS: $e")
+        Result.retry()
+    }
+
+    companion object {
+        private const val TAG = "SignalingRestartWorker"
+        private const val WORK_TAG = "signaling_fgs_restart"
+
+        fun enqueue(context: Context, delayMillis: Long = 15_000) {
+            val request = OneTimeWorkRequestBuilder<SignalingRestartWorker>()
+                .addTag(WORK_TAG)
+                .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(WORK_TAG, ExistingWorkPolicy.REPLACE, request)
+        }
+
+        fun remove(context: Context) {
+            WorkManager.getInstance(context).cancelAllWorkByTag(WORK_TAG)
+        }
+    }
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
@@ -1,6 +1,8 @@
 package com.webtrit.signaling_service
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
@@ -30,6 +32,8 @@ class SignalingRestartWorker(
         if (!SignalingForegroundService.isRunning &&
             !StorageDelegate.isPushBound(applicationContext) &&
             StorageDelegate.getCoreUrl(applicationContext).isNotEmpty() &&
+            StorageDelegate.getTenantId(applicationContext).isNotEmpty() &&
+            StorageDelegate.getToken(applicationContext).isNotEmpty() &&
             StorageDelegate.getCallbackDispatcher(applicationContext) != 0L
         ) {
             Log.w(TAG, "SignalingRestartWorker: restarting persistent FGS")
@@ -37,8 +41,14 @@ class SignalingRestartWorker(
         }
         Result.success()
     } catch (e: Exception) {
-        Log.e(TAG, "Failed to restart FGS: $e")
-        Result.retry()
+        Log.e(TAG, "Failed to restart FGS", e)
+        // Only ForegroundServiceStartNotAllowedException is transient (process left BFGS window).
+        // All other failures are permanent -- returning failure avoids infinite retry backoff.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+            Result.retry()
+        } else {
+            Result.failure()
+        }
     }
 
     companion object {
@@ -55,7 +65,7 @@ class SignalingRestartWorker(
         }
 
         fun remove(context: Context) {
-            WorkManager.getInstance(context).cancelAllWorkByTag(WORK_TAG)
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_TAG)
         }
     }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
@@ -1,6 +1,7 @@
 package com.webtrit.signaling_service
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
@@ -43,7 +44,7 @@ class SignalingRestartWorker(
         // ForegroundServiceStartNotAllowedException is expected on Android 12+ when the process
         // has left the BFGS window. Log at warning level (transient) and schedule a retry.
         // All other exceptions are permanent failures -- log at error level and stop retrying.
-        if (e.javaClass.name == "android.app.ForegroundServiceStartNotAllowedException") {
+        if (isForegroundServiceStartNotAllowed(e)) {
             Log.w(TAG, "Cannot restart FGS: process not in BFGS state, will retry", e)
             Result.retry()
         } else {
@@ -68,5 +69,13 @@ class SignalingRestartWorker(
         fun remove(context: Context) {
             WorkManager.getInstance(context).cancelUniqueWork(WORK_TAG)
         }
+
+        @Suppress("NewApi")
+        @androidx.annotation.RequiresApi(Build.VERSION_CODES.S)
+        private fun isFgsNotAllowed(e: Exception) =
+            e is android.app.ForegroundServiceStartNotAllowedException
+
+        private fun isForegroundServiceStartNotAllowed(e: Exception) =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isFgsNotAllowed(e)
     }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
@@ -1,8 +1,6 @@
 package com.webtrit.signaling_service
 
-import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
-import android.os.Build
 import android.util.Log
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
@@ -45,7 +43,7 @@ class SignalingRestartWorker(
         // ForegroundServiceStartNotAllowedException is expected on Android 12+ when the process
         // has left the BFGS window. Log at warning level (transient) and schedule a retry.
         // All other exceptions are permanent failures -- log at error level and stop retrying.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+        if (e.javaClass.name == "android.app.ForegroundServiceStartNotAllowedException") {
             Log.w(TAG, "Cannot restart FGS: process not in BFGS state, will retry", e)
             Result.retry()
         } else {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
@@ -18,11 +18,12 @@ import java.util.concurrent.TimeUnit
 /// The [ExistingWorkPolicy.REPLACE] policy resets the timer if both triggers fire
 /// close together, preventing duplicate restarts.
 ///
-/// [Result.retry] is returned on [Exception] so WorkManager retries with
-/// exponential back-off. On Android 12+ this handles the case where
-/// [startForegroundService] throws [ForegroundServiceStartNotAllowedException]
-/// because the process has left the BFGS window — the next retry happens when the
-/// user opens the app or another foreground service becomes active.
+/// On Android 12+ (API 31+), [startForegroundService] can throw
+/// [ForegroundServiceStartNotAllowedException] when the process has left the BFGS
+/// window. This is a transient condition — [Result.retry] is returned so WorkManager
+/// retries with exponential back-off until the process re-enters foreground.
+/// All other exceptions indicate permanent failures and return [Result.failure]
+/// to avoid unbounded retry loops.
 class SignalingRestartWorker(
     context: Context,
     workerParams: WorkerParameters,
@@ -41,12 +42,14 @@ class SignalingRestartWorker(
         }
         Result.success()
     } catch (e: Exception) {
-        Log.e(TAG, "Failed to restart FGS", e)
-        // Only ForegroundServiceStartNotAllowedException is transient (process left BFGS window).
-        // All other failures are permanent -- returning failure avoids infinite retry backoff.
+        // ForegroundServiceStartNotAllowedException is expected on Android 12+ when the process
+        // has left the BFGS window. Log at warning level (transient) and schedule a retry.
+        // All other exceptions are permanent failures -- log at error level and stop retrying.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+            Log.w(TAG, "Cannot restart FGS: process not in BFGS state, will retry", e)
             Result.retry()
         } else {
+            Log.e(TAG, "Failed to restart FGS (permanent)", e)
             Result.failure()
         }
     }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -1,6 +1,7 @@
 package com.webtrit.signaling_service
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.annotation.Keep
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -104,7 +105,7 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
         try {
             SignalingForegroundService.start(context)
         } catch (e: Exception) {
-            if (e.javaClass.name == "android.app.ForegroundServiceStartNotAllowedException") {
+            if (isForegroundServiceStartNotAllowed(e)) {
                 Log.w(TAG, "connect: process not in BFGS state, scheduling WorkManager restart", e)
                 SignalingRestartWorker.enqueue(context, delayMillis = 15_000)
             } else {
@@ -120,5 +121,18 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
 
     companion object {
         private const val TAG = "WebtritSignalingServicePlugin"
+
+        /// Returns true when [e] is [ForegroundServiceStartNotAllowedException] (API 31+).
+        ///
+        /// Isolated into an @RequiresApi helper so the class reference is only
+        /// loaded on devices that actually have the class, satisfying Lint while
+        /// keeping the check type-safe and idiomatic.
+        @Suppress("NewApi")
+        @androidx.annotation.RequiresApi(Build.VERSION_CODES.S)
+        private fun isFgsNotAllowed(e: Exception) =
+            e is android.app.ForegroundServiceStartNotAllowedException
+
+        private fun isForegroundServiceStartNotAllowed(e: Exception) =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isFgsNotAllowed(e)
     }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -1,8 +1,6 @@
 package com.webtrit.signaling_service
 
-import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
-import android.os.Build
 import android.util.Log
 import androidx.annotation.Keep
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -106,9 +104,7 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
         try {
             SignalingForegroundService.start(context)
         } catch (e: Exception) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
-                // Process left the BFGS window before connect() completed.
-                // Schedule a WorkManager job to retry when the process re-enters foreground.
+            if (e.javaClass.name == "android.app.ForegroundServiceStartNotAllowedException") {
                 Log.w(TAG, "connect: process not in BFGS state, scheduling WorkManager restart", e)
                 SignalingRestartWorker.enqueue(context, delayMillis = 15_000)
             } else {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -83,6 +83,7 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
 
     override fun stopService() {
         Log.d(TAG, "stopService")
+        SignalingRestartWorker.remove(context)  // cancel any pending restart before logout clears credentials
         StorageDelegate.clearConnectionConfig(context)
         val service = SignalingForegroundService.instance
         if (service != null) {
@@ -90,6 +91,15 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
         } else {
             SignalingForegroundService.stop(context)
         }
+    }
+
+    override fun connect() {
+        Log.d(TAG, "connect")
+        if (StorageDelegate.isPushBound(context)) return
+        if (SignalingForegroundService.isRunning) return
+        if (StorageDelegate.getCoreUrl(context).isEmpty()) return
+        if (StorageDelegate.getCallbackDispatcher(context) == 0L) return
+        SignalingForegroundService.start(context)
     }
 
     override fun notifyIsolateReady() {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -1,6 +1,8 @@
 package com.webtrit.signaling_service
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.annotation.Keep
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -98,8 +100,21 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
         if (StorageDelegate.isPushBound(context)) return
         if (SignalingForegroundService.isRunning) return
         if (StorageDelegate.getCoreUrl(context).isEmpty()) return
+        if (StorageDelegate.getTenantId(context).isEmpty()) return
+        if (StorageDelegate.getToken(context).isEmpty()) return
         if (StorageDelegate.getCallbackDispatcher(context) == 0L) return
-        SignalingForegroundService.start(context)
+        try {
+            SignalingForegroundService.start(context)
+        } catch (e: Exception) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+                // Process left the BFGS window before connect() completed.
+                // Schedule a WorkManager job to retry when the process re-enters foreground.
+                Log.w(TAG, "connect: process not in BFGS state, scheduling WorkManager restart", e)
+                SignalingRestartWorker.enqueue(context, delayMillis = 15_000)
+            } else {
+                Log.e(TAG, "connect: unexpected error starting FGS", e)
+            }
+        }
     }
 
     override fun notifyIsolateReady() {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/messages.g.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/messages.g.dart
@@ -435,6 +435,28 @@ class PSignalingServiceHostApi {
     )
     ;
   }
+
+  /// Restores the persistent foreground service if it was killed by the OS.
+  ///
+  /// No-op when push mode is active, the service is already running, credentials
+  /// are missing (post-logout), or the callback dispatcher is not registered.
+  Future<void> connect() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_signaling_service_android.PSignalingServiceHostApi.connect$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
 }
 
 abstract class PSignalingServiceFlutterApi {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -215,6 +215,12 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     await _hostApi.stopService();
   }
 
+  @override
+  Future<void> restoreService() async {
+    _logger.info('restoreService');
+    await _hostApi.connect();
+  }
+
   Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
     _logger.fine('_startService mode=$mode');
     final dispatcherHandle = PluginUtilities.getCallbackHandle(signalingServiceCallbackDispatcher);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
@@ -112,6 +112,12 @@ abstract class PSignalingServiceHostApi {
   /// Kotlin responds by calling [SignalingForegroundService.synchronizeIsolate] so
   /// the service delivers the current status to the freshly-initialised isolate.
   void notifyIsolateReady();
+
+  /// Restores the persistent foreground service if it was killed by the OS.
+  ///
+  /// No-op when push mode is active, the service is already running, credentials
+  /// are missing (post-logout), or the callback dispatcher is not registered.
+  void connect();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -10,6 +10,10 @@ void main() {
       'dev.flutter.pigeon.webtrit_signaling_service_android'
       '.PSignalingServiceHostApi.stopService';
 
+  const connectChannel =
+      'dev.flutter.pigeon.webtrit_signaling_service_android'
+      '.PSignalingServiceHostApi.connect';
+
   group('WebtritSignalingServiceAndroid -- stopService()', () {
     late WebtritSignalingServiceAndroid plugin;
 
@@ -47,6 +51,32 @@ void main() {
       await plugin.dispose();
 
       expect(stopCalled, isFalse);
+    });
+  });
+
+  group('WebtritSignalingServiceAndroid -- restoreService()', () {
+    late WebtritSignalingServiceAndroid plugin;
+
+    setUp(() {
+      plugin = WebtritSignalingServiceAndroid.forTesting();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(connectChannel, null);
+    });
+
+    test('calls the host API connect channel', () async {
+      var called = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(connectChannel, (
+        message,
+      ) async {
+        called = true;
+        return const StandardMessageCodec().encodeMessage(<Object?>[null]);
+      });
+
+      await plugin.restoreService();
+
+      expect(called, isTrue);
     });
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -85,4 +85,12 @@ abstract class SignalingServicePlatform extends PlatformInterface {
   /// with a stale token after the session ends. No-op on platforms that
   /// do not run a persistent background service (e.g. iOS).
   Future<void> stopService() async {}
+
+  /// Restores the persistent foreground service if it was killed by the OS.
+  ///
+  /// Called from the push-notification callback after the temporary push
+  /// WebSocket is disposed. No-op on platforms without a persistent background
+  /// service (e.g. iOS) and when push mode is active or the service is already
+  /// running.
+  Future<void> restoreService() async {}
 }


### PR DESCRIPTION
## Summary

- **Part 1 (FCM path):** add `WebtritSignalingService.restoreService()` static method that calls Kotlin `connect()` via Pigeon. Called from `onPushNotificationSyncCallback` `finally` block after `_disposeContext()` — restores the persistent WebSocket for future calls when FGS is dead and an FCM push arrives first.
- **Part 2 (no-GMS path):** add `SignalingRestartWorker` (WorkManager one-shot) — enqueued from `onDestroy` (15 s delay) and `onTaskRemoved` (1 s delay) in persistent mode. `Result.retry()` handles Android 12+ `ForegroundServiceStartNotAllowedException`. `SignalingRestartWorker.remove()` is called first in `stopService()` to prevent restart after explicit logout.
- **Thread safety fix:** `isRunning` is now `@Volatile` in `SignalingForegroundService`.

## Files changed

| File | Change |
|------|--------|
| `pigeons/signaling.messages.dart` | Add `void connect()` |
| `Messages.g.kt` | Add `connect()` to interface + setUp handler |
| `messages.g.dart` | Add `Future<void> connect()` to `PSignalingServiceHostApi` |
| `WebtritSignalingServicePlugin.kt` | Implement `connect()`; add `SignalingRestartWorker.remove()` in `stopService()` |
| `signaling_service_platform.dart` | Add `restoreService()` no-op default |
| `plugin.dart` | Add `restoreService()` override → `_hostApi.connect()` |
| `signaling_service.dart` | Add static `WebtritSignalingService.restoreService()` |
| `background_isolate_callbacks.dart` | `finally` block: `restoreService()` with try-catch |
| `build.gradle` | Add `work-runtime-ktx:2.9.0` |
| `SignalingForegroundService.kt` | `@Volatile isRunning`; `onDestroy` enqueue first; `onTaskRemoved` persistent branch |
| `SignalingRestartWorker.kt` | New file |

## Recovery scenarios covered

| Scenario | Device | Mechanism | Recovery time |
|----------|--------|-----------|---------------|
| FGS dead + FCM push arrives | With Google Services | Part 1: `restoreService()` in push callback | ~1–3 s |
| FGS dead, graceful kill | No FCM | Part 2: `onDestroy` → WorkManager | ~15 s |
| FGS dead, swipe from recents | No FCM | Part 2: `onTaskRemoved` → WorkManager | ~1 s |
| WorkManager job fails (Android 12+) | No FCM, Android 12+ | `Result.retry()` → on next app open | until open |
| Hard kill (SIGKILL) | Any | No guaranteed mechanism | until unlock/reboot |

## Part of

Umbrella fix: `fix/signaling-fgs-xiaomi-crash` (PR for `ForegroundServiceDidNotStartInTimeException` on Xiaomi HyperOS)