### PR TITLE
fix(settings): user-friendly error when delete account is not supported (WT-1346)

### DIFF
--- a/lib/features/settings/bloc/settings_bloc.dart
+++ b/lib/features/settings/bloc/settings_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/widgets.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 
@@ -11,6 +12,7 @@ import 'package:webtrit_api/webtrit_api.dart';
 import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/data/app_permissions.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
 part 'settings_event.dart';
@@ -76,6 +78,14 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       if (emit.isDone) return;
 
       emit(state.copyWith(progress: false));
+    } on EndpointNotSupportedException catch (e, stackTrace) {
+      _logger.warning('_onAccountDeleted: endpoint not supported', e, stackTrace);
+
+      notificationsBloc.add(NotificationsSubmitted(const _DeleteAccountNotSupportedNotification()));
+
+      if (emit.isDone) return;
+
+      emit(state.copyWith(progress: false));
     } catch (e, stackTrace) {
       _logger.warning('_onAccountDeleted', e, stackTrace);
 
@@ -93,4 +103,11 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     _unreadVoicemailsSub.cancel();
     return super.close();
   }
+}
+
+class _DeleteAccountNotSupportedNotification extends ErrorNotification {
+  const _DeleteAccountNotSupportedNotification();
+
+  @override
+  String l10n(BuildContext context) => context.l10n.settings_AccountDeleteNotSupported_message;
 }

--- a/lib/features/settings/bloc/settings_bloc.dart
+++ b/lib/features/settings/bloc/settings_bloc.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/widgets.dart';
+
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
-import 'package:flutter/widgets.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -3120,6 +3120,12 @@ abstract class AppLocalizations {
   /// **'Confirm delete account'**
   String get settings_AccountDeleteConfirmDialog_title;
 
+  /// No description provided for @settings_AccountDeleteNotSupported_message.
+  ///
+  /// In en, this message translates to:
+  /// **'Unfortunately, your product does not support account deletion.'**
+  String get settings_AccountDeleteNotSupported_message;
+
   /// No description provided for @settings_AppBarTitle_myAccount.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1682,6 +1682,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_AccountDeleteConfirmDialog_title => 'Confirm delete account';
 
   @override
+  String get settings_AccountDeleteNotSupported_message =>
+      'Unfortunately, your product does not support account deletion.';
+
+  @override
   String get settings_AppBarTitle_myAccount => 'My account';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1702,6 +1702,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_AccountDeleteConfirmDialog_title => 'Conferma eliminazione account';
 
   @override
+  String get settings_AccountDeleteNotSupported_message =>
+      'Unfortunately, your product does not support account deletion.';
+
+  @override
   String get settings_AppBarTitle_myAccount => 'Il mio account';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1703,7 +1703,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_AccountDeleteNotSupported_message =>
-      'Unfortunately, your product does not support account deletion.';
+      'Sfortunatamente, il tuo prodotto non supporta l\'eliminazione dell\'account.';
 
   @override
   String get settings_AppBarTitle_myAccount => 'Il mio account';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1703,6 +1703,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settings_AccountDeleteConfirmDialog_title => 'Підтвердіть видалення облікового запису';
 
   @override
+  String get settings_AccountDeleteNotSupported_message =>
+      'Unfortunately, your product does not support account deletion.';
+
+  @override
   String get settings_AppBarTitle_myAccount => 'Мій обліковий запис';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1704,7 +1704,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get settings_AccountDeleteNotSupported_message =>
-      'Unfortunately, your product does not support account deletion.';
+      'На жаль, ваш продукт не підтримує видалення облікового запису.';
 
   @override
   String get settings_AppBarTitle_myAccount => 'Мій обліковий запис';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1400,6 +1400,8 @@
   "@settings_AccountDeleteConfirmDialog_content": {},
   "settings_AccountDeleteConfirmDialog_title": "Confirm delete account",
   "@settings_AccountDeleteConfirmDialog_title": {},
+  "settings_AccountDeleteNotSupported_message": "Unfortunately, your product does not support account deletion.",
+  "@settings_AccountDeleteNotSupported_message": {},
   "settings_AppBarTitle_myAccount": "My account",
   "@settings_AppBarTitle_myAccount": {},
   "settings_audioProcessing_Section_AGC_title": "Auto gain control",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1400,6 +1400,8 @@
   "@settings_AccountDeleteConfirmDialog_content": {},
   "settings_AccountDeleteConfirmDialog_title": "Conferma eliminazione account",
   "@settings_AccountDeleteConfirmDialog_title": {},
+  "settings_AccountDeleteNotSupported_message": "Sfortunatamente, il tuo prodotto non supporta l'eliminazione dell'account.",
+  "@settings_AccountDeleteNotSupported_message": {},
   "settings_AppBarTitle_myAccount": "Il mio account",
   "@settings_AppBarTitle_myAccount": {},
   "settings_audioProcessing_Section_AGC_title": "Controllo automatico del guadagno",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1400,6 +1400,8 @@
   "@settings_AccountDeleteConfirmDialog_content": {},
   "settings_AccountDeleteConfirmDialog_title": "Підтвердіть видалення облікового запису",
   "@settings_AccountDeleteConfirmDialog_title": {},
+  "settings_AccountDeleteNotSupported_message": "На жаль, ваш продукт не підтримує видалення облікового запису.",
+  "@settings_AccountDeleteNotSupported_message": {},
   "settings_AppBarTitle_myAccount": "Мій обліковий запис",
   "@settings_AppBarTitle_myAccount": {},
   "settings_audioProcessing_Section_AGC_title": "Автоматичне регулювання посилення",


### PR DESCRIPTION
## Summary

- When server returns HTTP 501 (`EndpointNotSupportedException`) on delete account, the app now shows a localized snackbar instead of a raw technical error
- Added specific `on EndpointNotSupportedException` catch in `_onAccountDeleted` — no logout triggered, no `maybeHandleError` (not a fatal error)
- New l10n key: `settings_AccountDeleteNotSupported_message` → _"Unfortunately, your product does not support account deletion."_

## Test plan

- [ ] Tap "Delete Account" in Settings against a server with PortaSwitchAdapter 0.7.3
- [ ] Confirm user-friendly snackbar appears (no raw HTTP 501 / exception text)
- [ ] Verify user is NOT logged out after seeing the message
- [ ] Tap "Delete Account" against a server that supports the method — verify normal logout flow still works

## Related

Closes WT-1346