### PR TITLE
fix(WT-1337): suppress spurious disconnect toast on post-Doze app resume

### DIFF
--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -246,14 +246,19 @@ class SignalingReconnectController {
         _scheduleReconnect(recommendedReconnectDelay);
 
       // Unexpected TCP-level close without a preceding error event.
-      // Notify immediately - an established session was lost.
+      // Notify only when a session was actually established (_wasConnected) to
+      // avoid a spurious toast when _connectAsync closes a stale socket during
+      // the post-Doze forced reconnect on app resume (WT-1337).
       case SignalingDisconnected(:final recommendedReconnectDelay, :final knownCode, :final code, :final reason)
           when recommendedReconnectDelay != null:
-        _logger.fine('_onEvent: unexpected disconnect - notifying immediately');
+        final wasEstablished = _wasConnected;
         _wasConnected = false;
         _consecutiveFailures = 0;
-        if (_appActive || _hasActiveCalls) {
+        if (wasEstablished && (_appActive || _hasActiveCalls)) {
+          _logger.fine('_onEvent: unexpected disconnect - notifying immediately');
           _onConnectionFailed?.call((knownCode: knownCode, systemCode: code, systemReason: reason));
+        } else if (!wasEstablished) {
+          _logger.info('_onEvent: suppressing disconnect notification - no established session');
         } else {
           _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
         }

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -252,6 +252,7 @@ void main() {
         );
         addTearDown(controller.dispose);
 
+        module.emit(SignalingConnected());
         module.emit(_lost());
 
         expect(receivedCode, SignalingDisconnectCode.unmappedCode);
@@ -270,6 +271,7 @@ void main() {
         );
         addTearDown(controller.dispose);
 
+        module.emit(SignalingConnected());
         module.emit(_keepaliveTimeout());
 
         expect(receivedCode, SignalingDisconnectCode.signalingKeepaliveTimeoutError);
@@ -288,6 +290,7 @@ void main() {
         );
         addTearDown(controller.dispose);
 
+        module.emit(SignalingConnected());
         module.emit(_appUnregistered());
 
         expect(receivedCode, SignalingDisconnectCode.appUnregisteredError);
@@ -313,11 +316,35 @@ void main() {
         );
         addTearDown(controller.dispose);
 
+        module.emit(SignalingConnected());
         module.emit(_lost());
 
         expect(notifyCount, 1);
       });
     });
+
+    test(
+      'does not notify when disconnect arrives without established session (WT-1337: stale socket close on resume)',
+      () {
+        fakeAsync((async) {
+          final module = _FakeSignalingModule();
+          addTearDown(module.dispose);
+          int notifyCount = 0;
+          final controller = SignalingReconnectController(
+            signalingModule: module,
+            onConnectionFailed: (_) => notifyCount++,
+            reconnectEnabled: false,
+          );
+          addTearDown(controller.dispose);
+
+          // Simulates _connectAsync closing a stale socket after notifyAppResumed()
+          // resets _wasConnected to false. No prior SignalingConnected in this cycle.
+          module.emit(_lost());
+
+          expect(notifyCount, 0);
+        });
+      },
+    );
 
     test('resets consecutive failure counter on SignalingDisconnected (unexpected)', () {
       fakeAsync((async) {
@@ -336,7 +363,8 @@ void main() {
         module.emit(_failed());
         expect(notifyCount, 0);
 
-        // Session lost — resets counter and notifies immediately.
+        // Session established, then lost — resets counter and notifies immediately.
+        module.emit(SignalingConnected());
         module.emit(_lost());
         expect(notifyCount, 1);
 


### PR DESCRIPTION
## Summary

- `SignalingReconnectController` was calling `onConnectionFailed` when receiving a `SignalingDisconnected` with `recommendedReconnectDelay != null`, even if no session was ever established in the current lifecycle cycle
- After `notifyAppResumed()` resets `_wasConnected = false` and triggers a forced reconnect, `_connectAsync` closes the stale socket — this fired a spurious `SignalingDisconnected` event that caused a false "Connection failed" toast on every app resume after Doze + Wi-Fi interruption
- Fix: guard `onConnectionFailed` with `wasEstablished` check (same pattern used for `SignalingConnectionFailed`)
- Regression test added for the WT-1337 stale-socket-close scenario

## Root cause

`_connectAsync` in `SignalingModuleImpl` disconnects an existing stale client before opening a new connection. This fires `_onDisconnect` without `_intentionalDisconnect = true`, so `SignalingDisconnected(recommendedReconnectDelay != null)` is emitted — treated by the reconnect controller as an unexpected session loss.

## Test plan

- [ ] All 42 unit tests pass: `flutter test test/features/call/services/signaling_reconnect_controller_test.dart`
- [ ] Manual: reproduce WT-1337 with ADB force-idle steps, verify no "Connection failed" toast appears on app resume
- [ ] Manual: actual session drop (kill Wi-Fi mid-call) still shows the toast