### PR TITLE
fix(android): fix push-answered call handoff — handoffCall + SignalingHub event replay

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2096,6 +2096,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     event.fulfill();
 
     ActiveCall? call = state.retrieveActiveCall(event.callId);
+    _logger.info(
+      '__onCallPerformEventAnswered: retrieveActiveCall=${call != null ? "found" : "NULL"} callId=${event.callId}',
+    );
     if (call == null) return;
 
     // Prevent performing double answer and race conditions

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2096,9 +2096,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     event.fulfill();
 
     ActiveCall? call = state.retrieveActiveCall(event.callId);
-    _logger.info(
-      '__onCallPerformEventAnswered: retrieveActiveCall=${call != null ? "found" : "NULL"} callId=${event.callId}',
-    );
     if (call == null) return;
 
     // Prevent performing double answer and race conditions

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -69,6 +69,12 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   /// Completer resolved when all isolate work is done and [releaseCall] has been called.
   Completer<void>? _completer;
 
+  /// Set to true when [performAnswerCall] is received from the native side,
+  /// indicating the user answered via the push notification. Used in [close]
+  /// to call [handoffCall] instead of [releaseCall] so the PhoneConnection
+  /// is not terminated before the Activity can adopt it.
+  bool _callAnswered = false;
+
   // Workaround: captures init time as fallback timestamp for call logs.
   final DateTime _initialConnectionTime = DateTime.now();
 
@@ -121,7 +127,11 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       await _signalingSubscription.cancel();
       await _signalingModule.dispose();
     }
-    await _releaseCall(_metadata?.callId);
+    if (_callAnswered) {
+      await _handoffCall(_metadata?.callId);
+    } else {
+      await _releaseCall(_metadata?.callId);
+    }
     _completeWithError(StateError('PushNotificationIsolateManager closed'));
   }
 
@@ -140,6 +150,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
   @override
   void performAnswerCall(String callId) async {
+    _callAnswered = true;
     final hasNetwork = await Connectivity().checkConnectivity().then(
       (r) => r.isNotEmpty && !r.contains(ConnectivityResult.none),
     );
@@ -393,6 +404,15 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       await _pushService.releaseCall(callId);
     } catch (e) {
       logger.severe('_releaseCall failed: $e');
+    }
+  }
+
+  Future<void> _handoffCall(String? callId) async {
+    if (callId == null) return;
+    try {
+      await _pushService.handoffCall(callId);
+    } catch (e) {
+      logger.severe('_handoffCall failed: $e');
     }
   }
 

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -66,14 +66,17 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   /// Requests queued while the signaling module is not yet connected.
   final List<_PendingRequest> _pendingRequests = [];
 
-  /// Completer resolved when all isolate work is done and [releaseCall] has been called.
+  /// Completer resolved when all isolate work is done and [_releaseCall] or
+  /// [_handoffCall] has been called (depending on whether the call was answered).
   Completer<void>? _completer;
 
-  /// Set to true when [performAnswerCall] is received from the native side,
-  /// indicating the user answered via the push notification. Used in [close]
-  /// to call [handoffCall] instead of [releaseCall] so the PhoneConnection
-  /// is not terminated before the Activity can adopt it.
-  bool _callAnswered = false;
+  /// The callId of the call answered via the push notification.
+  ///
+  /// Set in [performAnswerCall] only when a network connection is confirmed.
+  /// Used in [close] to call [_handoffCall] instead of [_releaseCall] so the
+  /// PhoneConnection is not terminated before the Activity can adopt it.
+  /// Null means the call was not answered (missed, declined, or no network).
+  String? _answeredCallId;
 
   // Workaround: captures init time as fallback timestamp for call logs.
   final DateTime _initialConnectionTime = DateTime.now();
@@ -101,6 +104,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       throw StateError('PushNotificationIsolateManager.run() called before init()');
     }
     _metadata = metadata;
+    _answeredCallId = null;
     _completer = Completer<void>();
     logger.info('run: callId=${metadata?.callId} isConnected=${_signalingModule.isConnected}');
     // WebtritSignalingService.connect() is idempotent: the internal
@@ -127,8 +131,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       await _signalingSubscription.cancel();
       await _signalingModule.dispose();
     }
