### PR TITLE
feat(WT-1157): battery optimization warning on persistent connection select

### DIFF
--- a/lib/features/settings/features/network/bloc/network_cubit.dart
+++ b/lib/features/settings/features/network/bloc/network_cubit.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 
 import 'package:bloc/bloc.dart';
-import 'package:webtrit_phone/extensions/iterable.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
 import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/extensions/iterable.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/incoming_call_type/incoming_call_type_repository.dart';
 
@@ -64,13 +64,17 @@ class NetworkCubit extends Cubit<NetworkState> {
     if (state.incomingCallType != IncomingCallType.socket) return false;
     try {
       final mode = await _callkeepPermissions.getBatteryMode();
+      if (state.incomingCallType != IncomingCallType.socket) return false;
       return mode != CallkeepAndroidBatteryMode.unrestricted;
     } catch (_) {
       return false;
     }
   }
 
-  Future<void> openBatterySettings() {
-    return _callkeepPermissions.openSettings();
+  Future<void> openBatterySettings() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _callkeepPermissions.openSettings();
+    } catch (_) {}
   }
 }

--- a/lib/features/settings/features/network/bloc/network_cubit.dart
+++ b/lib/features/settings/features/network/bloc/network_cubit.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:bloc/bloc.dart';
 import 'package:webtrit_phone/extensions/iterable.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -18,6 +21,7 @@ class NetworkCubit extends Cubit<NetworkState> {
     this._deviceInfo,
     this._incomingCallTypeRepository,
     this._onIncomingCallTypeChanged,
+    this._callkeepPermissions,
   ) : super(NetworkState(smsFallbackEnabled: _callTriggerConfig.smsFallback.enabled)) {
     _initializeActiveIncomingType();
   }
