### PR TITLE
feat: add GitHub Actions workflow for Claude AI code review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,31 @@
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Action
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.WEBTRIT_ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-review.yml` with `anthropics/claude-code-action@v1`
- Workflow triggers on `issue_comment`, `pull_request_review_comment`, and `pull_request_review` events
- Job runs only when the comment/review body contains `@claude`
- Uses `WEBTRIT_ANTHROPIC_API_KEY` secret for authentication

## Test plan

- [ ] Add `@claude` comment to a PR and verify the workflow triggers
- [ ] Verify the workflow skips when `@claude` is not mentioned
- [ ] Confirm `WEBTRIT_ANTHROPIC_API_KEY` secret is set in repository settings