### PR TITLE
fix(signaling-hub): buffer IncomingCallEvent for late subscribers

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -42,6 +42,14 @@ class SignalingHub {
   /// Replayed to late subscribers so they receive the current session state.
   final List<List<dynamic>> _sessionBuffer = [];
 
+  /// callId -> encoded [IncomingCallEvent] for calls that are currently ringing.
+  ///
+  /// Replayed to late subscribers so they do not miss an in-flight incoming
+  /// call that arrived before they subscribed. Entries are removed when a
+  /// [HangupEvent] with the same callId is received, or when [SignalingConnecting]
+  /// resets the session.
+  final Map<String, List<dynamic>> _inflightIncomingCalls = {};
+
   StreamSubscription<SignalingModuleEvent>? _moduleSubscription;
   bool _started = false;
 
@@ -79,13 +87,23 @@ class SignalingHub {
     _receivePort.close();
     _subscribers.clear();
     _sessionBuffer.clear();
+    _inflightIncomingCalls.clear();
     _logger.fine('Hub disposed');
   }
 
   void _onModuleEvent(SignalingModuleEvent event) {
-    if (event is SignalingConnecting) _sessionBuffer.clear();
+    if (event is SignalingConnecting) {
+      _sessionBuffer.clear();
+      _inflightIncomingCalls.clear();
+    }
     final encoded = encodeHubEvent(event);
-    if (event is! SignalingProtocolEvent) _sessionBuffer.add(encoded);
+    if (event is! SignalingProtocolEvent) {
+      _sessionBuffer.add(encoded);
+    } else if (event.event is IncomingCallEvent) {
+      _inflightIncomingCalls[(event.event as IncomingCallEvent).callId] = encoded;
+    } else if (event.event is HangupEvent) {
+      _inflightIncomingCalls.remove((event.event as HangupEvent).callId);
+    }
     _broadcast(encoded);
   }
 
@@ -134,6 +152,12 @@ class SignalingHub {
     cmd.replyPort.send(encodeSubAck());
     // Replay current session buffer so the new subscriber gets the full state.
     for (final event in List<List<dynamic>>.from(_sessionBuffer)) {
+      cmd.replyPort.send(event);
+    }
+    // Replay any in-flight incoming calls that arrived before this subscriber.
+    // Without this, the push-notification isolate would receive a handshake
+    // with no active lines and incorrectly release a ringing Telecom call.
+    for (final event in _inflightIncomingCalls.values) {
       cmd.replyPort.send(event);
     }
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -611,6 +611,86 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // In-flight incoming call replay for late subscribers
+  // -------------------------------------------------------------------------
+
+  group('In-flight incoming call replay', () {
+    late _FakeSignalingClient fakeClient;
+    late _SignalingModule module;
+    late SignalingHub hub;
+
+    setUp(() async {
+      fakeClient = _FakeSignalingClient();
+      module = _buildModule(fakeClient);
+      hub = SignalingHub(module);
+      hub.start();
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    tearDown(() async {
+      await hub.dispose();
+      await module.dispose();
+    });
+
+    test('late subscriber receives IncomingCallEvent that arrived before subscription', () async {
+      fakeClient.injectHandshake(_kHandshake);
+      fakeClient.injectEvent(IncomingCallEvent(line: 0, callId: 'call-replay-1', callee: 'bob', caller: 'alice'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Subscribe after IncomingCallEvent was already broadcast.
+      final client = await _subscribeClient('inflight-1');
+      addTearDown(client.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      client.events.listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      final incoming = events.whereType<SignalingProtocolEvent>().where((e) => e.event is IncomingCallEvent).toList();
+      expect(incoming, hasLength(1), reason: 'Late subscriber must receive buffered IncomingCallEvent');
+      expect((incoming.first.event as IncomingCallEvent).callId, 'call-replay-1');
+    });
+
+    test('IncomingCallEvent is removed from replay buffer after HangupEvent', () async {
+      fakeClient.injectHandshake(_kHandshake);
+      fakeClient.injectEvent(IncomingCallEvent(line: 0, callId: 'call-replay-2', callee: 'bob', caller: 'alice'));
+      fakeClient.injectEvent(HangupEvent(line: 0, callId: 'call-replay-2', code: 487, reason: 'Request Terminated'));
+      await Future<void>.delayed(Duration.zero);
+
+      final client = await _subscribeClient('inflight-2');
+      addTearDown(client.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      client.events.listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      final incoming = events.whereType<SignalingProtocolEvent>().where((e) => e.event is IncomingCallEvent).toList();
+      expect(incoming, isEmpty, reason: 'IncomingCallEvent must be evicted after HangupEvent');
+    });
+
+    test('SignalingConnecting clears in-flight incoming calls', () async {
+      fakeClient.injectHandshake(_kHandshake);
+      fakeClient.injectEvent(IncomingCallEvent(line: 0, callId: 'call-replay-3', callee: 'bob', caller: 'alice'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Disconnect triggers a new SignalingConnecting which clears the buffer.
+      fakeClient.injectDisconnect(1000, 'done');
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      final client = await _subscribeClient('inflight-3');
+      addTearDown(client.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      client.events.listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      final incoming = events.whereType<SignalingProtocolEvent>().where((e) => e.event is IncomingCallEvent).toList();
+      expect(incoming, isEmpty, reason: 'IncomingCallEvent from previous session must not be replayed');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Execute routing through hub
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

When an incoming call arrives, the WebSocket `incoming_call` event reaches the main-process `WebtritSignalingClient` immediately. The push-notification isolate subscribes to `SignalingHub` ~1.7s later.

The hub replays `_sessionBuffer` to late subscribers to give them the current session state. But `_sessionBuffer` excluded all `SignalingProtocolEvent` — the wrapper that carries `IncomingCallEvent`. So the late subscriber received:

```
handshake lines=[null, null]   // no active lines
```

`PushNotificationIsolateManager._onNoActiveLines()` saw this and called `releaseCall()` — which auto-declined the ringing call. This happened for every incoming call, not just duplicates.

The root cause is documented in `bugs/open/2026-04-15-wt-1306-incoming-call-no-screen/auto-decline-duplicate-fcm.md`.

## Fix

Add `_inflightIncomingCalls: Map<String, List<dynamic>>` — a separate buffer keyed by `callId`.

- `IncomingCallEvent` arrives -> store encoded event in `_inflightIncomingCalls[callId]`
- `HangupEvent` arrives for same callId -> remove from map
- `SignalingConnecting` resets session -> clear the map
- New subscriber -> replay `_sessionBuffer` then replay `_inflightIncomingCalls.values`

Late subscribers now receive the `IncomingCallEvent` alongside the handshake, so `_onNoActiveLines()` is not triggered.

## Tests

Added 3 integration tests to `hub_client_integration_test.dart`:
- Late subscriber receives `IncomingCallEvent` that arrived before subscription
- `IncomingCallEvent` is removed after `HangupEvent` for same callId
- `SignalingConnecting` clears in-flight calls (no cross-session replay)

## Related

- PR #254 - Kotlin guard in `CallLifecycleHandler.releaseCall()` (stop-gap fix)
- This PR - root cause fix in `SignalingHub`