### PR TITLE
fix(WT-1083): hang up orphaned outgoing call when connection and BLoC state are both absent

### DIFF
--- a/lib/features/call/utils/handshake_processor.dart
+++ b/lib/features/call/utils/handshake_processor.dart
@@ -9,9 +9,14 @@ sealed class HandshakeAction {
 
 /// Send a [HangupRequest] to the signaling server and stop processing.
 ///
-/// Emitted when the Callkeep connection for the line is [CallkeepConnectionState.stateDisconnected]
-/// and the latest call event is neither [HangupEvent] nor [MissedCallEvent]
-/// (i.e. the call was live — accepted, proceeding, ringing, etc. — when the connection dropped).
+/// Emitted in two cases:
+/// 1. The Callkeep connection is [CallkeepConnectionState.stateDisconnected] and
+///    the latest call event is neither [HangupEvent] nor [MissedCallEvent]
+///    (i.e. the call was live when the connection dropped).
+/// 2. The Callkeep connection is null (removed or iOS), the call is not tracked
+///    in BLoC state, has no [AcceptedEvent] in its log, and the latest event is
+///    not a terminal or incoming event — i.e. an orphaned outgoing call whose
+///    [HangupRequest] was lost while the device was offline.
 final class HangupSignalingAction extends HandshakeAction {
   const HangupSignalingAction({required this.line, required this.callId});
 
@@ -123,6 +128,24 @@ class HandshakeProcessor {
           } else if (callEvent is! HangupEvent && callEvent is! MissedCallEvent) {
             return [HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
           }
+        } else if (connection == null &&
+            !activeCallIds.contains(activeLine.callId) &&
+            callEvent is! IncomingCallEvent &&
+            callEvent is! HangupEvent &&
+            callEvent is! MissedCallEvent &&
+            activeLine.callLogs.whereType<CallEventLog>().every((l) => l.callEvent is! AcceptedEvent)) {
+          // Orphaned outgoing call: the server still has the call but both
+          // CallKeep and BLoC have no record of it. This happens when the user
+          // hangs up while offline — performEndCall removed the local state but
+          // the HangupRequest never reached the server.
+          //
+          // The AcceptedEvent guard ensures we never hang up a call that should
+          // be restored (app-restart case where connection is null but the call
+          // was previously accepted).
+          //
+          // On iOS getConnection() always returns null, so activeCallIds is the
+          // decisive guard: calls that are still active in BLoC are not affected.
+          return [HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
         }
       }
 

--- a/lib/features/call/utils/handshake_processor.dart
+++ b/lib/features/call/utils/handshake_processor.dart
@@ -116,7 +116,16 @@ class HandshakeProcessor {
     final localConnections = await callkeepConnections.getConnections();
 
     for (final activeLine in allLines) {
-      final callEvent = activeLine.callLogs.whereType<CallEventLog>().map((log) => log.callEvent).firstOrNull;
+      // callLogs is newest-first: firstOrNull = latest, lastOrNull = earliest.
+      // Materialise once and reuse for both the connection guards below and the
+      // restoration logic further down to avoid redundant traversals.
+      final callEventLogEntries = activeLine.callLogs.whereType<CallEventLog>().toList();
+      final callEvent = callEventLogEntries.firstOrNull?.callEvent; // latest event
+      final earliestCallEvent = callEventLogEntries.lastOrNull?.callEvent;
+
+      // AcceptedEvent may not be the latest entry after a re-INVITE or transfer -
+      // search the full log list rather than checking only the newest entry.
+      final acceptedLogEntry = callEventLogEntries.where((log) => log.callEvent is AcceptedEvent).firstOrNull;
 
       CallkeepConnection? connection;
       if (callEvent != null) {
@@ -133,13 +142,13 @@ class HandshakeProcessor {
             callEvent is! IncomingCallEvent &&
             callEvent is! HangupEvent &&
             callEvent is! MissedCallEvent &&
-            activeLine.callLogs.whereType<CallEventLog>().every((l) => l.callEvent is! AcceptedEvent)) {
+            acceptedLogEntry == null) {
           // Orphaned outgoing call: the server still has the call but both
           // CallKeep and BLoC have no record of it. This happens when the user
           // hangs up while offline — performEndCall removed the local state but
           // the HangupRequest never reached the server.
           //
-          // The AcceptedEvent guard ensures we never hang up a call that should
+          // acceptedLogEntry == null ensures we never hang up a call that should
           // be restored (app-restart case where connection is null but the call
           // was previously accepted).
           //
@@ -149,17 +158,8 @@ class HandshakeProcessor {
         }
       }
 
-      // callLogs is newest-first: firstOrNull = latest, lastOrNull = earliest.
-      final callEventLogEntries = activeLine.callLogs.whereType<CallEventLog>().toList();
-      final latestCallEvent = callEventLogEntries.firstOrNull?.callEvent;
-      final earliestCallEvent = callEventLogEntries.lastOrNull?.callEvent;
-
-      // AcceptedEvent may not be the latest entry after a re-INVITE or transfer -
-      // search the full log list rather than checking only the newest entry.
-      final acceptedLogEntry = callEventLogEntries.where((log) => log.callEvent is AcceptedEvent).firstOrNull;
-
       // A call is server-terminated when the latest event is a final hangup or missed.
-      final isTerminated = latestCallEvent is HangupEvent || latestCallEvent is MissedCallEvent;
+      final isTerminated = callEvent is HangupEvent || callEvent is MissedCallEvent;
 
       if (!isTerminated &&
           acceptedLogEntry != null &&

--- a/test/features/call/bloc/handshake_processor_test.dart
+++ b/test/features/call/bloc/handshake_processor_test.dart
@@ -355,6 +355,78 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // Orphaned outgoing call (connection == null, not in BLoC, no AcceptedEvent)
+  // -------------------------------------------------------------------------
+
+  group('orphaned outgoing call — null connection, absent from BLoC', () {
+    test('returns HangupSignalingAction for unanswered outgoing call (ProceedingEvent)', () async {
+      // connection is null (CallKeep entry was removed by performEndCall)
+      // call is not in activeCallIds (BLoC also removed it)
+      // server still has it with ProceedingEvent → HangupRequest must be sent
+      final line = _makeLine(callLogs: [CallEventLog(timestamp: 1000, callEvent: _makeProceedingEvent())]);
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
+
+      expect(actions, hasLength(1));
+      expect(actions.first, isA<HangupSignalingAction>());
+      final a = actions.first as HangupSignalingAction;
+      expect(a.callId, _kCallId);
+      expect(a.line, _kLine);
+    });
+
+    test('does NOT return HangupSignalingAction when call is still in BLoC activeCallIds (iOS guard)', () async {
+      // On iOS getConnection() always returns null.
+      // If the call IS in activeCalls the user is still in the call — must not hang up.
+      final line = _makeLine(callLogs: [CallEventLog(timestamp: 1000, callEvent: _makeProceedingEvent())]);
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {_kCallId});
+
+      expect(actions.whereType<HangupSignalingAction>(), isEmpty);
+    });
+
+    test('does NOT interfere with restoration: accepted call with null connection returns RestoreCallAction', () async {
+      // App-restart case: connection is null but AcceptedEvent is in logs.
+      // Must produce RestoreCallAction, not HangupSignalingAction.
+      final line = _makeLine(
+        callLogs: [
+          CallEventLog(timestamp: 2000, callEvent: _makeAcceptedEvent()),
+          CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
+        ],
+      );
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
+
+      expect(actions.whereType<HangupSignalingAction>(), isEmpty);
+      expect(actions.whereType<RestoreCallAction>(), hasLength(1));
+    });
+
+    test('does NOT return HangupSignalingAction for IncomingCallEvent with null connection', () async {
+      // Unanswered incoming call with no connection — HandleIncomingCallAction path, not hangup.
+      final line = _makeLine(callLogs: [CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent())]);
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
+
+      expect(actions.whereType<HangupSignalingAction>(), isEmpty);
+    });
+
+    test('does NOT return HangupSignalingAction when server latest event is HangupEvent', () async {
+      final line = _makeLine(
+        callLogs: [
+          CallEventLog(
+            timestamp: 2000,
+            callEvent: HangupEvent(line: _kLine, callId: _kCallId, code: 487, reason: 'Request Terminated'),
+          ),
+          CallEventLog(timestamp: 1000, callEvent: _makeProceedingEvent()),
+        ],
+      );
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
+
+      expect(actions.whereType<HangupSignalingAction>(), isEmpty);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // guestLine is treated like a regular line
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Context

Part of the WT-1083 offline-hangup fix series. Targets
`fix/WT-1083-outgoing-call-reconciliation-v2`.

## Problem

When the user hangs up an outgoing call while offline:
1. `performEndCall` fires normally — call is removed from `activeCalls` and CallKeep
2. `HangupRequest` is sent → **fails** (no network) → error swallowed
3. Internet restores → `_handleHandshakeReceived` runs
4. `HandshakeProcessor.process()` sees the server line (call still ringing) but:
   - `getConnection(callId)` → `null` (CallKeep removed it)
   - `activeCallIds` does not contain the call (BLoC removed it)
   - No `AcceptedEvent` in call log (call was never answered)
   - `connection?.state == stateDisconnected` → `false` (null-safe skip)
5. **Nothing happens** — server continues ringing the callee indefinitely

## Fix

Add an `else if` branch after the `stateDisconnected` check in `HandshakeProcessor.process()`:

```dart
} else if (connection == null &&
    !activeCallIds.contains(activeLine.callId) &&
    callEvent is! IncomingCallEvent &&
    callEvent is! HangupEvent &&
    callEvent is! MissedCallEvent &&
    activeLine.callLogs.whereType<CallEventLog>().every((l) => l.callEvent is! AcceptedEvent)) {
  return [HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
}
```

## Guards explained

| Condition | Why |
|-----------|-----|
| `connection == null` | CallKeep has no record (removed or iOS) |
| `!activeCallIds.contains()` | BLoC also has no state — call is fully orphaned. **On iOS `getConnection()` always returns null** — this is the critical guard preventing hangup of still-active calls |
| `callEvent is! IncomingCallEvent` | Incoming calls with no connection may need `HandleIncomingCallAction` |
| `callEvent is! HangupEvent/MissedCallEvent` | Server already sending terminal event — no action needed |
| `every((l) => l.callEvent is! AcceptedEvent)` | Preserves app-restart restoration: accepted calls with null connection should produce `RestoreCallAction`, not `HangupSignalingAction` |

## Tests

5 new unit tests in `handshake_processor_test.dart`:
- Core case: ProceedingEvent + null connection + absent from BLoC → `HangupSignalingAction`
- iOS guard: call still in `activeCallIds` → no `HangupSignalingAction`
- Restoration not broken: `AcceptedEvent` in logs → `RestoreCallAction` (not hangup)
- Incoming calls not affected: `IncomingCallEvent` → no `HangupSignalingAction`
- Terminal server events: `HangupEvent` as latest → no action