### PR TITLE
fix: ensure system info is loaded before MainShell builds

### DIFF
--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -11,6 +11,7 @@ import 'package:webtrit_phone/blocs/app/app_bloc.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/resolvers/resolvers.dart';
 
 import 'deeplinks.dart';
@@ -27,6 +28,7 @@ class AppRouter extends RootStackRouter {
   AppRouter(
     this._appBloc,
     this._appPermissions,
+    this._systemInfoRepository,
     EmbeddedData? launchEmbeddedData,
     BottomMenuConfig bottomMenuFeature,
     InitialTabResolver initialTabResolver,
@@ -40,6 +42,7 @@ class AppRouter extends RootStackRouter {
 
   final AppBloc _appBloc;
   final AppPermissions _appPermissions;
+  final SystemInfoRepository _systemInfoRepository;
 
   late EmbeddedData? _launchEmbeddedData;
   late BottomMenuConfig _bottomMenuFeature;
@@ -334,6 +337,25 @@ class AppRouter extends RootStackRouter {
 
     // Redirect to authentication flow if the user is not logged in.
     if (state.status != AppLifecycleStatus.authenticated) {
+      resolver.next(false);
+      router.replaceAll([LoginRouterPageRoute(launchEmbeddedData: _launchEmbeddedData)]);
+      return;
+    }
+
+    // Ensure system info is in cache before MainShell builds.
+    // Several provider create: callbacks call getLocalSystemInfo() synchronously;
+    // without this guard the app crashes if system info was cleared (e.g. during
+    // session cleanup after an FGS failure) or was never fetched in this session.
+    try {
+      final systemInfo = await _systemInfoRepository.getSystemInfo(fetchPolicy: FetchPolicy.cacheFirst);
+      if (systemInfo == null) {
+        _logger.warning('onMainShellRouteGuardNavigation: system info unavailable, redirecting to login');
+        resolver.next(false);
+        router.replaceAll([LoginRouterPageRoute(launchEmbeddedData: _launchEmbeddedData)]);
+        return;
+      }
+    } catch (e, s) {
+      _logger.severe('onMainShellRouteGuardNavigation: failed to load system info', e, s);
       resolver.next(false);
       router.replaceAll([LoginRouterPageRoute(launchEmbeddedData: _launchEmbeddedData)]);
       return;

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -69,6 +69,7 @@ class _AppState extends State<App> {
     appRouter = AppRouter(
       appBloc,
       context.read<AppPermissions>(),
+      context.read<SystemInfoRepository>(),
       featureAccess.loginConfig.launchLoginPage,
       featureAccess.bottomMenuConfig,
       initialTabResolver,


### PR DESCRIPTION
## Problem

After an FGS failure (e.g. Xiaomi "did not start in time"), the app could crash with:

```
StateError: No system info in cache, ensure getLocalSystemInfo() has been called
on logged-in routes after the initial system info load

#0  SystemInfoRepositoryImpl.getLocalSystemInfo  (system_info_repository.dart:96)
#1  _MainShellState.build.<anonymous closure>    (main_shell.dart:257)
...
#6  _MainShellState._pollingRegistrations        (main_shell.dart)
```

**Root cause:** `CallerIdSettingsRepository.create` (and one other provider at line 176) call `getLocalSystemInfo()` synchronously. The `MainShellRoute` guard only checked for a valid session token — it did not verify that system info was actually in the cache.

After FGS failure the app can reach `MainShellRoute` in `authenticated` state (session token still in SecureStorage) while system info is absent — either because `userSessionCleanupResolver.clear()` ran in a previous process, or because the initial info fetch was interrupted before `setSystemInfo()` completed.

## Fix

Add `getSystemInfo(cacheFirst)` to `onMainShellRouteGuardNavigation`, executed after the auth check:

- If cache already has data → returns immediately (no network call)
- If cache is empty → fetches from network and populates cache before navigation resolves
- If both cache and network fail → redirects to login

`SystemInfoRepository` is injected into `AppRouter` via constructor.

## Test plan

- [ ] Normal launch: MainShell opens, no extra network round-trip (cache hit)
- [ ] Clear app data → launch → login → MainShell opens correctly after info fetch
- [ ] Simulate no-cache + offline → app redirects to login instead of crashing
- [ ] FGS crash on Xiaomi → app recovers to login, not crash