### PR TITLE
fix: signaling hub error encoding

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -197,7 +197,7 @@ class SignalingHubClient {
       final completer = _pendingExecutions.remove(correlationId);
       if (completer == null) return;
       if (error != null) {
-        completer.completeError(Exception(error));
+        completer.completeError(error);
       } else {
         completer.complete();
       }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -12,6 +12,28 @@ const _tagExecuteResult = 'execute_result';
 const _tagSubAck = 'sub_ack';
 const _tagPong = 'pong';
 
+const _executeErrorTypeKey = 'type';
+const _executeErrorTypeMessage = 'message';
+const _executeErrorTypeWebtritSignalingError = 'webtrit_signaling_error';
+const _executeErrorTypeWebtritSignalingDisconnected = 'webtrit_signaling_disconnected';
+const _executeErrorTypeWebtritSignalingUnknownMessage = 'webtrit_signaling_unknown_message';
+const _executeErrorTypeWebtritSignalingUnknownResponse = 'webtrit_signaling_unknown_response';
+const _executeErrorTypeWebtritSignalingTransactionTimeout = 'webtrit_signaling_transaction_timeout';
+const _executeErrorTypeWebtritSignalingBadState = 'webtrit_signaling_bad_state';
+const _executeErrorTypeWebtritSignalingKeepaliveTransactionTimeout = 'webtrit_signaling_keepalive_transaction_timeout';
+const _executeErrorTypeWebtritSignalingTransactionUnavailable = 'webtrit_signaling_transaction_unavailable';
+const _executeErrorTypeWebtritSignalingTransactionTerminateByDisconnect =
+    'webtrit_signaling_transaction_terminate_by_disconnect';
+const _executeErrorIdKey = 'id';
+const _executeErrorCodeKey = 'code';
+const _executeErrorReasonKey = 'reason';
+const _executeErrorMessageKey = 'message';
+const _executeErrorResponseKey = 'response';
+const _executeErrorTransactionIdKey = 'transaction_id';
+const _executeErrorStateErrorMessageKey = 'state_error_message';
+const _executeErrorCloseCodeKey = 'close_code';
+const _executeErrorCloseReasonKey = 'close_reason';
+
 /// Encodes a [SignalingModuleEvent] into an isolate-safe [List] for transport
 /// over a [SendPort].
 ///
@@ -88,13 +110,13 @@ SignalingModuleEvent? decodeHubEvent(List<dynamic> msg) {
 List<dynamic> encodeExecuteResult(String correlationId, Object? error) => [
   _tagExecuteResult,
   correlationId,
-  error?.toString(),
+  _encodeExecuteError(error),
 ];
 
 bool isExecuteResult(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagExecuteResult;
 
-({String correlationId, String? error}) decodeExecuteResult(List<dynamic> msg) =>
-    (correlationId: msg[1] as String, error: msg[2] as String?);
+({String correlationId, Object? error}) decodeExecuteResult(List<dynamic> msg) =>
+    (correlationId: msg[1] as String, error: _decodeExecuteError(msg[2]));
 
 /// Encodes a subscribe-ack sent by the hub to confirm a new subscriber's port is live.
 List<dynamic> encodeSubAck() => [_tagSubAck];
@@ -105,6 +127,156 @@ bool isSubAck(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagSubAck;
 List<dynamic> encodePong() => [_tagPong];
 
 bool isPong(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagPong;
+
+Object? _encodeExecuteError(Object? error) {
+  if (error == null) return null;
+  if (error is WebtritSignalingErrorException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingError,
+      _executeErrorIdKey: error.id,
+      _executeErrorCodeKey: error.code,
+      _executeErrorReasonKey: error.reason,
+    };
+  }
+  if (error is WebtritSignalingDisconnectedException) {
+    return {_executeErrorTypeKey: _executeErrorTypeWebtritSignalingDisconnected, _executeErrorIdKey: error.id};
+  }
+  if (error is WebtritSignalingUnknownMessageException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingUnknownMessage,
+      _executeErrorIdKey: error.id,
+      _executeErrorMessageKey: error.message,
+    };
+  }
+  if (error is WebtritSignalingUnknownResponseException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingUnknownResponse,
+      _executeErrorIdKey: error.id,
+      _executeErrorResponseKey: error.response,
+    };
+  }
+  if (error is WebtritSignalingKeepaliveTransactionTimeoutException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingKeepaliveTransactionTimeout,
+      _executeErrorIdKey: error.id,
+      _executeErrorTransactionIdKey: error.transactionId,
+    };
+  }
+  if (error is WebtritSignalingTransactionTimeoutException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingTransactionTimeout,
+      _executeErrorIdKey: error.id,
+      _executeErrorTransactionIdKey: error.transactionId,
+    };
+  }
+  if (error is WebtritSignalingBadStateException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingBadState,
+      _executeErrorIdKey: error.id,
+      _executeErrorStateErrorMessageKey: error.error.message.toString(),
+    };
+  }
+  if (error is WebtritSignalingTransactionUnavailableException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingTransactionUnavailable,
+      _executeErrorIdKey: error.id,
+      _executeErrorTransactionIdKey: error.transactionId,
+    };
+  }
+  if (error is WebtritSignalingTransactionTerminateByDisconnectException) {
+    return {
+      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingTransactionTerminateByDisconnect,
+      _executeErrorIdKey: error.id,
+      _executeErrorTransactionIdKey: error.transactionId,
+      _executeErrorCloseCodeKey: error.closeCode,
+      _executeErrorCloseReasonKey: error.closeReason,
+    };
+  }
+  return {_executeErrorTypeKey: _executeErrorTypeMessage, _executeErrorReasonKey: error.toString()};
+}
+
+Object? _decodeExecuteError(Object? encodedError) {
+  if (encodedError == null) return null;
+  if (encodedError is String) {
+    return Exception(encodedError);
+  }
+  if (encodedError is! Map) {
+    return Exception(encodedError.toString());
+  }
+
+  final map = Map<String, dynamic>.from(encodedError);
+  final type = map[_executeErrorTypeKey] as String?;
+  switch (type) {
+    case _executeErrorTypeWebtritSignalingError:
+      final id = map[_executeErrorIdKey] as int?;
+      final code = map[_executeErrorCodeKey] as int?;
+      final reason = map[_executeErrorReasonKey] as String?;
+      if (id == null || code == null || reason == null) {
+        return Exception('Malformed webtrit_signaling_error execute payload: $map');
+      }
+      return WebtritSignalingErrorException(id, code, reason);
+    case _executeErrorTypeWebtritSignalingDisconnected:
+      final id = map[_executeErrorIdKey] as int?;
+      if (id == null) return Exception('Malformed webtrit_signaling_disconnected execute payload: $map');
+      return WebtritSignalingDisconnectedException(id);
+    case _executeErrorTypeWebtritSignalingUnknownMessage:
+      final id = map[_executeErrorIdKey] as int?;
+      final message = map[_executeErrorMessageKey] as Map?;
+      if (id == null || message == null) {
+        return Exception('Malformed webtrit_signaling_unknown_message execute payload: $map');
+      }
+      return WebtritSignalingUnknownMessageException(id, Map<String, dynamic>.from(message));
+    case _executeErrorTypeWebtritSignalingUnknownResponse:
+      final id = map[_executeErrorIdKey] as int?;
+      final response = map[_executeErrorResponseKey] as Map?;
+      if (id == null || response == null) {
+        return Exception('Malformed webtrit_signaling_unknown_response execute payload: $map');
+      }
+      return WebtritSignalingUnknownResponseException(id, Map<String, dynamic>.from(response));
+    case _executeErrorTypeWebtritSignalingKeepaliveTransactionTimeout:
+      final id = map[_executeErrorIdKey] as int?;
+      final transactionId = map[_executeErrorTransactionIdKey] as String?;
+      if (id == null || transactionId == null) {
+        return Exception('Malformed webtrit_signaling_keepalive_transaction_timeout execute payload: $map');
+      }
+      return WebtritSignalingKeepaliveTransactionTimeoutException(id, transactionId);
+    case _executeErrorTypeWebtritSignalingTransactionTimeout:
+      final id = map[_executeErrorIdKey] as int?;
+      final transactionId = map[_executeErrorTransactionIdKey] as String?;
+      if (id == null || transactionId == null) {
+        return Exception('Malformed webtrit_signaling_transaction_timeout execute payload: $map');
+      }
+      return WebtritSignalingTransactionTimeoutException(id, transactionId);
+    case _executeErrorTypeWebtritSignalingBadState:
+      final id = map[_executeErrorIdKey] as int?;
+      final stateErrorMessage = map[_executeErrorStateErrorMessageKey] as String?;
+      if (id == null || stateErrorMessage == null) {
+        return Exception('Malformed webtrit_signaling_bad_state execute payload: $map');
+      }
+      return WebtritSignalingBadStateException(id, StateError(stateErrorMessage));
+    case _executeErrorTypeWebtritSignalingTransactionUnavailable:
+      final id = map[_executeErrorIdKey] as int?;
+      final transactionId = map[_executeErrorTransactionIdKey] as String?;
+      if (id == null || transactionId == null) {
+        return Exception('Malformed webtrit_signaling_transaction_unavailable execute payload: $map');
+      }
+      return WebtritSignalingTransactionUnavailableException(id, transactionId);
+    case _executeErrorTypeWebtritSignalingTransactionTerminateByDisconnect:
+      final id = map[_executeErrorIdKey] as int?;
+      final transactionId = map[_executeErrorTransactionIdKey] as String?;
+      final closeCode = map[_executeErrorCloseCodeKey] as int?;
+      final closeReason = map[_executeErrorCloseReasonKey] as String?;
+      if (id == null || transactionId == null) {
+        return Exception('Malformed webtrit_signaling_transaction_terminate_by_disconnect execute payload: $map');
+      }
+      return WebtritSignalingTransactionTerminateByDisconnectException(id, transactionId, closeCode, closeReason);
+    case _executeErrorTypeMessage:
+      final message = map[_executeErrorReasonKey] as String?;
+      return Exception(message ?? 'Unknown execute error');
+    default:
+      return Exception(map[_executeErrorReasonKey] as String? ?? map.toString());
+  }
+}
 
 Map<String, dynamic> _encodeHandshake(StateHandshake h) {
   return {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
@@ -267,12 +267,21 @@ void main() {
       expect(encoded[2], isNull);
     });
 
-    test('encodeExecuteResult with error stringifies the error', () {
+    test('encodeExecuteResult with unknown error stores message payload', () {
       final encoded = encodeExecuteResult('corr-2', Exception('boom'));
       expect(encoded[0], 'execute_result');
       expect(encoded[1], 'corr-2');
-      expect(encoded[2], isA<String>());
-      expect(encoded[2] as String, contains('boom'));
+      expect(encoded[2], isA<Map>());
+      expect((encoded[2] as Map)['type'], 'message');
+      expect((encoded[2] as Map)['reason'], contains('boom'));
+    });
+
+    test('encodeExecuteResult with WebtritSignalingErrorException stores structured payload', () {
+      const error = WebtritSignalingErrorException(7, 503, 'busy');
+      final encoded = encodeExecuteResult('corr-3', error);
+      expect(encoded[0], 'execute_result');
+      expect(encoded[1], 'corr-3');
+      expect(encoded[2], {'type': 'webtrit_signaling_error', 'id': 7, 'code': 503, 'reason': 'busy'});
     });
 
     test('isExecuteResult is true for [execute_result, ...]', () {
@@ -295,12 +304,84 @@ void main() {
       expect(result.error, isNull);
     });
 
-    test('decodeExecuteResult extracts correlationId and error string', () {
-      final errorMsg = Exception('request failed').toString();
+    test('decodeExecuteResult extracts correlationId and generic error object', () {
       final encoded = encodeExecuteResult('xyz', Exception('request failed'));
       final result = decodeExecuteResult(encoded);
       expect(result.correlationId, 'xyz');
-      expect(result.error, errorMsg);
+      expect(result.error, isA<Exception>());
+      expect(result.error.toString(), contains('request failed'));
+    });
+
+    test('decodeExecuteResult reconstructs WebtritSignalingErrorException', () {
+      final encoded = encodeExecuteResult(
+        'typed',
+        const WebtritSignalingErrorException(5, 503, 'call request on busy line error'),
+      );
+      final result = decodeExecuteResult(encoded);
+      expect(result.correlationId, 'typed');
+      expect(result.error, isA<WebtritSignalingErrorException>());
+      final signalingError = result.error! as WebtritSignalingErrorException;
+      expect(signalingError.id, 5);
+      expect(signalingError.code, 503);
+      expect(signalingError.reason, 'call request on busy line error');
+    });
+
+    test('decodeExecuteResult reconstructs all Webtrit signaling exceptions', () {
+      final errors = <WebtritSignalingException>[
+        const WebtritSignalingErrorException(1, 503, 'busy'),
+        const WebtritSignalingDisconnectedException(2),
+        const WebtritSignalingUnknownMessageException(3, {'kind': 'unknown', 'tx': 'a1'}),
+        const WebtritSignalingUnknownResponseException(4, {'result': 'unknown', 'tx': 'a2'}),
+        const WebtritSignalingTransactionTimeoutException(5, 'tx-timeout'),
+        WebtritSignalingBadStateException(6, StateError('invalid state')),
+        const WebtritSignalingKeepaliveTransactionTimeoutException(7, 'tx-keepalive'),
+        const WebtritSignalingTransactionUnavailableException(8, 'tx-unavailable'),
+        const WebtritSignalingTransactionTerminateByDisconnectException(9, 'tx-disconnect', 1001, 'closed'),
+      ];
+
+      for (final error in errors) {
+        final encoded = encodeExecuteResult('corr-${error.runtimeType}', error);
+        final decoded = decodeExecuteResult(encoded);
+        expect(decoded.error, isA<WebtritSignalingException>());
+
+        final reconstructed = decoded.error! as WebtritSignalingException;
+        expect(reconstructed.runtimeType, error.runtimeType);
+        expect(reconstructed.id, error.id);
+
+        switch (error) {
+          case WebtritSignalingErrorException source:
+            final target = reconstructed as WebtritSignalingErrorException;
+            expect(target.code, source.code);
+            expect(target.reason, source.reason);
+          case WebtritSignalingUnknownMessageException source:
+            final target = reconstructed as WebtritSignalingUnknownMessageException;
+            expect(target.message, source.message);
+          case WebtritSignalingUnknownResponseException source:
+            final target = reconstructed as WebtritSignalingUnknownResponseException;
+            expect(target.response, source.response);
+          case WebtritSignalingKeepaliveTransactionTimeoutException source:
+            final target = reconstructed as WebtritSignalingKeepaliveTransactionTimeoutException;
+            expect(target.transactionId, source.transactionId);
+          case WebtritSignalingTransactionTimeoutException source:
+            final target = reconstructed as WebtritSignalingTransactionTimeoutException;
+            expect(target.transactionId, source.transactionId);
+          case WebtritSignalingBadStateException source:
+            final target = reconstructed as WebtritSignalingBadStateException;
+            expect(target.error.message, source.error.message);
+          case WebtritSignalingTransactionUnavailableException source:
+            final target = reconstructed as WebtritSignalingTransactionUnavailableException;
+            expect(target.transactionId, source.transactionId);
+          case WebtritSignalingTransactionTerminateByDisconnectException source:
+            final target = reconstructed as WebtritSignalingTransactionTerminateByDisconnectException;
+            expect(target.transactionId, source.transactionId);
+            expect(target.closeCode, source.closeCode);
+            expect(target.closeReason, source.closeReason);
+          case WebtritSignalingDisconnectedException():
+            expect(reconstructed, isA<WebtritSignalingDisconnectedException>());
+          case WebtritSignalingException():
+            fail('Unhandled signaling exception type: ${error.runtimeType}');
+        }
+      }
     });
   });
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -217,6 +217,7 @@ class _FakeSignalingClient extends Fake implements WebtritSignalingClient {
 
   bool disconnected = false;
   final List<Request> executed = [];
+  Object? executeError;
 
   @override
   void listen({
@@ -234,7 +235,10 @@ class _FakeSignalingClient extends Fake implements WebtritSignalingClient {
   Future<void> disconnect([int? code, String? reason]) async => disconnected = true;
 
   @override
-  Future<void> execute(Request request, [Duration? timeout]) async => executed.add(request);
+  Future<void> execute(Request request, [Duration? timeout]) async {
+    if (executeError != null) throw executeError!;
+    executed.add(request);
+  }
 
   void injectHandshake(StateHandshake h) => _onStateHandshake?.call(h);
   void injectEvent(Event e) => _onEvent?.call(e);
@@ -291,6 +295,48 @@ Future<SignalingHubClient> _subscribeClient(String consumerId) async {
   final acked = await ackFuture;
   expect(acked, isTrue, reason: 'Sub-ack must arrive from hub within timeout');
   return client;
+}
+
+Matcher _matchesSignalingException(WebtritSignalingException expected) {
+  return predicate<Object>((error) {
+    if (error is! WebtritSignalingException) return false;
+    if (error.runtimeType != expected.runtimeType) return false;
+    if (error.id != expected.id) return false;
+
+    switch ((expected, error)) {
+      case (WebtritSignalingErrorException source, WebtritSignalingErrorException target):
+        return target.code == source.code && target.reason == source.reason;
+      case (WebtritSignalingUnknownMessageException source, WebtritSignalingUnknownMessageException target):
+        return target.message.toString() == source.message.toString();
+      case (WebtritSignalingUnknownResponseException source, WebtritSignalingUnknownResponseException target):
+        return target.response.toString() == source.response.toString();
+      case (
+        WebtritSignalingKeepaliveTransactionTimeoutException source,
+        WebtritSignalingKeepaliveTransactionTimeoutException target,
+      ):
+        return target.transactionId == source.transactionId;
+      case (WebtritSignalingTransactionTimeoutException source, WebtritSignalingTransactionTimeoutException target):
+        return target.transactionId == source.transactionId;
+      case (WebtritSignalingBadStateException source, WebtritSignalingBadStateException target):
+        return target.error.message.toString() == source.error.message.toString();
+      case (
+        WebtritSignalingTransactionUnavailableException source,
+        WebtritSignalingTransactionUnavailableException target,
+      ):
+        return target.transactionId == source.transactionId;
+      case (
+        WebtritSignalingTransactionTerminateByDisconnectException source,
+        WebtritSignalingTransactionTerminateByDisconnectException target,
+      ):
+        return target.transactionId == source.transactionId &&
+            target.closeCode == source.closeCode &&
+            target.closeReason == source.closeReason;
+      case (WebtritSignalingDisconnectedException _, WebtritSignalingDisconnectedException _):
+        return true;
+      case (WebtritSignalingException _, WebtritSignalingException _):
+        return false;
+    }
+  }, 'matches ${expected.runtimeType} with the same payload');
 }
 
 // ---------------------------------------------------------------------------
@@ -623,6 +669,52 @@ void main() {
             .timeout(const Duration(seconds: 2)),
         throwsA(anything),
       );
+    });
+
+    test('execute keeps WebtritSignalingErrorException type and fields', () async {
+      fakeClient.executeError = const WebtritSignalingErrorException(0, 503, 'call request on busy line error');
+
+      final client = await _subscribeClient('exec-typed');
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.execute(HangupRequest(transaction: 'tx-exec-typed', line: 1, callId: 'call-e')),
+        throwsA(
+          isA<WebtritSignalingErrorException>()
+              .having((error) => error.id, 'id', 0)
+              .having((error) => error.code, 'code', 503)
+              .having((error) => error.reason, 'reason', 'call request on busy line error'),
+        ),
+      );
+    });
+
+    test('execute keeps all Webtrit signaling exception subtypes', () async {
+      final errors = <WebtritSignalingException>[
+        const WebtritSignalingErrorException(1, 503, 'busy'),
+        const WebtritSignalingDisconnectedException(2),
+        const WebtritSignalingUnknownMessageException(3, {'kind': 'unknown', 'tx': 'a1'}),
+        const WebtritSignalingUnknownResponseException(4, {'result': 'unknown', 'tx': 'a2'}),
+        const WebtritSignalingTransactionTimeoutException(5, 'tx-timeout'),
+        WebtritSignalingBadStateException(6, StateError('invalid state')),
+        const WebtritSignalingKeepaliveTransactionTimeoutException(7, 'tx-keepalive'),
+        const WebtritSignalingTransactionUnavailableException(8, 'tx-unavailable'),
+        const WebtritSignalingTransactionTerminateByDisconnectException(9, 'tx-disconnect', 1001, 'closed'),
+      ];
+
+      final client = await _subscribeClient('exec-typed-all');
+      addTearDown(client.dispose);
+
+      for (var index = 0; index < errors.length; index++) {
+        final error = errors[index];
+        fakeClient.executeError = error;
+
+        await expectLater(
+          client.execute(HangupRequest(transaction: 'tx-exec-typed-$index', line: 1, callId: 'call-$index')),
+          throwsA(_matchesSignalingException(error)),
+        );
+      }
+
+      fakeClient.executeError = null;
     });
 
     test('pending execute completes with error on client dispose', () async {


### PR DESCRIPTION
This pull request introduces structured error encoding and decoding for signaling exceptions in the Webtrit signaling service, ensuring that specific exception types and their fields are preserved across message boundaries.