### PR TITLE
fix: signaling hub presence parsing

### DIFF
--- a/packages/webtrit_signaling/lib/src/requests/session/presence_settings_update_request.dart
+++ b/packages/webtrit_signaling/lib/src/requests/session/presence_settings_update_request.dart
@@ -16,6 +16,13 @@ class PresenceSettingsUpdateRequest extends SessionRequest {
   Map<String, dynamic> toJson() {
     return {Request.typeKey: typeValue, 'transaction': transaction, 'settings': settings.toJson()};
   }
+
+  factory PresenceSettingsUpdateRequest.fromJson(Map<String, dynamic> json) {
+    final transaction = json['transaction'] as String;
+    final settingsJson = json['settings'] as Map<String, dynamic>;
+    final settings = SignalingPresenceSettings.fromJson(settingsJson);
+    return PresenceSettingsUpdateRequest(transaction: transaction, settings: settings);
+  }
 }
 
 class SignalingPresenceSettings extends Equatable {
@@ -50,6 +57,19 @@ class SignalingPresenceSettings extends Equatable {
       'activity': activity,
       'dnd_mode': dndMode,
     };
+  }
+
+  factory SignalingPresenceSettings.fromJson(Map<String, dynamic> json) {
+    return SignalingPresenceSettings(
+      available: json['available'] as bool,
+      note: json['note'] as String,
+      statusIcon: json['status_icon'] as String?,
+      device: json['device'] as String,
+      timeOffsetMin: json['time_offset_min'] as int,
+      timestamp: json['timestamp'] as String,
+      activity: json['activity'] as String?,
+      dndMode: json['dnd_mode'] as bool,
+    );
   }
 
   @override

--- a/packages/webtrit_signaling/lib/src/requests/session_request.dart
+++ b/packages/webtrit_signaling/lib/src/requests/session_request.dart
@@ -1,3 +1,5 @@
+import 'package:webtrit_signaling/src/requests/session/session_requests.dart';
+
 import 'abstract_requests.dart';
 
 abstract class SessionRequest extends Request {
@@ -23,5 +25,7 @@ abstract class SessionRequest extends Request {
     return _sessionRequestFromJsonDecoders[requestTypeValue]?.call(json) ?? LineRequest.tryFromJson(json);
   }
 
-  static final Map<String, SessionRequest Function(Map<String, dynamic>)> _sessionRequestFromJsonDecoders = {};
+  static final Map<String, SessionRequest Function(Map<String, dynamic>)> _sessionRequestFromJsonDecoders = {
+    PresenceSettingsUpdateRequest.typeValue: PresenceSettingsUpdateRequest.fromJson,
+  };
 }


### PR DESCRIPTION
This pull request adds JSON deserialization support for presence settings update requests, enabling the application to reconstruct `PresenceSettingsUpdateRequest` and `SignalingPresenceSettings` objects from JSON data.