### PR TITLE
fix(WT-1083): cancel pending OutgoingCallRequest when call is hung up

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1437,6 +1437,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> __onCallControlEventEnded(_CallControlEventEnded event, Emitter<CallState> emit) async {
+    // Cancel any queued signaling requests for this call immediately.
+    // Handles the case where OutgoingCallRequest is still waiting in the queue
+    // (no connection yet) — without this, it would be sent on reconnect,
+    // causing the callee to see a phantom incoming call, and local cleanup
+    // (ringback stop, PeerConnection disposal) would be delayed by the
+    // 30-second queue timeout.
+    _signalingModule.cancelRequestsByCallId(event.callId);
+
     emit(
       state.copyWithMappedActiveCall(event.callId, (activeCall) {
         return activeCall.copyWith(processingStatus: CallProcessingStatus.disconnecting);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -121,6 +121,11 @@ class WebtritSignalingService implements SignalingModule {
   }
 
   @override
+  void cancelRequestsByCallId(String callId) {
+    _requestQueue.cancelByCallId(callId);
+  }
+
+  @override
   Future<void> dispose() async {
     _requestQueue.failAll(NotConnectedException('WebtritSignalingService is disposed'));
     await _serviceEventsSub?.cancel();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
@@ -83,6 +83,11 @@ class SignalingHubModule implements SignalingModule {
   @override
   Future<void> disconnect() async => _hubClient.sendDisconnect();
 
+  /// No-op: [SignalingHubModule] routes requests directly through the hub
+  /// WebSocket without a local queue, so there is nothing to cancel.
+  @override
+  void cancelRequestsByCallId(String callId) {}
+
   @override
   Future<void> dispose() async {
     await _sub?.cancel();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
@@ -100,6 +100,9 @@ class _SignalingModule implements SignalingModule {
   Future<void>? execute(Request request) => _client?.execute(request);
 
   @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
@@ -95,6 +95,9 @@ class _SignalingModule implements SignalingModule {
   Future<void>? execute(Request request) => _client?.execute(request);
 
   @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -96,6 +96,9 @@ class _SignalingModule implements SignalingModule {
   Future<void>? execute(Request request) => _client?.execute(request);
 
   @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -67,6 +67,9 @@ class _FakeSignalingModule implements SignalingModule {
   Future<void>? execute(Request request) => Future<void>.value();
 
   @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
@@ -98,6 +98,9 @@ class _SignalingModule implements SignalingModule {
   Future<void>? execute(Request request) => _client?.execute(request);
 
   @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
@@ -131,6 +131,9 @@ class _FakeSignalingModule implements SignalingModule {
   }
 
   @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
@@ -204,6 +207,9 @@ class _FailingSignalingModule implements SignalingModule {
 
   @override
   Future<void>? execute(Request request) => null;
+
+  @override
+  void cancelRequestsByCallId(String callId) {}
 
   @override
   Future<void> dispose() async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
@@ -36,4 +36,14 @@ abstract interface class SignalingModule {
 
   /// Releases all resources. After [dispose] the instance must not be used.
   Future<void> dispose();
+
+  /// Cancels all pending queued requests for [callId].
+  ///
+  /// Useful when a call is being terminated before the signaling connection
+  /// is established — prevents a queued [OutgoingCallRequest] from being
+  /// sent on reconnect and immediately unblocks any [execute] future
+  /// awaiting that request.
+  ///
+  /// No-op if there are no matching requests in the queue.
+  void cancelRequestsByCallId(String callId);
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -217,6 +217,11 @@ class SignalingModuleImpl implements SignalingModule {
     }
   }
 
+  @override
+  void cancelRequestsByCallId(String callId) {
+    _requestQueue.cancelByCallId(callId);
+  }
+
   /// Disconnects and closes the event stream. After [dispose], the instance
   /// must not be used.
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -76,6 +76,25 @@ class SignalingRequestQueue {
     }
   }
 
+  /// Cancels all queued requests whose [callId] matches [callId].
+  ///
+  /// Each matching entry is removed from the queue, its timeout timer is
+  /// cancelled, and its future is completed with [NotConnectedException].
+  /// This unblocks any caller awaiting [enqueue] for that call without
+  /// waiting for the 30-second timeout.
+  void cancelByCallId(String callId) {
+    final toCancel = _queue
+        .where((e) => e.request is CallRequest && (e.request as CallRequest).callId == callId)
+        .toList();
+    for (final entry in toCancel) {
+      if (!_queue.remove(entry)) continue;
+      entry.timer.cancel();
+      if (!entry.completer.isCompleted) {
+        entry.completer.completeError(NotConnectedException('Request cancelled: call $callId is ending'));
+      }
+    }
+  }
+
   // ---------------------------------------------------------------------------
 
   Future<void> _executeWithRetry(

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -46,12 +46,15 @@ class SignalingRequestQueue {
       final entry = _queue.first;
       try {
         await _executeWithRetry(execute, entry.request, isActive);
-        _queue.removeFirst();
+        // Use remove(entry) instead of removeFirst() to guard against concurrent
+        // cancelByCallId calls that may have already removed this entry while
+        // flush() was suspended at the await above.
+        _queue.remove(entry);
         entry.timer.cancel();
         if (!entry.completer.isCompleted) entry.completer.complete();
       } catch (error, stackTrace) {
         if (!isActive()) return;
-        _queue.removeFirst();
+        _queue.remove(entry);
         entry.timer.cancel();
         if (!entry.completer.isCompleted) entry.completer.completeError(error, stackTrace);
       }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
@@ -1,0 +1,167 @@
+/// Unit tests for [SignalingRequestQueue].
+///
+/// Covers:
+///   - [SignalingRequestQueue.cancelByCallId]: early completion with error,
+///     cancelled requests are not sent on flush, cross-call isolation.
+///   - [SignalingRequestQueue.flush]: removal-by-identity guard — a concurrent
+///     [cancelByCallId] during an in-flight flush must not corrupt queue order.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+import 'package:webtrit_signaling_service_platform_interface/src/signaling_request_queue.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+HangupRequest _hangup(String callId) => HangupRequest(transaction: 'tx-$callId', line: 0, callId: callId);
+
+// A simple execute stub that records which requests were sent.
+Future<void> Function(Request) _recordingExecute(List<Request> log) =>
+    (r) async => log.add(r);
+
+// An execute stub that suspends until a completer is resolved — used to
+// simulate an in-flight flush that is suspended at the await point.
+Future<void> Function(Request) _suspendingExecute(List<Request> log, Completer<void> gate) => (r) async {
+  await gate.future;
+  log.add(r);
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('SignalingRequestQueue.cancelByCallId —', () {
+    test('enqueue() future completes with NotConnectedException immediately on cancel', () async {
+      final queue = SignalingRequestQueue();
+      final future = queue.enqueue(_hangup('call-1'));
+
+      queue.cancelByCallId('call-1');
+
+      await expectLater(
+        future,
+        throwsA(isA<NotConnectedException>().having((e) => e.message, 'message', contains('call-1'))),
+      );
+    });
+
+    test('cancelled request is not sent on subsequent flush()', () async {
+      final queue = SignalingRequestQueue();
+      final sent = <Request>[];
+
+      // Enqueue and immediately cancel before any flush.
+      unawaited(queue.enqueue(_hangup('call-1')).catchError((_) {}));
+      queue.cancelByCallId('call-1');
+
+      // Flush should send nothing.
+      await queue.flush(execute: _recordingExecute(sent), isActive: () => true);
+
+      expect(sent, isEmpty);
+    });
+
+    test('only requests matching callId are cancelled; others remain', () async {
+      final queue = SignalingRequestQueue();
+      final sent = <Request>[];
+
+      unawaited(queue.enqueue(_hangup('call-A')).catchError((_) {}));
+      final futureB = queue.enqueue(_hangup('call-B'));
+
+      queue.cancelByCallId('call-A');
+
+      // call-A future must have thrown.
+      // call-B future must still be pending (not completed).
+      expect(futureB, isA<Future<void>>());
+      expect(queue.isNotEmpty, isTrue, reason: 'call-B must still be in the queue');
+
+      // Flush should send only call-B.
+      await queue.flush(execute: _recordingExecute(sent), isActive: () => true);
+
+      await expectLater(futureB, completes);
+      expect(sent.length, 1);
+      expect((sent.first as HangupRequest).callId, 'call-B');
+    });
+
+    test('cancelByCallId on unknown callId is a no-op', () async {
+      final queue = SignalingRequestQueue();
+      final future = queue.enqueue(_hangup('call-1'));
+
+      // Cancelling a different id must not affect call-1.
+      queue.cancelByCallId('call-X');
+
+      expect(queue.isNotEmpty, isTrue);
+
+      await queue.flush(execute: _recordingExecute([]), isActive: () => true);
+      await expectLater(future, completes);
+    });
+  });
+
+  group('SignalingRequestQueue.flush — identity-based removal guard —', () {
+    test('concurrent cancelByCallId during in-flight flush does not remove wrong entry', () async {
+      final queue = SignalingRequestQueue();
+      final sent = <Request>[];
+      final gate = Completer<void>();
+
+      // Enqueue two requests for different calls.
+      unawaited(queue.enqueue(_hangup('call-A')).catchError((_) {}));
+      final futureB = queue.enqueue(_hangup('call-B'));
+
+      // Start flush — it will suspend at the gate while processing call-A.
+      final flushFuture = queue.flush(execute: _suspendingExecute(sent, gate), isActive: () => true);
+
+      // While flush is suspended awaiting call-A, cancel call-A.
+      await Future<void>.delayed(Duration.zero);
+      queue.cancelByCallId('call-A');
+
+      // Release the gate so flush resumes.
+      gate.complete();
+      await flushFuture;
+
+      // call-A was cancelled: its completer already errored before flush resumed.
+      // flush must have used remove(entry) and kept call-B in the queue, then
+      // processed it normally.
+      await expectLater(futureB, completes);
+      // call-A's execute was still called (flush had already started it),
+      // but call-B must also have been sent.
+      expect(sent.map((r) => (r as HangupRequest).callId), contains('call-B'));
+    });
+
+    test('flush stops when isActive() returns false mid-queue', () async {
+      final queue = SignalingRequestQueue();
+      final sent = <Request>[];
+      var active = true;
+
+      unawaited(queue.enqueue(_hangup('call-A')).catchError((_) {}));
+      unawaited(queue.enqueue(_hangup('call-B')).catchError((_) {}));
+
+      await queue.flush(
+        execute: (r) async {
+          sent.add(r);
+          active = false; // deactivate after first request
+        },
+        isActive: () => active,
+      );
+
+      // Only the first request should have been sent.
+      expect(sent.length, 1);
+      expect(queue.isNotEmpty, isTrue, reason: 'second request remains in queue');
+    });
+  });
+
+  group('SignalingRequestQueue.failAll —', () {
+    test('fails all pending entries and clears the queue', () async {
+      final queue = SignalingRequestQueue();
+      final futureA = queue.enqueue(_hangup('call-A'));
+      final futureB = queue.enqueue(_hangup('call-B'));
+
+      final error = Exception('test error');
+      queue.failAll(error);
+
+      await expectLater(futureA, throwsA(same(error)));
+      await expectLater(futureB, throwsA(same(error)));
+      expect(queue.isEmpty, isTrue);
+    });
+  });
+}

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -36,6 +36,9 @@ class _FakeSignalingModule implements SignalingModule {
   Future<void>? execute(Request request) => null;
 
   @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
   Future<void> dispose() async => _controller.close();
 }
 


### PR DESCRIPTION
> **Part of [fix/WT-1083-outgoing-call-reconciliation-v2](https://github.com/WebTrit/webtrit_phone/tree/fix/WT-1083-outgoing-call-reconciliation-v2)** — all WT-1083 fixes accumulate there before a single PR to `develop`.

## Problem

When a user starts an outgoing call and cuts internet **before** `OutgoingCallRequest` is sent, the request sits in `SignalingRequestQueue` with a 30-second timeout. Pressing hangup at this point causes two bugs:

**1 — Local cleanup is blocked for ~30 seconds**

`__onCallPerformEventEnded` (which stops ringback and disposes PeerConnection) cannot run because the `sequential()` transformer queues it behind `__onCallPerformEventStarted`. That handler is stuck awaiting the `enqueue()` future, which only resolves after the 30-second queue timeout.

**Observed:** call screen stays visible, ringback plays for ~30s after pressing hangup.

**2 — Phantom incoming call on callee (if internet restores before timeout)**

`flush()` sends requests in FIFO order: `OutgoingCallRequest` goes first, server starts ringing the callee, `HangupRequest` follows only after `__onCallPerformEventStarted` completes.

## Fix

Add `cancelRequestsByCallId(callId)` to `SignalingModule` and call it at the very start of `__onCallControlEventEnded` — the earliest point where hangup intent is known.

This immediately removes the `OutgoingCallRequest` from the queue and completes its future with `NotConnectedException`. The existing `try/catch` in `__onCallPerformEventStarted` handles the error and returns cleanly, unblocking the sequential transformer so `__onCallPerformEventEnded` runs right away.

```
User presses hangup
→ __onCallControlEventEnded
    cancelRequestsByCallId(callId)     ← NEW: drops OutgoingCallRequest immediately
    processingStatus = disconnecting
    callkeep.endCall(...)

→ __onCallPerformEventStarted catches NotConnectedException → returns
→ __onCallPerformEventEnded runs immediately:
    _stopRingbackSound()               ← instant, no 30s wait
    disposePeerConnection()
    copyWithPopActiveCall              ← UI dismisses immediately
```

## Files changed

| File | Change |
|------|--------|
| `signaling_request_queue.dart` | Add `cancelByCallId(String callId)` |
| `signaling_module.dart` | Add `cancelRequestsByCallId` to interface |
| `signaling_module_impl.dart` | Implement — delegates to `_requestQueue.cancelByCallId` |
| `signaling_service.dart` | Implement — delegates to `_requestQueue.cancelByCallId` |
| `signaling_hub_module.dart` | No-op — hub routes requests directly, no local queue |
| `call_bloc.dart` | Call `cancelRequestsByCallId` at start of `__onCallControlEventEnded` |
| 6 test fakes | Add no-op `cancelRequestsByCallId` to satisfy interface |

## How to test

1. Start outgoing call
2. Cut internet while call is dialing (before offer is sent — `outgoingOfferPreparing` or earlier)
3. Press hangup while offline

**Expected (after fix):** call screen dismisses immediately, ringback stops immediately
**Expected (after fix):** on internet restore — callee does NOT see an incoming call
**Before fix:** UI freezes for ~30s, ringback continues, callee may see phantom call

## Scope

This PR covers the queue-cancellation path only (pre-offer hangup).
The remaining WT-1083 cases (post-offer orphan cleanup, HandshakeProcessor gap) are tracked in separate PRs targeting the same umbrella branch.