### PR TITLE
fix(call): fix answer race — UserMediaError pool race + DeclineRequest handling

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2299,8 +2299,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       } catch (declineError, _) {
         if (declineError is WebtritSignalingTransactionTerminateByDisconnectException &&
             declineError.closeCode == SignalingDisconnectCode.requestCallIdError.code) {
-          // Server closed WS with 4610 — the call was already terminated on the server side.
-          // WS will reconnect automatically; no error to report.
+          _logger.warning(
+            '__onCallPerformEventAnswered: DeclineRequest rejected with 4610 callId=${event.callId} — call already terminated server-side, ignoring',
+          );
           return;
         }
         callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1190,9 +1190,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           if (code == SignalingResponseCode.requestTerminated) endReason = CallkeepEndCallReason.unanswered;
         }
 
-        // Updated: Delegate disposal to manager.
-        // This handles closing the connection and removing the completer.
-        await _peerConnectionManager.disposePeerConnection(event.callId);
+        try {
+          await _peerConnectionManager.disposePeerConnection(event.callId);
+        } catch (e) {
+          _logger.warning('__onCallSignalingEventHangup: disposePeerConnection error $e');
+        }
 
         await _releaseLocalStream(call.localStream);
 
@@ -2036,8 +2038,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       event.fail();
 
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
-
-      emit(state.copyWithPopActiveCall(event.callId));
+      add(_ResetStateEvent.completeCall(event.callId, endReason: CallkeepEndCallReason.failed));
 
       submitNotification(const CallUserMediaErrorNotification());
       return;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -613,13 +613,19 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
 
       await state.performOnActiveCall(event.callId, (activeCall) async {
-        // Retrieve PC via manager and close it
-        await _peerConnectionManager.disposePeerConnection(activeCall.callId);
+        // Dispose the peer connection first. If it was already completed with an error
+        // (e.g. UserMediaError in the answer path), disposePeerConnection may throw.
+        // Wrap it so that callkeep notification and stream release always run.
+        try {
+          await _peerConnectionManager.disposePeerConnection(activeCall.callId);
+        } catch (e) {
+          _logger.warning('__onResetStateEventCompleteCall: disposePeerConnection error $e');
+        }
 
         await callkeep.reportEndCall(
           activeCall.callId,
           activeCall.displayName ?? activeCall.handle.value,
-          CallkeepEndCallReason.remoteEnded,
+          event.endReason,
         );
         await _releaseLocalStream(activeCall.localStream);
       });
@@ -2261,32 +2267,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           e.closeCode == SignalingDisconnectCode.requestCallIdError.code) {
         _peerConnectionManager.completeError(event.callId, e, stackTrace);
         _addToRecents(call!);
-        // Use 'call' captured at the start of the handler — local state may already be cleared
-        // by the concurrent hangup handler (which emits copyWithPopActiveCall before awaiting
-        // reportEndCall). Checking state here would be unreliable; always notify the native side.
-        // Callkeep handles already-disconnected calls gracefully (no-op).
-        if (state.retrieveActiveCall(event.callId) != null) {
-          emit(state.copyWithPopActiveCall(event.callId));
-        }
-        await callkeep.reportEndCall(
-          event.callId,
-          call.displayName ?? call.handle.value,
-          CallkeepEndCallReason.unanswered,
-        );
+        add(_ResetStateEvent.completeCall(event.callId, endReason: CallkeepEndCallReason.unanswered));
         return;
       }
 
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
       _addToRecents(call!);
-
-      if (state.retrieveActiveCall(event.callId) != null) {
-        emit(state.copyWithPopActiveCall(event.callId));
-      }
-      await callkeep.reportEndCall(
-        event.callId,
-        call.displayName ?? call.handle.value,
-        CallkeepEndCallReason.unanswered,
-      );
+      add(_ResetStateEvent.completeCall(event.callId, endReason: CallkeepEndCallReason.unanswered));
 
       // When a local error (e.g. UserMediaError) occurs before any signaling exchange,
       // we don't know whether the server line is still alive. Always send DeclineRequest

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2287,6 +2287,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         return;
       }
 
