### PR TITLE
refactor: wrong line errors handling (WT-1023, WT-1108)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2220,6 +2220,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _peerConnectionManager.complete(event.callId, peerConnection);
     } catch (e, stackTrace) {
       _logger.warning('__onCallPerformEventAnswered: failed callId=${event.callId} error=$e');
+
+      // If call gone right before answer
+      if (e is WebtritSignalingErrorException && e.code == 410) {
+        _peerConnectionManager.completeError(event.callId, e, stackTrace);
+        add(_ResetStateEvent.completeCall(event.callId));
+        _addToRecents(call!);
+        return;
+      }
+
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
       add(_ResetStateEvent.completeCall(event.callId));
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2221,7 +2221,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     } catch (e, stackTrace) {
       _logger.warning('__onCallPerformEventAnswered: failed callId=${event.callId} error=$e');
 
-      // If call gone right before answer
+      // If call gone right before answer, consider it as normal flow and avoid showing error notification
+      // TODO: implement signaling request response mechanism and handle request specific result instead of catching global errors
       if (e is WebtritSignalingErrorException && e.code == 410) {
         _peerConnectionManager.completeError(event.callId, e, stackTrace);
         add(_ResetStateEvent.completeCall(event.callId));

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -97,6 +97,15 @@ final class CallUndefinedLineNotification extends ErrorNotification {
   }
 }
 
+final class CallServiceBusyLineNotification extends ErrorNotification {
+  const CallServiceBusyLineNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.notifications_errorSnackBar_callServiceBusyLine;
+  }
+}
+
 final class CallWhileOfflineNotification extends ErrorNotification {
   const CallWhileOfflineNotification();
 

--- a/lib/features/call/utils/call_error_reporter.dart
+++ b/lib/features/call/utils/call_error_reporter.dart
@@ -52,6 +52,8 @@ class DefaultCallErrorReporter implements CallErrorReporter {
       return;
     }
 
+    // TODO: implement signaling request response mechanism and handle request specific result instead of catching global errors
+    // In such case it will be just result of OutgoingCallRequest
     if (error is WebtritSignalingErrorException && error.code == 503 && error.reason.contains('busy line')) {
       submitNotification(const CallServiceBusyLineNotification());
       return;

--- a/lib/features/call/utils/call_error_reporter.dart
+++ b/lib/features/call/utils/call_error_reporter.dart
@@ -52,6 +52,11 @@ class DefaultCallErrorReporter implements CallErrorReporter {
       return;
     }
 
+    if (error is WebtritSignalingErrorException && error.code == 503 && error.reason.contains('busy line')) {
+      submitNotification(const CallServiceBusyLineNotification());
+      return;
+    }
+
     if (error is UserMediaError) {
       submitNotification(const CallUserMediaErrorNotification());
     } else if (error is SDPConfigurationError) {

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2262,6 +2262,12 @@ abstract class AppLocalizations {
   /// **'Cannot establish the call, please try again later'**
   String get notifications_errorSnackBar_callNegotiationTimeout;
 
+  /// Shown in a notification or snackbar when the user tries to start a call but the selected line is already busy. Context: occurs at call initiation when no free channel is available on the current line or account; advise the user to wait and retry.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot make the call right now because the line is busy. Please try again later.'**
+  String get notifications_errorSnackBar_callServiceBusyLine;
+
   /// Shown in a notification or snackbar when the app cannot initiate a call because the signaling client is not connected to the WebTrit core. Context: occurs at call start when the signaling/WebSocket connection is absent or closed; typical causes include network connectivity issues, connection refused/timeouts, TLS/socket handshake failures, authentication/token errors (e.g. 401), or core server unavailability.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1211,6 +1211,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notifications_errorSnackBar_callNegotiationTimeout => 'Cannot establish the call, please try again later';
 
   @override
+  String get notifications_errorSnackBar_callServiceBusyLine =>
+      'Cannot make the call right now because the line is busy. Please try again later.';
+
+  @override
   String get notifications_errorSnackBar_callSignalingClientNotConnect =>
       'Cannot initiate the call, please check the connection status';
 

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1225,6 +1225,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile stabilire la chiamata, riprovare più tardi';
 
   @override
+  String get notifications_errorSnackBar_callServiceBusyLine =>
+      'Impossibile effettuare la chiamata in questo momento perché la linea è occupata. Riprova più tardi.';
+
+  @override
   String get notifications_errorSnackBar_callSignalingClientNotConnect =>
       'Impossibile eseguire la chiamata, verificare lo stato della connessione';
 

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1229,6 +1229,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get notifications_errorSnackBar_callNegotiationTimeout => 'Не вдається здійснити виклик, спробуйте пізніше';
 
   @override
+  String get notifications_errorSnackBar_callServiceBusyLine =>
+      'Неможливо здійснити дзвінок зараз, оскільки лінія зайнята. Спробуйте пізніше.';
+
+  @override
   String get notifications_errorSnackBar_callSignalingClientNotConnect =>
       'Не вдається ініціювати дзвінок, перевірте статус з\'єднання';
 

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1019,6 +1019,10 @@
   "@notifications_errorSnackBar_callNegotiationTimeout": {
     "description": "Shown in a notification or snackbar when call setup fails because media/signaling negotiation timed out. Context: occurs during SDP/ICE or signaling exchange when negotiation does not complete in time; typical causes include network connectivity problems, ICE or DTLS failures, incompatible SDP codecs, or an unresponsive remote endpoint or signaling server."
   },
+  "notifications_errorSnackBar_callServiceBusyLine": "Cannot make the call right now because the line is busy. Please try again later.",
+  "@notifications_errorSnackBar_callServiceBusyLine": {
+    "description": "Shown in a notification or snackbar when the user tries to start a call but the selected line is already busy. Context: occurs at call initiation when no free channel is available on the current line or account; advise the user to wait and retry."
+  },
   "notifications_errorSnackBar_callSignalingClientNotConnect": "Cannot initiate the call, please check the connection status",
   "@notifications_errorSnackBar_callSignalingClientNotConnect": {
     "description": "Shown in a notification or snackbar when the app cannot initiate a call because the signaling client is not connected to the WebTrit core. Context: occurs at call start when the signaling/WebSocket connection is absent or closed; typical causes include network connectivity issues, connection refused/timeouts, TLS/socket handshake failures, authentication/token errors (e.g. 401), or core server unavailability."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1019,6 +1019,10 @@
   "@notifications_errorSnackBar_callNegotiationTimeout": {
     "description": "Shown in a notification or snackbar when call setup fails because media/signaling negotiation timed out. Context: occurs during SDP/ICE or signaling exchange when negotiation does not complete in time; typical causes include network connectivity problems, ICE or DTLS failures, incompatible SDP codecs, or an unresponsive remote endpoint or signaling server."
   },
+  "notifications_errorSnackBar_callServiceBusyLine": "Impossibile effettuare la chiamata in questo momento perché la linea è occupata. Riprova più tardi.",
+  "@notifications_errorSnackBar_callServiceBusyLine": {
+    "description": "Shown in a notification or snackbar when the user tries to start a call but the selected line is already busy. Context: occurs at call initiation when no free channel is available on the current line or account; advise the user to wait and retry."
+  },
   "notifications_errorSnackBar_callSignalingClientNotConnect": "Impossibile eseguire la chiamata, verificare lo stato della connessione",
   "@notifications_errorSnackBar_callSignalingClientNotConnect": {
     "description": "Shown in a notification or snackbar when the app cannot initiate a call because the signaling client is not connected to the WebTrit core. Context: occurs at call start when the signaling/WebSocket connection is absent or closed; typical causes include network connectivity issues, connection refused/timeouts, TLS/socket handshake failures, authentication/token errors (e.g. 401), or core server unavailability."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1019,6 +1019,10 @@
   "@notifications_errorSnackBar_callNegotiationTimeout": {
     "description": "Shown in a notification or snackbar when call setup fails because media/signaling negotiation timed out. Context: occurs during SDP/ICE or signaling exchange when negotiation does not complete in time; typical causes include network connectivity problems, ICE or DTLS failures, incompatible SDP codecs, or an unresponsive remote endpoint or signaling server."
   },
+  "notifications_errorSnackBar_callServiceBusyLine": "Неможливо здійснити дзвінок зараз, оскільки лінія зайнята. Спробуйте пізніше.",
+  "@notifications_errorSnackBar_callServiceBusyLine": {
+    "description": "Shown in a notification or snackbar when the user tries to start a call but the selected line is already busy. Context: occurs at call initiation when no free channel is available on the current line or account; advise the user to wait and retry."
+  },
   "notifications_errorSnackBar_callSignalingClientNotConnect": "Не вдається ініціювати дзвінок, перевірте статус з'єднання",
   "@notifications_errorSnackBar_callSignalingClientNotConnect": {
     "description": "Shown in a notification or snackbar when the app cannot initiate a call because the signaling client is not connected to the WebTrit core. Context: occurs at call start when the signaling/WebSocket connection is absent or closed; typical causes include network connectivity issues, connection refused/timeouts, TLS/socket handshake failures, authentication/token errors (e.g. 401), or core server unavailability."


### PR DESCRIPTION
This pull request adds user-facing handling for the "busy line" scenario when attempting to start a call. It introduces a new notification to inform users when a call cannot be made because the selected line is busy, and provides localized messages for this condition in English, Italian, and Ukrainian. The error handling logic is updated to recognize this situation and trigger the appropriate notification.

**Busy Line Error Handling and Notification:**

* Added a new error notification class `CallServiceBusyLineNotification` to represent the "busy line" condition in the call feature.
* Updated the call error reporter (`DefaultCallErrorReporter`) to detect Webtrit signaling errors with code 503 and reason containing "busy line", and submit the new busy line notification.
* Enhanced the call bloc logic to handle signaling errors with code 410 (call gone before answer), ensuring proper state reset and recents update.

**Related to:**
[Core PR](https://github.com/WebTrit/webtrit_core/pull/97)