### PR TITLE
fix(signaling-service): recover from hub service death while Activity is alive

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:ui' show IsolateNameServer;
 
 import 'package:logging/logging.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
 
+import 'constants.dart';
 import 'hub/signaling_hub_client.dart';
 import 'hub/signaling_hub_module.dart';
 
@@ -33,6 +35,8 @@ class HubConnectionManager {
     required String consumerId,
     this.pingInterval = const Duration(seconds: 15),
     this.pongTimeout = const Duration(seconds: 2),
+    this.stalePortThreshold = 3,
+    this.onServiceDead,
   }) : _onEvent = onEvent,
        _onError = onError,
        _isActive = isActive,
@@ -48,6 +52,17 @@ class HubConnectionManager {
 
   /// How long to wait for a pong before treating the hub as dead.
   final Duration pongTimeout;
+
+  /// Number of consecutive stale ack timeouts before the hub service is
+  /// declared dead: the stale port is removed from [IsolateNameServer], a
+  /// [SignalingConnectionFailed] event is emitted, and [onServiceDead] is
+  /// called so the caller can restart the foreground service.
+  final int stalePortThreshold;
+
+  /// Called when [stalePortThreshold] consecutive ack timeouts indicate the
+  /// hub service is no longer running. Use this to restart the foreground
+  /// service so the hub is re-registered.
+  final void Function()? onServiceDead;
 
   SignalingHubModule? _module;
   StreamSubscription<SignalingModuleEvent>? _moduleSub;
@@ -106,6 +121,7 @@ class HubConnectionManager {
 
     _logger.fine('_initLoop started gen=$generation');
     var attempts = 0;
+    var consecutiveStaleAcks = 0;
 
     while (true) {
       if (_generation != generation || !_isActive()) {
@@ -125,6 +141,7 @@ class HubConnectionManager {
         final ackReceived = await ackFuture;
 
         if (ackReceived) {
+          consecutiveStaleAcks = 0;
           if (_generation != generation || !_isActive()) {
             _logger.fine('_initLoop gen=$generation ack received but generation changed, disposing stale module');
             await module.dispose();
@@ -146,8 +163,29 @@ class HubConnectionManager {
           return;
         }
 
-        _logger.fine('_initLoop gen=$generation ack timeout -- stale port, retrying');
+        consecutiveStaleAcks++;
+        _logger.fine(
+          '_initLoop gen=$generation ack timeout -- stale port ($consecutiveStaleAcks/$stalePortThreshold), retrying',
+        );
         await module.dispose();
+
+        if (consecutiveStaleAcks >= stalePortThreshold) {
+          consecutiveStaleAcks = 0;
+          _logger.warning(
+            '_initLoop gen=$generation stale port threshold reached -- hub service presumed dead, clearing port',
+          );
+          IsolateNameServer.removePortNameMapping(kSignalingHubPortName);
+          _onEvent(
+            SignalingConnectionFailed(
+              error: StateError('Signaling hub service died'),
+              isRepeated: false,
+              recommendedReconnectDelay: const Duration(seconds: 3),
+            ),
+          );
+          onServiceDead?.call();
+        }
+      } else {
+        consecutiveStaleAcks = 0;
       }
 
       attempts++;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -171,6 +171,7 @@ class HubConnectionManager {
 
         if (consecutiveStaleAcks >= stalePortThreshold) {
           consecutiveStaleAcks = 0;
+          if (_generation != generation || !_isActive() || _tearingDown) return;
           _logger.warning(
             '_initLoop gen=$generation stale port threshold reached -- hub service presumed dead, clearing port',
           );
@@ -179,7 +180,7 @@ class HubConnectionManager {
             SignalingConnectionFailed(
               error: StateError('Signaling hub service died'),
               isRepeated: false,
-              recommendedReconnectDelay: const Duration(seconds: 3),
+              recommendedReconnectDelay: kSignalingClientReconnectDelay,
             ),
           );
           onServiceDead?.call();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -138,7 +138,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       return;
     }
     _logger.warning('execute called but not connected (${request.runtimeType})');
-    throw StateError('SignalingServiceAndroid: not connected');
+    throw NotConnectedException('SignalingServiceAndroid: not connected');
   }
 
   /// Switches the service lifecycle mode.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -79,7 +79,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       if (!_eventsController.isClosed) _eventsController.addError(e, st);
     },
     isActive: () => !_eventsController.isClosed,
-    onServiceDead: _onHubServiceDead,
+    onServiceDead: () => unawaited(_onHubServiceDead()),
   );
 
   /// Last config passed to [start] -- reused when switching modes via [updateMode].
@@ -236,7 +236,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       _logger.warning('_onHubServiceDead: no config/mode available, cannot restart');
       return;
     }
-    await _startService(config, mode);
+    try {
+      await _startService(config, mode);
+    } catch (e, st) {
+      _logger.severe('_onHubServiceDead: failed to restart service', e, st);
+    }
   }
 
   Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -79,6 +79,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       if (!_eventsController.isClosed) _eventsController.addError(e, st);
     },
     isActive: () => !_eventsController.isClosed,
+    onServiceDead: _onHubServiceDead,
   );
 
   /// Last config passed to [start] -- reused when switching modes via [updateMode].
