### PR TITLE
fix(recents): prevent 'Unknown'/empty string in call history (WT-1324)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -814,7 +814,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     }
 
     final contactName = await contactNameResolver.resolveWithNumber(event.handle.value);
-    final displayName = contactName ?? event.displayName;
+    final displayName = contactName ?? (event.displayName?.isEmpty == true ? null : event.displayName);
 
     // Re-check after the async gap: the signaling path may have created an entry
     // for this callId while contact resolution was in progress.
@@ -909,7 +909,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final video = event.jsep?.hasVideo ?? false;
     final handle = CallkeepHandle.number(event.caller);
     final contactName = await contactNameResolver.resolveWithNumber(handle.value);
-    final displayName = contactName ?? event.callerDisplayName;
+    final displayName = contactName ?? (event.callerDisplayName?.isEmpty == true ? null : event.callerDisplayName);
 
     final activeCallWithSameId = state.retrieveActiveCall(event.callId);
     // Skip the "call to myself" check when the existing call was registered via push

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -142,7 +142,11 @@ Future<void> onSignalingBackgroundIncomingCall(IncomingCallEvent event) async {
   _logger.info('onSignalingBackgroundIncomingCall: callId=${event.callId} caller=${event.caller}');
 
   final error = await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
-      .reportNewIncomingCall(event.callId, CallkeepHandle.number(event.caller), displayName: event.callerDisplayName)
+      .reportNewIncomingCall(
+        event.callId,
+        CallkeepHandle.number(event.caller),
+        displayName: event.callerDisplayName?.isEmpty == true ? null : event.callerDisplayName,
+      )
       .timeout(
         const Duration(seconds: 10),
         onTimeout: () {

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -282,7 +282,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
           direction: CallDirection.incoming,
           number: incomingEventLog?.caller ?? 'unknown',
           video: JsepValue.fromOptional(incomingEventLog?.jsep)?.hasVideo ?? false,
-          username: incomingEventLog?.callerDisplayName ?? 'Unknown',
+          username: incomingEventLog?.callerDisplayName,
           createdTime: _initialConnectionTime,
           acceptedTime: null,
           hungUpTime: DateTime.now(),

--- a/lib/models/recent.dart
+++ b/lib/models/recent.dart
@@ -8,7 +8,10 @@ class Recent extends Equatable {
 
   const Recent({required this.callLogEntry, required this.contact});
 
-  String get name => contact?.maybeName ?? callLogEntry.username ?? callLogEntry.number;
+  String get name =>
+      contact?.maybeName ??
+      (callLogEntry.username?.isNotEmpty == true ? callLogEntry.username! : null) ??
+      callLogEntry.number;
 
   @override
   String toString() {

--- a/test/models/recent_test.dart
+++ b/test/models/recent_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/models/models.dart';
+
+void main() {
+  final _kCreatedTime = DateTime(2024, 1, 1);
+
+  CallLogEntry _makeEntry({String number = '555024', String? username}) => CallLogEntry(
+    id: 1,
+    direction: CallDirection.incoming,
+    number: number,
+    video: false,
+    createdTime: _kCreatedTime,
+    username: username,
+  );
+
+  Contact _makeContact({String? aliasName, String? firstName, String? lastName}) => Contact(
+    id: 1,
+    sourceType: ContactSourceType.local,
+    kind: ContactKind.visible,
+    aliasName: aliasName,
+    firstName: firstName,
+    lastName: lastName,
+  );
+
+  group('Recent.name — no contact', () {
+    test('username null → falls back to number', () {
+      final recent = Recent(callLogEntry: _makeEntry(username: null), contact: null);
+      expect(recent.name, '555024');
+    });
+
+    test('username empty string → falls back to number', () {
+      final recent = Recent(callLogEntry: _makeEntry(username: ''), contact: null);
+      expect(recent.name, '555024');
+    });
+
+    test('username non-empty → returns username', () {
+      final recent = Recent(callLogEntry: _makeEntry(username: 'John'), contact: null);
+      expect(recent.name, 'John');
+    });
+
+    test('username whitespace-only → returns whitespace (not empty, so kept)', () {
+      final recent = Recent(callLogEntry: _makeEntry(username: ' '), contact: null);
+      expect(recent.name, ' ');
+    });
+  });
+
+  group('Recent.name — contact with name', () {
+    test('contact aliasName wins over username', () {
+      final recent = Recent(
+        callLogEntry: _makeEntry(username: 'John'),
+        contact: _makeContact(aliasName: 'Alias'),
+      );
+      expect(recent.name, 'Alias');
+    });
+
+    test('contact aliasName wins even when username is empty', () {
+      final recent = Recent(
+        callLogEntry: _makeEntry(username: ''),
+        contact: _makeContact(aliasName: 'Alias'),
+      );
+      expect(recent.name, 'Alias');
+    });
+
+    test('contact firstName + lastName combined', () {
+      final recent = Recent(
+        callLogEntry: _makeEntry(username: null),
+        contact: _makeContact(firstName: 'John', lastName: 'Doe'),
+      );
+      expect(recent.name, 'John Doe');
+    });
+
+    test('contact firstName only', () {
+      final recent = Recent(
+        callLogEntry: _makeEntry(username: null),
+        contact: _makeContact(firstName: 'John'),
+      );
+      expect(recent.name, 'John');
+    });
+  });
+
+  group('Recent.name — contact without name', () {
+    test('contact maybeName null + username non-empty → returns username', () {
+      final recent = Recent(
+        callLogEntry: _makeEntry(username: 'John'),
+        contact: _makeContact(),
+      );
+      expect(recent.name, 'John');
+    });
+
+    test('contact maybeName null + username empty → falls back to number', () {
+      final recent = Recent(
+        callLogEntry: _makeEntry(username: ''),
+        contact: _makeContact(),
+      );
+      expect(recent.name, '555024');
+    });
+
+    test('contact maybeName null + username null → falls back to number', () {
+      final recent = Recent(callLogEntry: _makeEntry(username: null), contact: _makeContact());
+      expect(recent.name, '555024');
+    });
+  });
+}

--- a/test/models/recent_test.dart
+++ b/test/models/recent_test.dart
@@ -2,27 +2,27 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:webtrit_phone/models/models.dart';
 
+final _kCreatedTime = DateTime(2024, 1, 1);
+
+CallLogEntry _makeEntry({String number = '555024', String? username}) => CallLogEntry(
+  id: 1,
+  direction: CallDirection.incoming,
+  number: number,
+  video: false,
+  createdTime: _kCreatedTime,
+  username: username,
+);
+
+Contact _makeContact({String? aliasName, String? firstName, String? lastName}) => Contact(
+  id: 1,
+  sourceType: ContactSourceType.local,
+  kind: ContactKind.visible,
+  aliasName: aliasName,
+  firstName: firstName,
+  lastName: lastName,
+);
+
 void main() {
-  final _kCreatedTime = DateTime(2024, 1, 1);
-
-  CallLogEntry _makeEntry({String number = '555024', String? username}) => CallLogEntry(
-    id: 1,
-    direction: CallDirection.incoming,
-    number: number,
-    video: false,
-    createdTime: _kCreatedTime,
-    username: username,
-  );
-
-  Contact _makeContact({String? aliasName, String? firstName, String? lastName}) => Contact(
-    id: 1,
-    sourceType: ContactSourceType.local,
-    kind: ContactKind.visible,
-    aliasName: aliasName,
-    firstName: firstName,
-    lastName: lastName,
-  );
-
   group('Recent.name — no contact', () {
     test('username null → falls back to number', () {
       final recent = Recent(callLogEntry: _makeEntry(username: null), contact: null);


### PR DESCRIPTION
## Summary

- **Bug 1 — "Unknown" in history**: removed `?? 'Unknown'` fallback in `isolate_manager.dart:285` that was cargo-culted from notification code into call log construction during refactor `bec6c374c`. Notification title is unaffected — it has its own guard in `_getDisplayNameForMissedCall`.
- **Bug 2 — empty/blank in history**: server sends `caller_display_name: ""` which was not normalised anywhere in the push/signaling paths. Added `isEmpty` → `null` normalisation at all three entry points (`background_isolate_callbacks`, `call_bloc` push-path, `call_bloc` signaling-path). Added a backstop in `Recent.name` to handle records already persisted to the DB with `username=""`.

## Files changed

| File | Change |
|---|---|
| `lib/features/call/services/isolate_manager.dart` | Remove `?? 'Unknown'` from call log `username` field |
| `lib/features/call/services/background_isolate_callbacks.dart` | Normalise `callerDisplayName: "" → null` |
| `lib/features/call/bloc/call_bloc.dart` | Normalise `displayName: "" → null` on push-path (L817) and signaling-path (L912) |
| `lib/models/recent.dart` | Guard `username` with `isNotEmpty` as backstop for already-stored `""` records |
| `test/models/recent_test.dart` | 11 unit tests covering all `Recent.name` resolution cases |

## Test plan

- [ ] `flutter test test/models/recent_test.dart` — 11/11 pass
- [ ] `melos run analyze` — no issues
- [ ] Manual: incoming call from number without display name → history shows number, not "Unknown" or blank
- [ ] Manual: existing DB records with `username=""` → history shows number after `Recent.name` backstop

Fixes: WT-1324