-    if (_callAnswered) {
-      await _handoffCall(_metadata?.callId);
+    if (_answeredCallId != null) {
+      await _handoffCall(_answeredCallId);
     } else {
       await _releaseCall(_metadata?.callId);
     }
@@ -149,14 +153,19 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   }
 
   @override
-  void performAnswerCall(String callId) async {
-    _callAnswered = true;
+  void performAnswerCall(String callId) {
+    _handlePerformAnswerCall(callId);
+  }
+
+  Future<void> _handlePerformAnswerCall(String callId) async {
     final hasNetwork = await Connectivity().checkConnectivity().then(
       (r) => r.isNotEmpty && !r.contains(ConnectivityResult.none),
     );
     if (!hasNetwork) {
-      throw Exception('performAnswerCall: no network for callId=$callId');
+      logger.warning('performAnswerCall: no network for callId=$callId, skipping handoff');
+      return;
     }
+    _answeredCallId = callId;
   }
 
   // ---------------------------------------------------------------------------
@@ -432,8 +441,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     if (callId == null) return;
     try {
       await _pushService.handoffCall(callId);
-    } catch (e) {
-      logger.severe('_handoffCall failed: $e');
+    } catch (e, st) {
+      logger.severe('_handoffCall failed: $e', e, st);
     }
   }
 

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -216,8 +216,22 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     }
 
     if (_lines.isEmpty) {
-      logger.info('Handshake: no active lines - ending calls');
-      _onNoActiveLines();
+      // The hub sends StateHandshake first, then replays IncomingCallEvent entries
+      // from _callEventHistory. When a call arrived as a protocol event (not in
+      // StateHandshake lines), the push isolate would see 0 lines and immediately
+      // call _onNoActiveLines() before the IncomingCallEvent from _callEventHistory
+      // replay is processed. Defer to the next event-loop turn so any pending
+      // port messages (including replayed protocol events) are handled first.
+      logger.info('Handshake: no active lines, deferring check for protocol-event calls');
+      Future(() {
+        if (_incomingCallEvents.containsKey(_metadata?.callId)) {
+          logger.info('Handshake deferred: found incoming call from history callId=${_metadata?.callId}, proceeding');
+          _executePendingRequests();
+        } else {
+          logger.info('Handshake deferred: no incoming call found - ending calls');
+          _onNoActiveLines();
+        }
+      });
       return;
     }
 