@@ -225,6 +226,17 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   Future<void> simulateKill() async {
     _logger.info('simulateKill');
     await _hostApi.simulateKill();
+  }
+
+  Future<void> _onHubServiceDead() async {
+    _logger.warning('_onHubServiceDead: hub service dead, restarting');
+    final config = _currentConfig;
+    final mode = _currentMode;
+    if (config == null || mode == null) {
+      _logger.warning('_onHubServiceDead: no config/mode available, cannot restart');
+      return;
+    }
+    await _startService(config, mode);
   }
 
   Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -61,11 +61,20 @@ class SignalingRequestQueue {
   /// Executes [request] immediately via [execute] with up to [maxRetryCount] retries.
   ///
   /// Stops retrying if [isActive] returns false (e.g. the connection was replaced).
+  /// A [NotConnectedException] during an inactive period is dropped silently so
+  /// callers are not burdened with transient reconnect-window errors.
   Future<void> executeNow({
     required Future<void> Function(Request) execute,
     required Request request,
     required bool Function() isActive,
-  }) => _executeWithRetry(execute, request, isActive);
+  }) async {
+    try {
+      await _executeWithRetry(execute, request, isActive);
+    } on NotConnectedException {
+      if (!isActive()) return;
+      rethrow;
+    }
+  }
 
   /// Fails every pending request with [error] and clears the queue.
   void failAll(Object error) {
@@ -93,14 +102,14 @@ class SignalingRequestQueue {
       _logger.warning('_executeWithRetry retrying ${error.transactionId}, (retry #$retryCount)/$maxRetryCount');
       return _executeWithRetry(execute, request, isActive, retryCount + 1, notConnectedRetryCount);
     } on NotConnectedException {
-      if (!isActive()) return;
+      if (!isActive()) rethrow;
       if (notConnectedRetryCount >= maxRetryCount) rethrow;
 
       _logger.fine(
         '_executeWithRetry: not connected (attempt $notConnectedRetryCount/$maxRetryCount), backing off 2 s',
       );
       await Future<void>.delayed(const Duration(seconds: 2));
-      if (!isActive()) return;
+      if (!isActive()) rethrow;
       return _executeWithRetry(execute, request, isActive, retryCount, notConnectedRetryCount + 1);
     }
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -83,6 +83,7 @@ class SignalingRequestQueue {
     Request request,
     bool Function() isActive, [
     int retryCount = 0,
+    int notConnectedRetryCount = 0,
   ]) async {
     try {
       await execute(request);
@@ -90,7 +91,17 @@ class SignalingRequestQueue {
       if (!isActive() || retryCount >= maxRetryCount) rethrow;
 
       _logger.warning('_executeWithRetry retrying ${error.transactionId}, (retry #$retryCount)/$maxRetryCount');
-      return _executeWithRetry(execute, request, isActive, retryCount + 1);
+      return _executeWithRetry(execute, request, isActive, retryCount + 1, notConnectedRetryCount);
+    } on NotConnectedException {
+      if (!isActive()) return;
+      if (notConnectedRetryCount >= maxRetryCount) rethrow;
+
+      _logger.fine(
+        '_executeWithRetry: not connected (attempt $notConnectedRetryCount/$maxRetryCount), backing off 2 s',
+      );
+      await Future<void>.delayed(const Duration(seconds: 2));
+      if (!isActive()) return;
+      return _executeWithRetry(execute, request, isActive, retryCount, notConnectedRetryCount + 1);
     }
   }
 


### PR DESCRIPTION
## Problem

After `simulateKill()` (or an OS-forced service stop) in push-bound mode, the signaling service
never recovered while the Activity remained open. Two symptoms:

1. The connection status indicator stayed frozen at "connected" — the dead hub was not detected.
2. The foreground service was not restarted — no recovery path existed for the case where
   the hub dies while the main isolate is still running.

Root cause: `HubConnectionManager._initLoop` would loop forever awaiting subscribe acks from a
stale `IsolateNameServer` port left behind by the killed isolate. The port was never cleared, so
the poll-and-ack cycle repeated indefinitely without declaring the service dead.

## Fix

### Stale-port detection (`HubConnectionManager`)

- Added `stalePortThreshold` (default 3) — counts consecutive subscribe-ack timeouts on the
  same port.
- When the threshold is reached:
  - Removes the stale port via `IsolateNameServer.removePortNameMapping`.
  - Emits `SignalingConnectionFailed` so the connection indicator reflects the real state.
  - Calls the new `onServiceDead` callback.

### Service restart (`WebtritSignalingServiceAndroid`)

- Wired `onServiceDead: _onHubServiceDead` into `HubConnectionManager`.
- `_onHubServiceDead()` calls `_startService(config, mode)` using the last known config and
  mode, restarting the foreground service and re-entering the hub-init loop.

## Recovery timeline

| Phase | Duration |
|---|---|
| Ping/pong detects dead hub module | ~17 s (15 s interval + 2 s timeout) |
| 3 × stale ack timeouts (500 ms each) | ~1.5 s |
| `startForegroundService` + hub registration | ~1–2 s |
| **Total to reconnected** | **~20 s** |