### PR TITLE
feat: local media tracks pool for parallel calls (WT-1089, WT-1228)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -211,6 +211,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     await _stopRingbackSound();
 
+    for (final activeCall in state.activeCalls) {
+      await _releaseLocalStream(activeCall.localStream);
+    }
+
     await _peerConnectionManager.dispose();
 
     _clearRenegotiationHandlers();
@@ -610,7 +614,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           activeCall.displayName ?? activeCall.handle.value,
           CallkeepEndCallReason.remoteEnded,
         );
-        await activeCall.localStream?.dispose();
+        await _releaseLocalStream(activeCall.localStream);
       });
       emit(state.copyWithPopActiveCall(event.callId));
     } catch (e) {
@@ -1177,7 +1181,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         // This handles closing the connection and removing the completer.
         await _peerConnectionManager.disposePeerConnection(event.callId);
 
-        await call.localStream?.dispose();
+        await _releaseLocalStream(call.localStream);
 
         emit(state.copyWithPopActiveCall(event.callId));
 
@@ -1229,7 +1233,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
               '__onCallSignalingEventCallUpdating: peerConnection is null - most likely some state issue',
             );
           } else {
-            await peerConnectionPolicyApplier?.apply(peerConnection, hasRemoteVideo: jsep.hasVideo);
+            final localStream = activeCall.localStream;
+            if (localStream != null) {
+              await peerConnectionPolicyApplier?.apply(
+                peerConnection,
+                hasRemoteVideo: jsep.hasVideo,
+                localStream: localStream,
+                frontCamera: activeCall.frontCamera,
+              );
+            }
 
             // Optimistic pre-check for glare condition. May be stale because
             // flutter_webrtc caches signalingState and updates it only when the
@@ -1607,42 +1619,23 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (peerConnection == null) return;
 
     try {
-      // Capture new audio and video pair together to avoid time sync issues
-      // and avoid storing separate audio and video tracks to control them on mute, camera switch etc
-      final newLocalStream = await userMediaBuilder.build(video: true, frontCamera: activeCall.frontCamera);
-
-      final newAudioTrack = newLocalStream.getAudioTracks().firstOrNull;
-      final newVideoTrack = newLocalStream.getVideoTracks().firstOrNull;
-
-      final senders = await peerConnection.getSenders();
-      final audioSender = senders.firstWhereOrNull((s) => s.track?.kind == 'audio');
-      final videoSender = senders.firstWhereOrNull((s) => s.track?.kind == 'video');
-
-      /// Replace audio/video tracks using existing senders to avoid adding new m= lines
-      ///
-      /// Alternatively, you can use (remove || stop) + add tracks flow
-      /// but it has weak support on infrastructure level:
-      /// - second audio m= line causes problems with call recordings and music on hold
-      /// - second video m= line causes empty video stream
-      ///
-      /// So for best compatibility, use existing senders and control them via .enabled or .replaceTrack
-      if (audioSender != null && newAudioTrack != null) {
-        await audioSender.replaceTrack(newAudioTrack);
-      } else if (newAudioTrack != null) {
-        final audioSenderResult = await peerConnection.safeAddTrack(newAudioTrack, newLocalStream);
-        _checkSenderResult(audioSenderResult, 'audio');
+      final newVideoTrack = await userMediaBuilder.ensureVideoTrack(localStream, frontCamera: activeCall.frontCamera);
+      if (newVideoTrack == null) {
+        submitNotification(const CallUserMediaErrorNotification());
+        return;
       }
 
-      if (videoSender != null && newVideoTrack != null) {
+      final senders = await peerConnection.getSenders();
+      final videoSender = senders.firstWhereOrNull((s) => s.track?.kind == 'video');
+
+      if (videoSender != null) {
         await videoSender.replaceTrack(newVideoTrack);
-      } else if (newVideoTrack != null) {
-        final videoSenderResult = await peerConnection.safeAddTrack(newVideoTrack, newLocalStream);
+      } else {
+        final videoSenderResult = await peerConnection.safeAddTrack(newVideoTrack, localStream);
         _checkSenderResult(videoSenderResult, 'video');
       }
 
-      emit(
-        state.copyWithMappedActiveCall(event.callId, (call) => call.copyWith(localStream: newLocalStream, video: true)),
-      );
+      emit(state.copyWithMappedActiveCall(event.callId, (call) => call.copyWith(video: true)));
 
       await callkeep.reportUpdateCall(event.callId, hasVideo: true);
     } on UserMediaError catch (e) {
@@ -2316,7 +2309,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // or after skipping it for blind transfer, to prevent "Simulate a 'hangup' coming from the
       // application" triggered by "No WebRTC media anymore".
       await _peerConnectionManager.disposePeerConnection(activeCall.callId);
-      await activeCall.localStream?.dispose();
+      await _releaseLocalStream(activeCall.localStream);
     });
 
     emit(state.copyWithPopActiveCall(event.callId));
@@ -2893,7 +2886,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       add(_PeerConnectionEvent.renegotiationNeeded(event.callId, event.line));
     } catch (e, stackTrace) {
       localStream?.getTracks().forEach((t) => t.stop());
-      await localStream?.dispose();
+      await _releaseLocalStream(localStream);
       await peerConnection?.dispose();
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
       add(_ResetStateEvent.completeCall(event.callId));
@@ -3274,6 +3267,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> _playRingbackSound() => _callkeepSound.playRingbackSound();
 
   Future<void> _stopRingbackSound() => _callkeepSound.stopRingbackSound();
+
+  Future<void> _releaseLocalStream(MediaStream? stream) async {
+    if (stream == null) return;
+    await userMediaBuilder.release(stream);
+  }
 
   Future<void> _assignInitialPresence(List<SignalingPresenceInfo> data) async {
     _logger.info('Received initial presence info: ${data.length} entries');

--- a/lib/features/call/utils/peer_connection_policy_applier.dart
+++ b/lib/features/call/utils/peer_connection_policy_applier.dart
@@ -15,7 +15,12 @@ abstract class PeerConnectionPolicyApplier {
   ///
   /// The [hasRemoteVideo] parameter indicates whether the remote SDP includes a video m-line.
   /// This allows conditional policy application based on call capabilities.
-  Future<void> apply(RTCPeerConnection peerConnection, {required bool hasRemoteVideo});
+  Future<void> apply(
+    RTCPeerConnection peerConnection, {
+    required bool hasRemoteVideo,
+    required MediaStream localStream,
+    bool? frontCamera,
+  });
 }
 
 /// Applies peer connection policies based on the provided [PeerConnectionSettings].
@@ -51,7 +56,12 @@ class ModifyWithSettingsPeerConnectionPolicyApplier implements PeerConnectionPol
       .negotiationSettings;
 
   @override
-  Future<void> apply(RTCPeerConnection peerConnection, {required bool hasRemoteVideo}) async {
+  Future<void> apply(
+    RTCPeerConnection peerConnection, {
+    required bool hasRemoteVideo,
+    required MediaStream localStream,
+    bool? frontCamera,
+  }) async {
     _logger.fine('Applying peer connection policies with settings: $_negotiationSettings');
     // Check if the policy requires inserting an inactive video track for negotiation purposes
     if (_negotiationSettings.includeInactiveVideoInOfferAnswer && hasRemoteVideo) {
@@ -64,9 +74,7 @@ class ModifyWithSettingsPeerConnectionPolicyApplier implements PeerConnectionPol
         return;
       }
 
-      // Acquire a local stream with video
-      final localStream = await _userMediaBuilder.build(video: true);
-      final localVideoTrack = localStream.getVideoTracks().firstOrNull;
+      final localVideoTrack = await _userMediaBuilder.ensureVideoTrack(localStream, frontCamera: frontCamera);
 
       // Add the video track to the peer connection, disabled initially
       if (localVideoTrack != null) {

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -7,14 +7,19 @@ import 'video_constraints_builder.dart';
 
 abstract class UserMediaBuilder {
   Future<MediaStream> build({required bool video, bool? frontCamera, bool allowAudioFallback = false});
+
+  Future<MediaStreamTrack?> ensureVideoTrack(MediaStream stream, {bool? frontCamera});
+
+  Future<void> release(MediaStream stream);
 }
 
 class DefaultUserMediaBuilder implements UserMediaBuilder {
-  const DefaultUserMediaBuilder({
+  DefaultUserMediaBuilder({
     this.audioConstraintsBuilder,
     this.videoConstraintsBuilder,
     this.isCameraPermissionGranted,
     this.getUserMedia,
+    this.createLocalStream,
   });
 
   final AudioConstraintsBuilder? audioConstraintsBuilder;
@@ -32,6 +37,16 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   /// Intended for use in tests only.
   @visibleForTesting
   final Future<MediaStream> Function(Map<String, dynamic>)? getUserMedia;
+
+  /// Injectable override for [createLocalMediaStream].
+  ///
+  /// Defaults to the real platform API when [null].
+  @visibleForTesting
+  final Future<MediaStream> Function(String label)? createLocalStream;
+
+  final Map<String, _BorrowedStreamLease> _borrowedStreams = {};
+  _PooledTrack? _audioTrack;
+  _PooledTrack? _videoTrack;
 
   /// Requests access to the user's media input devices (camera and/or microphone).
   ///
@@ -54,29 +69,151 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     final resolvedVideo = video && (!allowAudioFallback || await _isCameraAvailable());
 
     try {
-      return await _acquireStream(resolvedVideo: resolvedVideo, frontCamera: frontCamera);
+      return await _acquirePooledStream(resolvedVideo: resolvedVideo, frontCamera: frontCamera);
     } catch (_) {
       if (!allowAudioFallback || !resolvedVideo) rethrow;
-      return _acquireStream(resolvedVideo: false, frontCamera: frontCamera);
+      return _acquirePooledStream(resolvedVideo: false, frontCamera: frontCamera);
     }
   }
 
-  Future<MediaStream> _acquireStream({required bool resolvedVideo, bool? frontCamera}) async {
+  @override
+  Future<MediaStreamTrack?> ensureVideoTrack(MediaStream stream, {bool? frontCamera}) async {
+    final existingTrack = stream.getVideoTracks().firstOrNull;
+    if (existingTrack != null) return existingTrack;
+
+    final videoTrack = await _acquireVideoTrack(frontCamera: frontCamera);
+
+    try {
+      await stream.addTrack(videoTrack);
+      _borrowedStreams.update(
+        stream.id,
+        (lease) => lease.copyWith(videoTrackId: videoTrack.id),
+        ifAbsent: () => _BorrowedStreamLease(videoTrackId: videoTrack.id),
+      );
+
+      await _configureAppleAudio(hasVideo: true);
+      return videoTrack;
+    } catch (e) {
+      await _releaseVideoTrack(videoTrack.id);
+      throw UserMediaError(e.toString());
+    }
+  }
+
+  @override
+  Future<void> release(MediaStream stream) async {
+    final lease = _borrowedStreams.remove(stream.id);
+
+    if (lease != null) {
+      await _releaseAudioTrack(lease.audioTrackId);
+      await _releaseVideoTrack(lease.videoTrackId);
+    }
+
+    await stream.dispose();
+  }
+
+  Future<MediaStream> _acquirePooledStream({required bool resolvedVideo, bool? frontCamera}) async {
+    MediaStream? stream;
+    MediaStreamTrack? audioTrack;
+    MediaStreamTrack? videoTrack;
+
+    try {
+      stream = await (createLocalStream ?? createLocalMediaStream)(_nextStreamLabel());
+      final lease = _BorrowedStreamLease();
+
+      audioTrack = await _acquireAudioTrack();
+      await stream.addTrack(audioTrack);
+      lease.audioTrackId = audioTrack.id;
+
+      if (resolvedVideo) {
+        videoTrack = await _acquireVideoTrack(frontCamera: frontCamera);
+        await stream.addTrack(videoTrack);
+        lease.videoTrackId = videoTrack.id;
+      }
+
+      _borrowedStreams[stream.id] = lease;
+      await _configureAppleAudio(hasVideo: resolvedVideo);
+
+      return stream;
+    } catch (e) {
+      await _releaseVideoTrack(videoTrack?.id);
+      await _releaseAudioTrack(audioTrack?.id);
+      await stream?.dispose();
+
+      if (e is UserMediaError) rethrow;
+      throw UserMediaError(e.toString());
+    }
+  }
+
+  Future<MediaStreamTrack> _acquireAudioTrack() async {
+    final pooledTrack = _audioTrack;
+    if (pooledTrack != null) {
+      pooledTrack.references++;
+      return pooledTrack.track;
+    }
+
+    final sourceStream = await _requestStream(audio: true, video: false);
+    final track = sourceStream.getAudioTracks().firstOrNull;
+    if (track == null) {
+      await sourceStream.dispose();
+      throw UserMediaError('Unable to acquire local audio track');
+    }
+
+    _audioTrack = _PooledTrack(track: track, sourceStream: sourceStream)..references = 1;
+    return track;
+  }
+
+  Future<MediaStreamTrack> _acquireVideoTrack({bool? frontCamera}) async {
+    final pooledTrack = _videoTrack;
+    if (pooledTrack != null) {
+      pooledTrack.references++;
+      return pooledTrack.track;
+    }
+
+    final sourceStream = await _requestStream(audio: false, video: true, frontCamera: frontCamera);
+    final track = sourceStream.getVideoTracks().firstOrNull;
+    if (track == null) {
+      await sourceStream.dispose();
+      throw UserMediaError('Unable to acquire local video track');
+    }
+
+    _videoTrack = _PooledTrack(track: track, sourceStream: sourceStream)..references = 1;
+    return track;
+  }
+
+  Future<void> _releaseAudioTrack(String? trackId) async {
+    final pooledTrack = _audioTrack;
+    if (pooledTrack == null || trackId == null || pooledTrack.track.id != trackId) return;
+
+    if (pooledTrack.references == 0) return;
+    pooledTrack.references--;
+    if (pooledTrack.references > 0) return;
+
+    await pooledTrack.track.stop();
+    await pooledTrack.sourceStream.dispose();
+    _audioTrack = null;
+  }
+
+  Future<void> _releaseVideoTrack(String? trackId) async {
+    final pooledTrack = _videoTrack;
+    if (pooledTrack == null || trackId == null || pooledTrack.track.id != trackId) return;
+
+    if (pooledTrack.references == 0) return;
+    pooledTrack.references--;
+    if (pooledTrack.references > 0) return;
+
+    await pooledTrack.track.stop();
+    await pooledTrack.sourceStream.dispose();
+    _videoTrack = null;
+  }
+
+  Future<MediaStream> _requestStream({required bool audio, required bool video, bool? frontCamera}) async {
     final Map<String, dynamic> mediaConstraints = {
-      'audio': _buildAudioConstraints(),
-      'video': resolvedVideo ? _buildVideoConstraintsMap(frontCamera: frontCamera) : false,
+      'audio': audio ? _buildAudioConstraints() : false,
+      'video': video ? _buildVideoConstraintsMap(frontCamera: frontCamera) : false,
     };
 
     try {
-      final localStream = await (getUserMedia ?? navigator.mediaDevices.getUserMedia)(mediaConstraints);
-
-      if (!kIsWeb) {
-        await Helper.setAppleAudioConfiguration(
-          AppleAudioConfiguration(appleAudioMode: resolvedVideo ? AppleAudioMode.videoChat : AppleAudioMode.voiceChat),
-        );
-      }
-
-      return localStream;
+      return await (getUserMedia ?? navigator.mediaDevices.getUserMedia)(mediaConstraints);
     } catch (e) {
       throw UserMediaError(e.toString());
     }
@@ -86,6 +223,16 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     if (kIsWeb || isCameraPermissionGranted == null) return true;
     return isCameraPermissionGranted!();
   }
+
+  Future<void> _configureAppleAudio({required bool hasVideo}) async {
+    if (kIsWeb) return;
+
+    await Helper.setAppleAudioConfiguration(
+      AppleAudioConfiguration(appleAudioMode: hasVideo ? AppleAudioMode.videoChat : AppleAudioMode.voiceChat),
+    );
+  }
+
+  String _nextStreamLabel() => 'user_media_${DateTime.now().microsecondsSinceEpoch}';
 
   /// Constructs the map structure for audio constraints.
   Map<String, dynamic> _buildAudioConstraints() {
@@ -112,4 +259,26 @@ class UserMediaError implements Exception {
 
   @override
   String toString() => 'UserMediaError: $message';
+}
+
+class _PooledTrack {
+  _PooledTrack({required this.track, required this.sourceStream});
+
+  final MediaStreamTrack track;
+  final MediaStream sourceStream;
+  int references = 0;
+}
+
+class _BorrowedStreamLease {
+  _BorrowedStreamLease({this.audioTrackId, this.videoTrackId});
+
+  String? audioTrackId;
+  String? videoTrackId;
+
+  _BorrowedStreamLease copyWith({String? audioTrackId, String? videoTrackId}) {
+    return _BorrowedStreamLease(
+      audioTrackId: audioTrackId ?? this.audioTrackId,
+      videoTrackId: videoTrackId ?? this.videoTrackId,
+    );
+  }
 }

--- a/test/features/call/utils/user_media_builder_test.dart
+++ b/test/features/call/utils/user_media_builder_test.dart
@@ -6,43 +6,159 @@ import 'package:webtrit_phone/features/call/utils/user_media_builder.dart';
 
 class MockMediaStream extends Mock implements MediaStream {}
 
+class MockMediaStreamTrack extends Mock implements MediaStreamTrack {}
+
+class FakeMediaStreamTrack extends Fake implements MediaStreamTrack {}
+
+class _TestMediaStreamFactory {
+  int _counter = 0;
+
+  final streams = <MockMediaStream>[];
+
+  MockMediaStream create() {
+    _counter++;
+    final stream = MockMediaStream();
+
+    final audioTracks = <MediaStreamTrack>[];
+    final videoTracks = <MediaStreamTrack>[];
+
+    when(() => stream.id).thenReturn('local-stream-$_counter');
+    when(() => stream.getAudioTracks()).thenAnswer((_) => audioTracks);
+    when(() => stream.getVideoTracks()).thenAnswer((_) => videoTracks);
+    when(() => stream.addTrack(any())).thenAnswer((invocation) async {
+      final track = invocation.positionalArguments.first as MediaStreamTrack;
+      if (track.kind == 'audio') {
+        audioTracks.add(track);
+      } else if (track.kind == 'video') {
+        videoTracks.add(track);
+      }
+    });
+    when(() => stream.dispose()).thenAnswer((_) async {});
+
+    streams.add(stream);
+    return stream;
+  }
+}
+
 void main() {
-  late MockMediaStream mockStream;
-  late Map<String, dynamic> capturedConstraints;
+  setUpAll(() {
+    registerFallbackValue(FakeMediaStreamTrack());
+  });
+
+  late _TestMediaStreamFactory localStreamFactory;
+  late MockMediaStream audioSourceStream;
+  late MockMediaStream videoSourceStream;
+  late MockMediaStreamTrack audioTrack;
+  late MockMediaStreamTrack videoTrack;
+  late List<Map<String, dynamic>> capturedConstraints;
   late Future<MediaStream> Function(Map<String, dynamic>) fakeGetUserMedia;
+  late Future<MediaStream> Function(String label) fakeCreateLocalStream;
 
   setUp(() {
-    mockStream = MockMediaStream();
-    capturedConstraints = {};
+    localStreamFactory = _TestMediaStreamFactory();
+    audioSourceStream = MockMediaStream();
+    videoSourceStream = MockMediaStream();
+    audioTrack = MockMediaStreamTrack();
+    videoTrack = MockMediaStreamTrack();
+    capturedConstraints = [];
+
+    when(() => audioTrack.id).thenReturn('audio-track-1');
+    when(() => audioTrack.kind).thenReturn('audio');
+    when(() => audioTrack.stop()).thenAnswer((_) async {});
+
+    when(() => videoTrack.id).thenReturn('video-track-1');
+    when(() => videoTrack.kind).thenReturn('video');
+    when(() => videoTrack.stop()).thenAnswer((_) async {});
+
+    when(() => audioSourceStream.getAudioTracks()).thenReturn([audioTrack]);
+    when(() => audioSourceStream.getVideoTracks()).thenReturn([]);
+    when(() => audioSourceStream.dispose()).thenAnswer((_) async {});
+
+    when(() => videoSourceStream.getAudioTracks()).thenReturn([]);
+    when(() => videoSourceStream.getVideoTracks()).thenReturn([videoTrack]);
+    when(() => videoSourceStream.dispose()).thenAnswer((_) async {});
 
     fakeGetUserMedia = (constraints) async {
-      capturedConstraints = constraints;
-      return mockStream;
+      capturedConstraints.add(Map<String, dynamic>.from(constraints));
+      final hasAudio = constraints['audio'] != false;
+      final hasVideo = constraints['video'] != false;
+
+      if (hasAudio && !hasVideo) return audioSourceStream;
+      if (!hasAudio && hasVideo) return videoSourceStream;
+
+      throw Exception('Unsupported constraints in test: $constraints');
     };
+
+    fakeCreateLocalStream = (_) async => localStreamFactory.create();
   });
 
-  DefaultUserMediaBuilder builder({Future<bool> Function()? isCameraPermissionGranted}) =>
-      DefaultUserMediaBuilder(isCameraPermissionGranted: isCameraPermissionGranted, getUserMedia: fakeGetUserMedia);
+  DefaultUserMediaBuilder builder({Future<bool> Function()? isCameraPermissionGranted}) => DefaultUserMediaBuilder(
+    isCameraPermissionGranted: isCameraPermissionGranted,
+    getUserMedia: fakeGetUserMedia,
+    createLocalStream: fakeCreateLocalStream,
+  );
 
-  group('DefaultUserMediaBuilder — audio/video constraints', () {
-    test('passes video: false to getUserMedia when video is false', () async {
-      await builder().build(video: false);
-      expect(capturedConstraints['video'], isFalse);
+  group('DefaultUserMediaBuilder — pooling', () {
+    test('reuses pooled audio track for multiple streams', () async {
+      final subject = builder();
+      await subject.build(video: false);
+      await subject.build(video: false);
+
+      final audioRequests = capturedConstraints.where((it) => it['audio'] != false && it['video'] == false).length;
+      expect(audioRequests, 1);
     });
 
-    test('passes video map to getUserMedia when video is true', () async {
-      await builder().build(video: true);
-      expect(capturedConstraints['video'], isA<Map>());
+    test('reuses pooled video track for multiple streams', () async {
+      final subject = builder();
+      await subject.build(video: true);
+      await subject.build(video: true);
+
+      final videoRequests = capturedConstraints.where((it) => it['audio'] == false && it['video'] != false).length;
+      expect(videoRequests, 1);
     });
 
-    test('passes audio constraints to getUserMedia', () async {
-      await builder().build(video: false);
-      expect(capturedConstraints['audio'], isNotNull);
+    test('disposes pooled source tracks only after releasing the last borrower', () async {
+      final subject = builder();
+      final stream1 = await subject.build(video: true);
+      final stream2 = await subject.build(video: true);
+
+      await subject.release(stream1);
+
+      verifyNever(() => audioTrack.stop());
+      verifyNever(() => videoTrack.stop());
+      verifyNever(() => audioSourceStream.dispose());
+      verifyNever(() => videoSourceStream.dispose());
+
+      await subject.release(stream2);
+
+      verify(() => audioTrack.stop()).called(1);
+      verify(() => videoTrack.stop()).called(1);
+      verify(() => audioSourceStream.dispose()).called(1);
+      verify(() => videoSourceStream.dispose()).called(1);
     });
   });
 
-  group('DefaultUserMediaBuilder — allowAudioFallback: false (default)', () {
-    test('does not call isCameraPermissionGranted when allowAudioFallback is false', () async {
+  group('DefaultUserMediaBuilder — dynamic video acquisition', () {
+    test('ensureVideoTrack acquires only missing video track', () async {
+      final subject = builder();
+      final localStream = await subject.build(video: false);
+
+      expect(localStream.getVideoTracks(), isEmpty);
+
+      final ensuredTrack = await subject.ensureVideoTrack(localStream, frontCamera: true);
+      expect(ensuredTrack, isNotNull);
+      expect(localStream.getVideoTracks(), hasLength(1));
+
+      final audioRequests = capturedConstraints.where((it) => it['audio'] != false && it['video'] == false).length;
+      final videoRequests = capturedConstraints.where((it) => it['audio'] == false && it['video'] != false).length;
+
+      expect(audioRequests, 1);
+      expect(videoRequests, 1);
+    });
+  });
+
+  group('DefaultUserMediaBuilder — allowAudioFallback', () {
+    test('does not call camera permission check when allowAudioFallback is false', () async {
       var permissionCalled = false;
       await builder(
         isCameraPermissionGranted: () async {
@@ -52,40 +168,9 @@ void main() {
       ).build(video: true);
 
       expect(permissionCalled, isFalse);
-      expect(capturedConstraints['video'], isA<Map>());
     });
 
-    test('passes video: true regardless of camera permission when allowAudioFallback is false', () async {
-      await builder(isCameraPermissionGranted: () async => false).build(video: true);
-      expect(capturedConstraints['video'], isA<Map>());
-    });
-  });
-
-  group('DefaultUserMediaBuilder — allowAudioFallback: true', () {
-    test('passes video: true when camera permission is granted', () async {
-      await builder(isCameraPermissionGranted: () async => true).build(video: true, allowAudioFallback: true);
-
-      expect(capturedConstraints['video'], isA<Map>());
-    });
-
-    test('passes video: false when camera permission is denied', () async {
-      await builder(isCameraPermissionGranted: () async => false).build(video: true, allowAudioFallback: true);
-
-      expect(capturedConstraints['video'], isFalse);
-    });
-
-    test('passes video: false when video is false regardless of camera permission', () async {
-      await builder(isCameraPermissionGranted: () async => true).build(video: false, allowAudioFallback: true);
-
-      expect(capturedConstraints['video'], isFalse);
-    });
-
-    test('passes video: true when isCameraPermissionGranted is null', () async {
-      await builder().build(video: true, allowAudioFallback: true);
-      expect(capturedConstraints['video'], isA<Map>());
-    });
-
-    test('calls isCameraPermissionGranted exactly once per build call', () async {
+    test('calls isCameraPermissionGranted exactly once when fallback enabled', () async {
       var callCount = 0;
       await builder(
         isCameraPermissionGranted: () async {
@@ -96,30 +181,43 @@ void main() {
 
       expect(callCount, 1);
     });
-  });
 
-  group('DefaultUserMediaBuilder — allowAudioFallback: true, getUserMedia retry', () {
-    test('retries with video: false when getUserMedia fails on first video attempt', () async {
-      final capturedAttempts = <bool>[];
+    test('falls back to audio-only when camera permission is denied', () async {
+      await builder(isCameraPermissionGranted: () async => false).build(video: true, allowAudioFallback: true);
+
+      final videoRequests = capturedConstraints.where((it) => it['audio'] == false && it['video'] != false).length;
+      expect(videoRequests, 0);
+    });
+
+    test('retries in audio-only mode when video acquisition fails', () async {
+      final attempts = <String>[];
       final subject = DefaultUserMediaBuilder(
         isCameraPermissionGranted: () async => true,
+        createLocalStream: fakeCreateLocalStream,
         getUserMedia: (constraints) async {
+          final hasAudio = constraints['audio'] != false;
           final hasVideo = constraints['video'] != false;
-          capturedAttempts.add(hasVideo);
-          if (hasVideo) throw Exception('NotAllowedError');
-          return mockStream;
+          attempts.add('audio:$hasAudio,video:$hasVideo');
+
+          if (hasAudio && !hasVideo) return audioSourceStream;
+          if (!hasAudio && hasVideo) throw Exception('NotAllowedError');
+
+          throw Exception('Unsupported constraints in test: $constraints');
         },
       );
 
       final result = await subject.build(video: true, allowAudioFallback: true);
 
-      expect(capturedAttempts, [true, false]);
-      expect(result, mockStream);
+      expect(result, isA<MediaStream>());
+      expect(attempts, ['audio:true,video:false', 'audio:false,video:true', 'audio:true,video:false']);
     });
+  });
 
+  group('DefaultUserMediaBuilder — error handling', () {
     test('does not retry when allowAudioFallback is false', () async {
       var callCount = 0;
       final subject = DefaultUserMediaBuilder(
+        createLocalStream: fakeCreateLocalStream,
         getUserMedia: (_) async {
           callCount++;
           throw Exception('NotAllowedError');
@@ -133,6 +231,7 @@ void main() {
     test('does not retry when video was already false', () async {
       var callCount = 0;
       final subject = DefaultUserMediaBuilder(
+        createLocalStream: fakeCreateLocalStream,
         getUserMedia: (_) async {
           callCount++;
           throw Exception('device error');
@@ -146,27 +245,32 @@ void main() {
     test('throws UserMediaError when retry also fails', () async {
       final subject = DefaultUserMediaBuilder(
         isCameraPermissionGranted: () async => true,
+        createLocalStream: fakeCreateLocalStream,
         getUserMedia: (_) async => throw Exception('no mic'),
       );
 
       await expectLater(subject.build(video: true, allowAudioFallback: true), throwsA(isA<UserMediaError>()));
     });
-  });
 
-  group('DefaultUserMediaBuilder — error handling', () {
     test('wraps getUserMedia exception in UserMediaError', () async {
-      final subject = DefaultUserMediaBuilder(getUserMedia: (_) async => throw Exception('device not found'));
+      final subject = DefaultUserMediaBuilder(
+        createLocalStream: fakeCreateLocalStream,
+        getUserMedia: (_) async => throw Exception('device not found'),
+      );
 
       await expectLater(subject.build(video: false), throwsA(isA<UserMediaError>()));
     });
 
     test('UserMediaError message contains original error', () async {
-      final subject = DefaultUserMediaBuilder(getUserMedia: (_) async => throw Exception('device not found'));
+      final subject = DefaultUserMediaBuilder(
+        createLocalStream: fakeCreateLocalStream,
+        getUserMedia: (_) async => throw Exception('device not found'),
+      );
 
       UserMediaError? captured;
       await subject.build(video: false).catchError((Object e) {
         captured = e as UserMediaError;
-        return mockStream as MediaStream;
+        return localStreamFactory.create();
       });
       expect(captured?.message, contains('device not found'));
     });


### PR DESCRIPTION
Implemented shared media track pooling so parallel calls reuse local audio and video tracks instead of creating a new stream per call. 
Created to avoid bugs: 
- switching between two parallel video calls cause video stuck on first call + crash on ios
- switching to front camera on two parallel video calls cause crash