### PR TITLE
feat: remote video frame detector, show remote video if local disabled (WT-1329, WT-1352, WT-1243)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2630,9 +2630,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _PeerConnectionEventStreamAdded event,
     Emitter<CallState> emit,
   ) async {
-    // Skip stub stream created by Janus on unidirectional video
-    if (event.stream.id == 'janus') return;
-
     final currentStream = state.retrieveActiveCall(event.callId)?.remoteStream;
     final sameRef = identical(currentStream, event.stream);
     _logger.info(
@@ -3318,6 +3315,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         // state is updated with the latest stream reference when video is added
         // mid-call (e.g. after a glare-resolution rollback).
         onAddTrack: (stream, track) => add(_PeerConnectionEvent.streamAdded(callId, stream)),
+        onTrack: (event) {
+          // Typically fired on upgrade to video, without firing onAddStream.
+          // The event may contain multiple streams but in practice we only handle the first one since our use case is limited to a single audio/video stream per call.
+          final stream = event.streams.isNotEmpty ? event.streams.first : null;
+          if (stream != null) {
+            add(_PeerConnectionEvent.streamAdded(callId, stream));
+          } else {
+            _logger.warning('PeerConnectionObserver.onTrack fired with empty streams for callId=$callId');
+          }
+        },
         onRenegotiationNeeded: (pc) {
           // Skips initial triggering that happens during peer connection setup
           if (pc.signalingState != null) add(_PeerConnectionEvent.renegotiationNeeded(callId, lineId));

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1303,6 +1303,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
                 jsep: localDescription.toMap(),
               ),
             );
+
+            if (localStream?.getVideoTracks().firstOrNull?.enabled == false) {
+              emit(
+                state.copyWithMappedActiveCall(event.callId, (activeCall) {
+                  return activeCall.copyWith(localStream: localStream, video: false);
+                }),
+              );
+            }
           }
         });
       }

