### PR TITLE
fix(call): skip decline on 4610 wrong-line error to prevent reconnect loop

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2230,6 +2230,18 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         return;
       }
 
+      // If the server closed the connection because the line no longer exists (4610 "call request on wrong line"),
+      // the call is already gone on the server side — clean up locally without sending a decline request.
+      // Sending decline here would cause a reconnect loop: each reconnect attempt would send decline again,
+      // receive 4610 again, disconnect again, and reconnect indefinitely.
+      if (e is WebtritSignalingTransactionTerminateByDisconnectException &&
+          e.closeCode == SignalingDisconnectCode.requestCallIdError.code) {
+        _peerConnectionManager.completeError(event.callId, e, stackTrace);
+        add(_ResetStateEvent.completeCall(event.callId));
+        _addToRecents(call!);
+        return;
+      }
+
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
       add(_ResetStateEvent.completeCall(event.callId));
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2207,6 +2207,20 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       await peerConnection.setLocalDescription(localDescription).catchError((e) => throw SDPConfigurationError(e));
       _logger.info('__onCallPerformEventAnswered: localDescription set, sending AcceptRequest');
 
+      // Re-check that the call still exists before sending AcceptRequest.
+      // __onCallSignalingEventHangup may have run concurrently (e.g. 487 "Request Terminated"
+      // from the server while SDP was being prepared), removing the call from state.
+      // Sending accept on an already-terminated line results in a 4610 disconnect.
+      if (state.retrieveActiveCall(event.callId) == null) {
+        _logger.info('__onCallPerformEventAnswered: call terminated during SDP setup, skipping AcceptRequest');
+        _peerConnectionManager.completeError(
+          event.callId,
+          Exception('call terminated during SDP setup'),
+          StackTrace.current,
+        );
+        return;
+      }
+
       await _signalingModule.execute(
         AcceptRequest(
           transaction: WebtritSignalingClient.generateTransactionId(),

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2218,6 +2218,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           Exception('call terminated during SDP setup'),
           StackTrace.current,
         );
+        // __onCallSignalingEventHangup emits copyWithPopActiveCall before awaiting
+        // callkeep.reportEndCall, so the native side may not have been notified yet.
+        // Call it explicitly here to avoid leaving the Telecom connection in ACTIVE state.
+        // Callkeep handles double calls gracefully (already-disconnected is a no-op).
+        await callkeep.reportEndCall(
+          event.callId,
+          call!.displayName ?? call.handle.value,
+          CallkeepEndCallReason.unanswered,
+        );
         return;
       }
 
@@ -2251,8 +2260,20 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       if (e is WebtritSignalingTransactionTerminateByDisconnectException &&
           e.closeCode == SignalingDisconnectCode.requestCallIdError.code) {
         _peerConnectionManager.completeError(event.callId, e, stackTrace);
-        add(_ResetStateEvent.completeCall(event.callId));
         _addToRecents(call!);
+        // _ResetStateEvent.completeCall calls callkeep.reportEndCall inside performOnActiveCall,
+        // which is wrapped in a try/catch. If disposePeerConnection throws (PC already completed
+        // with error), reportEndCall is silently skipped and the Telecom connection stays ACTIVE.
+        // Notify the native side directly to avoid zombie TC connections.
+        final activeCall = state.retrieveActiveCall(event.callId);
+        if (activeCall != null) {
+          emit(state.copyWithPopActiveCall(event.callId));
+          await callkeep.reportEndCall(
+            event.callId,
+            activeCall.displayName ?? activeCall.handle.value,
+            CallkeepEndCallReason.unanswered,
+          );
+        }
         return;
       }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2224,7 +2224,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         // Callkeep handles double calls gracefully (already-disconnected is a no-op).
         await callkeep.reportEndCall(
           event.callId,
-          call!.displayName ?? call.handle.value,
+          call.displayName ?? call.handle.value,
           CallkeepEndCallReason.unanswered,
         );
         return;


### PR DESCRIPTION
## Summary

- When `AcceptRequest` fails with WS close code **4610** ("call request on wrong line error"), the call session is already gone on the server — the caller hung up before the callee finished the answer flow
- Previously the `catch` block sent a `DeclineRequest` to clean up, which **also received 4610**, triggering a reconnect loop: reconnect → decline → 4610 → disconnect → reconnect → ... (**8 iterations / ~29 seconds** observed in WT-1327 logs)
- Added an early-return branch in `__onCallPerformEventAnswered` for `WebtritSignalingTransactionTerminateByDisconnectException` with `closeCode == 4610`, mirroring the existing 410 handling: clean up locally, add to recents, return without decline or error notification

## Root cause (from WT-1327 logs)

**Race condition:** caller (iPhone) hung up at `10:31:16.605`, but callee (Android) had just received `incoming_call` WS event at `10:31:16.475` (130 ms gap). The callee completed the answer flow (~3 s) and sent `accept` at `10:31:19.693` — the server had already killed the session.

## Files changed

- `lib/features/call/bloc/call_bloc.dart` — added 4610 guard in `__onCallPerformEventAnswered` catch block

## Test plan

- [ ] Reproduce race: caller calls and hangs up just as callee taps Answer — verify no reconnect storm, call ends cleanly
- [ ] Normal answer flow unaffected
- [ ] Normal decline flow (user manually declines) unaffected
- [ ] 410 error path still works as before

Fixes WT-1327