### PR TITLE
fix(signaling): guard Transaction against double-complete race (WT-1046)

### DIFF
--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -2,6 +2,19 @@ import 'dart:async';
 
 import 'exceptions.dart';
 
+/// Represents a single in-flight signaling request and its expected response.
+///
+/// A [Transaction] is created for every request sent to the signaling server.
+/// It holds a [Completer] that resolves when one of three terminal events occurs:
+///
+/// - [handleResponse] — the server replied within the timeout window.
+/// - [terminateByDisconnect] — the WebSocket closed before a reply arrived.
+/// - The internal timeout timer fires (after [timeoutDuration]).
+///
+/// Only the **first** terminal event takes effect. Subsequent calls to any of
+/// the three completion paths are silently ignored via the [_isDone] guard,
+/// preventing a `StateError: Future already completed` if, for example, a
+/// late server response arrives after the timeout has already fired.
 class Transaction {
   static int _createCounter = 0;
 
@@ -13,6 +26,10 @@ class Transaction {
 
   final _completer = Completer<Map<String, dynamic>>();
   late final Timer _timer;
+
+  /// `true` once any terminal path ([handleResponse], [terminateByDisconnect],
+  /// or timeout) has run. Guards against double-completion of [_completer].
+  var _isDone = false;
 
   Transaction({required this.signalingClientId, String? id, required Duration timeoutDuration}) {
     if (id != null) {
@@ -28,22 +45,40 @@ class Transaction {
 
   Future<Map<String, dynamic>> get future => _completer.future;
 
+  /// Called when the server sends a response matching this transaction's [id].
+  ///
+  /// Completes [future] with [responseMessage]. No-op if the transaction has
+  /// already been resolved by a timeout or disconnect.
   void handleResponse(Map<String, dynamic> responseMessage) {
-    _timer.cancel();
+    if (_isDone) return;
+    _finish();
     _completer.complete(responseMessage);
   }
 
+  /// Called when the WebSocket disconnects before a response is received.
+  ///
+  /// Completes [future] with a
+  /// [WebtritSignalingTransactionTerminateByDisconnectException]. No-op if the
+  /// transaction has already been resolved.
   void terminateByDisconnect([int? closeCode, String? closeReason]) {
-    _timer.cancel();
+    if (_isDone) return;
+    _finish();
     _completer.completeError(
       WebtritSignalingTransactionTerminateByDisconnectException(signalingClientId, id, closeCode, closeReason),
     );
   }
 
   void _onTimeout() {
-    if (_completer.isCompleted) {
-      return;
-    }
+    if (_isDone) return;
+    _finish();
     _completer.completeError(WebtritSignalingTransactionTimeoutException(signalingClientId, id), StackTrace.current);
+  }
+
+  /// Marks the transaction as done and cancels the timeout timer.
+  ///
+  /// Must be called before completing [_completer] in every terminal path.
+  void _finish() {
+    _isDone = true;
+    _timer.cancel();
   }
 }

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
 
+import 'package:logging/logging.dart';
+
 import 'exceptions.dart';
+
+final _logger = Logger('Transaction');
 
 /// Represents a single in-flight signaling request and its expected response.
 ///
@@ -50,7 +54,12 @@ class Transaction {
   /// Completes [future] with [responseMessage]. No-op if the transaction has
   /// already been resolved by a timeout or disconnect.
   void handleResponse(Map<String, dynamic> responseMessage) {
-    if (_isDone) return;
+    if (_isDone) {
+      _logger.warning(
+        '$signalingClientId handleResponse called on already-completed transaction $id — ignoring late response',
+      );
+      return;
+    }
     _finish();
     _completer.complete(responseMessage);
   }
@@ -61,7 +70,12 @@ class Transaction {
   /// [WebtritSignalingTransactionTerminateByDisconnectException]. No-op if the
   /// transaction has already been resolved.
   void terminateByDisconnect([int? closeCode, String? closeReason]) {
-    if (_isDone) return;
+    if (_isDone) {
+      _logger.warning(
+        '$signalingClientId terminateByDisconnect called on already-completed transaction $id — ignoring (code: $closeCode reason: $closeReason)',
+      );
+      return;
+    }
     _finish();
     _completer.completeError(
       WebtritSignalingTransactionTerminateByDisconnectException(signalingClientId, id, closeCode, closeReason),
@@ -69,7 +83,12 @@ class Transaction {
   }
 
   void _onTimeout() {
-    if (_isDone) return;
+    if (_isDone) {
+      _logger.warning(
+        '$signalingClientId _onTimeout fired on already-completed transaction $id — ignoring late timeout',
+      );
+      return;
+    }
     _finish();
     _completer.completeError(WebtritSignalingTransactionTimeoutException(signalingClientId, id), StackTrace.current);
   }

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -16,9 +16,10 @@ final _logger = Logger('Transaction');
 /// - The internal timeout timer fires (after [timeoutDuration]).
 ///
 /// Only the **first** terminal event takes effect. Subsequent calls to any of
-/// the three completion paths are silently ignored via the [_isDone] guard,
-/// preventing a `StateError: Future already completed` if, for example, a
-/// late server response arrives after the timeout has already fired.
+/// the three completion paths are logged at [Level.WARNING] and ignored via
+/// the [_isDone] guard, preventing a `StateError: Future already completed`
+/// if, for example, a late server response arrives after the timeout has
+/// already fired.
 class Transaction {
   static int _createCounter = 0;
 

--- a/packages/webtrit_signaling/test/src/transaction_test.dart
+++ b/packages/webtrit_signaling/test/src/transaction_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
 
@@ -11,7 +13,7 @@ void main() {
   // Helper to suppress unhandled future errors inside fakeAsync blocks.
   // catchError must return the same type as the future.
   void suppressError(Transaction tx) {
-    tx.future.catchError((_) => <String, dynamic>{});
+    unawaited(tx.future.catchError((_) => <String, dynamic>{}));
   }
 
   group('Transaction.handleResponse', () {
@@ -27,10 +29,12 @@ void main() {
         tx.handleResponse({'response': 'ack'});
 
         Object? error;
-        tx.future.catchError((e) {
-          error = e;
-          return <String, dynamic>{};
-        });
+        unawaited(
+          tx.future.catchError((e) {
+            error = e;
+            return <String, dynamic>{};
+          }),
+        );
         async.elapse(timeout * 2);
 
         expect(error, isNull);
@@ -47,7 +51,7 @@ void main() {
     test('late call after timeout does not throw StateError', () {
       fakeAsync((async) {
         final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
-        suppressError(tx); // prevent unhandled error when timeout fires
+        suppressError(tx);
         async.elapse(timeout);
         expect(() => tx.handleResponse({'late': 'response'}), returnsNormally);
       });
@@ -66,10 +70,12 @@ void main() {
         final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
 
         Object? capturedError;
-        tx.future.catchError((e) {
-          capturedError = e;
-          return <String, dynamic>{};
-        });
+        unawaited(
+          tx.future.catchError((e) {
+            capturedError = e;
+            return <String, dynamic>{};
+          }),
+        );
 
         tx.terminateByDisconnect();
         async.flushMicrotasks();
@@ -82,7 +88,7 @@ void main() {
     test('late call after timeout does not throw StateError', () {
       fakeAsync((async) {
         final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
-        suppressError(tx); // prevent unhandled error when timeout fires
+        suppressError(tx);
         async.elapse(timeout);
         expect(() => tx.terminateByDisconnect(1001, 'going away'), returnsNormally);
       });
@@ -95,10 +101,12 @@ void main() {
         final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
 
         Object? capturedError;
-        tx.future.catchError((e) {
-          capturedError = e;
-          return <String, dynamic>{};
-        });
+        unawaited(
+          tx.future.catchError((e) {
+            capturedError = e;
+            return <String, dynamic>{};
+          }),
+        );
 
         expect(capturedError, isNull);
         async.elapse(timeout);
@@ -112,10 +120,12 @@ void main() {
         tx.handleResponse({'ok': true});
 
         Object? error;
-        tx.future.catchError((e) {
-          error = e;
-          return <String, dynamic>{};
-        });
+        unawaited(
+          tx.future.catchError((e) {
+            error = e;
+            return <String, dynamic>{};
+          }),
+        );
         async.elapse(timeout * 2);
 
         expect(error, isNull);

--- a/packages/webtrit_signaling/test/src/transaction_test.dart
+++ b/packages/webtrit_signaling/test/src/transaction_test.dart
@@ -1,0 +1,125 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:test/test.dart';
+
+import 'package:webtrit_signaling/src/exceptions.dart';
+import 'package:webtrit_signaling/src/transaction.dart';
+
+void main() {
+  const clientId = 0;
+  const timeout = Duration(seconds: 5);
+
+  // Helper to suppress unhandled future errors inside fakeAsync blocks.
+  // catchError must return the same type as the future.
+  void suppressError(Transaction tx) {
+    tx.future.catchError((_) => <String, dynamic>{});
+  }
+
+  group('Transaction.handleResponse', () {
+    test('completes future with response value', () async {
+      final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+      tx.handleResponse({'response': 'ack'});
+      expect(await tx.future, {'response': 'ack'});
+    });
+
+    test('cancels timeout — timer does not fire after response', () {
+      fakeAsync((async) {
+        final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+        tx.handleResponse({'response': 'ack'});
+
+        Object? error;
+        tx.future.catchError((e) {
+          error = e;
+          return <String, dynamic>{};
+        });
+        async.elapse(timeout * 2);
+
+        expect(error, isNull);
+      });
+    });
+
+    test('second call is silently ignored — no StateError', () async {
+      final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+      tx.handleResponse({'first': true});
+      expect(() => tx.handleResponse({'second': true}), returnsNormally);
+      expect(await tx.future, {'first': true});
+    });
+
+    test('late call after timeout does not throw StateError', () {
+      fakeAsync((async) {
+        final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+        suppressError(tx); // prevent unhandled error when timeout fires
+        async.elapse(timeout);
+        expect(() => tx.handleResponse({'late': 'response'}), returnsNormally);
+      });
+    });
+  });
+
+  group('Transaction.terminateByDisconnect', () {
+    test('completes future with disconnect error', () {
+      final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+      tx.terminateByDisconnect(1000, 'normal');
+      expect(tx.future, throwsA(isA<WebtritSignalingTransactionTerminateByDisconnectException>()));
+    });
+
+    test('cancels timeout — timer does not fire after disconnect', () {
+      fakeAsync((async) {
+        final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+
+        Object? capturedError;
+        tx.future.catchError((e) {
+          capturedError = e;
+          return <String, dynamic>{};
+        });
+
+        tx.terminateByDisconnect();
+        async.flushMicrotasks();
+        async.elapse(timeout * 2);
+
+        expect(capturedError, isA<WebtritSignalingTransactionTerminateByDisconnectException>());
+      });
+    });
+
+    test('late call after timeout does not throw StateError', () {
+      fakeAsync((async) {
+        final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+        suppressError(tx); // prevent unhandled error when timeout fires
+        async.elapse(timeout);
+        expect(() => tx.terminateByDisconnect(1001, 'going away'), returnsNormally);
+      });
+    });
+  });
+
+  group('Transaction timeout', () {
+    test('completes future with timeout error after duration elapses', () {
+      fakeAsync((async) {
+        final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+
+        Object? capturedError;
+        tx.future.catchError((e) {
+          capturedError = e;
+          return <String, dynamic>{};
+        });
+
+        expect(capturedError, isNull);
+        async.elapse(timeout);
+        expect(capturedError, isA<WebtritSignalingTransactionTimeoutException>());
+      });
+    });
+
+    test('does not fire if handleResponse called first', () {
+      fakeAsync((async) {
+        final tx = Transaction(signalingClientId: clientId, timeoutDuration: timeout);
+        tx.handleResponse({'ok': true});
+
+        Object? error;
+        tx.future.catchError((e) {
+          error = e;
+          return <String, dynamic>{};
+        });
+        async.elapse(timeout * 2);
+
+        expect(error, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Problem

`Transaction` in `packages/webtrit_signaling/lib/src/transaction.dart` has three terminal paths that complete the same `Completer`:

- `handleResponse()` — server replied
- `terminateByDisconnect()` — WebSocket closed
- `_onTimeout()` — timeout expired

Previously only `_onTimeout()` had a guard (`if (_completer.isCompleted) return`). The other two did not.

**Race scenario:** if the timeout fires and a late server response arrives in the same event loop tick, `_onTimeout()` completes the `Completer` first, then `handleResponse()` calls `_completer.complete()` on an already-completed `Completer` → `StateError: Bad state: Future already completed` → cascading `WebtritSignalingTransactionTimeoutException` for all ICE candidate transactions → call connects but audio/video never establishes.

Confirmed in Logzio: 100 entries across ASUS_AI2202_B, Xiaomi 2311DRK48G, Samsung SM-S911B.

## Fix

Introduce a `_isDone` boolean flag and a `_finish()` helper that centralises `_isDone = true` + `_timer.cancel()`. All three terminal paths now follow the same symmetric pattern:

```dart
if (_isDone) return;
_finish();
_completer.complete / completeError(...);
```

This also fixes `terminateByDisconnect()` which had the same missing guard.

## Tests

Added `test/src/transaction_test.dart` — 9 unit tests using `fake_async` for deterministic timer control:

- Normal resolution via `handleResponse` and `terminateByDisconnect`
- Timeout fires after duration
- Timer is cancelled when response/disconnect arrives first
- Late `handleResponse` after timeout does not throw `StateError`
- Late `terminateByDisconnect` after timeout does not throw `StateError`
- Double `handleResponse` is silently ignored

## Related

- WT-1046
- WT-1186