### PR TITLE
fix(signaling): add missing warning logs for silent failure paths

### DIFF
--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -417,7 +417,10 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     }
 
     final lineIndex = _lines[callId];
-    if (lineIndex == null) return;
+    if (lineIndex == null) {
+      logger.warning('_sendRequest: callId=$callId not in active lines — dropping request');
+      return;
+    }
 
     final future = _signalingModule.execute(
       requestBuilder(lineIndex, callId, WebtritSignalingClient.generateTransactionId()),

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -1,5 +1,8 @@
+import 'package:logging/logging.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
+
+final _logger = Logger('SignalingHubCodec');
 
 const _tagConnecting = 'connecting';
 const _tagConnected = 'connected';
@@ -101,7 +104,8 @@ SignalingModuleEvent? decodeHubEvent(List<dynamic> msg) {
       default:
         return null;
     }
-  } catch (_) {
+  } catch (e, s) {
+    _logger.warning('decodeHubEvent: failed to decode tag=$tag msg=$msg', e, s);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Adds warning logs to silent failure paths in the signaling module that previously failed without any log output
- Helps diagnose connection issues that were invisible in production logs

## Test plan

- [ ] Verify warning logs appear when signaling connection fails silently
- [ ] Confirm no regression in existing signaling behavior