### PR TITLE
fix(signaling-service): stop orphaned SignalingForegroundService in pushBound mode

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/Messages.g.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/Messages.g.kt
@@ -236,7 +236,15 @@ data class PSignalingServiceStatus (
    * Obtained via [PluginUtilities.getCallbackHandle] and persisted via
    * [PSignalingServiceHostApi.saveModuleFactory]. 0 means no factory registered.
    */
-  val moduleFactoryHandle: Long
+  val moduleFactoryHandle: Long,
+  /**
+   * The mode the service was started with.
+   *
+   * Included in every onSynchronize call so the background Dart isolate can
+   * adapt its behaviour without reading Kotlin SharedPreferences directly.
+   * When [enabled] is false this field carries PERSISTENT as a placeholder.
+   */
+  val mode: PSignalingServiceMode
 )
  {
   companion object {
@@ -248,7 +256,8 @@ data class PSignalingServiceStatus (
       val trustedCertificatesJson = pigeonVar_list[4] as String?
       val incomingCallHandlerHandle = pigeonVar_list[5] as Long
       val moduleFactoryHandle = pigeonVar_list[6] as Long
-      return PSignalingServiceStatus(enabled, coreUrl, tenantId, token, trustedCertificatesJson, incomingCallHandlerHandle, moduleFactoryHandle)
+      val mode = PSignalingServiceMode.ofRaw((pigeonVar_list[7] as Long).toInt())!!
+      return PSignalingServiceStatus(enabled, coreUrl, tenantId, token, trustedCertificatesJson, incomingCallHandlerHandle, moduleFactoryHandle, mode)
     }
   }
   fun toList(): List<Any?> {
@@ -260,6 +269,7 @@ data class PSignalingServiceStatus (
       trustedCertificatesJson,
       incomingCallHandlerHandle,
       moduleFactoryHandle,
+      mode.raw.toLong(),
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -270,7 +280,7 @@ data class PSignalingServiceStatus (
       return true
     }
     val other = other as PSignalingServiceStatus
-    return MessagesPigeonUtils.deepEquals(this.enabled, other.enabled) && MessagesPigeonUtils.deepEquals(this.coreUrl, other.coreUrl) && MessagesPigeonUtils.deepEquals(this.tenantId, other.tenantId) && MessagesPigeonUtils.deepEquals(this.token, other.token) && MessagesPigeonUtils.deepEquals(this.trustedCertificatesJson, other.trustedCertificatesJson) && MessagesPigeonUtils.deepEquals(this.incomingCallHandlerHandle, other.incomingCallHandlerHandle) && MessagesPigeonUtils.deepEquals(this.moduleFactoryHandle, other.moduleFactoryHandle)
+    return MessagesPigeonUtils.deepEquals(this.enabled, other.enabled) && MessagesPigeonUtils.deepEquals(this.coreUrl, other.coreUrl) && MessagesPigeonUtils.deepEquals(this.tenantId, other.tenantId) && MessagesPigeonUtils.deepEquals(this.token, other.token) && MessagesPigeonUtils.deepEquals(this.trustedCertificatesJson, other.trustedCertificatesJson) && MessagesPigeonUtils.deepEquals(this.incomingCallHandlerHandle, other.incomingCallHandlerHandle) && MessagesPigeonUtils.deepEquals(this.moduleFactoryHandle, other.moduleFactoryHandle) && MessagesPigeonUtils.deepEquals(this.mode, other.mode)
   }
 
   override fun hashCode(): Int {
@@ -282,6 +292,7 @@ data class PSignalingServiceStatus (
     result = 31 * result + MessagesPigeonUtils.deepHash(this.trustedCertificatesJson)
     result = 31 * result + MessagesPigeonUtils.deepHash(this.incomingCallHandlerHandle)
     result = 31 * result + MessagesPigeonUtils.deepHash(this.moduleFactoryHandle)
+    result = 31 * result + MessagesPigeonUtils.deepHash(this.mode)
     return result
   }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -237,6 +237,7 @@ class SignalingForegroundService : Service() {
                 trustedCertificatesJson = null,
                 incomingCallHandlerHandle = 0L,
                 moduleFactoryHandle = 0L,
+                mode = PSignalingServiceMode.PERSISTENT,
             ),
         ) { result ->
             result.onSuccess { settle("isolate ACKed stop signal") }
@@ -278,6 +279,7 @@ class SignalingForegroundService : Service() {
                 trustedCertificatesJson = StorageDelegate.getTrustedCertificatesJson(applicationContext),
                 incomingCallHandlerHandle = StorageDelegate.getIncomingCallHandler(applicationContext),
                 moduleFactoryHandle = StorageDelegate.getModuleFactoryHandle(applicationContext),
+                mode = if (StorageDelegate.isPushBound(applicationContext)) PSignalingServiceMode.PUSH_BOUND else PSignalingServiceMode.PERSISTENT,
             ),
         ) { result ->
             result.onSuccess {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -38,6 +38,12 @@ class SignalingHub {
   /// (no subscribers — app is closed, persistent-service mode).
   bool get hasSubscribers => _subscribers.isNotEmpty;
 
+  /// Called when [hasSubscribers] transitions (false → true or true → false).
+  ///
+  /// Used by [SignalingForegroundIsolateManager] in pushBound mode to detect
+  /// when no subscriber remains and schedule a cleanup timer.
+  void Function(bool hasSubscribers)? onHasSubscribersChanged;
+
   /// Encoded events since the last [SignalingConnecting] event.
   /// Replayed to late subscribers so they receive the current session state.
   final List<List<dynamic>> _sessionBuffer = [];
@@ -128,8 +134,10 @@ class SignalingHub {
   }
 
   void _handleSubscribe(SignalingHubSubscribeCommand cmd) {
+    final wasEmpty = _subscribers.isEmpty;
     _subscribers[cmd.consumerId] = cmd.replyPort;
     _logger.fine('Hub subscriber added: ${cmd.consumerId} (total: ${_subscribers.length})');
+    if (wasEmpty) onHasSubscribersChanged?.call(true);
     // Ack first so the subscriber knows the hub port is alive (not stale).
     cmd.replyPort.send(encodeSubAck());
     // Replay current session buffer so the new subscriber gets the full state.
@@ -141,6 +149,7 @@ class SignalingHub {
   void _handleUnsubscribe(SignalingHubUnsubscribeCommand cmd) {
     _subscribers.remove(cmd.consumerId);
     _logger.fine('Hub subscriber removed: ${cmd.consumerId} (total: ${_subscribers.length})');
+    if (_subscribers.isEmpty) onHasSubscribersChanged?.call(false);
   }
 
   void _handleExecute(SignalingHubExecuteCommand cmd) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -147,9 +147,10 @@ class SignalingHub {
   }
 
   void _handleUnsubscribe(SignalingHubUnsubscribeCommand cmd) {
+    final wasNotEmpty = _subscribers.isNotEmpty;
     _subscribers.remove(cmd.consumerId);
     _logger.fine('Hub subscriber removed: ${cmd.consumerId} (total: ${_subscribers.length})');
-    if (_subscribers.isEmpty) onHasSubscribersChanged?.call(false);
+    if (wasNotEmpty && _subscribers.isEmpty) onHasSubscribersChanged?.call(false);
   }
 
   void _handleExecute(SignalingHubExecuteCommand cmd) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -267,8 +267,9 @@ class SignalingForegroundIsolateManager {
   /// [START_NOT_STICKY], so after [stopService] the OS will not restart the service.
   void _requestServiceStop() {
     _logger.info('pushBound: grace period elapsed with no subscribers — requesting service stop');
-    if (_testStopService != null) {
-      _testStopService!();
+    final stopOverride = _testStopService;
+    if (stopOverride != null) {
+      stopOverride();
     } else {
       PSignalingServiceHostApi().stopService();
     }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'dart:ui' show CallbackHandle, PluginUtilities;
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart' show VoidCallback, visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
@@ -47,8 +47,10 @@ class SignalingForegroundIsolateManager {
     this.pushBoundNoSubscriberGrace = const Duration(seconds: 10),
     @visibleForTesting SignalingModuleFactory? moduleFactory,
     @visibleForTesting SignalingHubFactory? hubFactory,
+    @visibleForTesting VoidCallback? stopServiceOverride,
   }) : _testModuleFactory = moduleFactory,
-       _testHubFactory = hubFactory;
+       _testHubFactory = hubFactory,
+       _testStopService = stopServiceOverride;
 
   final String coreUrl;
   final String tenantId;
@@ -94,6 +96,10 @@ class SignalingForegroundIsolateManager {
 
   /// Overrides [SignalingHub] construction in tests to avoid [IsolateNameServer].
   final SignalingHubFactory? _testHubFactory;
+
+  /// Overrides [PSignalingServiceHostApi().stopService()] in tests to avoid
+  /// binary-messenger dependency.
+  final VoidCallback? _testStopService;
 
   SignalingModule? _signalingModule;
   SignalingHub? _hub;
@@ -151,6 +157,12 @@ class SignalingForegroundIsolateManager {
       _hub!.onHasSubscribersChanged = _onHubHasSubscribersChanged;
     }
     _hub!.start();
+    if (isPushBound && !_hub!.hasSubscribers) {
+      // No subscriber at start time (typical push-started service where the
+      // Activity has not connected yet). Schedule the cleanup timer now so
+      // the service stops if the Activity never launches.
+      _onHubHasSubscribersChanged(false);
+    }
 
     _eventsSubscription = _signalingModule!.events.listen(_onEvent);
     _signalingModule!.connect();
@@ -255,7 +267,11 @@ class SignalingForegroundIsolateManager {
   /// [START_NOT_STICKY], so after [stopService] the OS will not restart the service.
   void _requestServiceStop() {
     _logger.info('pushBound: grace period elapsed with no subscribers — requesting service stop');
-    PSignalingServiceHostApi().stopService();
+    if (_testStopService != null) {
+      _testStopService!();
+    } else {
+      PSignalingServiceHostApi().stopService();
+    }
   }
 
   /// Schedules an auto-reconnect for persistent-service mode (no hub subscribers).

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -108,7 +108,7 @@ class SignalingForegroundIsolateManager {
   Timer? _reconnectTimer;
 
   /// Scheduled in pushBound mode when [SignalingHub.hasSubscribers] drops to
-  /// false. Fires [_requestServiceStop] after [_pushBoundNoSubscriberGrace] if
+  /// false. Fires [_requestServiceStop] after [pushBoundNoSubscriberGrace] if
   /// no new subscriber arrives. Cancelled when a subscriber connects.
   Timer? _pushBoundCleanupTimer;
 
@@ -271,7 +271,12 @@ class SignalingForegroundIsolateManager {
     if (stopOverride != null) {
       stopOverride();
     } else {
-      PSignalingServiceHostApi().stopService();
+      unawaited(
+        PSignalingServiceHostApi().stopService().catchError(
+          (Object error, StackTrace stackTrace) =>
+              _logger.warning('pushBound: failed to request foreground service stop', error, stackTrace),
+        ),
+      );
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -9,6 +9,7 @@ import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_s
 import 'package:ssl_certificates/ssl_certificates.dart';
 
 import '../hub/signaling_hub.dart';
+import '../messages.g.dart';
 
 final _logger = Logger('SignalingForegroundIsolateManager');
 
@@ -42,6 +43,7 @@ class SignalingForegroundIsolateManager {
     this.trustedCertificatesJson,
     this.incomingCallHandlerHandle = 0,
     this.moduleFactoryHandle = 0,
+    this.isPushBound = false,
     @visibleForTesting SignalingModuleFactory? moduleFactory,
     @visibleForTesting SignalingHubFactory? hubFactory,
   }) : _testModuleFactory = moduleFactory,
@@ -69,6 +71,14 @@ class SignalingForegroundIsolateManager {
   /// 0 means no factory is registered -- the isolate will log an error and skip start.
   final int moduleFactoryHandle;
 
+  /// Whether the service was started in pushBound mode.
+  ///
+  /// In pushBound mode the service lifetime is tied to the Activity: it should
+  /// stop automatically when no subscriber (Activity or push-notification isolate)
+  /// remains connected after a short grace period. Without this guard the service
+  /// becomes orphaned when a call is declined before the Activity connects.
+  final bool isPushBound;
+
   /// Overrides handle-based [SignalingModule] creation in tests.
   final SignalingModuleFactory? _testModuleFactory;
 
@@ -80,6 +90,11 @@ class SignalingForegroundIsolateManager {
 
   StreamSubscription<SignalingModuleEvent>? _eventsSubscription;
   Timer? _reconnectTimer;
+
+  /// Scheduled in pushBound mode when [SignalingHub.hasSubscribers] drops to
+  /// false. Fires [_requestServiceStop] after [_pushBoundNoSubscriberGrace] if
+  /// no new subscriber arrives. Cancelled when a subscriber connects.
+  Timer? _pushBoundCleanupTimer;
 
   bool _started = false;
 
@@ -122,6 +137,9 @@ class SignalingForegroundIsolateManager {
     _signalingModule = factory(config);
 
     _hub = (_testHubFactory ?? SignalingHub.new)(_signalingModule!);
+    if (isPushBound) {
+      _hub!.onHasSubscribersChanged = _onHubHasSubscribersChanged;
+    }
     _hub!.start();
 
     _eventsSubscription = _signalingModule!.events.listen(_onEvent);
@@ -138,6 +156,8 @@ class SignalingForegroundIsolateManager {
 
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    _pushBoundCleanupTimer?.cancel();
+    _pushBoundCleanupTimer = null;
     await _eventsSubscription?.cancel();
     await _hub?.dispose();
     await _signalingModule?.dispose();
@@ -198,6 +218,40 @@ class SignalingForegroundIsolateManager {
       default:
         break;
     }
+  }
+
+  /// Grace period before stopping the service in pushBound mode when no
+  /// subscriber is present. Long enough for the Activity to start and subscribe
+  /// after a normal incoming call, but short enough to reclaim resources when
+  /// the call is declined before the Activity connects.
+  static const _pushBoundNoSubscriberGrace = Duration(seconds: 30);
+
+  /// Called by [SignalingHub] when [hasSubscribers] transitions.
+  ///
+  /// In pushBound mode: schedules a cleanup timer when the last subscriber
+  /// leaves, and cancels it when a new subscriber arrives. When the timer fires
+  /// with no subscriber present the service is asked to stop — it means the
+  /// Activity never connected (call declined/missed before it launched).
+  void _onHubHasSubscribersChanged(bool hasSubscribers) {
+    if (hasSubscribers) {
+      _pushBoundCleanupTimer?.cancel();
+      _pushBoundCleanupTimer = null;
+      _logger.info('pushBound: subscriber arrived — cleanup timer cancelled');
+    } else {
+      _pushBoundCleanupTimer?.cancel();
+      _pushBoundCleanupTimer = Timer(_pushBoundNoSubscriberGrace, _requestServiceStop);
+      _logger.info('pushBound: no subscribers — scheduling stop in ${_pushBoundNoSubscriberGrace.inSeconds}s');
+    }
+  }
+
+  /// Asks Kotlin to stop the foreground service via the existing Pigeon HostApi.
+  ///
+  /// Called when the pushBound cleanup timer fires (no subscriber for the full
+  /// grace period). Kotlin's [SignalingForegroundService.onStartCommand] returned
+  /// [START_NOT_STICKY], so after [stopService] the OS will not restart the service.
+  void _requestServiceStop() {
+    _logger.info('pushBound: grace period elapsed with no subscribers — requesting service stop');
+    PSignalingServiceHostApi().stopService();
   }
 
   /// Schedules an auto-reconnect for persistent-service mode (no hub subscribers).

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -44,6 +44,7 @@ class SignalingForegroundIsolateManager {
     this.incomingCallHandlerHandle = 0,
     this.moduleFactoryHandle = 0,
     this.isPushBound = false,
+    this.pushBoundNoSubscriberGrace = const Duration(seconds: 10),
     @visibleForTesting SignalingModuleFactory? moduleFactory,
     @visibleForTesting SignalingHubFactory? hubFactory,
   }) : _testModuleFactory = moduleFactory,
@@ -78,6 +79,15 @@ class SignalingForegroundIsolateManager {
   /// remains connected after a short grace period. Without this guard the service
   /// becomes orphaned when a call is declined before the Activity connects.
   final bool isPushBound;
+
+  /// How long to wait after the last subscriber disconnects before stopping
+  /// the service in pushBound mode.
+  ///
+  /// Allows time for the Activity to start and subscribe after a normal incoming
+  /// call. If a subscriber arrives within this window the timer is cancelled and
+  /// the service continues normally. Exposed as a constructor parameter so it
+  /// can be overridden in tests without sleeping.
+  final Duration pushBoundNoSubscriberGrace;
 
   /// Overrides handle-based [SignalingModule] creation in tests.
   final SignalingModuleFactory? _testModuleFactory;
@@ -220,12 +230,6 @@ class SignalingForegroundIsolateManager {
     }
   }
 
-  /// Grace period before stopping the service in pushBound mode when no
-  /// subscriber is present. Long enough for the Activity to start and subscribe
-  /// after a normal incoming call, but short enough to reclaim resources when
-  /// the call is declined before the Activity connects.
-  static const _pushBoundNoSubscriberGrace = Duration(seconds: 30);
-
   /// Called by [SignalingHub] when [hasSubscribers] transitions.
   ///
   /// In pushBound mode: schedules a cleanup timer when the last subscriber
@@ -239,8 +243,8 @@ class SignalingForegroundIsolateManager {
       _logger.info('pushBound: subscriber arrived — cleanup timer cancelled');
     } else {
       _pushBoundCleanupTimer?.cancel();
-      _pushBoundCleanupTimer = Timer(_pushBoundNoSubscriberGrace, _requestServiceStop);
-      _logger.info('pushBound: no subscribers — scheduling stop in ${_pushBoundNoSubscriberGrace.inSeconds}s');
+      _pushBoundCleanupTimer = Timer(pushBoundNoSubscriberGrace, _requestServiceStop);
+      _logger.info('pushBound: no subscribers — scheduling stop in ${pushBoundNoSubscriberGrace.inSeconds}s');
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
@@ -36,7 +36,8 @@ Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
           existing.token != status.token ||
           existing.trustedCertificatesJson != status.trustedCertificatesJson ||
           existing.incomingCallHandlerHandle != status.incomingCallHandlerHandle ||
-          existing.moduleFactoryHandle != status.moduleFactoryHandle;
+          existing.moduleFactoryHandle != status.moduleFactoryHandle ||
+          existing.isPushBound != (status.mode == PSignalingServiceMode.pushBound);
       if (configChanged) {
         _logger.info('onSignalingServiceSync config changed, recreating manager');
         await existing.handleStatus(enabled: false);
@@ -53,6 +54,7 @@ Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
       trustedCertificatesJson: status.trustedCertificatesJson,
       incomingCallHandlerHandle: status.incomingCallHandlerHandle,
       moduleFactoryHandle: status.moduleFactoryHandle,
+      isPushBound: status.mode == PSignalingServiceMode.pushBound,
     );
   }
   await _manager?.handleStatus(enabled: status.enabled);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/messages.g.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/messages.g.dart
@@ -122,6 +122,7 @@ class PSignalingServiceStatus {
     this.trustedCertificatesJson,
     required this.incomingCallHandlerHandle,
     required this.moduleFactoryHandle,
+    required this.mode,
   });
 
   bool enabled;
@@ -153,6 +154,14 @@ class PSignalingServiceStatus {
   /// [PSignalingServiceHostApi.saveModuleFactory]. 0 means no factory registered.
   int moduleFactoryHandle;
 
+  /// The mode the service was started with.
+  ///
+  /// Included in every [onSynchronize] call so the background Dart isolate can
+  /// adapt its behaviour without reading Kotlin SharedPreferences directly.
+  /// When [enabled] is false this field carries [PSignalingServiceMode.persistent]
+  /// as a placeholder; consumers must not act on it in that case.
+  PSignalingServiceMode mode;
+
   List<Object?> _toList() {
     return <Object?>[
       enabled,
@@ -162,6 +171,7 @@ class PSignalingServiceStatus {
       trustedCertificatesJson,
       incomingCallHandlerHandle,
       moduleFactoryHandle,
+      mode.index,
     ];
   }
 
@@ -178,6 +188,7 @@ class PSignalingServiceStatus {
       trustedCertificatesJson: result[4] as String?,
       incomingCallHandlerHandle: result[5]! as int,
       moduleFactoryHandle: result[6]! as int,
+      mode: PSignalingServiceMode.values[result[7]! as int],
     );
   }
 
@@ -190,7 +201,7 @@ class PSignalingServiceStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(enabled, other.enabled) && _deepEquals(coreUrl, other.coreUrl) && _deepEquals(tenantId, other.tenantId) && _deepEquals(token, other.token) && _deepEquals(trustedCertificatesJson, other.trustedCertificatesJson) && _deepEquals(incomingCallHandlerHandle, other.incomingCallHandlerHandle) && _deepEquals(moduleFactoryHandle, other.moduleFactoryHandle);
+    return _deepEquals(enabled, other.enabled) && _deepEquals(coreUrl, other.coreUrl) && _deepEquals(tenantId, other.tenantId) && _deepEquals(token, other.token) && _deepEquals(trustedCertificatesJson, other.trustedCertificatesJson) && _deepEquals(incomingCallHandlerHandle, other.incomingCallHandlerHandle) && _deepEquals(moduleFactoryHandle, other.moduleFactoryHandle) && _deepEquals(mode, other.mode);
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
@@ -29,6 +29,7 @@ class PSignalingServiceStatus {
     required this.token,
     required this.incomingCallHandlerHandle,
     required this.moduleFactoryHandle,
+    required this.mode,
     this.trustedCertificatesJson,
   });
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
@@ -57,6 +57,14 @@ class PSignalingServiceStatus {
   /// Obtained via [PluginUtilities.getCallbackHandle] and persisted via
   /// [PSignalingServiceHostApi.saveModuleFactory]. 0 means no factory registered.
   final int moduleFactoryHandle;
+
+  /// The mode the service was started with.
+  ///
+  /// Included in every [onSynchronize] call so the background Dart isolate can
+  /// adapt its behaviour without reading Kotlin SharedPreferences directly.
+  /// When [enabled] is false this field carries [PSignalingServiceMode.persistent]
+  /// as a placeholder; consumers must not act on it in that case.
+  final PSignalingServiceMode mode;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
@@ -98,11 +98,25 @@ class _FakeSignalingHub extends Fake implements SignalingHub {
   @override
   bool hasSubscribers = true;
 
+  /// Mirrors the real hub's [onHasSubscribersChanged] hook so tests can
+  /// drive subscriber-count transitions directly.
+  @override
+  void Function(bool hasSubscribers)? onHasSubscribersChanged;
+
   @override
   void start() {}
 
   @override
   Future<void> dispose() async {}
+
+  /// Simulates a subscriber connecting or disconnecting.
+  ///
+  /// Updates [hasSubscribers] and fires [onHasSubscribersChanged], matching
+  /// what the real hub does on a 0→1 or 1→0 transition.
+  void simulateSubscriberChange({required bool hasSubscribers}) {
+    this.hasSubscribers = hasSubscribers;
+    onHasSubscribersChanged?.call(hasSubscribers);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +150,34 @@ SignalingForegroundIsolateManager _makeManagerPersistentMode(_FakeSignalingModul
     moduleFactory: (_) => module,
     hubFactory: (m) => _FakeSignalingHub(m)..hasSubscribers = false,
   );
+}
+
+/// Creates a pushBound manager and exposes the hub so tests can trigger
+/// subscriber transitions.
+///
+/// [stopServiceCalls] is incremented every time [_requestServiceStop] fires,
+/// which substitutes for the Pigeon [PSignalingServiceHostApi().stopService()]
+/// call that is unavailable in unit tests.
+({SignalingForegroundIsolateManager manager, _FakeSignalingHub Function() hub, List<int> stopServiceCalls})
+_makePushBoundManager(_FakeSignalingModule module, {Duration grace = const Duration(milliseconds: 50)}) {
+  _FakeSignalingHub? capturedHub;
+  final stopCalls = <int>[];
+
+  final manager = SignalingForegroundIsolateManager(
+    coreUrl: 'wss://example.com',
+    tenantId: 'tenant',
+    token: 'tok',
+    isPushBound: true,
+    pushBoundNoSubscriberGrace: grace,
+    moduleFactory: (_) => module,
+    hubFactory: (m) {
+      capturedHub = _FakeSignalingHub(m)..hasSubscribers = false;
+      return capturedHub!;
+    },
+    stopServiceOverride: () => stopCalls.add(1),
+  );
+
+  return (manager: manager, hub: () => capturedHub!, stopServiceCalls: stopCalls);
 }
 
 // ---------------------------------------------------------------------------
@@ -339,6 +381,122 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 150));
 
       expect(module.connectCount, 1, reason: 'timer cancelled by stop() — no reconnect after dispose');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // pushBound mode — orphan-service cleanup
+  // -------------------------------------------------------------------------
+
+  // In pushBound mode the service is started by a push notification and is
+  // expected to stop itself when the Activity never connects (e.g. call
+  // declined from lock screen before the app launches).
+  //
+  // The manager schedules a cleanup timer when no subscriber is present and
+  // cancels it when a subscriber arrives. If the timer fires with still no
+  // subscriber, stopService() is called so the service does not linger.
+
+  group('SignalingForegroundIsolateManager -- pushBound cleanup timer', () {
+    test('stopService called after grace period when no subscriber ever connects', () async {
+      final module = _FakeSignalingModule();
+      final (:manager, :hub, :stopServiceCalls) = _makePushBoundManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      // Start: hub has no subscribers by default (push-started service, no
+      // Activity yet). The manager should schedule the cleanup timer.
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Grace period has not elapsed yet — stopService not called.
+      expect(stopServiceCalls, isEmpty);
+
+      // Wait past the grace period.
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(stopServiceCalls, hasLength(1), reason: 'stopService must fire after grace period with no subscriber');
+    });
+
+    test('cleanup timer is cancelled when a subscriber arrives within the grace period', () async {
+      final module = _FakeSignalingModule();
+      final (:manager, :hub, :stopServiceCalls) = _makePushBoundManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Activity connects before the grace period expires.
+      hub().simulateSubscriberChange(hasSubscribers: true);
+
+      // Wait past the grace period — timer should have been cancelled.
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(stopServiceCalls, isEmpty, reason: 'subscriber arrived — cleanup timer must be cancelled');
+    });
+
+    test('new cleanup timer is scheduled when subscriber disconnects after initial connect', () async {
+      final module = _FakeSignalingModule();
+      final (:manager, :hub, :stopServiceCalls) = _makePushBoundManager(module);
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Activity connects, cancelling the first cleanup timer.
+      hub().simulateSubscriberChange(hasSubscribers: true);
+
+      // Activity disconnects — a new cleanup timer should be scheduled.
+      hub().simulateSubscriberChange(hasSubscribers: false);
+
+      // Wait past the grace period.
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(stopServiceCalls, hasLength(1), reason: 'last subscriber left — stopService must fire after grace period');
+    });
+
+    test('stop() cancels the cleanup timer — stopService not called after explicit stop', () async {
+      final module = _FakeSignalingModule();
+      final (:manager, :hub, :stopServiceCalls) = _makePushBoundManager(module);
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Explicit stop before the grace period expires.
+      await manager.handleStatus(enabled: false);
+
+      // Wait past the grace period — timer should have been cancelled by stop().
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(stopServiceCalls, isEmpty, reason: 'explicit stop cancels cleanup timer');
+    });
+
+    test('persistent mode (isPushBound=false) never schedules a cleanup timer', () async {
+      final module = _FakeSignalingModule();
+      _FakeSignalingHub? capturedHub;
+      final stopCalls = <int>[];
+
+      final manager = SignalingForegroundIsolateManager(
+        coreUrl: 'wss://example.com',
+        tenantId: 'tenant',
+        token: 'tok',
+        isPushBound: false,
+        moduleFactory: (_) => module,
+        hubFactory: (m) {
+          capturedHub = _FakeSignalingHub(m);
+          return capturedHub!;
+        },
+        stopServiceOverride: () => stopCalls.add(1),
+      );
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Simulate subscriber leaving — in persistent mode this must be a no-op.
+      capturedHub!.simulateSubscriberChange(hasSubscribers: false);
+
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(stopCalls, isEmpty, reason: 'persistent mode must not schedule cleanup timer');
     });
   });
 


### PR DESCRIPTION
## Problem

In pushBound mode `SignalingForegroundService` is designed to live only while the Activity is connected — `onStartCommand` returns `START_NOT_STICKY` and `onTaskRemoved` calls `gracefulStop`. 

The service becomes orphaned when a call is declined **before** the Activity launches (declined from lock-screen, missed call, or the auto-decline bug from PR #1127). The Activity never subscribes to `SignalingHub`, `hasSubscribers` stays false, and the service runs indefinitely — behaving like an unintended persistent mode with an open WebSocket and a visible "Signaling Service" notification.

Root cause documented in `bugs/open/2026-04-15-wt-1306-incoming-call-no-screen/pushbound-orphan-signaling-service.md`.

## Fix

1. **`PSignalingServiceStatus`** — add `mode: PSignalingServiceMode` field (Pigeon Dart + Kotlin). Kotlin passes `isPushBound ? PUSH_BOUND : PERSISTENT` in every `synchronizeIsolate()` call so the background Dart isolate knows the mode without reading SharedPreferences.

2. **`SignalingHub.onHasSubscribersChanged`** — new callback fired on 0↔1 subscriber transitions. Avoids polling; the manager reacts immediately when the last subscriber leaves.

3. **`SignalingForegroundIsolateManager.isPushBound`** — new field threaded from `onSignalingServiceSync`. When `true`, wires the hub callback and starts a 30s cleanup timer whenever `hasSubscribers` drops to false. If a subscriber arrives before the timer fires (normal Activity flow), the timer is cancelled. If the timer fires with no subscriber, calls `PSignalingServiceHostApi().stopService()` — `START_NOT_STICKY` prevents OS restart.

## Timeline (fixed)

```
FCM -> SignalingForegroundService starts (START_NOT_STICKY)
     -> SignalingHub starts, WebSocket connects
     -> push-isolate subscribes, processes call, unsubscribes
        hasSubscribers -> false -> 30s timer starts
     -> Activity NEVER launches (call declined)
     -> 30s grace elapses -> PSignalingServiceHostApi().stopService()
        -> service stops, WebSocket closed, no orphan
```

## Related

- PR #1127 - SignalingHub fix: buffer IncomingCallEvent for late subscribers (root cause of most auto-declines)
- PR #254 - Kotlin guard in `CallLifecycleHandler.releaseCall()`