### PR TITLE
fix: signaling hub presence handshake parsing

### DIFF
--- a/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
+++ b/packages/webtrit_signaling/test/webtrit_signaling_integration_test.dart
@@ -24,8 +24,8 @@ String _handshakeJson({int keepaliveInterval = _kKeepaliveIntervalMs}) {
     'keepalive_interval': keepaliveInterval,
     'registration': {'status': 'registered'},
     'lines': [],
-    'user_active_calls': [],
-    'presence_contacts_info': {},
+    'dialog_infos': [],
+    'presence_infos': [],
     'guest_line': null,
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -296,7 +296,7 @@ Map<String, dynamic> _encodeHandshake(StateHandshake h) {
           .toList();
       return {'call_id': line.callId, 'call_logs': encodedLogs};
     }).toList(),
-    'user_active_calls': <dynamic>[],
-    'presence_contacts_info': <String, dynamic>{},
+    'presence_infos': h.presenceInfos.map((info) => info.toJson()).toList(),
+    'dialog_infos': h.dialogInfos.map((info) => info.toJson()).toList(),
   };
 }


### PR DESCRIPTION
This pull request updates the handshake encoding logic in the signaling hub codec to include serializing of `presenceInfos` and `dialogInfos` from the handshake state.