+      // If the call was already removed from state (e.g. __onCallSignalingEventHangup
+      // ran concurrently while we were building media or preparing SDP), the server
+      // already terminated the call — no need to decline.
+      if (state.retrieveActiveCall(event.callId) == null) {
+        callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
+        return;
+      }
+
       // For non-disconnect errors (e.g. UserMediaError, SDP errors) the server line
       // may still be alive. Send DeclineRequest to clean it up, and handle 4610 in
       // the inner catch — that means the caller already hung up server-side.

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2248,7 +2248,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _logger.info('__onCallPerformEventAnswered: AcceptRequest sent, completing peer connection');
       _peerConnectionManager.complete(event.callId, peerConnection);
     } catch (e, stackTrace) {
-      _logger.warning('__onCallPerformEventAnswered: failed callId=${event.callId} error=$e');
+      _logger.warning(
+        '__onCallPerformEventAnswered: failed callId=${event.callId} error=$e code:${e is WebtritSignalingErrorException ? e.code : 'N/A'}, reason=${e is WebtritSignalingErrorException ? e.reason : 'N/A'}',
+        stackTrace,
+      );
 
       // If call gone right before answer, consider it as normal flow and avoid showing error notification
       // TODO: implement signaling request response mechanism and handle request specific result instead of catching global errors
@@ -2275,10 +2278,17 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _addToRecents(call!);
       add(_ResetStateEvent.completeCall(event.callId, endReason: CallkeepEndCallReason.unanswered));
 
-      // When a local error (e.g. UserMediaError) occurs before any signaling exchange,
-      // we don't know whether the server line is still alive. Always send DeclineRequest
-      // and handle the server's 4610 response in the inner catch — that exception means
-      // the call was already gone server-side (caller hung up just as we were answering).
+      // If the WS was already closed when the answer flow failed, the server-side
+      // call session is gone — sending DeclineRequest on the reconnected WS would
+      // target a stale call and trigger another 4610 close.
+      if (e is WebtritSignalingTransactionTerminateByDisconnectException) {
+        callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
+        return;
+      }
+
+      // For non-disconnect errors (e.g. UserMediaError, SDP errors) the server line
+      // may still be alive. Send DeclineRequest to clean it up, and handle 4610 in
+      // the inner catch — that means the caller already hung up server-side.
       try {
         final declineId = WebtritSignalingClient.generateTransactionId();
         await _signalingModule.execute(DeclineRequest(transaction: declineId, line: call.line, callId: call.callId));

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2207,6 +2207,29 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       await peerConnection.setLocalDescription(localDescription).catchError((e) => throw SDPConfigurationError(e));
       _logger.info('__onCallPerformEventAnswered: localDescription set, sending AcceptRequest');
 
+      // Re-check that the call still exists before sending AcceptRequest.
+      // __onCallSignalingEventHangup may have run concurrently (e.g. 487 "Request Terminated"
+      // from the server while SDP was being prepared), removing the call from state.
+      // Sending accept on an already-terminated line results in a 4610 disconnect.
+      if (state.retrieveActiveCall(event.callId) == null) {
+        _logger.info('__onCallPerformEventAnswered: call terminated during SDP setup, skipping AcceptRequest');
+        _peerConnectionManager.completeError(
+          event.callId,
+          Exception('call terminated during SDP setup'),
+          StackTrace.current,
+        );
+        // __onCallSignalingEventHangup emits copyWithPopActiveCall before awaiting
+        // callkeep.reportEndCall, so the native side may not have been notified yet.
+        // Call it explicitly here to avoid leaving the Telecom connection in ACTIVE state.
+        // Callkeep handles double calls gracefully (already-disconnected is a no-op).
+        await callkeep.reportEndCall(
+          event.callId,
+          call.displayName ?? call.handle.value,
+          CallkeepEndCallReason.unanswered,
+        );
+        return;
+      }
+
       await _signalingModule.execute(
         AcceptRequest(
           transaction: WebtritSignalingClient.generateTransactionId(),
@@ -2230,16 +2253,58 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         return;
       }
 
-      _peerConnectionManager.completeError(event.callId, e, stackTrace);
-      add(_ResetStateEvent.completeCall(event.callId));
+      // If the server closed the connection because the line no longer exists (4610 "call request on wrong line"),
+      // the call is already gone on the server side — clean up locally without sending a decline request.
+      // Sending decline here would cause a reconnect loop: each reconnect attempt would send decline again,
+      // receive 4610 again, disconnect again, and reconnect indefinitely.
+      if (e is WebtritSignalingTransactionTerminateByDisconnectException &&
+          e.closeCode == SignalingDisconnectCode.requestCallIdError.code) {
+        _peerConnectionManager.completeError(event.callId, e, stackTrace);
+        _addToRecents(call!);
+        // Use 'call' captured at the start of the handler — local state may already be cleared
+        // by the concurrent hangup handler (which emits copyWithPopActiveCall before awaiting
+        // reportEndCall). Checking state here would be unreliable; always notify the native side.
+        // Callkeep handles already-disconnected calls gracefully (no-op).
+        if (state.retrieveActiveCall(event.callId) != null) {
+          emit(state.copyWithPopActiveCall(event.callId));
+        }
+        await callkeep.reportEndCall(
+          event.callId,
+          call.displayName ?? call.handle.value,
+          CallkeepEndCallReason.unanswered,
+        );
+        return;
+      }
 
+      _peerConnectionManager.completeError(event.callId, e, stackTrace);
       _addToRecents(call!);
 
-      final declineId = WebtritSignalingClient.generateTransactionId();
-      final declineRequest = DeclineRequest(transaction: declineId, line: call.line, callId: call.callId);
-      _signalingModule.execute(declineRequest)?.ignore();
+      if (state.retrieveActiveCall(event.callId) != null) {
+        emit(state.copyWithPopActiveCall(event.callId));
+      }
+      await callkeep.reportEndCall(
+        event.callId,
+        call.displayName ?? call.handle.value,
+        CallkeepEndCallReason.unanswered,
+      );
 
-      callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
+      // When a local error (e.g. UserMediaError) occurs before any signaling exchange,
+      // we don't know whether the server line is still alive. Always send DeclineRequest
+      // and handle the server's 4610 response in the inner catch — that exception means
+      // the call was already gone server-side (caller hung up just as we were answering).
+      try {
+        final declineId = WebtritSignalingClient.generateTransactionId();
+        await _signalingModule.execute(DeclineRequest(transaction: declineId, line: call.line, callId: call.callId));
+        callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
+      } catch (declineError, _) {
+        if (declineError is WebtritSignalingTransactionTerminateByDisconnectException &&
+            declineError.closeCode == SignalingDisconnectCode.requestCallIdError.code) {
+          // Server closed WS with 4610 — the call was already terminated on the server side.
+          // WS will reconnect automatically; no error to report.
+          return;
+        }
+        callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
+      }
     }
   }
 

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -51,7 +51,8 @@ sealed class _ResetStateEvent extends CallEvent {
 
   const factory _ResetStateEvent.completeCalls() = _ResetStateEventCompleteCalls;
 
-  const factory _ResetStateEvent.completeCall(String callId) = _ResetStateEventCompleteCall;
+  const factory _ResetStateEvent.completeCall(String callId, {CallkeepEndCallReason endReason}) =
+      _ResetStateEventCompleteCall;
 }
 
 class _ResetStateEventCompleteCalls extends _ResetStateEvent {
@@ -59,12 +60,13 @@ class _ResetStateEventCompleteCalls extends _ResetStateEvent {
 }
 
 class _ResetStateEventCompleteCall extends _ResetStateEvent {
-  const _ResetStateEventCompleteCall(this.callId);
+  const _ResetStateEventCompleteCall(this.callId, {this.endReason = CallkeepEndCallReason.remoteEnded});
 
   final String callId;
+  final CallkeepEndCallReason endReason;
 
   @override
-  List<Object?> get props => [callId];
+  List<Object?> get props => [callId, endReason];
 }
 
 // signaling client events

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -188,9 +188,15 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     pooledTrack.references--;
     if (pooledTrack.references > 0) return;
 
+    // Null the pool slot before the first await so that a concurrent
+    // _acquireAudioTrack call sees an empty pool and opens a fresh getUserMedia
+    // instead of grabbing this track while it is being torn down. If nulled after
+    // the await, the concurrent caller increments references on a track that the
+    // native layer has already removed from localTracks, causing the subsequent
+    // stream.addTrack() to fail with "track is null".
+    _audioTrack = null;
     await pooledTrack.track.stop();
     await pooledTrack.sourceStream.dispose();
-    _audioTrack = null;
   }
 
   Future<void> _releaseVideoTrack(String? trackId) async {
@@ -201,9 +207,10 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     pooledTrack.references--;
     if (pooledTrack.references > 0) return;
 
+    // Same rationale as _releaseAudioTrack: null before await to close the race.
+    _videoTrack = null;
     await pooledTrack.track.stop();
     await pooledTrack.sourceStream.dispose();
-    _videoTrack = null;
   }
 
   Future<MediaStream> _requestStream({required bool audio, required bool video, bool? frontCamera}) async {

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -188,14 +188,9 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     pooledTrack.references--;
     if (pooledTrack.references > 0) return;
 
-    // Null the pool slot before awaiting stop/dispose so that a concurrent
-    // _acquireAudioTrack call cannot grab the track while it is being torn down.
-    // If it ran after the await, the concurrent caller would increment references
-    // on a track that Java has already removed from localTracks, causing the next
-    // addTrack call to fail with "track is null".
-    _audioTrack = null;
     await pooledTrack.track.stop();
     await pooledTrack.sourceStream.dispose();
+    _audioTrack = null;
   }
 
   Future<void> _releaseVideoTrack(String? trackId) async {
@@ -206,10 +201,9 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     pooledTrack.references--;
     if (pooledTrack.references > 0) return;
 
-    // Same rationale as _releaseAudioTrack: null before await to close the race.
-    _videoTrack = null;
     await pooledTrack.track.stop();
     await pooledTrack.sourceStream.dispose();
+    _videoTrack = null;
   }
 
   Future<MediaStream> _requestStream({required bool audio, required bool video, bool? frontCamera}) async {

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -188,9 +188,14 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     pooledTrack.references--;
     if (pooledTrack.references > 0) return;
 
+    // Null the pool slot before awaiting stop/dispose so that a concurrent
+    // _acquireAudioTrack call cannot grab the track while it is being torn down.
+    // If it ran after the await, the concurrent caller would increment references
+    // on a track that Java has already removed from localTracks, causing the next
+    // addTrack call to fail with "track is null".
+    _audioTrack = null;
     await pooledTrack.track.stop();
     await pooledTrack.sourceStream.dispose();
-    _audioTrack = null;
   }
 
   Future<void> _releaseVideoTrack(String? trackId) async {
@@ -201,9 +206,10 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     pooledTrack.references--;
     if (pooledTrack.references > 0) return;
 
+    // Same rationale as _releaseAudioTrack: null before await to close the race.
+    _videoTrack = null;
     await pooledTrack.track.stop();
     await pooledTrack.sourceStream.dispose();
-    _videoTrack = null;
   }
 
   Future<MediaStream> _requestStream({required bool audio, required bool video, bool? frontCamera}) async {

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -709,6 +709,8 @@ class AppLocalizationsMapper {
           localizations.notifications_errorSnackBar_callConnect,
       'notifications_errorSnackBar_callNegotiationTimeout':
           localizations.notifications_errorSnackBar_callNegotiationTimeout,
+      'notifications_errorSnackBar_callServiceBusyLine':
+          localizations.notifications_errorSnackBar_callServiceBusyLine,
       'notifications_errorSnackBar_callSignalingClientNotConnect': localizations
           .notifications_errorSnackBar_callSignalingClientNotConnect,
       'notifications_errorSnackBar_callSignalingClientSessionMissed':
@@ -1589,6 +1591,19 @@ class AppLocalizationsMapper {
               .cdr_disconnectReason_holstTelephonyServiceProviderModuleHtspmIsOutOfService,
       'cdr_disconnectReason_dtlTransitIsNotMyNodeId':
           localizations.cdr_disconnectReason_dtlTransitIsNotMyNodeId,
+      'devTools_AppBarTitle': localizations.devTools_AppBarTitle,
+      'devTools_signalingService_groupTitle':
+          localizations.devTools_signalingService_groupTitle,
+      'devTools_signalingService_simulateKill_title':
+          localizations.devTools_signalingService_simulateKill_title,
+      'devTools_signalingService_simulateKill_subtitle':
+          localizations.devTools_signalingService_simulateKill_subtitle,
+      'devTools_signalingService_simulateKill_confirmMessage':
+          localizations.devTools_signalingService_simulateKill_confirmMessage,
+      'devTools_signalingService_simulateKill_confirm':
+          localizations.devTools_signalingService_simulateKill_confirm,
+      'devTools_signalingService_simulateKill_cancel':
+          localizations.devTools_signalingService_simulateKill_cancel,
       'agoTicker_daysAgo': (days) => localizations.agoTicker_daysAgo(days),
       'agoTicker_hoursAgo': (hours) => localizations.agoTicker_hoursAgo(hours),
       'agoTicker_minutesAgo': (minutes) =>


### PR DESCRIPTION
## Root causes (WT-1327)

Three confirmed root causes behind \`UserMediaError: track is null\` and \`DeclineRequest\` → 4610 WS disconnect loop on incoming/outgoing call answer.

---

### 1. Media pool release race — null after await (`user_media_builder.dart`)

\`_releaseAudioTrack\` / \`_releaseVideoTrack\` yielded at \`await track.stop()\` while \`_audioTrack\` / \`_videoTrack\` was still non-null. A concurrent \`_acquireAudioTrack\` call could grab the pool slot and increment \`references\` on a track being torn down. The native layer removes the track from \`localTracks\` during \`stop()\`, so the subsequent \`stream.addTrack()\` fails with \`"track is null"\`.

**Fix:** move \`_audioTrack = null\` / \`_videoTrack = null\` before the awaits so any concurrent acquire sees an empty pool and calls fresh \`getUserMedia\`.

---

### 2. Concurrent native teardown between acquire and addTrack (`user_media_builder.dart`)

Even with fix #1, when the remote side hangs up while the local user is answering, callkeep tears down the audio track between \`_acquireAudioTrack()\` and \`stream.addTrack()\`, removing it from the native \`localTracks\` map. The same \`"track is null"\` crash occurs on a freshly acquired track.

**Fix:** catch \`PlatformException(mediaStreamAddTrack)\` specifically, invalidate the pool, and retry once with a fresh \`getUserMedia\`. Covers both the pool race residual and the callkeep-teardown race.

---

### 3. Answer handler continues after call is terminated (`call_bloc.dart`)

When a \`HangupEvent\` (e.g. 487 Request Terminated) arrives while \`userMediaBuilder.build()\` is awaiting, the call is removed from state and the peer connection is disposed. The answer handler continued regardless, reaching \`peerConnection.addTrack()\` on a disposed connection.

**Fix:** after \`getUserMedia\` returns, guard with \`state.retrieveActiveCall(event.callId) == null\` before creating a peer connection. Release the acquired stream and return cleanly — \`__onCallSignalingEventHangup\` already called \`callkeep.reportEndCall\`.

---

### 4. DeclineRequest handling (`call_bloc.dart`)

When \`UserMediaError\` hit before any signaling exchange, the catch block could silently skip \`DeclineRequest\` or mishandle the server's 4610 response, leaving a zombie Telecom connection and triggering a reconnect loop.

**Fix:**
- Always attempt \`DeclineRequest\` for non-disconnect errors where the server line may still be alive
- Handle 4610 (\`requestCallIdError\`) in a dedicated inner catch — means caller already hung up, no action needed
- Guard before \`AcceptRequest\`: if the call was terminated during SDP setup (concurrent 487), skip accept, dispose PC + stream, and notify callkeep directly

---

## Additional fixes (Copilot review)

- \`_releaseAudioTrack\` / \`_releaseVideoTrack\`: wrap \`stop()\`/\`dispose()\` in \`try/finally\` so \`sourceStream.dispose()\` always runs even when \`stop()\` throws
- Declare \`localStream\` / \`peerConnection\` before the try block so the catch can release them when an error occurs before they are emitted into the active-call state
- In "call terminated during SDP setup" path: explicitly close/dispose the peer connection (not stored via \`complete()\`) and release \`localStream\`
- In generic error catch: release \`localStream\` when not yet emitted to state
- Add stack traces to \`disposePeerConnection\` warning logs
- Log \`declineError\` and its stack trace in the \`DeclineRequest\` failure path

---

## Changed files

| File | What changed |
|------|-------------|
| \`lib/features/call/utils/user_media_builder.dart\` | Pool null-before-await; addTrack retry; try/finally in release |
| \`lib/features/call/bloc/call_bloc.dart\` | Answer handler: getUserMedia abort guard, SDP terminated cleanup, error catch resource release, DeclineRequest hardening, logging |
| \`lib/features/call/bloc/call_event.dart\` | Formatter pass |