### PR TITLE
fix(signaling): detect hub death via ping/pong and recover automatically

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -117,6 +117,13 @@ class SignalingHub {
         }
         _logger.fine('Hub received disconnect command from ${cmd.consumerId}');
         unawaited(_signalingModule.disconnect());
+      case SignalingHubPingCommand():
+        final port = _subscribers[cmd.consumerId];
+        if (port == null) {
+          _logger.warning('Hub ping: unknown subscriber ${cmd.consumerId}');
+          return;
+        }
+        port.send(encodePong());
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -30,18 +30,36 @@ final _logger = Logger('SignalingHubClient');
 /// }
 /// ```
 class SignalingHubClient {
-  SignalingHubClient._({required this.consumerId, required SendPort hubPort}) : _hubPort = hubPort;
+  SignalingHubClient._({
+    required this.consumerId,
+    required SendPort hubPort,
+    required Duration pingInterval,
+    required Duration pongTimeout,
+  }) : _hubPort = hubPort,
+       _pingInterval = pingInterval,
+       _pongTimeout = pongTimeout;
 
   /// Returns a [SignalingHubClient] connected to the hub, or null when no
   /// hub is currently registered in [IsolateNameServer].
-  static SignalingHubClient? tryConnect(String consumerId) {
+  static SignalingHubClient? tryConnect(
+    String consumerId, {
+    Duration pingInterval = const Duration(seconds: 15),
+    Duration pongTimeout = const Duration(seconds: 2),
+  }) {
     final port = IsolateNameServer.lookupPortByName(kSignalingHubPortName);
     if (port == null) return null;
-    return SignalingHubClient._(consumerId: consumerId, hubPort: port);
+    return SignalingHubClient._(
+      consumerId: consumerId,
+      hubPort: port,
+      pingInterval: pingInterval,
+      pongTimeout: pongTimeout,
+    );
   }
 
   final String consumerId;
   final SendPort _hubPort;
+  final Duration _pingInterval;
+  final Duration _pongTimeout;
   final ReceivePort _receivePort = ReceivePort();
   final _controller = StreamController<SignalingModuleEvent>.broadcast();
   final Map<String, Completer<void>> _pendingExecutions = {};
@@ -49,15 +67,46 @@ class SignalingHubClient {
   StreamSubscription<Object?>? _subscription;
   bool _started = false;
   Completer<bool>? _subAckCompleter;
+  Timer? _pingTimer;
+  Completer<void>? _pendingPong;
 
   /// Sends the subscribe command and begins forwarding hub events to [events].
   /// Safe to call more than once -- subsequent calls are no-ops.
+  ///
+  /// Also starts a periodic liveness ping. If the hub does not reply within
+  /// [_pongTimeout] the client closes [events], signalling hub death to
+  /// [HubConnectionManager] via its [onDone] handler.
   void start() {
     if (_started) return;
     _started = true;
     _subscription = _receivePort.listen((msg) => _onMessage(msg as List<Object?>));
     _hubPort.send(SignalingHubSubscribeCommand(consumerId: consumerId, replyPort: _receivePort.sendPort).encode());
     _logger.fine('Hub client $consumerId subscribed');
+    _schedulePing();
+  }
+
+  void _schedulePing() {
+    _pingTimer?.cancel();
+    _pingTimer = Timer(_pingInterval, _sendPing);
+  }
+
+  void _sendPing() {
+    if (_controller.isClosed) return;
+    _logger.fine('Hub client $consumerId sending ping (interval=$_pingInterval pongTimeout=$_pongTimeout)');
+    _pendingPong = Completer<void>();
+    _hubPort.send(SignalingHubPingCommand(consumerId: consumerId).encode());
+    _pendingPong!.future
+        .timeout(_pongTimeout)
+        .then((_) {
+          _logger.fine('Hub client $consumerId pong received — hub alive');
+          _schedulePing();
+        })
+        .catchError((_) {
+          _logger.warning('Hub client $consumerId pong timeout after $_pongTimeout — hub unreachable, closing stream');
+          _pingTimer?.cancel();
+          _pendingPong = null;
+          if (!_controller.isClosed) _controller.close();
+        });
   }
 
   /// Returns [true] when the hub confirms subscription within [timeout],
@@ -115,6 +164,9 @@ class SignalingHubClient {
 
   /// Sends the unsubscribe command and closes all resources.
   Future<void> dispose() async {
+    _pingTimer?.cancel();
+    _pingTimer = null;
+    _pendingPong = null;
     _hubPort.send(SignalingHubUnsubscribeCommand(consumerId: consumerId).encode());
     await _subscription?.cancel();
     _receivePort.close();
@@ -122,7 +174,7 @@ class SignalingHubClient {
       if (!c.isCompleted) c.completeError(StateError('Hub client disposed'));
     }
     _pendingExecutions.clear();
-    await _controller.close();
+    if (!_controller.isClosed) await _controller.close();
     _logger.fine('Hub client $consumerId disposed');
   }
 
@@ -132,6 +184,12 @@ class SignalingHubClient {
       final completer = _subAckCompleter;
       _subAckCompleter = null;
       if (completer != null && !completer.isCompleted) completer.complete(true);
+      return;
+    }
+    if (isPong(msg)) {
+      final completer = _pendingPong;
+      _pendingPong = null;
+      if (completer != null && !completer.isCompleted) completer.complete();
       return;
     }
     if (isExecuteResult(msg)) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -10,6 +10,7 @@ const _tagHandshakeReceived = 'handshake_received';
 const _tagProtocolEvent = 'protocol_event';
 const _tagExecuteResult = 'execute_result';
 const _tagSubAck = 'sub_ack';
+const _tagPong = 'pong';
 
 /// Encodes a [SignalingModuleEvent] into an isolate-safe [List] for transport
 /// over a [SendPort].
@@ -99,6 +100,11 @@ bool isExecuteResult(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagExecu
 List<dynamic> encodeSubAck() => [_tagSubAck];
 
 bool isSubAck(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagSubAck;
+
+/// Encodes a pong reply sent by the hub in response to a [SignalingHubPingCommand].
+List<dynamic> encodePong() => [_tagPong];
+
+bool isPong(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagPong;
 
 Map<String, dynamic> _encodeHandshake(StateHandshake h) {
   return {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_command.dart
@@ -47,6 +47,9 @@ sealed class SignalingHubCommand {
         case _tagDisconnect:
           if (wire.length < 2) return null;
           return SignalingHubDisconnectCommand(consumerId: wire[1] as String);
+        case _tagPing:
+          if (wire.length < 2) return null;
+          return SignalingHubPingCommand(consumerId: wire[1] as String);
         default:
           return null;
       }
@@ -70,6 +73,9 @@ const _tagConnect = 'connect';
 
 /// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubDisconnectCommand].
 const _tagDisconnect = 'disconnect';
+
+/// Wire tag placed at index 0 of the encoded [List] to identify a [SignalingHubPingCommand].
+const _tagPing = 'ping';
 
 /// Registers [replyPort] as a subscriber in the hub.
 ///
@@ -138,4 +144,17 @@ class SignalingHubDisconnectCommand extends SignalingHubCommand {
 
   @override
   List<Object?> encode() => [_tagDisconnect, consumerId];
+}
+
+/// Hub liveness probe sent by [SignalingHubClient] on a periodic timer.
+///
+/// The hub responds with a pong message ([encodePong] / [isPong]). When no
+/// pong arrives within [SignalingHubClient._pongTimeout] the client treats the
+/// hub as dead and closes its event stream, triggering hub-death recovery in
+/// [HubConnectionManager].
+class SignalingHubPingCommand extends SignalingHubCommand {
+  const SignalingHubPingCommand({required String consumerId}) : super(consumerId);
+
+  @override
+  List<Object?> encode() => [_tagPing, consumerId];
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
@@ -33,7 +33,7 @@ final _logger = Logger('SignalingHubModule');
 /// same order, so they cannot diverge.
 class SignalingHubModule implements SignalingModule {
   SignalingHubModule(this._hubClient) {
-    _sub = _hubClient.events.listen(_onHubEvent);
+    _sub = _hubClient.events.listen(_onHubEvent, onDone: _onHubDone);
     _hubClient.start();
     _logger.fine('SignalingHubModule created, consumerId=${_hubClient.consumerId}');
   }
@@ -87,9 +87,14 @@ class SignalingHubModule implements SignalingModule {
   Future<void> dispose() async {
     await _sub?.cancel();
     await _hubClient.dispose();
-    await _controller.close();
+    if (!_controller.isClosed) await _controller.close();
     _eventBuffer.clear();
     _logger.fine('SignalingHubModule disposed');
+  }
+
+  void _onHubDone() {
+    _logger.warning('SignalingHubModule: hub client stream closed — hub unreachable');
+    if (!_controller.isClosed) _controller.close();
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -31,6 +31,8 @@ class HubConnectionManager {
     required void Function(Object, StackTrace) onError,
     required bool Function() isActive,
     required String consumerId,
+    this.pingInterval = const Duration(seconds: 15),
+    this.pongTimeout = const Duration(seconds: 2),
   }) : _onEvent = onEvent,
        _onError = onError,
        _isActive = isActive,
@@ -40,6 +42,12 @@ class HubConnectionManager {
   final void Function(Object, StackTrace) _onError;
   final bool Function() _isActive;
   final String _consumerId;
+
+  /// How often the hub liveness ping is sent.
+  final Duration pingInterval;
+
+  /// How long to wait for a pong before treating the hub as dead.
+  final Duration pongTimeout;
 
   SignalingHubModule? _module;
   StreamSubscription<SignalingModuleEvent>? _moduleSub;
@@ -107,7 +115,7 @@ class HubConnectionManager {
         return;
       }
 
-      final client = SignalingHubClient.tryConnect(_consumerId);
+      final client = SignalingHubClient.tryConnect(_consumerId, pingInterval: pingInterval, pongTimeout: pongTimeout);
       if (client != null) {
         _logger.fine('_initLoop gen=$generation hub port found after $attempts attempts, awaiting ack');
         // awaitAck MUST be called before SignalingHubModule is constructed so the
@@ -124,7 +132,17 @@ class HubConnectionManager {
           }
           _module = module;
           _logger.info('_initLoop gen=$generation hub connected (consumerId=${client.consumerId})');
-          _moduleSub = _module!.events.listen(_onEvent, onError: _onError);
+          _moduleSub = _module!.events.listen(
+            _onEvent,
+            onError: _onError,
+            onDone: () {
+              if (_tearingDown) return;
+              _logger.warning('HubConnectionManager: hub module stream closed — hub died, restarting discovery');
+              _module = null;
+              _moduleSub = null;
+              if (_isActive()) begin();
+            },
+          );
           return;
         }
 


### PR DESCRIPTION
## Problem

On Samsung SM-M325FV (Android 13) and other devices with aggressive battery optimization, the Android OS kills the `SignalingForegroundService` background isolate without terminating the main app process. This leaves the `SignalingHub`'s `ReceivePort` dead and its `SendPort` mapping stale in `IsolateNameServer`.

**Root cause**: Dart's `ReceivePort`/`SendPort` mechanism has no isolate lifecycle awareness. When the background isolate is killed (SIGKILL), all ports go permanently silent — no `onDone`, no error, no notification of any kind. The main isolate's `HubConnectionManager` holds a live-looking `_module` reference and continues dispatching `connect()` commands into the void, while `SignalingReconnectController` keeps scheduling reconnects that silently disappear.

**User-visible symptom**: `CallStatus.inProgress` stuck indefinitely — `SignalingConnecting` cleared the error flags but `SignalingConnected` never arrives because the hub is dead.

**Proof from logcat**: With a 3-second `reconnectDelay`, a 114-second silent window implies ~38 missed reconnect cycles with zero logs — conclusive evidence the hub stopped processing commands.

## Fix

Introduce a periodic **ping/pong liveness probe** between `SignalingHubClient` (main isolate) and `SignalingHub` (background isolate).

- `SignalingHubClient` sends a `ping` command on a configurable interval (default 15s)
- `SignalingHub` replies with a `pong` message immediately
- If no pong arrives within `pongTimeout` (default 2s), the client closes its event stream
- Closing the stream cascades: `SignalingHubModule._onHubDone` → closes its broadcast controller → `HubConnectionManager._moduleSub.onDone` → nulls `_module` → calls `begin()` to restart hub discovery

## Changes

| File | Change |
|------|--------|
| `signaling_hub_command.dart` | Add `SignalingHubPingCommand` with `'ping'` wire tag |
| `signaling_hub_codec.dart` | Add `encodePong()` / `isPong()` helpers |
| `signaling_hub.dart` | Handle `SignalingHubPingCommand` → send pong to subscriber |
| `signaling_hub_client.dart` | Periodic ping timer, configurable `pingInterval`/`pongTimeout`, pong handling, close stream on timeout |
| `signaling_hub_module.dart` | Wire `onDone` on hub client subscription to propagate hub death upstream |
| `hub_connection_manager.dart` | Pass `pingInterval`/`pongTimeout` to `SignalingHubClient`, add `onDone` handler on `_moduleSub` to restart discovery |

## Configuration

`HubConnectionManager` now accepts `pingInterval` and `pongTimeout` parameters (defaulting to 15s / 2s). Tests can pass short intervals to verify the recovery path without waiting.

## Test plan

- [ ] Verify normal operation: ping/pong exchange does not interrupt connected session
- [ ] Simulate hub death (force-stop FGS via ADB, keep main process alive) — confirm recovery within `pingInterval + pongTimeout`
- [ ] Verify `CallStatus` does not get stuck after hub death recovery
- [ ] Test on Samsung device with battery optimization enabled
- [ ] Verify `tearDown()` cancels the ping timer cleanly (no timer fires after dispose)