### PR TITLE
fix(WT-1340): bottom navigation bar overlaps Settings menu on Android 16

### DIFF
--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -63,7 +63,7 @@ class SettingsScreen extends StatelessWidget {
                 bottom: false,
                 child: ListView(
                   padding: (effectiveStyle?.listViewPadding ?? const EdgeInsets.only(top: 16)).add(
-                    EdgeInsets.only(top: topPadding),
+                    EdgeInsets.only(top: topPadding, bottom: mediaQuery.padding.bottom),
                   ),
                   children: [
                     BlocBuilder<UserInfoCubit, UserInfoState>(


### PR DESCRIPTION
## Summary

- **Issue**: [WT-1340](https://youtrack.portaone.com/issue/WT-1340) — bottom navigation bar overlaps the last item in the Settings/My Account screen on Samsung A55 5G (One UI 8.0 / Android 16)
- **Root cause**: `SettingsScreen` ListView had no bottom inset padding. `SafeArea(bottom: false)` is intentional (the `ThemedScaffold` manages layout), but `mediaQuery.padding.bottom` was never added to the list padding — unlike `padding.top` which was already accounted for via `topPadding`.
- **Fix**: Add `bottom: mediaQuery.padding.bottom` to the ListView padding in `settings_screen.dart`. On devices where the inset is fully consumed by the outer Scaffold, this value is `0` (no-op). On Android 16 edge-to-edge mode it correctly offsets the last item above the transparent system navigation bar.

## Test plan

- [ ] Open Settings / My Account screen and scroll to the bottom — last item (Terms and Conditions) fully visible
- [ ] Verify on Android 16 / One UI 8.0 (Samsung) — no overlap with system nav bar
- [ ] Verify on older Android versions — no visual regression
- [ ] Verify on iOS — no visual regression