### PR TITLE
fix(WT-1339): fix incoming call frozen in accepting state on Android

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2239,6 +2239,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         return;
       }
 
+      _logger.info(
+        '__onCallPerformEventAnswered: AcceptRequest callId=${call.callId} line=${call.line} eventCallId=${event.callId}',
+      );
       await _signalingModule.execute(
         AcceptRequest(
           transaction: WebtritSignalingClient.generateTransactionId(),

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:logging/logging.dart';
 
@@ -21,9 +22,14 @@ final _logger = Logger('Transaction');
 /// if, for example, a late server response arrives after the timeout has
 /// already fired.
 class Transaction {
+  // Random 4-byte hex prefix unique per isolate run. Prevents transaction ID
+  // collisions when a new isolate restarts with _createCounter = 0 while the
+  // server still has a cached mapping from the previous session.
+  static final String _sessionPrefix = Random().nextInt(0xFFFFFFFF).toRadixString(16).padLeft(8, '0');
+
   static int _createCounter = 0;
 
-  static String generateId() => 'transaction-${_createCounter++}';
+  static String generateId() => '$_sessionPrefix-${_createCounter++}';
 
   final int signalingClientId;
   late final String id;

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:logging/logging.dart';
 
@@ -22,14 +21,12 @@ final _logger = Logger('Transaction');
 /// if, for example, a late server response arrives after the timeout has
 /// already fired.
 class Transaction {
-  // Random 4-byte hex prefix unique per isolate run. Prevents transaction ID
-  // collisions when a new isolate restarts with _createCounter = 0 while the
-  // server still has a cached mapping from the previous session.
-  static final String _sessionPrefix = Random().nextInt(0xFFFFFFFF).toRadixString(16).padLeft(8, '0');
+  static const _counterDivider = '00000';
 
   static int _createCounter = 0;
 
-  static String generateId() => '$_sessionPrefix-${_createCounter++}';
+  static String generateId() =>
+      'transaction-${DateTime.now().millisecondsSinceEpoch}${_counterDivider}${_createCounter++}';
 
   final int signalingClientId;
   late final String id;

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -23,7 +23,10 @@ final _logger = Logger('Transaction');
 class Transaction {
   static int _createCounter = 0;
 
-  static String generateId() => 'transaction-${DateTime.now().millisecondsSinceEpoch}-${_createCounter++}';
+  static const _counterWidth = 5;
+
+  static String generateId() =>
+      'transaction-${DateTime.now().millisecondsSinceEpoch}${(_createCounter++).toString().padLeft(_counterWidth, '0')}';
 
   final int signalingClientId;
   late final String id;

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:logging/logging.dart';
 
@@ -21,20 +22,27 @@ final _logger = Logger('Transaction');
 /// if, for example, a late server response arrives after the timeout has
 /// already fired.
 class Transaction {
+  /// Cryptographically random session prefix, initialized once per isolate run.
+  ///
+  /// Each push-notification isolate gets a different value so the server
+  /// cannot match IDs from a previous session against the current one.
+  /// [Random.secure] draws from OS entropy, reducing the risk of two isolates
+  /// receiving the same prefix compared to [Random].
+  static final _sessionId = Random.secure().nextInt(1000000000);
+
   static int _createCounter = 0;
 
   /// Generates a transaction ID unique across Dart isolate restarts.
   ///
-  /// Format: `transaction-{millisecondsSinceEpoch}{counter}`
+  /// Format: `transaction-{sessionId}{counter}`
   ///
-  /// The millisecond timestamp acts as a per-isolate-run prefix: each time the
-  /// push-notification isolate (re)starts its counter from 0, the timestamp
-  /// differs, so the server cannot match IDs against a previous session.
-  /// The counter ensures uniqueness within a single isolate run.
+  /// [_sessionId] is a random 9-digit number fixed for the lifetime of this
+  /// isolate. [_createCounter] increments with each call, ensuring uniqueness
+  /// within a single isolate run.
   ///
   /// The ID contains only digits after the `transaction-` prefix — empirically
   /// required by the server; non-digit separators cause audio dropout.
-  static String generateId() => 'transaction-${DateTime.now().millisecondsSinceEpoch}${_createCounter++}';
+  static String generateId() => 'transaction-$_sessionId${_createCounter++}';
 
   final int signalingClientId;
   late final String id;

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -25,6 +25,17 @@ class Transaction {
 
   static const _counterWidth = 5;
 
+  /// Generates a transaction ID unique across Dart isolate restarts.
+  ///
+  /// Format: `transaction-{millisecondsSinceEpoch}{counter:05}`
+  ///
+  /// The millisecond timestamp acts as a per-isolate-run prefix: each time the
+  /// push-notification isolate (re)starts its counter from 0, the timestamp
+  /// differs, so the server cannot match IDs against a previous session.
+  /// The zero-padded counter ensures uniqueness within a single isolate run.
+  ///
+  /// The ID contains only digits after the `transaction-` prefix — empirically
+  /// required by the server; non-digit separators cause audio dropout.
   static String generateId() =>
       'transaction-${DateTime.now().millisecondsSinceEpoch}${(_createCounter++).toString().padLeft(_counterWidth, '0')}';
 

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -21,12 +21,9 @@ final _logger = Logger('Transaction');
 /// if, for example, a late server response arrives after the timeout has
 /// already fired.
 class Transaction {
-  static const _counterDivider = '00000';
-
   static int _createCounter = 0;
 
-  static String generateId() =>
-      'transaction-${DateTime.now().millisecondsSinceEpoch}${_counterDivider}${_createCounter++}';
+  static String generateId() => 'transaction-${DateTime.now().millisecondsSinceEpoch}-${_createCounter++}';
 
   final int signalingClientId;
   late final String id;

--- a/packages/webtrit_signaling/lib/src/transaction.dart
+++ b/packages/webtrit_signaling/lib/src/transaction.dart
@@ -23,21 +23,18 @@ final _logger = Logger('Transaction');
 class Transaction {
   static int _createCounter = 0;
 
-  static const _counterWidth = 5;
-
   /// Generates a transaction ID unique across Dart isolate restarts.
   ///
-  /// Format: `transaction-{millisecondsSinceEpoch}{counter:05}`
+  /// Format: `transaction-{millisecondsSinceEpoch}{counter}`
   ///
   /// The millisecond timestamp acts as a per-isolate-run prefix: each time the
   /// push-notification isolate (re)starts its counter from 0, the timestamp
   /// differs, so the server cannot match IDs against a previous session.
-  /// The zero-padded counter ensures uniqueness within a single isolate run.
+  /// The counter ensures uniqueness within a single isolate run.
   ///
   /// The ID contains only digits after the `transaction-` prefix — empirically
   /// required by the server; non-digit separators cause audio dropout.
-  static String generateId() =>
-      'transaction-${DateTime.now().millisecondsSinceEpoch}${(_createCounter++).toString().padLeft(_counterWidth, '0')}';
+  static String generateId() => 'transaction-${DateTime.now().millisecondsSinceEpoch}${_createCounter++}';
 
   final int signalingClientId;
   late final String id;

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -247,13 +247,15 @@ class WebtritSignalingClient {
     _transactions[transaction.id] = transaction;
     requestJson['transaction'] = transaction.id;
 
-    _logger.info('$_id → ${requestJson['type']} transaction=${transaction.id} callId=${requestJson['call_id']}');
+    _logger.fine(
+      '$_id → ${requestJson[Request.typeKey]} transaction=${transaction.id} callId=${requestJson['call_id']}',
+    );
 
     try {
       _addMessage(requestJson);
 
       final responseJson = await transaction.future;
-      _logger.info(
+      _logger.fine(
         '$_id ← response transaction=${transaction.id} '
         'callId=${responseJson['call_id']} response=${responseJson['response']}',
       );

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -235,17 +235,13 @@ class WebtritSignalingClient {
   }
 
   Future<Map<String, dynamic>> _executeTransaction(Map<String, dynamic> requestJson, Duration timeoutDuration) async {
-    // Always generate the transaction ID here, in the isolate that owns the
-    // WebSocket, so IDs are monotonically increasing within the session.
-    // Caller-provided IDs are discarded: each Dart isolate has its own static
-    // counter starting from 0, so a push-notification isolate and the main
-    // isolate can both produce "transaction-0" for separate calls on the same
-    // open WebSocket — causing the server to map the second request to the
-    // first call's session.
-    final transaction = Transaction(signalingClientId: _id, timeoutDuration: timeoutDuration);
+    final transaction = Transaction(
+      signalingClientId: _id,
+      id: requestJson['transaction'] as String?,
+      timeoutDuration: timeoutDuration,
+    );
 
     _transactions[transaction.id] = transaction;
-    requestJson['transaction'] = transaction.id;
 
     _logger.fine(
       '$_id → ${requestJson[Request.typeKey]} transaction=${transaction.id} callId=${requestJson['call_id']}',

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -235,25 +235,30 @@ class WebtritSignalingClient {
   }
 
   Future<Map<String, dynamic>> _executeTransaction(Map<String, dynamic> requestJson, Duration timeoutDuration) async {
-    final transaction = Transaction(
-      signalingClientId: _id,
-      id: requestJson['transaction'],
-      timeoutDuration: timeoutDuration,
-    );
+    // Always generate the transaction ID here, in the isolate that owns the
+    // WebSocket, so IDs are monotonically increasing within the session.
+    // Caller-provided IDs are discarded: each Dart isolate has its own static
+    // counter starting from 0, so a push-notification isolate and the main
+    // isolate can both produce "transaction-0" for separate calls on the same
+    // open WebSocket — causing the server to map the second request to the
+    // first call's session.
+    final transaction = Transaction(signalingClientId: _id, timeoutDuration: timeoutDuration);
 
     _transactions[transaction.id] = transaction;
-    if (transaction.isIdGenerate) {
-      requestJson['transaction'] = transaction.id;
-    }
+    requestJson['transaction'] = transaction.id;
+
+    _logger.info('$_id → ${requestJson['type']} transaction=${transaction.id} callId=${requestJson['call_id']}');
 
     try {
       _addMessage(requestJson);
 
       final responseJson = await transaction.future;
-      if (transaction.isIdGenerate) {
-        responseJson.remove('transaction');
-      }
+      _logger.info(
+        '$_id ← response transaction=${transaction.id} '
+        'callId=${responseJson['call_id']} response=${responseJson['response']}',
+      );
 
+      responseJson.remove('transaction');
       return responseJson;
     } catch (e) {
       _transactions.remove(transaction.id);

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -237,26 +237,23 @@ class WebtritSignalingClient {
   Future<Map<String, dynamic>> _executeTransaction(Map<String, dynamic> requestJson, Duration timeoutDuration) async {
     final transaction = Transaction(
       signalingClientId: _id,
-      id: requestJson['transaction'] as String?,
+      id: requestJson['transaction'],
       timeoutDuration: timeoutDuration,
     );
 
     _transactions[transaction.id] = transaction;
-
-    _logger.fine(
-      '$_id → ${requestJson[Request.typeKey]} transaction=${transaction.id} callId=${requestJson['call_id']}',
-    );
+    if (transaction.isIdGenerate) {
+      requestJson['transaction'] = transaction.id;
+    }
 
     try {
       _addMessage(requestJson);
 
       final responseJson = await transaction.future;
-      _logger.fine(
-        '$_id ← response transaction=${transaction.id} '
-        'callId=${responseJson['call_id']} response=${responseJson['response']}',
-      );
+      if (transaction.isIdGenerate) {
+        responseJson.remove('transaction');
+      }
 
-      responseJson.remove('transaction');
       return responseJson;
     } catch (e) {
       _transactions.remove(transaction.id);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -38,6 +38,13 @@ class SignalingHub {
   /// (no subscribers — app is closed, persistent-service mode).
   bool get hasSubscribers => _subscribers.isNotEmpty;
 
+  /// True when at least one call is currently active (tracked via [_callEventHistory]).
+  ///
+  /// Used by [SignalingSyncHandler] to skip manager recreation when a config-change
+  /// sync arrives mid-call, preventing the WebSocket from being torn down while
+  /// the user is on a call.
+  bool get hasActiveCalls => _callEventHistory.isNotEmpty;
+
   /// Called when [hasSubscribers] transitions (false → true or true → false).
   ///
   /// Used by [SignalingForegroundIsolateManager] in pushBound mode to detect

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -66,13 +66,16 @@ class SignalingForegroundIsolateManager {
   /// Registered by the app via [WebtritSignalingService.setIncomingCallHandler].
   /// 0 means no handler is registered -- incoming calls are only forwarded to
   /// the hub (main isolate) and silently ignored in the background.
-  final int incomingCallHandlerHandle;
+  /// Mutable so it can be updated in-place when the Activity re-registers the
+  /// handler without requiring a WebSocket restart.
+  int incomingCallHandlerHandle;
 
   /// Raw handle for the app-side [SignalingModuleFactory] callback.
   ///
   /// Registered by the app via [WebtritSignalingService.setModuleFactory].
   /// 0 means no factory is registered -- the isolate will log an error and skip start.
-  final int moduleFactoryHandle;
+  /// Mutable so it can be updated in-place without requiring a WebSocket restart.
+  int moduleFactoryHandle;
 
   /// Whether the service was started in pushBound mode.
   ///
@@ -113,6 +116,27 @@ class SignalingForegroundIsolateManager {
   Timer? _pushBoundCleanupTimer;
 
   bool _started = false;
+
+  /// True when the hub is tracking at least one active call.
+  ///
+  /// Delegated to [SignalingHub.hasActiveCalls] so that [SignalingSyncHandler]
+  /// can skip manager recreation while a call is in progress.
+  bool get hasActiveCalls => _hub?.hasActiveCalls ?? false;
+
+  /// Updates runtime handles in-place without restarting the WebSocket connection.
+  ///
+  /// Called by [SignalingSyncHandler] when only [incomingCallHandlerHandle] or
+  /// [moduleFactoryHandle] changed — e.g. when the Activity re-registers them
+  /// after opening from a push notification. Neither handle affects the live
+  /// WebSocket session, so no reconnect is needed.
+  void updateHandles({required int incomingCallHandlerHandle, required int moduleFactoryHandle}) {
+    this.incomingCallHandlerHandle = incomingCallHandlerHandle;
+    this.moduleFactoryHandle = moduleFactoryHandle;
+    _logger.info(
+      'SignalingForegroundIsolateManager handles updated in-place '
+      'incomingCallHandlerHandle=$incomingCallHandlerHandle moduleFactoryHandle=$moduleFactoryHandle',
+    );
+  }
 
   /// Called by the entry point when the service status changes.
   Future<void> handleStatus({required bool enabled}) async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_sync_handler.dart
@@ -27,19 +27,47 @@ Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
     'hasModuleFactory=${status.moduleFactoryHandle != 0}',
   );
   if (status.enabled) {
-    // Re-create manager when credentials or factory handle change (e.g. after re-login).
     final existing = _manager;
     if (existing != null) {
-      final configChanged =
+      // Handles (incomingCallHandlerHandle, moduleFactoryHandle) are runtime
+      // metadata — they change when the Activity re-registers them after opening
+      // from a push notification but do not affect the live WebSocket session.
+      final handlesChanged =
+          existing.incomingCallHandlerHandle != status.incomingCallHandlerHandle ||
+          existing.moduleFactoryHandle != status.moduleFactoryHandle;
+
+      // Connection params require a new WebSocket session (re-login, token
+      // refresh, server change, or mode switch).
+      final connectionConfigChanged =
           existing.coreUrl != status.coreUrl ||
           existing.tenantId != status.tenantId ||
           existing.token != status.token ||
           existing.trustedCertificatesJson != status.trustedCertificatesJson ||
-          existing.incomingCallHandlerHandle != status.incomingCallHandlerHandle ||
-          existing.moduleFactoryHandle != status.moduleFactoryHandle ||
           existing.isPushBound != (status.mode == PSignalingServiceMode.pushBound);
-      if (configChanged) {
-        _logger.info('onSignalingServiceSync config changed, recreating manager');
+
+      // Invariant: connection params change only on logout/login, which cannot
+      // happen while a call is active. WebSocket is never recreated mid-call.
+      if (existing.hasActiveCalls) {
+        if (handlesChanged) {
+          _logger.info('onSignalingServiceSync handles changed during active call — updating in-place');
+          existing.updateHandles(
+            incomingCallHandlerHandle: status.incomingCallHandlerHandle,
+            moduleFactoryHandle: status.moduleFactoryHandle,
+          );
+        }
+        if (connectionConfigChanged) {
+          _logConnectionConfigDelta(existing, status);
+          _logger.warning('onSignalingServiceSync connection config changed during active call — skipping recreate');
+        }
+      } else if (handlesChanged && !connectionConfigChanged) {
+        _logger.info('onSignalingServiceSync handles changed — updating in-place, no WebSocket restart');
+        existing.updateHandles(
+          incomingCallHandlerHandle: status.incomingCallHandlerHandle,
+          moduleFactoryHandle: status.moduleFactoryHandle,
+        );
+      } else if (connectionConfigChanged) {
+        _logConnectionConfigDelta(existing, status);
+        _logger.info('onSignalingServiceSync connection config changed, recreating manager');
         await existing.handleStatus(enabled: false);
         _manager = null;
       }
@@ -58,4 +86,24 @@ Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
     );
   }
   await _manager?.handleStatus(enabled: status.enabled);
+}
+
+void _logConnectionConfigDelta(SignalingForegroundIsolateManager existing, PSignalingServiceStatus next) {
+  if (existing.coreUrl != next.coreUrl) {
+    _logger.info('onSignalingServiceSync delta: coreUrl changed');
+  }
+  if (existing.tenantId != next.tenantId) {
+    _logger.info('onSignalingServiceSync delta: tenantId "${existing.tenantId}" -> "${next.tenantId}"');
+  }
+  if (existing.token != next.token) {
+    _logger.info('onSignalingServiceSync delta: token changed');
+  }
+  if (existing.trustedCertificatesJson != next.trustedCertificatesJson) {
+    _logger.info('onSignalingServiceSync delta: trustedCertificatesJson changed');
+  }
+  if (existing.isPushBound != (next.mode == PSignalingServiceMode.pushBound)) {
+    _logger.info(
+      'onSignalingServiceSync delta: isPushBound ${existing.isPushBound} -> ${next.mode == PSignalingServiceMode.pushBound}',
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Fixes two independent bugs that caused the UI to freeze indefinitely in the \"accepting call\" state when answering a push notification call on Android.

### Bug 1 — WebSocket torn down mid-call by handles sync

`SignalingSyncHandler.onSignalingServiceSync` was treating `incomingCallHandlerHandle` and `moduleFactoryHandle` changes as a full config change requiring manager recreation. These handles are re-registered by the Activity on startup — they are runtime metadata, not connection credentials. The handler was destroying the `SignalingHub` and closing the WebSocket while a call was active.

**Fix:** split the single `configChanged` check into two separate paths:
- **Handles** (`incomingCallHandlerHandle`, `moduleFactoryHandle`) → update in-place via `updateHandles()`, no WebSocket restart
- **Connection params** (`coreUrl`, `tenantId`, `token`, `trustedCerts`, `isPushBound`) → recreate manager

Added invariant guard: `hasActiveCalls` is checked first — connection params change only on logout/login, never during a call, so any recreation during a call indicates a bug.

### Bug 2 — Transaction ID collision across push notification isolate restarts

`Transaction._createCounter` is a `static int` — each Dart isolate has its own independent copy starting from `0`. The push notification isolate is a fresh isolate for every incoming call, so its counter always resets to `0`, producing `transaction-0`, `transaction-1` on every new session. The server cached the `transaction-1 → call_id` mapping from a previous session and returned the wrong `call_id` in the ack. The expected `AcceptedEvent` for the current call never arrived → stuck in `incomingAnswering`.

**Fix:** added `static final _sessionId = Random.secure().nextInt(1000000000)` — a cryptographically random 9-digit number initialized once per isolate run. `generateId()` now returns `transaction-{sessionId}{counter}`. Each push notification isolate gets a distinct prefix so the server cannot match IDs against a previous session's cached responses.

Note: the ID uses digits only after `transaction-` — non-digit separators cause audio dropout on the server side.

## Files changed

| File | Change |
|------|--------|
| `transaction.dart` | `Random.secure` session prefix + doc comment on `generateId` |
| `signaling_hub.dart` | `hasActiveCalls` getter |
| `signaling_foreground_isolate_manager.dart` | mutable handles, `updateHandles()`, `hasActiveCalls` |
| `signaling_sync_handler.dart` | split handles/connection-config paths, invariant guard, delta logging |
| `call_bloc.dart` | diagnostic log of `callId`/`line` before `AcceptRequest` |

## Tested on

Samsung SM-A505FN Android 11 — call acceptance from push notification stable across consecutive calls.