### PR TITLE
fix: remove redundant null-aware operator after catchError chain in CallBloc

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2705,7 +2705,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             ),
           )
           ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived pendingHangup retry error'))
-          ?.ignore();
+          .ignore();
     }
 
     final actions = await _handshakeProcessor.process(


### PR DESCRIPTION
## Summary

- `SignalingModule.execute()` returns `Future<void>?`; the chain `?.catchError(...).ignore()` is correct — after the first `?.`, Dart short-circuits the entire chain when `execute()` returns `null`, so `.ignore()` is only ever called on a non-null `Future<void>` result of `catchError`
- Replaced `?.ignore()` → `.ignore()` at `call_bloc.dart:2708` to resolve the `invalid_null_aware_operator` analyzer warning

## Test plan

- [ ] `flutter analyze` passes with no warnings on `call_bloc.dart`
- [ ] Existing call flow tests pass