### PR TITLE
fix(WT-1083): exit signaling wait immediately when user hangs up

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1823,6 +1823,19 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   // processing call perform events
 
+  /// Returns true when [__onCallPerformEventStarted] should stop waiting for
+  /// signaling readiness.
+  ///
+  /// Exits as soon as both the handshake and signaling are established, or when
+  /// the call leaves [CallProcessingStatus.outgoingConnectingToSignaling] — for
+  /// example because the user pressed hangup (status → disconnecting) or
+  /// another code path removed the call entirely.
+  bool _shouldExitOutgoingSignalingWait(CallState next, String callId) {
+    if (next.isHandshakeEstablished && next.isSignalingEstablished) return true;
+    final call = next.retrieveActiveCall(callId);
+    return call == null || call.processingStatus != CallProcessingStatus.outgoingConnectingToSignaling;
+  }
+
   Future<void> _onCallPerformEvent(_CallPerformEvent event, Emitter<CallState> emit) {
     return switch (event) {
       _CallPerformEventStarted() => __onCallPerformEventStarted(event, emit),
@@ -1884,13 +1897,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
 
       currentState = await stream
-          .firstWhere((next) {
-            if (next.isHandshakeEstablished && next.isSignalingEstablished) return true;
-            // Exit early if the call left outgoingConnectingToSignaling — either the user
-            // pressed hangup (-> disconnecting) or another code path removed the call.
-            final call = next.retrieveActiveCall(event.callId);
-            return call == null || call.processingStatus != CallProcessingStatus.outgoingConnectingToSignaling;
-          }, orElse: () => state)
+          .firstWhere((next) => _shouldExitOutgoingSignalingWait(next, event.callId), orElse: () => state)
           .timeout(kOutgoingCallSignalingWaitTimeout, onTimeout: () => state);
       if (isClosed) return;
     }
@@ -2164,6 +2171,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> __onCallPerformEventEnded(_CallPerformEventEnded event, Emitter<CallState> emit) async {
+    try {
+      await _onCallPerformEventEndedImpl(event, emit);
+    } finally {
+      // Release the post-cancel enqueue guard so the entry does not accumulate
+      // for the lifetime of the signaling module.
+      _signalingModule.clearTerminatingMark(event.callId);
+    }
+  }
+
+  Future<void> _onCallPerformEventEndedImpl(_CallPerformEventEnded event, Emitter<CallState> emit) async {
     // Condition occur when the user interacts with a push notification before signaling is properly initialized.
     // In this case, the CallKeep method "reportNewIncomingCall" may return callIdAlreadyTerminated.
     if (state.retrieveActiveCall(event.callId)?.line == _kUndefinedLine) {

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1884,14 +1884,27 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
 
       currentState = await stream
-          .firstWhere((next) => next.isHandshakeEstablished && next.isSignalingEstablished, orElse: () => state)
+          .firstWhere((next) {
+            if (next.isHandshakeEstablished && next.isSignalingEstablished) return true;
+            // Exit early if the call left outgoingConnectingToSignaling — either the user
+            // pressed hangup (-> disconnecting) or another code path removed the call.
+            final call = next.retrieveActiveCall(event.callId);
+            return call == null || call.processingStatus != CallProcessingStatus.outgoingConnectingToSignaling;
+          }, orElse: () => state)
           .timeout(kOutgoingCallSignalingWaitTimeout, onTimeout: () => state);
       if (isClosed) return;
     }
 
-    // If the signaling client is not connected, hung up the call and notify user
+    // If the signaling client is not connected, decide how to clean up.
     if (!currentState.isSignalingEstablished) {
       event.fail();
+
+      // If the call is no longer in outgoingConnectingToSignaling the hangup flow
+      // has already taken over — avoid double-ending or showing a wrong notification.
+      final waitingCall = state.retrieveActiveCall(event.callId);
+      if (waitingCall?.processingStatus != CallProcessingStatus.outgoingConnectingToSignaling) {
+        return;
+      }
 
       // Notice that the tube was already hung up to avoid sending an extra event to the server
       emit(

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -126,6 +126,11 @@ class WebtritSignalingService implements SignalingModule {
   }
 
   @override
+  void clearTerminatingMark(String callId) {
+    _requestQueue.removeTerminatingMark(callId);
+  }
+
+  @override
   Future<void> dispose() async {
     _requestQueue.failAll(NotConnectedException('WebtritSignalingService is disposed'));
     await _serviceEventsSub?.cancel();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_module.dart
@@ -62,6 +62,8 @@ class SignalingHubModule implements SignalingModule {
 
   @override
   Future<void>? execute(Request request) {
+    // DEBUG: log state at the moment execute is called on the main-isolate side
+    _logger.info('SignalingHubModule execute: request=${request.runtimeType} _connected=$_connected');
     if (!_connected) return null;
     return _hubClient.execute(request);
   }
@@ -87,6 +89,11 @@ class SignalingHubModule implements SignalingModule {
   /// WebSocket without a local queue, so there is nothing to cancel.
   @override
   void cancelRequestsByCallId(String callId) {}
+
+  /// No-op: [SignalingHubModule] has no local request queue and therefore no
+  /// terminating marks to clear.
+  @override
+  void clearTerminatingMark(String callId) {}
 
   @override
   Future<void> dispose() async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
@@ -103,6 +103,9 @@ class _SignalingModule implements SignalingModule {
   void cancelRequestsByCallId(String callId) {}
 
   @override
+  void clearTerminatingMark(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
@@ -98,6 +98,9 @@ class _SignalingModule implements SignalingModule {
   void cancelRequestsByCallId(String callId) {}
 
   @override
+  void clearTerminatingMark(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -99,6 +99,9 @@ class _SignalingModule implements SignalingModule {
   void cancelRequestsByCallId(String callId) {}
 
   @override
+  void clearTerminatingMark(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -70,6 +70,9 @@ class _FakeSignalingModule implements SignalingModule {
   void cancelRequestsByCallId(String callId) {}
 
   @override
+  void clearTerminatingMark(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
@@ -101,6 +101,9 @@ class _SignalingModule implements SignalingModule {
   void cancelRequestsByCallId(String callId) {}
 
   @override
+  void clearTerminatingMark(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
@@ -134,6 +134,9 @@ class _FakeSignalingModule implements SignalingModule {
   void cancelRequestsByCallId(String callId) {}
 
   @override
+  void clearTerminatingMark(String callId) {}
+
+  @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
@@ -210,6 +213,9 @@ class _FailingSignalingModule implements SignalingModule {
 
   @override
   void cancelRequestsByCallId(String callId) {}
+
+  @override
+  void clearTerminatingMark(String callId) {}
 
   @override
   Future<void> dispose() async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
@@ -46,4 +46,13 @@ abstract interface class SignalingModule {
   ///
   /// No-op if there are no matching requests in the queue.
   void cancelRequestsByCallId(String callId);
+
+  /// Removes the post-cancel enqueue guard set by [cancelRequestsByCallId].
+  ///
+  /// Call this once the call teardown is fully complete to prevent guard
+  /// entries from accumulating for the lifetime of the module. Safe to call
+  /// even if [cancelRequestsByCallId] was never called for [callId].
+  ///
+  /// No-op on implementations that do not use a local request queue.
+  void clearTerminatingMark(String callId);
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -222,6 +222,11 @@ class SignalingModuleImpl implements SignalingModule {
     _requestQueue.cancelByCallId(callId);
   }
 
+  @override
+  void clearTerminatingMark(String callId) {
+    _requestQueue.removeTerminatingMark(callId);
+  }
+
   /// Disconnects and closes the event stream. After [dispose], the instance
   /// must not be used.
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -23,11 +23,13 @@ class SignalingRequestQueue {
   ///
   /// Any subsequent [enqueue] for a matching callId is rejected immediately
   /// with [NotConnectedException] instead of being queued. This handles the
-  /// case where [cancelByCallId] is called before the request is created (e.g.
-  /// a [HangupRequest] built inside [performEndCall] after [cancelByCallId]
-  /// was already called in [performControlEnd]).
+  /// case where [cancelByCallId] is called before the termination request is
+  /// even created — for example when the hangup flow cancels the queue before
+  /// the [HangupRequest] is constructed in the call-end handler.
   ///
-  /// Cleared by [failAll] so that a fresh session can re-use the same callId.
+  /// Entries are removed individually by [removeTerminatingMark] once the
+  /// caller confirms the call is fully torn down, and the entire set is
+  /// cleared by [failAll] on session end.
   final _terminatingCallIds = <String>{};
 
   bool get isEmpty => _queue.isEmpty;
@@ -97,6 +99,13 @@ class SignalingRequestQueue {
       if (!entry.completer.isCompleted) entry.completer.completeError(error);
     }
   }
+
+  /// Removes the terminating mark for [callId] set by [cancelByCallId].
+  ///
+  /// Call this once the call teardown is fully complete so the guard entry
+  /// does not accumulate for the lifetime of the queue. Safe to call even if
+  /// [cancelByCallId] was never called for [callId].
+  void removeTerminatingMark(String callId) => _terminatingCallIds.remove(callId);
 
   /// Cancels all queued requests whose [callId] matches [callId] and prevents
   /// any future [enqueue] for the same [callId] from being accepted.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -19,6 +19,17 @@ class SignalingRequestQueue {
 
   final Queue<_QueuedRequest> _queue = Queue();
 
+  /// Call IDs for which [cancelByCallId] has been called.
+  ///
+  /// Any subsequent [enqueue] for a matching callId is rejected immediately
+  /// with [NotConnectedException] instead of being queued. This handles the
+  /// case where [cancelByCallId] is called before the request is created (e.g.
+  /// a [HangupRequest] built inside [performEndCall] after [cancelByCallId]
+  /// was already called in [performControlEnd]).
+  ///
+  /// Cleared by [failAll] so that a fresh session can re-use the same callId.
+  final _terminatingCallIds = <String>{};
+
   bool get isEmpty => _queue.isEmpty;
 
   bool get isNotEmpty => _queue.isNotEmpty;
@@ -26,8 +37,12 @@ class SignalingRequestQueue {
   /// Adds [request] to the queue.
   ///
   /// The returned future completes when the request is sent, or fails with
-  /// [NotConnectedException] if [requestTimeout] elapses before a flush.
+  /// [NotConnectedException] if [requestTimeout] elapses before a flush,
+  /// or immediately if [cancelByCallId] was already called for this callId.
   Future<void> enqueue(Request request) {
+    if (request is CallRequest && _terminatingCallIds.contains(request.callId)) {
+      return Future.error(NotConnectedException('Request cancelled: call ${request.callId} is ending'));
+    }
     final completer = Completer<void>();
     late final _QueuedRequest entry;
     final timer = Timer(requestTimeout, () => _onTimeout(entry));
@@ -71,7 +86,11 @@ class SignalingRequestQueue {
   }) => _executeWithRetry(execute, request, isActive);
 
   /// Fails every pending request with [error] and clears the queue.
+  ///
+  /// Also clears [_terminatingCallIds] so that a fresh signaling session can
+  /// re-use the same callId without being immediately rejected.
   void failAll(Object error) {
+    _terminatingCallIds.clear();
     while (_queue.isNotEmpty) {
       final entry = _queue.removeFirst();
       entry.timer.cancel();
@@ -79,13 +98,20 @@ class SignalingRequestQueue {
     }
   }
 
-  /// Cancels all queued requests whose [callId] matches [callId].
+  /// Cancels all queued requests whose [callId] matches [callId] and prevents
+  /// any future [enqueue] for the same [callId] from being accepted.
   ///
   /// Each matching entry is removed from the queue, its timeout timer is
   /// cancelled, and its future is completed with [NotConnectedException].
   /// This unblocks any caller awaiting [enqueue] for that call without
   /// waiting for the 30-second timeout.
+  ///
+  /// After this call, any subsequent [enqueue] for [callId] is also rejected
+  /// immediately — this handles the case where [cancelByCallId] is called
+  /// before the termination request (e.g. [HangupRequest]) is even created.
+  /// The guard is cleared by [failAll].
   void cancelByCallId(String callId) {
+    _terminatingCallIds.add(callId);
     final toCancel = _queue
         .where((e) => e.request is CallRequest && (e.request as CallRequest).callId == callId)
         .toList();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
@@ -150,6 +150,57 @@ void main() {
     });
   });
 
+  group('SignalingRequestQueue.cancelByCallId — post-cancel guard —', () {
+    test('enqueue after cancelByCallId rejects immediately for same callId', () async {
+      final queue = SignalingRequestQueue();
+
+      // Cancel before the request is created — simulates the hangup flow where
+      // cancelByCallId runs in __onCallControlEventEnded before HangupRequest
+      // is built inside __onCallPerformEventEnded.
+      queue.cancelByCallId('call-1');
+
+      final future = queue.enqueue(_hangup('call-1'));
+
+      await expectLater(
+        future,
+        throwsA(isA<NotConnectedException>().having((e) => e.message, 'message', contains('call-1'))),
+      );
+      expect(queue.isEmpty, isTrue, reason: 'rejected request must not enter the queue');
+    });
+
+    test('post-cancel guard is per-callId — other calls still enqueue normally', () async {
+      final queue = SignalingRequestQueue();
+
+      queue.cancelByCallId('call-A');
+
+      await expectLater(queue.enqueue(_hangup('call-A')), throwsA(isA<NotConnectedException>()));
+
+      // call-B must still be accepted.
+      final futureB = queue.enqueue(_hangup('call-B'));
+      expect(queue.isNotEmpty, isTrue);
+
+      final sent = <Request>[];
+      await queue.flush(execute: _recordingExecute(sent), isActive: () => true);
+      await expectLater(futureB, completes);
+      expect((sent.first as HangupRequest).callId, 'call-B');
+    });
+
+    test('failAll clears the terminating set — same callId can be enqueued in next session', () async {
+      final queue = SignalingRequestQueue();
+      queue.cancelByCallId('call-1');
+      queue.failAll(Exception('dispose'));
+
+      // After failAll the guard must be lifted so a new session can reuse the callId.
+      final future = queue.enqueue(_hangup('call-1'));
+      expect(queue.isNotEmpty, isTrue);
+
+      final sent = <Request>[];
+      await queue.flush(execute: _recordingExecute(sent), isActive: () => true);
+      await expectLater(future, completes);
+      expect((sent.first as HangupRequest).callId, 'call-1');
+    });
+  });
+
   group('SignalingRequestQueue.failAll —', () {
     test('fails all pending entries and clears the queue', () async {
       final queue = SignalingRequestQueue();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
@@ -185,6 +185,26 @@ void main() {
       expect((sent.first as HangupRequest).callId, 'call-B');
     });
 
+    test('removeTerminatingMark lifts the guard — enqueue succeeds again for same callId', () async {
+      final queue = SignalingRequestQueue();
+      queue.cancelByCallId('call-1');
+
+      // Guard is active — must reject.
+      await expectLater(queue.enqueue(_hangup('call-1')), throwsA(isA<NotConnectedException>()));
+
+      // Lift the guard explicitly (simulates call teardown complete).
+      queue.removeTerminatingMark('call-1');
+
+      // Now must accept again.
+      final future = queue.enqueue(_hangup('call-1'));
+      expect(queue.isNotEmpty, isTrue);
+
+      final sent = <Request>[];
+      await queue.flush(execute: _recordingExecute(sent), isActive: () => true);
+      await expectLater(future, completes);
+      expect((sent.first as HangupRequest).callId, 'call-1');
+    });
+
     test('failAll clears the terminating set — same callId can be enqueued in next session', () async {
       final queue = SignalingRequestQueue();
       queue.cancelByCallId('call-1');

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -39,6 +39,9 @@ class _FakeSignalingModule implements SignalingModule {
   void cancelRequestsByCallId(String callId) {}
 
   @override
+  void clearTerminatingMark(String callId) {}
+
+  @override
   Future<void> dispose() async => _controller.close();
 }
 


### PR DESCRIPTION
## Problem

When the user presses hangup during an outgoing call while offline (call stuck in `outgoingConnectingToSignaling`), the call screen stayed unresponsive for up to **30 seconds** before closing.

**Root cause:** `__onCallPerformEventStarted` was blocked on:
```dart
currentState = await stream
    .firstWhere((next) => next.isHandshakeEstablished && next.isSignalingEstablished, ...)
    .timeout(kOutgoingCallSignalingWaitTimeout, onTimeout: () => state);
```
The `firstWhere` only exited on signaling ready or timeout. A user hangup transitioned the call to `disconnecting` and Callkeep correctly closed the native connection — but `firstWhere` kept waiting for the remaining 30s.

After the timeout, `__onCallPerformEventStarted` called `callkeep.endCall()` a second time (→ `"already terminated"` error) and emitted `CallWhileOfflineNotification` despite the user explicitly pressing hangup.

**From logcat (call `TCRYVHUpP8vuKtZjXz40pyAu`):**
```
13:30:51.092  outgoingConnectingToSignaling  (firstWhere starts, 30s timeout)
13:30:53.334  outgoingConnectingToSignaling → disconnecting  (user pressed hangup)
13:30:53.398  callkeep.endCall — HungUpCall dispatched — DISCONNECTED
              ... 27.8 seconds blocked in firstWhere ...
13:31:21.128  disconnecting →   (timeout fires, call finally closes)
13:31:21.317  endCall → "already terminated"
```

## Fix

**1. `firstWhere` exits on hangup:**
Added condition: if the call is no longer in `outgoingConnectingToSignaling` (user pressed hangup → `disconnecting`, or call removed), exit `firstWhere` immediately instead of waiting for timeout.

**2. "not connected" block guards against double-end:**
After `firstWhere` exits, the existing cleanup block now checks if the call is still in `outgoingConnectingToSignaling`. If the hangup flow already took over, only `event.fail()` is called — no `callkeep.endCall()` and no `CallWhileOfflineNotification`.

## Test plan

- [ ] Call with no internet → press hangup → call screen closes immediately (not after 30s)
- [ ] Call with no internet → wait 30s without pressing hangup → closes with "Call while offline" notification
- [ ] Call with no internet → restore internet within 30s → call proceeds normally
- [ ] Normal call (internet available) — no regression