### PR TITLE
fix(signaling): ignore stale onDisconnect from superseded WS client (WT-1359)

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -283,11 +283,31 @@ class SignalingModuleImpl implements SignalingModule {
           return;
         }
 
+        // Capture the client identity so the onDisconnect closure can guard
+        // against a stale callback from a superseded connection. Without this,
+        // a zombie client[n-1] whose server-side close (code 4441) arrives
+        // after client[n] is already assigned would call _onDisconnect and
+        // unconditionally clear _client, corrupting the active session.
+        //
+        // Guard condition: skip only when _client is a *different* non-null
+        // client. If _client is null (cleared by disconnect() or _onError),
+        // we are still the responsible client and must forward the callback.
+        //
+        // The same identity pattern is already used for _requestQueue.flush
+        // (isActive: () => identical(_client, client)) — this extends it to
+        // the disconnect path.
+        final activeClient = client;
         client.listen(
           onStateHandshake: _onHandshake,
           onEvent: _onEvent,
           onError: _onError,
-          onDisconnect: _onDisconnect,
+          onDisconnect: (code, reason) {
+            if (_client != null && !identical(_client, activeClient)) {
+              _logger.fine('_onDisconnect: ignoring stale close code=$code from superseded client');
+              return;
+            }
+            _onDisconnect(code, reason);
+          },
         );
 
         _client = client;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -283,26 +283,34 @@ class SignalingModuleImpl implements SignalingModule {
           return;
         }
 
-        // Capture the client identity so the onDisconnect closure can guard
-        // against a stale callback from a superseded connection. Without this,
-        // a zombie client[n-1] whose server-side close (code 4441) arrives
-        // after client[n] is already assigned would call _onDisconnect and
-        // unconditionally clear _client, corrupting the active session.
+        // Wrap onError and onDisconnect in closures that capture [client] and
+        // guard against stale callbacks from a superseded connection.
+        //
+        // Race: a zombie client[n-1] whose server-side close (code 4441) or
+        // late network error arrives after client[n] is already assigned would
+        // unconditionally clear _client and emit a spurious disconnect/failure,
+        // corrupting the active session with no auto-recovery.
         //
         // Guard condition: skip only when _client is a *different* non-null
-        // client. If _client is null (cleared by disconnect() or _onError),
-        // we are still the responsible client and must forward the callback.
+        // client (new connection replaced us). If _client is null — cleared by
+        // disconnect() or _onError — we are still the responsible client and
+        // must forward the callback.
         //
         // The same identity pattern is already used for _requestQueue.flush
         // (isActive: () => identical(_client, client)) — this extends it to
-        // the disconnect path.
-        final activeClient = client;
+        // the error and disconnect paths.
         client.listen(
           onStateHandshake: _onHandshake,
           onEvent: _onEvent,
-          onError: _onError,
+          onError: (error, [stackTrace]) {
+            if (_client != null && !identical(_client, client)) {
+              _logger.fine('_onError: ignoring stale error from superseded client: $error');
+              return;
+            }
+            _onError(error, stackTrace);
+          },
           onDisconnect: (code, reason) {
-            if (_client != null && !identical(_client, activeClient)) {
+            if (_client != null && !identical(_client, client)) {
               _logger.fine('_onDisconnect: ignoring stale close code=$code from superseded client');
               return;
             }


### PR DESCRIPTION
## Problem

After a forced reconnect on app resume (following 1+ hour idle), a zombie WebSocket (`client[n-1]`) can receive a server-side `4441` close **after** `client[n]` is already assigned to `_client`. The `onDisconnect: _onDisconnect` was a direct method reference with no identity check, so it unconditionally:

1. Cleared `_client = null` — wiping the freshly-established active client
2. Emitted `SignalingDisconnected` — telling the hub the session is gone

`SignalingReconnectController` had already consumed the `SignalingConnected` event and reset its failure counter, so no new reconnect was scheduled. Result: `SignalingHub.execute()` threw `Bad state: Signaling not connected` on every call for ~70 seconds with no auto-recovery.

Confirmed in log: `bugs/open/WT-1359/bad_state_pixel8a.log`

```
15:37:40.298  WebtritSignalingClient [1] connected
15:37:40.300  WebtritSignalingClient [0] _wsOnDone code: 4441 reason: force attach close
15:37:41.551  SignalingHub execute error: Bad state: Signaling not connected  ← persists ~70s
```

## Fix

Wrap `onDisconnect` in a closure that captures the client reference at `listen()` time and skips `_onDisconnect` when a **different non-null** client is currently active:

```dart
final activeClient = client;
client.listen(
  onDisconnect: (code, reason) {
    if (_client != null && !identical(_client, activeClient)) {
      // Stale close from superseded client — ignore.
      return;
    }
    _onDisconnect(code, reason);
  },
);
```

**Guard semantics:**

| `_client` state | Meaning | Action |
|---|---|---|
| `null` | Cleared by `disconnect()` or `_onError` — we are the responsible client | forward to `_onDisconnect` |
| `identical(activeClient)` | We are still the current client (server-initiated close) | forward to `_onDisconnect` |
| different non-null client | A new connection replaced us — our close is stale | **skip** |

This mirrors the `identical(_client, client)` guard already used for `_requestQueue.flush` (line 312).

## Testing

- All 608 existing tests pass (including the `signaling_module_test.dart` suite that covers intentional `disconnect()` + server `4610` echo)
- YouTrack: https://youtrack.portaone.com/issue/WT-1359