@@ -241,6 +255,13 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     switch (event) {
       case IncomingCallEvent():
         _incomingCallEvents[event.callId] = event;
+        // Populate _lines so _sendRequest can resolve the line index for this call.
+        // Calls that arrive as protocol events (not in StateHandshake) are not
+        // present in _lines after _onHandshake; add them here so pending requests
+        // can be executed once the deferred handshake check runs.
+        if (event.line != null) {
+          _lines[event.callId] = event.line!;
+        }
       case HangupEvent():
         final incomingEventLog = _incomingCallEvents[event.callId];
         _onHangupCall(event, (

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -44,8 +44,16 @@ class SignalingHub {
   /// when no subscriber remains and schedule a cleanup timer.
   void Function(bool hasSubscribers)? onHasSubscribersChanged;
 
-  /// Encoded events since the last [SignalingConnecting] event.
-  /// Replayed to late subscribers so they receive the current session state.
+  /// Encoded non-protocol events since the last [SignalingConnecting] event.
+  ///
+  /// Replayed to late subscribers so they receive the current connection state
+  /// ([SignalingConnecting], [SignalingConnected], [SignalingHandshakeReceived]).
+  ///
+  /// Protocol events ([SignalingProtocolEvent]) are intentionally excluded:
+  /// call-level events are tracked separately in [_callEventHistory] so that
+  /// ended calls can be evicted in O(1) without scanning this list. Storing
+  /// all protocol events here would require decoding each entry on eviction
+  /// and would cause the buffer to grow unboundedly over a long session.
   final List<List<dynamic>> _sessionBuffer = [];
 
   /// callId → ordered list of encoded [SignalingProtocolEvent]s for that call.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -48,6 +48,25 @@ class SignalingHub {
   /// Replayed to late subscribers so they receive the current session state.
   final List<List<dynamic>> _sessionBuffer = [];
 
+  /// callId → ordered list of encoded [SignalingProtocolEvent]s for that call.
+  ///
+  /// Tracks the lifecycle of each incoming call that arrived during the current
+  /// WebSocket session so that late subscribers (e.g. the Activity opening
+  /// after a push-notification isolate has already processed the call) receive
+  /// the full event sequence and can reconstruct the correct current state.
+  ///
+  /// Without this map a subscriber that opens after [AcceptedEvent] would only
+  /// receive [IncomingCallEvent] from [_inflightIncomingCalls] and incorrectly
+  /// treat an already-answered call as still ringing.
+  ///
+  /// Lifecycle:
+  /// - [IncomingCallEvent] → new entry created for callId.
+  /// - Subsequent [CallEvent]s (e.g. [AcceptedEvent], [RingingEvent]) → appended.
+  /// - Terminal events ([HangupEvent], [MissedCallEvent]) → entry removed;
+  ///   the dead call's line is also evicted from the buffered handshake.
+  /// - [SignalingConnecting] → entire map cleared (new session).
+  final Map<String, List<List<dynamic>>> _callEventHistory = {};
+
   StreamSubscription<SignalingModuleEvent>? _moduleSubscription;
   bool _started = false;
 
@@ -85,14 +104,81 @@ class SignalingHub {
     _receivePort.close();
     _subscribers.clear();
     _sessionBuffer.clear();
+    _callEventHistory.clear();
     _logger.fine('Hub disposed');
   }
 
   void _onModuleEvent(SignalingModuleEvent event) {
-    if (event is SignalingConnecting) _sessionBuffer.clear();
+    if (event is SignalingConnecting) {
+      _sessionBuffer.clear();
+      _callEventHistory.clear();
+    }
     final encoded = encodeHubEvent(event);
-    if (event is! SignalingProtocolEvent) _sessionBuffer.add(encoded);
+    if (event is! SignalingProtocolEvent) {
+      _sessionBuffer.add(encoded);
+    } else {
+      _updateCallHistory(event.event, encoded);
+    }
     _broadcast(encoded);
+  }
+
+  /// Updates [_callEventHistory] based on a protocol event.
+  ///
+  /// - [IncomingCallEvent]: starts a new history entry for that callId.
+  /// - Subsequent [CallEvent]s: appended to the existing history so that late
+  ///   subscribers replay the full sequence (e.g. [IncomingCallEvent] →
+  ///   [AcceptedEvent]) and reach the correct current state.
+  /// - Terminal events ([HangupEvent], [MissedCallEvent]): remove the history
+  ///   entry and evict the dead call's line from the buffered handshake.
+  /// - Non-[CallEvent] protocol events: no call history affected.
+  void _updateCallHistory(Event event, List<dynamic> encoded) {
+    if (event is IncomingCallEvent) {
+      _callEventHistory[event.callId] = [encoded];
+      return;
+    }
+    if (event is! CallEvent) return;
+
+    if (event is HangupEvent || event is MissedCallEvent) {
+      // Always evict the dead call's line from the handshake — regardless of
+      // whether this call was tracked in [_callEventHistory]. Calls that arrived
+      // in the initial [StateHandshake] (before the hub started) are never added
+      // to [_callEventHistory], but their stale handshake line must still be
+      // removed so late subscribers don't see an ended call in handshake.lines.
+      _evictHandshakeLine(event.callId);
+      _callEventHistory.remove(event.callId);
+      _logger.fine('Hub: call history removed (terminal) callId=${event.callId}');
+      return;
+    }
+
+    // Non-terminal event: append to history if this call is being tracked
+    // (i.e. it arrived via IncomingCallEvent during this session).
+    final history = _callEventHistory[event.callId];
+    if (history != null) {
+      history.add(encoded);
+      _logger.fine('Hub: call history appended ${event.runtimeType} callId=${event.callId}');
+    }
+  }
+
+  /// Removes the [callId] entry from the [lines] list inside the buffered
+  /// [SignalingHandshakeReceived] entry (if present).
+  ///
+  /// Mutates the encoded map in-place: no re-encoding required because
+  /// [_sessionBuffer] holds a direct reference to the same [Map] object that
+  /// [encodeHubEvent] produced for the handshake.
+  void _evictHandshakeLine(String callId) {
+    for (final entry in _sessionBuffer) {
+      if (!isHubEventHandshakeReceived(entry) || entry.length < 2) continue;
+      final map = entry[1];
+      if (map is! Map) continue;
+      final lines = map['lines'];
+      if (lines is! List) continue;
+      final before = lines.length;
+      lines.removeWhere((l) => l is Map && l['call_id'] == callId);
+      if (lines.length != before) {
+        _logger.fine('Hub: evicted handshake line callId=$callId');
+      }
+      return;
+    }
   }
 
   void _broadcast(List<dynamic> encoded) {
@@ -140,9 +226,19 @@ class SignalingHub {
     if (wasEmpty) onHasSubscribersChanged?.call(true);
     // Ack first so the subscriber knows the hub port is alive (not stale).
     cmd.replyPort.send(encodeSubAck());
-    // Replay current session buffer so the new subscriber gets the full state.
+    // Replay current session buffer so the new subscriber gets the full connection state.
     for (final event in List<List<dynamic>>.from(_sessionBuffer)) {
       cmd.replyPort.send(event);
+    }
+    // Replay the full event history for each active in-session call.
+    // Protocol events are not stored in [_sessionBuffer], so without this
+    // replay a late subscriber would miss events that arrived after the initial
+    // handshake — e.g. an [AcceptedEvent] that already moved the call out of
+    // the ringing state before the Activity opened.
+    for (final history in List<List<List<dynamic>>>.from(_callEventHistory.values)) {
+      for (final encoded in history) {
+        cmd.replyPort.send(encoded);
+      }
     }
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -56,7 +56,7 @@ class SignalingHub {
   /// the full event sequence and can reconstruct the correct current state.
   ///
   /// Without this map a subscriber that opens after [AcceptedEvent] would only
-  /// receive [IncomingCallEvent] from [_inflightIncomingCalls] and incorrectly
+  /// receive [IncomingCallEvent] replayed from [_sessionBuffer] and incorrectly
   /// treat an already-answered call as still ringing.
   ///
   /// Lifecycle:

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -131,7 +131,8 @@ bool isPong(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagPong;
 /// Returns true when [entry] is an encoded [SignalingHandshakeReceived] event.
 ///
 /// Used by [SignalingHub] to evict stale handshake entries from the session
-/// buffer when a [HangupEvent] arrives — avoids exposing the private tag.
+/// buffer when a terminal call event ([HangupEvent] or [MissedCallEvent])
+/// arrives — avoids exposing the private tag.
 bool isHubEventHandshakeReceived(List<dynamic> entry) => entry.isNotEmpty && entry[0] == _tagHandshakeReceived;
 
 Object? _encodeExecuteError(Object? error) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -128,6 +128,12 @@ List<dynamic> encodePong() => [_tagPong];
 
 bool isPong(List<dynamic> msg) => msg.isNotEmpty && msg[0] == _tagPong;
 
+/// Returns true when [entry] is an encoded [SignalingHandshakeReceived] event.
+///
+/// Used by [SignalingHub] to evict stale handshake entries from the session
+/// buffer when a [HangupEvent] arrives — avoids exposing the private tag.
+bool isHubEventHandshakeReceived(List<dynamic> entry) => entry.isNotEmpty && entry[0] == _tagHandshakeReceived;
+
 Object? _encodeExecuteError(Object? error) {
   if (error == null) return null;
   if (error is WebtritSignalingErrorException) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
@@ -451,6 +451,131 @@ void main() {
       expect(events.whereType<SignalingHandshakeReceived>(), isEmpty);
       expect(events.whereType<SignalingConnecting>(), hasLength(1));
     });
+
+    test('stale call line is evicted from handshake after HangupEvent', () async {
+      // Scenario: push isolate handles first call; first call ends (HangupEvent).
+      // The handshake must still be replayed to late subscribers but without the
+      // dead call's line in handshake.lines.
+      final kHandshakeWithLine = StateHandshake(
+        keepaliveInterval: const Duration(seconds: 30),
+        timestamp: 1705322000000,
+        registration: const Registration(status: RegistrationStatus.registered),
+        lines: [Line(callId: 'first-call-id', callLogs: const [])],
+        presenceInfos: const [],
+        dialogInfos: const [],
+        guestLine: null,
+      );
+
+      final (:manager, :fakeClient) = await _startServiceSide();
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      // Inject handshake that contains the first call's line.
+      fakeClient.injectHandshake(kHandshakeWithLine);
+      await Future<void>.delayed(Duration.zero);
+
+      // First call ends — hub evicts its line from the buffered handshake.
+      fakeClient.injectEvent(HangupEvent(line: 1, callId: 'first-call-id', code: 200, reason: 'OK'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Activity opens and attaches as a late subscriber.
+      final (:hubClient, :hubModule) = await _attachMainSide('attach-stale-line-1');
+      addTearDown(hubModule.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      hubModule.events.listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      // Handshake is still replayed (registration status etc. still useful).
+      final handshakes = events.whereType<SignalingHandshakeReceived>().toList();
+      expect(handshakes, hasLength(1), reason: 'Handshake itself must still be replayed');
+      // But the dead call's line must have been removed.
+      expect(
+        handshakes.first.handshake.lines,
+        isEmpty,
+        reason: 'Dead call line must be evicted from handshake.lines on HangupEvent',
+      );
+    });
+
+    test('call history is replayed to late subscriber — ringing state', () async {
+      // Scenario: call arrives via IncomingCallEvent; Activity opens while still ringing.
+      // Late subscriber must receive IncomingCallEvent so CallBloc reaches incomingFromOffer.
+      final (:manager, :fakeClient) = await _startServiceSide();
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      fakeClient.injectHandshake(_kHandshake);
+      fakeClient.injectEvent(HangupEvent(line: 1, callId: 'first-call-id', code: 200, reason: 'OK'));
+      fakeClient.injectEvent(IncomingCallEvent(line: 1, callId: 'second-call-id', callee: 'bob', caller: 'alice'));
+      await Future<void>.delayed(Duration.zero);
+
+      final (:hubClient, :hubModule) = await _attachMainSide('history-ringing-1');
+      addTearDown(hubModule.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      hubModule.events.listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      final protocolEvents = events.whereType<SignalingProtocolEvent>().toList();
+      expect(
+        protocolEvents.where((e) => e.event is IncomingCallEvent).length,
+        1,
+        reason: 'Ringing call: IncomingCallEvent must be replayed',
+      );
+      expect(
+        protocolEvents.where((e) => e.event is AcceptedEvent).length,
+        0,
+        reason: 'Ringing call: no AcceptedEvent yet',
+      );
+    });
+
+    test('call history is replayed to late subscriber — answered state', () async {
+      // Scenario: call arrived and was answered (AcceptedEvent) before Activity opened.
+      // Late subscriber must receive both IncomingCallEvent AND AcceptedEvent so that
+      // CallBloc reaches the active/accepted state rather than staying in incomingFromOffer.
+      final (:manager, :fakeClient) = await _startServiceSide();
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      fakeClient.injectEvent(IncomingCallEvent(line: 1, callId: 'call-id', callee: 'bob', caller: 'alice'));
+      fakeClient.injectEvent(AcceptedEvent(line: 1, callId: 'call-id'));
+      await Future<void>.delayed(Duration.zero);
+
+      final (:hubClient, :hubModule) = await _attachMainSide('history-answered-1');
+      addTearDown(hubModule.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      hubModule.events.listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      final protocolEvents = events.whereType<SignalingProtocolEvent>().toList();
+      // Both events must be replayed in order.
+      expect(protocolEvents.where((e) => e.event is IncomingCallEvent).length, 1);
+      expect(protocolEvents.where((e) => e.event is AcceptedEvent).length, 1);
+      final incoming = protocolEvents.indexWhere((e) => e.event is IncomingCallEvent);
+      final accepted = protocolEvents.indexWhere((e) => e.event is AcceptedEvent);
+      expect(incoming < accepted, isTrue, reason: 'IncomingCallEvent must come before AcceptedEvent');
+    });
+
+    test('call history is NOT replayed after HangupEvent', () async {
+      // After the call ends, no events should be replayed to late subscribers.
+      final (:manager, :fakeClient) = await _startServiceSide();
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      fakeClient.injectEvent(IncomingCallEvent(line: 1, callId: 'call-id', callee: 'bob', caller: 'alice'));
+      fakeClient.injectEvent(HangupEvent(line: 1, callId: 'call-id', code: 200, reason: 'OK'));
+      await Future<void>.delayed(Duration.zero);
+
+      final (:hubClient, :hubModule) = await _attachMainSide('history-hangup-1');
+      addTearDown(hubModule.dispose);
+
+      final events = <SignalingModuleEvent>[];
+      hubModule.events.listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        events.whereType<SignalingProtocolEvent>(),
+        isEmpty,
+        reason: 'Ended call: no protocol events must be replayed',
+      );
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Companion to webtrit_callkeep#256

Requires `webtrit_callkeep` with `handoffCall()` in `BackgroundPushNotificationService`.

---

## Problem

Two independent issues combined to break the push-answered call handoff to the Activity.

### Issue 1 — wrong release method in `close()`

`PushNotificationIsolateManager.close()` always called `releaseCall(callId)`, which terminates the PhoneConnection. For answered calls this destroyed the connection before the Activity could adopt it via `CALL_ID_ALREADY_EXISTS_AND_ANSWERED`.

### Issue 2 — Activity missing call events from SignalingHub

When the Activity opens after the push isolate has already processed a call, it subscribes to `SignalingHub` and receives only the `StateHandshake` session buffer. This gives it `IncomingCallEvent` (call still ringing), but **never** `AcceptedEvent` — so `CallBloc` stays at `incomingFromOffer`. When `performAnswerCall` arrives, `__onCallPerformEventAnswered` finds `call == null` (no active call in state yet) and exits silently. The call never connects.

---

## Fix

### Commit 1 — `handoffCall` instead of `releaseCall` for answered calls

Added `_callAnswered` flag, set in `performAnswerCall()`. `close()` now branches:

```dart
if (_callAnswered) {
  await _handoffCall(_metadata?.callId);  // stopService only — PhoneConnection stays alive
} else {
  await _releaseCall(_metadata?.callId);  // terminateCall + stopService
}
```

### Commit 2 — `_callEventHistory` replay in `SignalingHub`

Added `_callEventHistory: Map<String, List<List<dynamic>>>` to `SignalingHub`. Tracks the ordered event sequence per callId (starting from `IncomingCallEvent`, appending subsequent `CallEvent`s). Late subscribers (Activity opening after push isolate) receive the full replay and reconstruct the correct current state.

```
push isolate: IncomingCallEvent → AcceptedEvent → history = [IncomingCallEvent, AcceptedEvent]
Activity subscribes → receives StateHandshake + full call history replay
CallBloc: incomingFromOffer → ready for performAnswerCall
performAnswerCall arrives → __onCallPerformEventAnswered → call found → answer → connected ✓
```

Terminal events (`HangupEvent`, `MissedCallEvent`) remove the history entry and evict the dead call's line from the buffered handshake so late subscribers never see ended calls.

Also adds `isHubEventHandshakeReceived()` helper in `signaling_hub_codec.dart` for handshake line eviction without exposing the private tag constant.

---

## Full flow after both fixes

```
push isolate: answered → PhoneConnection ACTIVE
push isolate: close() → _callAnswered=true → handoffCall() → stopService only
PhoneConnection: stays ACTIVE

Activity opens → subscribes to SignalingHub
SignalingHub: replays [IncomingCallEvent, AcceptedEvent] for callId
CallBloc: receives IncomingCallEvent → incomingFromOffer
          receives AcceptedEvent    → call state updated

Activity: reportNewIncomingCall → CALL_ID_ALREADY_EXISTS_AND_ANSWERED → performAnswerCall
CallBloc: __onCallPerformEventAnswered → call found ✓ → incomingAnswering → connected ✓
```

---

## Files changed

| File | Change |
|------|--------|
| `isolate_manager.dart` | `_callAnswered` flag; `_handoffCall()`; branch in `close()` |
| `signaling_hub.dart` | `_callEventHistory` map; replay on subscribe; evict on terminal events |
| `signaling_hub_codec.dart` | `isHubEventHandshakeReceived()` helper |
| `call_bloc.dart` | Diagnostic log in `__onCallPerformEventAnswered` for null call lookup |
| `attach_pattern_integration_test.dart` | Tests covering full event replay path |