--- a/lib/features/call/utils/peer_connection_policy_applier.dart
+++ b/lib/features/call/utils/peer_connection_policy_applier.dart
@@ -63,8 +63,13 @@ class ModifyWithSettingsPeerConnectionPolicyApplier implements PeerConnectionPol
     bool? frontCamera,
   }) async {
     _logger.fine('Applying peer connection policies with settings: $_negotiationSettings');
-    // Check if the policy requires inserting an inactive video track for negotiation purposes
-    if (_negotiationSettings.includeInactiveVideoInOfferAnswer && hasRemoteVideo) {
+
+    // // Check if the policy requires inserting an inactive video track for negotiation purposes
+    // if (_negotiationSettings.includeInactiveVideoInOfferAnswer && hasRemoteVideo) {
+    //
+    // Enabled by default for test purposes
+    // TODO: if everything works well remove all related settings
+    if (hasRemoteVideo) {
       // Check if a video track is already added to the peer connection
       final senders = await peerConnection.getSenders();
       final alreadyHasVideo = senders.any((sender) => sender.track != null && sender.track!.kind == 'video');

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -100,238 +100,250 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     // activeCall.remoteStream.getVideoTracks().first.captureFrame
 
-    return ThemedScaffold(
-      background: style?.background,
-      extendBodyBehindAppBar: true,
-      body: OrientationBuilder(
-        builder: (context, orientation) {
-          return Stack(
-            children: [
-              if (activeCall.remoteVideo)
-                RemoteVideoViewOverlay(
-                  activeCallWasAccepted: activeCall.wasAccepted,
-                  remoteStream: activeCall.remoteStream,
-                  videoFit: _videoFit,
-                  onTap: _compactController.toggle,
-                  remotePlaceholderBuilder: widget.remotePlaceholderBuilder,
-                  backgroundMode: _backgroundMode,
-                  hasRenderableRemoteFrame: _hasRenderableRemoteFrame,
-                  // Its important to hide video if held to avoid showing frozen/last frames when held,
-                  // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
-                  hideVideo: activeCall.held,
-                ),
-              AnimatedBuilder(
-                animation: _compactController,
-                builder: (context, _) => Positioned.fill(
-                  left: mediaQueryData.padding.left,
-                  right: mediaQueryData.padding.right,
-                  top: mediaQueryData.padding.top,
-                  bottom: mediaQueryData.padding.bottom,
-                  child: AnimatedOpacity(
-                    opacity: _compactController.compact ? 0 : 1,
-                    duration: kThemeAnimationDuration,
-                    child: IgnorePointer(
-                      ignoring: _compactController.compact,
-                      child: Column(
-                        children: [
-                          AppBar(
-                            leading: style?.appBar?.showBackButton == false ? null : const ExtBackButton(),
-                            backgroundColor: style?.appBar?.backgroundColor,
-                            foregroundColor: style?.appBar?.foregroundColor,
-                            primary: style?.appBar?.primary ?? false,
-                            actions: [
-                              if (activeCalls.shouldAutoCompact)
-                                CallPopupMenuButton<void>(
-                                  items: _buildPopupMenuItems,
-                                  child: const Icon(Icons.more_vert),
+    return GestureDetector(
+      onTap: _compactController.toggle,
+
+      child: ThemedScaffold(
+        background: style?.background,
+        extendBodyBehindAppBar: true,
+        body: OrientationBuilder(
+          builder: (context, orientation) {
+            return GestureDetector(
+              child: Stack(
+                children: [
+                  if (_hasRenderableRemoteFrame)
+                    RemoteVideoViewOverlay(
+                      activeCallWasAccepted: activeCall.wasAccepted,
+                      remoteStream: activeCall.remoteStream,
+                      videoFit: _videoFit,
+                      onTap: _compactController.toggle,
+                      remotePlaceholderBuilder: widget.remotePlaceholderBuilder,
+                      backgroundMode: _backgroundMode,
+                      hasRenderableRemoteFrame: _hasRenderableRemoteFrame,
+                      // Its important to hide video if held to avoid showing frozen/last frames when held,
+                      // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
+                      hideVideo: activeCall.held,
+                    ),
+                  AnimatedBuilder(
+                    animation: _compactController,
+                    builder: (context, _) => Positioned.fill(
+                      left: mediaQueryData.padding.left,
+                      right: mediaQueryData.padding.right,
+                      top: mediaQueryData.padding.top,
+                      bottom: mediaQueryData.padding.bottom,
+                      child: AnimatedOpacity(
+                        opacity: _compactController.compact ? 0 : 1,
+                        duration: kThemeAnimationDuration,
+                        child: IgnorePointer(
+                          ignoring: _compactController.compact,
+                          child: Column(
+                            children: [
+                              AppBar(
+                                leading: style?.appBar?.showBackButton == false ? null : const ExtBackButton(),
+                                backgroundColor: style?.appBar?.backgroundColor,
+                                foregroundColor: style?.appBar?.foregroundColor,
+                                primary: style?.appBar?.primary ?? false,
+                                actions: [
+                                  if (activeCalls.shouldAutoCompact)
+                                    CallPopupMenuButton<void>(
+                                      items: _buildPopupMenuItems,
+                                      child: const Icon(Icons.more_vert),
+                                    ),
+                                ],
+                              ),
+                              Expanded(
+                                child: LayoutBuilder(
+                                  builder: (context, constraints) {
+                                    return FittedBox(
+                                      child: ConstrainedBox(
+                                        constraints: BoxConstraints(
+                                          maxWidth: constraints.maxWidth,
+                                          minHeight: constraints.minHeight,
+                                        ),
+                                        child: Column(
+                                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                          children: [
+                                            for (final activeCall in activeCalls)
+                                              CallInfo(
+                                                transfering: activeTransfer is Transfering,
+                                                requestToAttendedTransfer: false,
+                                                inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
+                                                isIncoming: activeCall.isIncoming,
+                                                held: activeCall.held,
+                                                number: activeCall.handle.value,
+                                                username: activeCall.displayName,
+                                                acceptedTime: activeCall.acceptedTime,
+                                                style: style?.callInfo,
+                                                processingStatus: activeCall.processingStatus,
+                                                callStatus: widget.callStatus,
+                                              ),
+                                            if (activeTransfer is AttendedTransferConfirmationRequested)
+                                              CallInfo(
+                                                transfering: false,
+                                                requestToAttendedTransfer: true,
+                                                inviteToAttendedTransfer: false,
+                                                isIncoming: false,
+                                                held: false,
+                                                number: activeCall.handle.value,
+                                                username: activeCall.displayName,
+                                                style: style?.callInfo,
+                                                callStatus: widget.callStatus,
+                                              ),
+                                            CallActions(
+                                              style: style?.actions,
+                                              enableInteractions:
+                                                  widget.callStatus == CallStatus.ready &&
+                                                  activeCalls.any((call) => call.updating) == false,
+                                              isIncoming: activeCall.isIncoming,
+                                              remoteVideo:
+                                                  activeCall.remoteVideo &&
+                                                  _hasRenderableRemoteFrame &&
+                                                  activeCall.held == false,
+                                              wasAccepted: activeCall.wasAccepted,
+                                              wasHungUp: activeCall.wasHungUp,
+                                              cameraValue: activeCall.isCameraActive,
+                                              inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
+                                              onCameraChanged: widget.callConfig.isVideoCallEnabled
+                                                  ? (bool value) => _callBloc.add(
+                                                      CallControlEvent.cameraEnabled(activeCall.callId, value),
+                                                    )
+                                                  : null,
+                                              mutedValue: activeCall.muted,
+                                              onMutedChanged: (bool value) =>
+                                                  _callBloc.add(CallControlEvent.setMuted(activeCall.callId, value)),
+                                              audioDevice: widget.audioDevice,
+                                              availableAudioDevices: widget.availableAudioDevices,
+                                              onAudioDeviceChanged: (CallAudioDevice device) {
+                                                _callBloc.add(
+                                                  CallControlEvent.audioDeviceSet(activeCall.callId, device),
+                                                );
+                                              },
+                                              transferableCalls: heldCalls,
+                                              onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
+                                                  ? (!activeCall.wasAccepted || activeTransfer != null
+                                                        ? null
+                                                        : () {
+                                                            _callBloc.add(
+                                                              CallControlEvent.blindTransferInitiated(
+                                                                activeCall.callId,
+                                                              ),
+                                                            );
+                                                          })
+                                                  : null,
+                                              // TODO (Serdun): Simplify complex condition in the widget tree.
+                                              onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
+                                                  ? (!activeCall.wasAccepted || activeTransfer != null
+                                                        ? null
+                                                        : () {
+                                                            _callBloc.add(
+                                                              CallControlEvent.attendedTransferInitiated(
+                                                                activeCall.callId,
+                                                              ),
+                                                            );
+                                                          })
+                                                  : null,
+                                              // TODO (Serdun): Simplify complex condition in the widget tree.
+                                              onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
+                                                  ? (!activeCall.wasAccepted || activeTransfer != null
+                                                        ? null
+                                                        : (ActiveCall referorCall) {
+                                                            _callBloc.add(
+                                                              CallControlEvent.attendedTransferSubmitted(
+                                                                referorCall: referorCall,
+                                                                replaceCall: activeCall,
+                                                              ),
+                                                            );
+                                                          })
+                                                  : null,
+                                              heldValue: activeCall.held,
+                                              onHeldChanged: (bool value) {
+                                                _callBloc.add(CallControlEvent.setHeld(activeCall.callId, value));
+                                              },
+                                              onSwapPressed: activeCalls.length == 2
+                                                  ? () {
+                                                      _callBloc.add(CallControlEvent.setHeld(activeCall.callId, true));
+                                                      for (final otherActiveCall in activeCalls) {
+                                                        if (otherActiveCall.callId != activeCall.callId) {
+                                                          _callBloc.add(
+                                                            CallControlEvent.setHeld(otherActiveCall.callId, false),
+                                                          );
+                                                        }
+                                                      }
+                                                    }
+                                                  : null,
+                                              onHangupPressed: () {
+                                                _callBloc.add(CallControlEvent.ended(activeCall.callId));
+                                              },
+                                              onHangupAndAcceptPressed: activeCalls.length > 1
+                                                  ? () {
+                                                      for (final otherActiveCall in activeCalls) {
+                                                        if (otherActiveCall.callId != activeCall.callId) {
+                                                          _callBloc.add(CallControlEvent.ended(otherActiveCall.callId));
+                                                        }
+                                                      }
+                                                      _callBloc.add(CallControlEvent.answered(activeCall.callId));
+                                                    }
+                                                  : null,
+                                              onHoldAndAcceptPressed: activeCalls.length > 1
+                                                  ? () {
+                                                      for (final otherActiveCall in activeCalls) {
+                                                        if (otherActiveCall.callId != activeCall.callId) {
+                                                          _callBloc.add(
+                                                            CallControlEvent.setHeld(otherActiveCall.callId, true),
+                                                          );
+                                                        }
+                                                      }
+                                                      _callBloc.add(CallControlEvent.answered(activeCall.callId));
+                                                    }
+                                                  : null,
+                                              onAcceptPressed: () {
+                                                _callBloc.add(CallControlEvent.answered(activeCall.callId));
+                                              },
+                                              onApproveTransferPressed:
+                                                  activeTransfer is AttendedTransferConfirmationRequested
+                                                  ? () {
+                                                      _callBloc.add(
+                                                        CallControlEvent.attendedRequestApproved(
+                                                          referId: activeTransfer.referId,
+                                                          referTo: activeTransfer.referTo,
+                                                        ),
+                                                      );
+                                                    }
+                                                  : null,
+                                              onDeclineTransferPressed:
+                                                  activeTransfer is AttendedTransferConfirmationRequested
+                                                  ? () {
+                                                      _callBloc.add(
+                                                        CallControlEvent.attendedRequestDeclined(
+                                                          callId: activeCall.callId,
+                                                          referId: activeTransfer.referId,
+                                                        ),
+                                                      );
+                                                    }
+                                                  : null,
+                                              onKeyPressed: (value) {
+                                                _callBloc.add(CallControlEvent.sentDTMF(activeCall.callId, value));
+                                              },
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    );
+                                  },
                                 ),
+                              ),
+                              const SizedBox(height: 20),
                             ],
                           ),
-                          Expanded(
-                            child: LayoutBuilder(
-                              builder: (context, constraints) {
-                                return FittedBox(
-                                  child: ConstrainedBox(
-                                    constraints: BoxConstraints(
-                                      maxWidth: constraints.maxWidth,
-                                      minHeight: constraints.minHeight,
-                                    ),
-                                    child: Column(
-                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                      children: [
-                                        for (final activeCall in activeCalls)
-                                          CallInfo(
-                                            transfering: activeTransfer is Transfering,
-                                            requestToAttendedTransfer: false,
-                                            inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
-                                            isIncoming: activeCall.isIncoming,
-                                            held: activeCall.held,
-                                            number: activeCall.handle.value,
-                                            username: activeCall.displayName,
-                                            acceptedTime: activeCall.acceptedTime,
-                                            style: style?.callInfo,
-                                            processingStatus: activeCall.processingStatus,
-                                            callStatus: widget.callStatus,
-                                          ),
-                                        if (activeTransfer is AttendedTransferConfirmationRequested)
-                                          CallInfo(
-                                            transfering: false,
-                                            requestToAttendedTransfer: true,
-                                            inviteToAttendedTransfer: false,
-                                            isIncoming: false,
-                                            held: false,
-                                            number: activeCall.handle.value,
-                                            username: activeCall.displayName,
-                                            style: style?.callInfo,
-                                            callStatus: widget.callStatus,
-                                          ),
-                                        CallActions(
-                                          style: style?.actions,
-                                          enableInteractions:
-                                              widget.callStatus == CallStatus.ready &&
-                                              activeCalls.any((call) => call.updating) == false,
-                                          isIncoming: activeCall.isIncoming,
-                                          remoteVideo:
-                                              activeCall.remoteVideo &&
-                                              _hasRenderableRemoteFrame &&
-                                              activeCall.held == false,
-                                          wasAccepted: activeCall.wasAccepted,
-                                          wasHungUp: activeCall.wasHungUp,
-                                          cameraValue: activeCall.isCameraActive,
-                                          inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
-                                          onCameraChanged: widget.callConfig.isVideoCallEnabled
-                                              ? (bool value) => _callBloc.add(
-                                                  CallControlEvent.cameraEnabled(activeCall.callId, value),
-                                                )
-                                              : null,
-                                          mutedValue: activeCall.muted,
-                                          onMutedChanged: (bool value) =>
-                                              _callBloc.add(CallControlEvent.setMuted(activeCall.callId, value)),
-                                          audioDevice: widget.audioDevice,
-                                          availableAudioDevices: widget.availableAudioDevices,
-                                          onAudioDeviceChanged: (CallAudioDevice device) {
-                                            _callBloc.add(CallControlEvent.audioDeviceSet(activeCall.callId, device));
-                                          },
-                                          transferableCalls: heldCalls,
-                                          onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
-                                              ? (!activeCall.wasAccepted || activeTransfer != null
-                                                    ? null
-                                                    : () {
-                                                        _callBloc.add(
-                                                          CallControlEvent.blindTransferInitiated(activeCall.callId),
-                                                        );
-                                                      })
-                                              : null,
-                                          // TODO (Serdun): Simplify complex condition in the widget tree.
-                                          onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
-                                              ? (!activeCall.wasAccepted || activeTransfer != null
-                                                    ? null
-                                                    : () {
-                                                        _callBloc.add(
-                                                          CallControlEvent.attendedTransferInitiated(activeCall.callId),
-                                                        );
-                                                      })
-                                              : null,
-                                          // TODO (Serdun): Simplify complex condition in the widget tree.
-                                          onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
-                                              ? (!activeCall.wasAccepted || activeTransfer != null
-                                                    ? null
-                                                    : (ActiveCall referorCall) {
-                                                        _callBloc.add(
-                                                          CallControlEvent.attendedTransferSubmitted(
-                                                            referorCall: referorCall,
-                                                            replaceCall: activeCall,
-                                                          ),
-                                                        );
-                                                      })
-                                              : null,
-                                          heldValue: activeCall.held,
-                                          onHeldChanged: (bool value) {
-                                            _callBloc.add(CallControlEvent.setHeld(activeCall.callId, value));
-                                          },
-                                          onSwapPressed: activeCalls.length == 2
-                                              ? () {
-                                                  _callBloc.add(CallControlEvent.setHeld(activeCall.callId, true));
-                                                  for (final otherActiveCall in activeCalls) {
-                                                    if (otherActiveCall.callId != activeCall.callId) {
-                                                      _callBloc.add(
-                                                        CallControlEvent.setHeld(otherActiveCall.callId, false),
-                                                      );
-                                                    }
-                                                  }
-                                                }
-                                              : null,
-                                          onHangupPressed: () {
-                                            _callBloc.add(CallControlEvent.ended(activeCall.callId));
-                                          },
-                                          onHangupAndAcceptPressed: activeCalls.length > 1
-                                              ? () {
-                                                  for (final otherActiveCall in activeCalls) {
-                                                    if (otherActiveCall.callId != activeCall.callId) {
-                                                      _callBloc.add(CallControlEvent.ended(otherActiveCall.callId));
-                                                    }
-                                                  }
-                                                  _callBloc.add(CallControlEvent.answered(activeCall.callId));
-                                                }
-                                              : null,
-                                          onHoldAndAcceptPressed: activeCalls.length > 1
-                                              ? () {
-                                                  for (final otherActiveCall in activeCalls) {
-                                                    if (otherActiveCall.callId != activeCall.callId) {
-                                                      _callBloc.add(
-                                                        CallControlEvent.setHeld(otherActiveCall.callId, true),
-                                                      );
-                                                    }
-                                                  }
-                                                  _callBloc.add(CallControlEvent.answered(activeCall.callId));
-                                                }
-                                              : null,
-                                          onAcceptPressed: () {
-                                            _callBloc.add(CallControlEvent.answered(activeCall.callId));
-                                          },
-                                          onApproveTransferPressed:
-                                              activeTransfer is AttendedTransferConfirmationRequested
-                                              ? () {
-                                                  _callBloc.add(
-                                                    CallControlEvent.attendedRequestApproved(
-                                                      referId: activeTransfer.referId,
-                                                      referTo: activeTransfer.referTo,
-                                                    ),
-                                                  );
-                                                }
-                                              : null,
-                                          onDeclineTransferPressed:
-                                              activeTransfer is AttendedTransferConfirmationRequested
-                                              ? () {
-                                                  _callBloc.add(
-                                                    CallControlEvent.attendedRequestDeclined(
-                                                      callId: activeCall.callId,
-                                                      referId: activeTransfer.referId,
-                                                    ),
-                                                  );
-                                                }
-                                              : null,
-                                          onKeyPressed: (value) {
-                                            _callBloc.add(CallControlEvent.sentDTMF(activeCall.callId, value));
-                                          },
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                          ),
-                          const SizedBox(height: 20),
-                        ],
+                        ),
                       ),
                     ),
                   ),
-                ),
+                ],
               ),
-            ],
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -7,11 +7,14 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../call.dart';
+
+final _logger = Logger('CallActiveScaffold');
 
 class CallActiveScaffold extends StatefulWidget {
   const CallActiveScaffold({
@@ -38,7 +41,7 @@ class CallActiveScaffold extends StatefulWidget {
 }
 
 class CallActiveScaffoldState extends State<CallActiveScaffold> {
-  static const Duration _remoteFrameProbeInterval = Duration(seconds: 2);
+  static const Duration _remoteFrameProbeInterval = Duration(seconds: 1);
   static const int _remoteFrameMaxSamples = 1200;
   static const int _blackLumaThreshold = 16;
   static const double _blackFrameRatioThreshold = 0.98;
@@ -63,8 +66,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
   Timer? _remoteFrameWatcher;
   bool _remoteFrameProbeInProgress = false;
-  bool _hasRenderableRemoteFrame = true;
-  String? _watchedRemoteTrackId;
+  bool _hasRenderableRemoteFrame = false;
 
   @override
   void initState() {
@@ -74,7 +76,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     // Synchronize the auto-hide logic with the initial call list configuration.
     _compactController = CompactAutoResetController(initiallyActive: widget.activeCalls.shouldAutoCompact);
-    _syncRemoteFrameWatcher();
+    _remoteFrameWatcher = Timer.periodic(_remoteFrameProbeInterval, (_) => _probeRemoteFrame());
   }
 
   @override
@@ -82,7 +84,6 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     super.didUpdateWidget(oldWidget);
     // Synchronize the auto-hide logic with the latest call list configuration.
     _compactController.setActive(widget.activeCalls.shouldAutoCompact, reason: 'didUpdateWidget');
-    _syncRemoteFrameWatcher();
   }
 
   @override
@@ -379,29 +380,6 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     setState(() => _backgroundMode = _backgroundMode.toggled);
   }
 
-  void _syncRemoteFrameWatcher() {
-    final track = _currentRemoteVideoTrack;
-    final trackId = track?.id;
-
-    if (trackId == null) {
-      _disposeRemoteFrameWatcher();
-      _remoteFrameProbeInProgress = false;
-      _watchedRemoteTrackId = null;
-      _setHasRenderableRemoteFrame(true);
-      return;
-    }
-
-    if (_watchedRemoteTrackId == trackId && _remoteFrameWatcher != null) {
-      return;
-    }
-
-    _disposeRemoteFrameWatcher();
-    _watchedRemoteTrackId = trackId;
-    _setHasRenderableRemoteFrame(true);
-    _probeRemoteFrame();
-    _remoteFrameWatcher = Timer.periodic(_remoteFrameProbeInterval, (_) => _probeRemoteFrame());
-  }
-
   MediaStreamTrack? get _currentRemoteVideoTrack {
     final stream = widget.activeCalls.current.remoteStream;
     final tracks = stream?.getVideoTracks();
@@ -414,29 +392,23 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   }
 
   Future<void> _probeRemoteFrame() async {
-    if (_remoteFrameProbeInProgress || mounted == false) {
-      return;
-    }
+    if (_remoteFrameProbeInProgress || mounted == false) return;
 
     final track = _currentRemoteVideoTrack;
-
-    if (track == null) {
-      _setHasRenderableRemoteFrame(true);
-      return;
-    }
+    if (track == null) return;
 
     _remoteFrameProbeInProgress = true;
+    final startTime = DateTime.now();
     try {
-      final isBlackOrEmpty = await _isTrackFrameBlackOrEmpty(track);
-      if (mounted) {
-        _setHasRenderableRemoteFrame(!isBlackOrEmpty);
-      }
+      final isBlackOrEmpty = await _isTrackFrameBlackOrEmpty(track).timeout(const Duration(seconds: 5));
+      _setHasRenderableRemoteFrame(!isBlackOrEmpty);
     } catch (_) {
-      if (mounted) {
-        _setHasRenderableRemoteFrame(true);
-      }
+      // In case of any errors during frame capture or analysis, we optimistically assume that the remote frame is renderable.
+      _setHasRenderableRemoteFrame(true);
     } finally {
       _remoteFrameProbeInProgress = false;
+      final elapsed = DateTime.now().difference(startTime);
+      _logger.fine('Remote frame probe completed in ${elapsed.inMilliseconds}ms, $_hasRenderableRemoteFrame');
     }
   }
 

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -1,3 +1,8 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -33,6 +38,11 @@ class CallActiveScaffold extends StatefulWidget {
 }
 
 class CallActiveScaffoldState extends State<CallActiveScaffold> {
+  static const Duration _remoteFrameProbeInterval = Duration(seconds: 2);
+  static const int _remoteFrameMaxSamples = 1200;
+  static const int _blackLumaThreshold = 16;
+  static const double _blackFrameRatioThreshold = 0.98;
+
   /// Cached `CallBloc` obtained in `initState`.
   /// Avoids unsafe `context.read` during widget deactivation (e.g., navigation pop).
   late final CallBloc _callBloc;
@@ -51,6 +61,11 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   /// Consider moving this to a global state (e.g., BLoC or Some config provider).
   VideoBackgroundMode _backgroundMode = VideoBackgroundMode.blur;
 
+  Timer? _remoteFrameWatcher;
+  bool _remoteFrameProbeInProgress = false;
+  bool _hasRenderableRemoteFrame = true;
+  String? _watchedRemoteTrackId;
+
   @override
   void initState() {
     super.initState();
@@ -59,6 +74,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     // Synchronize the auto-hide logic with the initial call list configuration.
     _compactController = CompactAutoResetController(initiallyActive: widget.activeCalls.shouldAutoCompact);
+    _syncRemoteFrameWatcher();
   }
 
   @override
@@ -66,6 +82,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     super.didUpdateWidget(oldWidget);
     // Synchronize the auto-hide logic with the latest call list configuration.
     _compactController.setActive(widget.activeCalls.shouldAutoCompact, reason: 'didUpdateWidget');
+    _syncRemoteFrameWatcher();
   }
 
   @override
@@ -80,6 +97,8 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     final MediaQueryData mediaQueryData = MediaQuery.of(context);
 
     final style = themeData.extension<CallScreenStyles>()?.primary;
+
+    // activeCall.remoteStream.getVideoTracks().first.captureFrame
 
     return ThemedScaffold(
       background: style?.background,
@@ -96,6 +115,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                   onTap: _compactController.toggle,
                   remotePlaceholderBuilder: widget.remotePlaceholderBuilder,
                   backgroundMode: _backgroundMode,
+                  hasRenderableRemoteFrame: _hasRenderableRemoteFrame,
                   // Its important to hide video if held to avoid showing frozen/last frames when held,
                   // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
                   hideVideo: activeCall.held,
@@ -171,7 +191,10 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                               widget.callStatus == CallStatus.ready &&
                                               activeCalls.any((call) => call.updating) == false,
                                           isIncoming: activeCall.isIncoming,
-                                          remoteVideo: activeCall.remoteVideo,
+                                          remoteVideo:
+                                              activeCall.remoteVideo &&
+                                              _hasRenderableRemoteFrame &&
+                                              activeCall.held == false,
                                           wasAccepted: activeCall.wasAccepted,
                                           wasHungUp: activeCall.wasHungUp,
                                           cameraValue: activeCall.isCameraActive,
@@ -344,8 +367,153 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     setState(() => _backgroundMode = _backgroundMode.toggled);
   }
 
+  void _syncRemoteFrameWatcher() {
+    final track = _currentRemoteVideoTrack;
+    final trackId = track?.id;
+
+    if (trackId == null) {
+      _disposeRemoteFrameWatcher();
+      _remoteFrameProbeInProgress = false;
+      _watchedRemoteTrackId = null;
+      _setHasRenderableRemoteFrame(true);
+      return;
+    }
+
+    if (_watchedRemoteTrackId == trackId && _remoteFrameWatcher != null) {
+      return;
+    }
+
+    _disposeRemoteFrameWatcher();
+    _watchedRemoteTrackId = trackId;
+    _setHasRenderableRemoteFrame(true);
+    _probeRemoteFrame();
+    _remoteFrameWatcher = Timer.periodic(_remoteFrameProbeInterval, (_) => _probeRemoteFrame());
+  }
+
+  MediaStreamTrack? get _currentRemoteVideoTrack {
+    final stream = widget.activeCalls.current.remoteStream;
+    final tracks = stream?.getVideoTracks();
+
+    if (tracks == null || tracks.isEmpty) {
+      return null;
+    }
+
+    return tracks.first;
+  }
+
+  Future<void> _probeRemoteFrame() async {
+    if (_remoteFrameProbeInProgress || mounted == false) {
+      return;
+    }
+
+    final track = _currentRemoteVideoTrack;
+
+    if (track == null) {
+      _setHasRenderableRemoteFrame(true);
+      return;
+    }
+
+    _remoteFrameProbeInProgress = true;
+    try {
+      final isBlackOrEmpty = await _isTrackFrameBlackOrEmpty(track);
+      if (mounted) {
+        _setHasRenderableRemoteFrame(!isBlackOrEmpty);
+      }
+    } catch (_) {
+      if (mounted) {
+        _setHasRenderableRemoteFrame(true);
+      }
+    } finally {
+      _remoteFrameProbeInProgress = false;
+    }
+  }
+
+  Future<bool> _isTrackFrameBlackOrEmpty(MediaStreamTrack track) async {
+    final capturedFrame = await track.captureFrame();
+    final framePngBytes = capturedFrame.asUint8List();
+
+    if (framePngBytes.isEmpty) {
+      return true;
+    }
+
+    final codec = await ui.instantiateImageCodec(framePngBytes);
+    try {
+      final nextFrame = await codec.getNextFrame();
+      final image = nextFrame.image;
+      try {
+        final frameRgbaBytes = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+
+        if (frameRgbaBytes == null || frameRgbaBytes.lengthInBytes == 0) {
+          return true;
+        }
+
+        final rgbaBytes = frameRgbaBytes.buffer.asUint8List(frameRgbaBytes.offsetInBytes, frameRgbaBytes.lengthInBytes);
+
+        return _isMostlyBlackRgbaFrame(rgbaBytes);
+      } finally {
+        image.dispose();
+      }
+    } finally {
+      codec.dispose();
+    }
+  }
+
+  bool _isMostlyBlackRgbaFrame(Uint8List rgbaBytes) {
+    final totalPixels = rgbaBytes.length ~/ 4;
+
+    if (totalPixels == 0) {
+      return true;
+    }
+
+    final step = math.max(1, totalPixels ~/ _remoteFrameMaxSamples);
+    var sampledPixels = 0;
+    var opaquePixels = 0;
+    var blackPixels = 0;
+
+    for (var pixelIndex = 0; pixelIndex < totalPixels; pixelIndex += step) {
+      final offset = pixelIndex * 4;
+      final red = rgbaBytes[offset];
+      final green = rgbaBytes[offset + 1];
+      final blue = rgbaBytes[offset + 2];
+      final alpha = rgbaBytes[offset + 3];
+
+      sampledPixels++;
+
+      if (alpha == 0) {
+        continue;
+      }
+
+      opaquePixels++;
+
+      final luma = ((red * 299) + (green * 587) + (blue * 114)) ~/ 1000;
+      if (luma <= _blackLumaThreshold) {
+        blackPixels++;
+      }
+    }
+
+    if (sampledPixels == 0 || opaquePixels == 0) {
+      return true;
+    }
+
+    return blackPixels / opaquePixels >= _blackFrameRatioThreshold;
+  }
+
+  void _setHasRenderableRemoteFrame(bool value) {
+    if (_hasRenderableRemoteFrame == value || mounted == false) {
+      return;
+    }
+
+    setState(() => _hasRenderableRemoteFrame = value);
+  }
+
+  void _disposeRemoteFrameWatcher() {
+    _remoteFrameWatcher?.cancel();
+    _remoteFrameWatcher = null;
+  }
+
   @override
   void dispose() {
+    _disposeRemoteFrameWatcher();
     _compactController.dispose();
     super.dispose();
   }

--- a/lib/features/call/widgets/remote_video_view_overlay.dart
+++ b/lib/features/call/widgets/remote_video_view_overlay.dart
@@ -40,6 +40,7 @@ class RemoteVideoViewOverlay extends StatelessWidget {
     super.key,
     this.remotePlaceholderBuilder,
     this.backgroundMode = VideoBackgroundMode.blur,
+    this.hasRenderableRemoteFrame = true,
     this.hideVideo = false,
   });
 
@@ -63,6 +64,12 @@ class RemoteVideoViewOverlay extends StatelessWidget {
   /// Whether to hide the video stream entirely.
   final bool hideVideo;
 
+  /// Whether the sampled remote frame contains renderable content.
+  ///
+  /// When false, the widget falls back to the placeholder instead of rendering
+  /// a black/empty remote video frame.
+  final bool hasRenderableRemoteFrame;
+
   /// Determines how the empty space behind the video is rendered.
   ///
   /// Only applies when [videoFit] is [RTCVideoViewObjectFit.RTCVideoViewObjectFitContain].
@@ -70,10 +77,15 @@ class RemoteVideoViewOverlay extends StatelessWidget {
   final VideoBackgroundMode backgroundMode;
 
   bool get _shouldRenderBackground =>
-      videoFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain && backgroundMode != VideoBackgroundMode.none;
+      hideVideo == false &&
+      hasRenderableRemoteFrame &&
+      videoFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain &&
+      backgroundMode != VideoBackgroundMode.none;
 
   @override
   Widget build(BuildContext context) {
+    final stream = hasRenderableRemoteFrame ? remoteStream : null;
+
     return Positioned.fill(
       child: GestureDetector(
         onTap: activeCallWasAccepted ? onTap : null,
@@ -81,9 +93,8 @@ class RemoteVideoViewOverlay extends StatelessWidget {
         child: Stack(
           fit: StackFit.expand,
           children: [
-            if (_shouldRenderBackground) _BackgroundLayer(stream: remoteStream, mode: backgroundMode),
-            if (!hideVideo)
-              RTCStreamView(stream: remoteStream, placeholderBuilder: remotePlaceholderBuilder, fit: videoFit),
+            if (_shouldRenderBackground) _BackgroundLayer(stream: stream, mode: backgroundMode),
+            if (!hideVideo) RTCStreamView(stream: stream, placeholderBuilder: remotePlaceholderBuilder, fit: videoFit),
           ],
         ),
       ),


### PR DESCRIPTION
This pull request introduces logic to detect and handle black or empty remote video frames during calls. It periodically samples the remote video stream, analyzes the frame content, and hides the video if only black or empty frames are detected, falling back to the placeholder UI. This improves the user experience by preventing display of uninformative or misleading video frames.

**Remote Video Frame Analysis and UI Handling:**

* Added periodic probing of the remote video track in `CallActiveScaffoldState` to detect if the current remote frame is black or empty, using image sampling and luma thresholding. If detected, the UI hides the video and shows the placeholder instead. [[1]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR41-R45) [[2]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR64-R68) [[3]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR77-R85) [[4]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR370-R516)
* Updated `RemoteVideoViewOverlay` to accept a `hasRenderableRemoteFrame` parameter, using it to control whether the video stream or the placeholder is rendered. [[1]](diffhunk://#diff-fda0b19146c68a3ef398c5a87f71dbc0ab54b1da5b30d211c3358f974501cb91R43) [[2]](diffhunk://#diff-fda0b19146c68a3ef398c5a87f71dbc0ab54b1da5b30d211c3358f974501cb91R67-R97)
* Modified the rendering logic in `CallActiveScaffold` to consider both the original remote video state and the new black frame detection before displaying the remote video. [[1]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR118) [[2]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dL174-R197)

**Technical Enhancements:**

* Added imports for image processing and timer utilities (`dart:ui`, `dart:typed_data`, `dart:math`, `dart:async`) to support frame analysis.
* Ensured proper cleanup of timers and state in the widget lifecycle to prevent leaks and stale state.