@@ -26,6 +30,7 @@ class NetworkCubit extends Cubit<NetworkState> {
   final DeviceInfo _deviceInfo;
   final IncomingCallTypeRepository _incomingCallTypeRepository;
   final Future<void> Function(IncomingCallType) _onIncomingCallTypeChanged;
+  final WebtritCallkeepPermissions _callkeepPermissions;
 
   bool get smsFallbackAvailable => _callTriggerConfig.smsFallback.available;
 
@@ -52,5 +57,20 @@ class NetworkCubit extends Cubit<NetworkState> {
     await _incomingCallTypeRepository.setIncomingCallType(selectedTypeModel.incomingCallType);
     await _onIncomingCallTypeChanged(selectedTypeModel.incomingCallType);
     _initializeActiveIncomingType();
+  }
+
+  Future<bool> isSocketMissingBatteryExemption() async {
+    if (!Platform.isAndroid) return false;
+    if (state.incomingCallType != IncomingCallType.socket) return false;
+    try {
+      final mode = await _callkeepPermissions.getBatteryMode();
+      return mode != CallkeepAndroidBatteryMode.unrestricted;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> openBatterySettings() {
+    return _callkeepPermissions.openSettings();
   }
 }

--- a/lib/features/settings/features/network/view/network_screen.dart
+++ b/lib/features/settings/features/network/view/network_screen.dart
@@ -30,10 +30,7 @@ class _NetworkScreenState extends State<NetworkScreen> {
         listenWhen: (previous, current) {
           return previous.incomingCallType != current.incomingCallType;
         },
-        listener: (context, state) async {
-          if (state.isSelectedTypeInRemainder) await _showTypeReminder(state.incomingCallType);
-          if (state.incomingCallType == IncomingCallType.socket) await _checkAndShowBatteryWarning();
-        },
+        listener: (context, state) => _onIncomingTypeChanged(state),
         builder: (context, state) {
           return SingleChildScrollView(
             child: Column(
@@ -92,6 +89,11 @@ class _NetworkScreenState extends State<NetworkScreen> {
         },
       ),
     );
+  }
+
+  Future<void> _onIncomingTypeChanged(NetworkState state) async {
+    if (state.isSelectedTypeInRemainder) await _showTypeReminder(state.incomingCallType);
+    if (state.incomingCallType == IncomingCallType.socket) await _checkAndShowBatteryWarning();
   }
 
   Future<void> _showTypeReminder(IncomingCallType type) async {

--- a/lib/features/settings/features/network/view/network_screen.dart
+++ b/lib/features/settings/features/network/view/network_screen.dart
@@ -30,8 +30,9 @@ class _NetworkScreenState extends State<NetworkScreen> {
         listenWhen: (previous, current) {
           return previous.incomingCallType != current.incomingCallType;
         },
-        listener: (context, state) {
-          if (state.isSelectedTypeInRemainder) _showTypeReminder(state.incomingCallType);
+        listener: (context, state) async {
+          if (state.isSelectedTypeInRemainder) await _showTypeReminder(state.incomingCallType);
+          if (state.incomingCallType == IncomingCallType.socket) await _checkAndShowBatteryWarning();
         },
         builder: (context, state) {
           return SingleChildScrollView(
@@ -93,12 +94,35 @@ class _NetworkScreenState extends State<NetworkScreen> {
     );
   }
 
-  void _showTypeReminder(IncomingCallType type) {
+  Future<void> _showTypeReminder(IncomingCallType type) async {
     final title = type.remainderTitleL10n(context);
     final description = type.remainderDescriptionL10n(context);
 
     if (context.mounted && title != null && description != null) {
-      AcknowledgeDialog.show(context, title: title, content: description);
+      await AcknowledgeDialog.show(context, title: title, content: description);
+    }
+  }
+
+  Future<void> _checkAndShowBatteryWarning() async {
+    final needsWarning = await _cubit.isSocketMissingBatteryExemption();
+    if (!needsWarning || !mounted) return;
+
+    final openSettings = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(ctx.l10n.batteryOptimizationWarningTitle),
+        content: Text(ctx.l10n.batteryOptimizationWarningContent),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: Text(ctx.l10n.alertDialogActions_no)),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(ctx.l10n.batteryOptimizationWarningOpenSettings),
+          ),
+        ],
+      ),
+    );
+    if (openSettings == true && mounted) {
+      await _cubit.openBatterySettings();
     }
   }
 }

--- a/lib/features/settings/features/network/view/network_screen_page.dart
+++ b/lib/features/settings/features/network/view/network_screen_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
 import 'package:webtrit_phone/data/data.dart';
@@ -31,6 +32,7 @@ class NetworkScreenPage extends StatelessWidget {
             (type) async {
               await WebtritSignalingService.updateMode(type.toSignalingServiceMode());
             },
+            WebtritCallkeepPermissions(),
           ),
         ),
       ],

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2532,6 +2532,24 @@ abstract class AppLocalizations {
   /// **'Important Reminder'**
   String get persistentConnectionReminderTitle;
 
+  /// Title of dialog warning the user about battery optimization being active when persistent connection is selected
+  ///
+  /// In en, this message translates to:
+  /// **'Battery Optimization Active'**
+  String get batteryOptimizationWarningTitle;
+
+  /// Content of dialog warning the user about battery optimization when persistent connection is selected
+  ///
+  /// In en, this message translates to:
+  /// **'Battery optimization is active on this device. This may cause missed calls when the screen turns off. Disable it to keep the persistent connection alive.'**
+  String get batteryOptimizationWarningContent;
+
+  /// Button label to open battery settings from the battery optimization warning dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Open Settings'**
+  String get batteryOptimizationWarningOpenSettings;
+
   /// No description provided for @presence_activity_appointment_name.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1367,6 +1367,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get persistentConnectionReminderTitle => 'Important Reminder';
 
   @override
+  String get batteryOptimizationWarningTitle => 'Battery Optimization Active';
+
+  @override
+  String get batteryOptimizationWarningContent =>
+      'Battery optimization is active on this device. This may cause missed calls when the screen turns off. Disable it to keep the persistent connection alive.';
+
+  @override
+  String get batteryOptimizationWarningOpenSettings => 'Open Settings';
+
+  @override
   String get presence_activity_appointment_name => 'At an appointment';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1386,6 +1386,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get persistentConnectionReminderTitle => 'Promemoria importante';
 
   @override
+  String get batteryOptimizationWarningTitle => 'Ottimizzazione batteria attiva';
+
+  @override
+  String get batteryOptimizationWarningContent =>
+      'L\'ottimizzazione della batteria è attiva su questo dispositivo. Ciò potrebbe causare la perdita di chiamate quando lo schermo è spento. Disabilitala per mantenere attiva la connessione persistente.';
+
+  @override
+  String get batteryOptimizationWarningOpenSettings => 'Apri impostazioni';
+
+  @override
   String get presence_activity_appointment_name => 'In appuntamento';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1388,6 +1388,16 @@ class AppLocalizationsUk extends AppLocalizations {
   String get persistentConnectionReminderTitle => 'Важливе нагадування';
 
   @override
+  String get batteryOptimizationWarningTitle => 'Оптимізацію батареї активовано';
+
+  @override
+  String get batteryOptimizationWarningContent =>
+      'На цьому пристрої активна оптимізація батареї. Це може призвести до пропущених дзвінків, коли екран вимкнено. Вимкніть її, щоб підтримувати постійне з\'єднання.';
+
+  @override
+  String get batteryOptimizationWarningOpenSettings => 'Відкрити налаштування';
+
+  @override
   String get presence_activity_appointment_name => 'На зустрічі';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1169,6 +1169,21 @@
     "type": "text",
     "description": "Title of a dialog shown when the user selects persistent connection on Android 14+"
   },
+  "batteryOptimizationWarningTitle": "Battery Optimization Active",
+  "@batteryOptimizationWarningTitle": {
+    "type": "text",
+    "description": "Title of dialog warning the user about battery optimization being active when persistent connection is selected"
+  },
+  "batteryOptimizationWarningContent": "Battery optimization is active on this device. This may cause missed calls when the screen turns off. Disable it to keep the persistent connection alive.",
+  "@batteryOptimizationWarningContent": {
+    "type": "text",
+    "description": "Content of dialog warning the user about battery optimization when persistent connection is selected"
+  },
+  "batteryOptimizationWarningOpenSettings": "Open Settings",
+  "@batteryOptimizationWarningOpenSettings": {
+    "type": "text",
+    "description": "Button label to open battery settings from the battery optimization warning dialog"
+  },
   "presence_activity_appointment_name": "At an appointment",
   "@presence_activity_appointment_name": {},
   "presence_activity_away_name": "Away",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1169,6 +1169,21 @@
     "type": "text",
     "description": "Title of a dialog shown when the user selects persistent connection on Android 14+"
   },
