### PR TITLE
fix(signaling): guard _onError against secondary errors after connection failure (WT-1308)

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -323,6 +323,15 @@ class SignalingModuleImpl implements SignalingModule {
 
   void _onError(Object error, [StackTrace? stackTrace]) {
     if (_disposed) return;
+    if (_client == null) {
+      // Secondary error from an already-failed connection (e.g. a late server
+      // response arriving after the keepalive timeout cleaned up its transaction).
+      // The first _onError already emitted SignalingConnectionFailed and cleared
+      // _client — re-emitting here would double-count the failure and push
+      // consecutive failures past the notification threshold incorrectly.
+      _logger.fine('_onError: secondary error after connection already failed — ignoring: $error');
+      return;
+    }
     _logger.severe('_onError', error, stackTrace);
     _client = null;
     _errorHandled = true;


### PR DESCRIPTION
## Problem

A transient network hiccup (1–3 seconds) causes the app to show "core connection error" to the user even though the network recovers almost immediately.

**Root cause — double-counting from one dead transaction:**

1. Keepalive `transaction-N` times out → `KeepaliveTransactionTimeoutException` → `consecutive = 1`
2. `_executeTransaction`'s `catch` block removes the transaction from `_transactions`
3. The server's delayed ACK arrives → `_onMessage` finds no transaction → `TransactionUnavailableException` → `_onError` is called **again** → `consecutive = 2` → threshold crossed → UI shows error

Both failures come from the same root cause (one brief network gap), but `_onError` had no guard against being called a second time from the same dead connection.

## Fix

Add `_client == null` guard to `_onError` in `SignalingModuleImpl`:

```dart
void _onError(Object error, [StackTrace? stackTrace]) {
  if (_disposed) return;
  if (_client == null) {
    _logger.fine('secondary error after connection already failed — ignoring: $error');
    return;
  }
  ...
}
```

`_client` is set to `null` on the first `_onError` call. Any subsequent call from the same WebSocket (late responses, cleanup artifacts) is a no-op. A new connection creates a new `_client` instance, so legitimate errors from the new connection are unaffected.

**Why `_client == null` is safe:**
- `_connectToken` is cleared in `_connectAsync`'s `finally` block after the connection is established — it is `null` by the time keepalive fires
- `connect()` checks `_connectToken == null` before starting a new attempt, so reconnect is not blocked

## What this does NOT change
- Threshold logic in `SignalingReconnectController` — unchanged
- Behavior for real consecutive failures (two independent connection drops still reach `consecutive = 2`)
- PR #1110 (`Transaction._isDone` guard) addressed a different scenario (transaction still in map); this PR addresses the case where the transaction was already removed by `_executeTransaction`'s catch block

## Related
- YouTrack: WT-1308
- Log: `logs/1308/connecting_core_error_2.log`