### PR TITLE
fix(signaling): force reconnect on app resume + foreground call push signal

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -25,9 +25,9 @@ import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/l10n/app_localizations.g.mapper.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/common/common.dart';
+import 'package:webtrit_phone/push_notification/push_notifications.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/services/services.dart';
-import 'package:webtrit_phone/push_notification/push_notifications.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 final _logger = Logger('MainShell');

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -27,6 +27,7 @@ import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/services/services.dart';
+import 'package:webtrit_phone/push_notification/push_notifications.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 final _logger = Logger('MainShell');
@@ -555,6 +556,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         peerConnectionManager: peerConnectionManager,
                         onSessionInvalidated: () =>
                             appBloc.add(const AppLogoutRequested(reason: AppLogoutReason.sessionMissed)),
+                        foregroundCallPushSignal: RemotePushBroker.pendingCallForegroundPushs,
                       )..add(const CallStarted());
                     },
                   ),

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -86,6 +86,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final OnDiagnosticReportRequested onDiagnosticReportRequested;
 
   StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
+  StreamSubscription<void>? _foregroundCallPushSubscription;
 
   late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
@@ -122,6 +123,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required SignalingModule signalingModule,
     required PeerConnectionManager peerConnectionManager,
     this.onCallEnded,
+    Stream<void>? foregroundCallPushSignal,
   }) : super(const CallState()) {
     _signalingModule = signalingModule;
     _peerConnectionManager = peerConnectionManager;
@@ -133,6 +135,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       onConnectionPresenceChanged: (isAvailable) =>
           _logger.info('signaling presence changed: isAvailable=$isAvailable'),
     );
+
+    _foregroundCallPushSubscription = foregroundCallPushSignal?.listen((_) {
+      _reconnectController.notifyForceReconnect();
+    });
 
     // Translates SignalingModule events into BLoC state-transition events.
     // Reconnect scheduling and notification decisions are fully handled by
@@ -202,6 +208,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     navigator.mediaDevices.ondevicechange = null;
 
     await _connectivityChangedSubscription?.cancel();
+    await _foregroundCallPushSubscription?.cancel();
 
     _reconnectController.dispose();
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -136,9 +136,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           _logger.info('signaling presence changed: isAvailable=$isAvailable'),
     );
 
-    _foregroundCallPushSubscription = foregroundCallPushSignal?.listen((_) {
-      _reconnectController.notifyForceReconnect();
-    });
+    _foregroundCallPushSubscription = foregroundCallPushSignal?.listen(
+      (_) => _reconnectController.notifyForceReconnect(),
+    );
 
     // Translates SignalingModule events into BLoC state-transition events.
     // Reconnect scheduling and notification decisions are fully handled by

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -125,7 +125,7 @@ class SignalingReconnectController {
       _wasConnected = false;
     }
     _consecutiveFailures = 0;
-    _scheduleReconnect(kSignalingClientFastReconnectDelay);
+    _scheduleReconnect(kSignalingClientFastReconnectDelay, force: true);
   }
 
   /// Call when [AppLifecycleState.paused] or [AppLifecycleState.detached] fires.

--- a/lib/push_notification/remote_push_broker.dart
+++ b/lib/push_notification/remote_push_broker.dart
@@ -22,6 +22,9 @@ class RemotePushBroker {
   static final _snForegroundController = StreamController<SystemNotificationPush>();
   static final _snForegroundBroadcastStream = _snForegroundController.stream.asBroadcastStream();
 
+  // Pending call push that received while the app was in foreground
+  static final _pendingCallForegroundController = StreamController<PendingCallPush>.broadcast();
+
   /// Stream of messaging remote push that opens app
   /// while the app was in terminated state when the notification is tapped
   ///
@@ -46,6 +49,13 @@ class RemotePushBroker {
   /// The stream is broadcasted so it can be listened by multiple components
   static Stream<SystemNotificationPush> get systemNotificationsForegroundPushs => _snForegroundBroadcastStream;
 
+  /// Stream of pending call push that received while the app was in foreground.
+  ///
+  /// Signals that there is an incoming call waiting on the server.
+  /// Consumers should use this only as a hint to trigger a signaling reconnect —
+  /// the actual call arrives via the WebSocket handshake once signaling is up.
+  static Stream<PendingCallPush> get pendingCallForegroundPushs => _pendingCallForegroundController.stream;
+
   /// Handles the remote notification that opens the app
   /// and routes it to the apropriate stream
   static void handleOpenedPush(AppRemotePush notification) {
@@ -58,5 +68,6 @@ class RemotePushBroker {
   static void handleForegroundPush(AppRemotePush notification) {
     if (notification is MessagePush) _msgForegroundController.add(notification);
     if (notification is SystemNotificationPush) _snForegroundController.add(notification);
+    if (notification is PendingCallPush) _pendingCallForegroundController.add(notification);
   }
 }

--- a/lib/push_notification/remote_push_broker.dart
+++ b/lib/push_notification/remote_push_broker.dart
@@ -22,8 +22,8 @@ class RemotePushBroker {
   static final _snForegroundController = StreamController<SystemNotificationPush>();
   static final _snForegroundBroadcastStream = _snForegroundController.stream.asBroadcastStream();
 
-  // Pending call push that received while the app was in foreground
-  static final _pendingCallForegroundController = StreamController<PendingCallPush>.broadcast();
+  static final _pendingCallForegroundController = StreamController<PendingCallPush>();
+  static final _pendingCallForegroundBroadcastStream = _pendingCallForegroundController.stream.asBroadcastStream();
 
   /// Stream of messaging remote push that opens app
   /// while the app was in terminated state when the notification is tapped
@@ -49,12 +49,12 @@ class RemotePushBroker {
   /// The stream is broadcasted so it can be listened by multiple components
   static Stream<SystemNotificationPush> get systemNotificationsForegroundPushs => _snForegroundBroadcastStream;
 
-  /// Stream of pending call push that received while the app was in foreground.
+  /// Stream of pending call push that was received while the app was in foreground.
   ///
   /// Signals that there is an incoming call waiting on the server.
   /// Consumers should use this only as a hint to trigger a signaling reconnect —
   /// the actual call arrives via the WebSocket handshake once signaling is up.
-  static Stream<PendingCallPush> get pendingCallForegroundPushs => _pendingCallForegroundController.stream;
+  static Stream<PendingCallPush> get pendingCallForegroundPushs => _pendingCallForegroundBroadcastStream;
 
   /// Handles the remote notification that opens the app
   /// and routes it to the apropriate stream


### PR DESCRIPTION
## Pull request overview

Fixes missed incoming calls by ensuring signaling reconnects reliably on app resume and by surfacing foreground “pending call” push notifications as a reconnect trigger to the calling layer.

**Changes:**
- Force reconnect on `notifyAppResumed()` to avoid relying on a potentially stale “connected” flag.
- Add a foreground `PendingCallPush` stream in `RemotePushBroker` and route pending call pushes into it.
- Inject the new foreground call-push signal into `CallBloc` and trigger `notifyForceReconnect()` when it emits.

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 5 comments.

| File | Description |
| ---- | ----------- |
| lib/features/call/services/signaling_reconnect_controller.dart | Forces reconnect on app resume to avoid stale connection state skipping reconnect. |
| lib/push_notification/remote_push_broker.dart | Adds routing + stream for foreground pending-call pushes. |
| lib/features/call/bloc/call_bloc.dart | Subscribes to an injected foreground-call signal and forces reconnect on emission. |
| lib/app/router/main_shell.dart | Wires `RemotePushBroker` pending-call stream into `CallBloc` at the injection point. |