+  "batteryOptimizationWarningTitle": "Ottimizzazione batteria attiva",
+  "@batteryOptimizationWarningTitle": {
+    "type": "text",
+    "description": "Title of dialog warning the user about battery optimization being active when persistent connection is selected"
+  },
+  "batteryOptimizationWarningContent": "L'ottimizzazione della batteria è attiva su questo dispositivo. Ciò potrebbe causare la perdita di chiamate quando lo schermo è spento. Disabilitala per mantenere attiva la connessione persistente.",
+  "@batteryOptimizationWarningContent": {
+    "type": "text",
+    "description": "Content of dialog warning the user about battery optimization when persistent connection is selected"
+  },
+  "batteryOptimizationWarningOpenSettings": "Apri impostazioni",
+  "@batteryOptimizationWarningOpenSettings": {
+    "type": "text",
+    "description": "Button label to open battery settings from the battery optimization warning dialog"
+  },
   "presence_activity_appointment_name": "In appuntamento",
   "@presence_activity_appointment_name": {},
   "presence_activity_away_name": "Assente",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1169,6 +1169,21 @@
     "type": "text",
     "description": "Title of a dialog shown when the user selects persistent connection on Android 14+"
   },
+  "batteryOptimizationWarningTitle": "Оптимізацію батареї активовано",
+  "@batteryOptimizationWarningTitle": {
+    "type": "text",
+    "description": "Title of dialog warning the user about battery optimization being active when persistent connection is selected"
+  },
+  "batteryOptimizationWarningContent": "На цьому пристрої активна оптимізація батареї. Це може призвести до пропущених дзвінків, коли екран вимкнено. Вимкніть її, щоб підтримувати постійне з'єднання.",
+  "@batteryOptimizationWarningContent": {
+    "type": "text",
+    "description": "Content of dialog warning the user about battery optimization when persistent connection is selected"
+  },
+  "batteryOptimizationWarningOpenSettings": "Відкрити налаштування",
+  "@batteryOptimizationWarningOpenSettings": {
+    "type": "text",
+    "description": "Button label to open battery settings from the battery optimization warning dialog"
+  },
   "presence_activity_appointment_name": "На зустрічі",
   "@presence_activity_appointment_name": {},
   "presence_activity_away_name": "Відійшов",


### PR DESCRIPTION
## Summary

- When user selects **Persistent Connection** on Android and battery optimization is not exempted, a warning dialog is shown after the existing reboot reminder
- Dialog offers two actions: **No** (dismiss) and **Open Settings** (opens system battery settings via `WebtritCallkeepPermissions.openSettings()`)
- `WebtritCallkeepPermissions` injected via `NetworkCubit` constructor (not instantiated inline)
- Check is Android-only; iOS and errors are silently ignored
- l10n added for EN / UK / IT

## Test plan

- [ ] Android device with battery optimization **active** → select Persistent Connection → reboot reminder appears first, then battery warning; tapping "Open Settings" opens system battery settings
- [ ] Android device with battery optimization **exempted** → select Persistent Connection → only the reboot reminder dialog appears
- [ ] iOS → select Persistent Connection → only the reboot reminder dialog appears (no battery warning)
- [ ] Select Push Notification mode → no battery warning shown