### PR TITLE
fix(signaling): silence controllerUnknownError (4400) on reconnect (WT-1039)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -132,7 +132,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         switch (knownCode) {
           case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
           case SignalingDisconnectCode.controllerForceAttachClose:
-            // Expected silent reconnect: keepalive timeout on lock-screen or duplicate-session cleanup.
+          case SignalingDisconnectCode.controllerUnknownError:
+            // Expected silent reconnect: keepalive timeout on lock-screen, duplicate-session cleanup,
+            // or transient server-side state after long inactivity / multi-device reconnect.
             _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
             return;
           default:
@@ -721,6 +723,20 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _logger.warning(
         '__onSignalingClientEventDisconnected: signaling race detected - '
         'server force-closed duplicate session (code=${event.code}, reason="${event.reason}").',
+      );
+      newState = state.copyWith(
+        callServiceState: state.callServiceState.copyWith(
+          signalingClientStatus: SignalingClientStatus.disconnect,
+          lastSignalingDisconnectCode: null,
+        ),
+      );
+    } else if (code == SignalingDisconnectCode.controllerUnknownError) {
+      // Server-side transient state after long inactivity or multi-device reconnect.
+      // The subsequent reconnect resolves it; keep lastSignalingDisconnectCode null
+      // so connectIssue status is never shown to the user.
+      _logger.warning(
+        '__onSignalingClientEventDisconnected: transient controllerUnknownError - '
+        'silent reconnect (code=${event.code})',
       );
       newState = state.copyWith(
         callServiceState: state.callServiceState.copyWith(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -133,8 +133,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
           case SignalingDisconnectCode.controllerForceAttachClose:
           case SignalingDisconnectCode.controllerUnknownError:
-            // Expected silent reconnect: keepalive timeout on lock-screen, duplicate-session cleanup,
-            // or transient server-side state after long inactivity / multi-device reconnect.
+            // controllerUnknownError (4400): the server-side Controller process died because
+            // the Janus connection went down. The new WebSocket timed out (GenServer.call,
+            // 5s default) waiting for the Controller to finish re-initializing (new Janus
+            // session + SIP registration). The Controller continues initializing in the
+            // background — the next reconnect attempt will succeed once it is ready.
+            //
+            // Silent reconnect: no user-visible notification needed.
             _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
             return;
           default:

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -131,7 +131,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         final (:knownCode, :systemCode, :systemReason) = failure;
         switch (knownCode) {
           case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
+            // Keepalive timeout: the server did not receive a ping in time.
+            // The connection is recoverable via silent reconnect.
+            _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
+            return;
           case SignalingDisconnectCode.controllerForceAttachClose:
+            // Force-attach close: a duplicate signaling session replaced this one
+            // (e.g. background push isolate still connected when main engine reconnects).
+            // Silent reconnect: no user-visible notification needed.
+            _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
+            return;
           case SignalingDisconnectCode.controllerUnknownError:
             // controllerUnknownError (4400): the server-side Controller process died because
             // the Janus connection went down. The new WebSocket timed out (GenServer.call,
@@ -741,7 +750,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // so connectIssue status is never shown to the user.
       _logger.warning(
         '__onSignalingClientEventDisconnected: transient controllerUnknownError - '
-        'silent reconnect (code=${event.code})',
+        'silent reconnect (code=${event.code}, reason="${event.reason}").',
       );
       newState = state.copyWith(
         callServiceState: state.callServiceState.copyWith(


### PR DESCRIPTION
## Summary

- Adds `controllerUnknownError` (4400) to the silent reconnect list in `onConnectionFailed`, consistent with how `controllerForceAttachClose` (4441) is handled
- Keeps `lastSignalingDisconnectCode` null on 4400 disconnect so the UI never briefly enters `CallStatus.connectIssue`
- No change to reconnect behavior — auto-recovery already worked; this only removes the spurious user-facing error

## Root cause

After multi-day inactivity (or multi-device use), the server emits code 4400 (`controllerUnknownError`) on the first reconnect attempt because its internal controller state for the previous session has been garbage-collected. The second reconnect (3s later) always succeeds with a full handshake. The client was surfacing this transient server error to the user even though it self-healed automatically.

## Changes

`lib/features/call/bloc/call_bloc.dart`

**1. `onConnectionFailed` switch:**
```dart
case SignalingDisconnectCode.signalingKeepaliveTimeoutError:
case SignalingDisconnectCode.controllerForceAttachClose:
case SignalingDisconnectCode.controllerUnknownError:  // added
  _logger.warning('onConnectionFailed: silent reconnect for code=$knownCode');
  return;
```

**2. `__onSignalingClientEventDisconnected`:**
Added `controllerUnknownError` branch that sets `lastSignalingDisconnectCode: null`, preventing the transient `connectIssue` status flash in the UI.

## Test plan

- [ ] Open app after several days of inactivity — no error toast shown on first reconnect
- [ ] App reconnects successfully and reaches `CallStatus.ready`
- [ ] Calls and presence work normally after reconnect
- [ ] Genuine disconnect errors (e.g. `sessionMissedError`) still show notifications

Fixes: WT-1039