### PR TITLE
fix(android): set extractNativeLibs=true to fix crash on sideloaded installs (WT-1019)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
+        android:extractNativeLibs="true"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
## Problem

Flutter app crashes immediately on launch on Android devices where the APK was installed via sideloading (direct APK download, without Google Play).

**YouTrack:** https://youtrack.portaone.com/issue/WT-1019

```
MissingLibraryException: Could not find 'libflutter.so'.
  Looked for: [arm64-v8a, armeabi-v7a, armeabi]
  But only found: []
```

`lib/` directory is completely empty at runtime — not a wrong ABI, but zero native libraries present.

## Root cause

**AGP 8.x silently injects `extractNativeLibs=false`** as the default into the compiled manifest — even though it is not set in the source `AndroidManifest.xml`.

This causes bundletool to generate a Universal APK where all `.so` files are stored **uncompressed** (`Stored`, method=0):

```
lib/arm64-v8a/libflutter.so    Stored   0%
lib/armeabi-v7a/libflutter.so  Stored   0%
```

On **certified Google Android**, the package manager handles this correctly — it memory-maps (mmap) the `.so` files directly from the APK without extracting them to disk.

On **non-certified Android** (Huawei without GMS, custom ROMs, AOSP forks), the mmap-from-APK path is either unsupported or broken. The `lib/` directory remains empty at runtime → `MissingLibraryException` on every launch.

## Fix

Explicitly set `android:extractNativeLibs="true"` in `AndroidManifest.xml`.

With this setting, the Android package manager **always extracts** `.so` files to disk during installation — regardless of GMS certification or ROM variant.

## Trade-offs

| | `false` (before) | `true` (this PR) |
|---|---|---|
| AAB size | unchanged | unchanged |
| APK download size | larger (uncompressed libs) | smaller |
| Device disk usage | less | more (~2x libs) |
| Certified Google Android | ✅ | ✅ |
| Huawei / custom ROM / sideload | ❌ crash | ✅ works |

## Verification

After building with this change, verify the Universal APK:

```bash
unzip -v app-universal.apk | grep "libflutter.so"
# Expected: Defl:N  (compressed)
# Before:   Stored  0%  ← broken on non-certified devices
```