### PR TITLE
fix(WT-1083): skip disconnecting calls on reconnect and retry lost HangupRequest

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2618,7 +2618,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
               callId: activeCall.callId,
             ),
           )
-          ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived pendingHangup retry error'));
+          ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived pendingHangup retry error'))
+          .ignore();
     }
 
     final actions = await _handshakeProcessor.process(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -642,6 +642,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // user turn off all network interfaces >> __onPeerConnectionEventIceConnectionStateChanged >> RTCIceConnectionStateFailed >> peerConnection.restartIce() >> onRenegotiationNeeded >> _safeRenegotiate >> if(!signalingConnected) return;
     // user turn on network interfaces >> _onSignalingClientEventConnected >> safeRenegotiate
     for (final call in state.activeCalls) {
+      // Skip calls that are being torn down — sending UpdateRequest for a
+      // disconnecting call would keep the server-side leg alive unnecessarily.
+      if (call.processingStatus == CallProcessingStatus.disconnecting) continue;
       _logger.warning('__onSignalingClientEventConnected: triggering safe renegotiation for call ${call.callId}');
       _safeRenegotiate(call.callId, call.line);
     }
@@ -2599,6 +2602,23 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           reason: 'Request Terminated',
         ),
       );
+    }
+
+    // Retry HangupRequest for calls that were being terminated when signaling dropped.
+    // If a call is locally disconnecting AND the server still lists it in activeLineCallIds,
+    // the hangup was lost mid-flight — resend it now so the server-side leg is torn down.
+    for (final activeCall in state.activeCalls) {
+      if (activeCall.processingStatus != CallProcessingStatus.disconnecting) continue;
+      if (!activeLineCallIds.contains(activeCall.callId)) continue;
+      _signalingModule
+          .execute(
+            HangupRequest(
+              transaction: WebtritSignalingClient.generateTransactionId(),
+              line: activeCall.line,
+              callId: activeCall.callId,
+            ),
+          )
+          ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived pendingHangup retry error'));
     }
 
     final actions = await _handshakeProcessor.process(


### PR DESCRIPTION
## Context

Part of the WT-1083 offline-hangup fix series. Targets the umbrella branch
`fix/WT-1083-outgoing-call-reconciliation-v2`.

Covers two bugs that both occur when signaling reconnects while a call is in
`disconnecting` state (user pressed hangup while offline).

## Bug A — `_safeRenegotiate` fires for `disconnecting` calls on reconnect

**File:** `lib/features/call/bloc/call_bloc.dart` — `__onSignalingClientEventConnected`

When signaling reconnects, the loop over `state.activeCalls` had no status
filter. Calls in `disconnecting` state (user already pressed hangup) triggered
`_safeRenegotiate`, which created a new WebRTC offer and sent `UpdateRequest` to
the server — keeping the server-side leg alive and causing the callee's phone to
keep ringing.

**Fix:** Skip `disconnecting` calls in the renegotiation loop, consistent with
the existing guard in the glare-detection path (line 882).

## Bug B — `HangupRequest` not retried on handshake for `disconnecting` calls

**File:** `lib/features/call/bloc/call_bloc.dart` — `_handleHandshakeReceived`

When `__onCallPerformEventEnded` runs while signaling is offline, the
`HangupRequest` fails and the error is caught-and-swallowed. On reconnect,
`_handleHandshakeReceived` builds `activeLineCallIds` from the server handshake.
The call is present in both `state.activeCalls` (as `disconnecting`) and in the
server lines — so `callsToTerminate()` skips it and `HandshakeProcessor` takes no
action. The server never receives the hangup.

**Fix:** After `callsToTerminate()`, iterate `state.activeCalls` and resend
`HangupRequest` for any call that is locally `disconnecting` AND still present in
`activeLineCallIds`. If the server returns an error (call already gone), it is
handled by `callErrorReporter`.

## Test scenarios

1. Outgoing call → cut internet → press hangup → restore internet
   - Callee's phone stops ringing within one reconnect cycle
   - No ringback sound after hangup

2. Active call (accepted) → cut internet → press hangup → restore internet
   - `HangupRequest` retried on reconnect, call ends on server

3. Normal reconnect (no hangup pending) — regression check
   - `_safeRenegotiate` still fires for all non-disconnecting calls
   - No change to normal renegotiation behavior