### PR TITLE
fix(signaling): disable auto-plugin registration on FGS engine; add no-port watchdog

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -59,7 +59,7 @@ class FlutterEngineHelper(
             }
 
             hasInvalidHandle = false
-            backgroundEngine = FlutterEngine(context.applicationContext).also { engine ->
+            backgroundEngine = FlutterEngine(context.applicationContext, null, null, null, false).also { engine ->
                 val dartCallback = DartCallback(
                     context.assets,
                     flutterLoader.findAppBundlePath(),

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterJNI
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback
 import io.flutter.view.FlutterCallbackInformation
 
@@ -59,7 +60,15 @@ class FlutterEngineHelper(
             }
 
             hasInvalidHandle = false
-            backgroundEngine = FlutterEngine(context.applicationContext, null, null, null, false).also { engine ->
+            // automaticallyRegisterPlugins=false: prevents GeneratedPluginRegistrant from
+            // registering all app plugins (AudioSessionPlugin, FlutterWebRTCPlugin, etc.)
+            // on this background FGS engine. On Android 16 REMOTE_MESSAGING services,
+            // audio/hardware init in onAttachedToEngine blocks the Dart VM from running
+            // the background entry point. Only the two Pigeon channels set up manually
+            // in onStartCommand are needed here.
+            // FlutterJNI() is passed explicitly — the parameter is @NonNull in the Flutter
+            // Java API; relying on null handling would bypass the annotation contract.
+            backgroundEngine = FlutterEngine(context.applicationContext, null, FlutterJNI(), null, false).also { engine ->
                 val dartCallback = DartCallback(
                     context.assets,
                     flutterLoader.findAppBundlePath(),

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -36,6 +36,7 @@ class HubConnectionManager {
     this.pingInterval = const Duration(seconds: 15),
     this.pongTimeout = const Duration(seconds: 2),
     this.stalePortThreshold = 3,
+    this.noPortTimeout = const Duration(seconds: 15),
     this.onServiceDead,
   }) : _onEvent = onEvent,
        _onError = onError,
@@ -58,6 +59,12 @@ class HubConnectionManager {
   /// [SignalingConnectionFailed] event is emitted, and [onServiceDead] is
   /// called so the caller can restart the foreground service.
   final int stalePortThreshold;
+
+  /// How long [_initLoop] waits for a hub port to appear before treating the
+  /// service as dead. When no port is found for this duration, a
+  /// [SignalingConnectionFailed] event is emitted and [onServiceDead] is
+  /// called so the caller can attempt to restart the foreground service.
+  final Duration noPortTimeout;
 
   /// Called when [stalePortThreshold] consecutive ack timeouts indicate the
   /// hub service is no longer running. Use this to restart the foreground
@@ -118,10 +125,12 @@ class HubConnectionManager {
   Future<void> _initLoop(int generation) async {
     const retryDelay = Duration(milliseconds: 100);
     const ackTimeout = Duration(milliseconds: 500);
+    final noPortDeadThreshold = noPortTimeout.inMilliseconds ~/ retryDelay.inMilliseconds;
 
     _logger.fine('_initLoop started gen=$generation');
     var attempts = 0;
     var consecutiveStaleAcks = 0;
+    var emptyPortPolls = 0;
 
     while (true) {
       if (_generation != generation || !_isActive()) {
@@ -133,6 +142,7 @@ class HubConnectionManager {
 
       final client = SignalingHubClient.tryConnect(_consumerId, pingInterval: pingInterval, pongTimeout: pongTimeout);
       if (client != null) {
+        emptyPortPolls = 0;
         _logger.fine('_initLoop gen=$generation hub port found after $attempts attempts, awaiting ack');
         // awaitAck MUST be called before SignalingHubModule is constructed so the
         // internal Completer is in place before the hub's sub-ack can arrive.
@@ -187,6 +197,22 @@ class HubConnectionManager {
         }
       } else {
         consecutiveStaleAcks = 0;
+        emptyPortPolls++;
+        if (emptyPortPolls >= noPortDeadThreshold) {
+          emptyPortPolls = 0;
+          if (_generation != generation || !_isActive() || _tearingDown) return;
+          _logger.warning(
+            '_initLoop gen=$generation no hub port for ${noPortTimeout.inSeconds}s — service likely dead, triggering recovery',
+          );
+          _onEvent(
+            SignalingConnectionFailed(
+              error: StateError('Signaling hub service not found'),
+              isRepeated: false,
+              recommendedReconnectDelay: kSignalingClientReconnectDelay,
+            ),
+          );
+          onServiceDead?.call();
+        }
       }
 
       attempts++;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -125,7 +125,9 @@ class HubConnectionManager {
   Future<void> _initLoop(int generation) async {
     const retryDelay = Duration(milliseconds: 100);
     const ackTimeout = Duration(milliseconds: 500);
-    final noPortDeadThreshold = noPortTimeout.inMilliseconds ~/ retryDelay.inMilliseconds;
+    // Clamp to 1 so a noPortTimeout shorter than retryDelay (e.g. in tests)
+    // never fires the watchdog on the very first poll before any waiting occurs.
+    final noPortDeadThreshold = (noPortTimeout.inMilliseconds ~/ retryDelay.inMilliseconds).clamp(1, 1 << 31);
 
     _logger.fine('_initLoop started gen=$generation');
     var attempts = 0;
@@ -197,6 +199,13 @@ class HubConnectionManager {
         }
       } else {
         consecutiveStaleAcks = 0;
+        // No-port watchdog: hub port absent for noPortTimeout → FGS likely failed
+        // to start or was killed before registering. Emit a failure event so
+        // SignalingReconnectController can schedule a reconnect, then call
+        // onServiceDead to trigger a FGS restart attempt.
+        // Return immediately after onServiceDead — it increments the generation
+        // so the generation guard at the top of begin() stops this loop cleanly,
+        // preventing repeated watchdog firing before the new loop takes over.
         emptyPortPolls++;
         if (emptyPortPolls >= noPortDeadThreshold) {
           emptyPortPolls = 0;
@@ -212,6 +221,7 @@ class HubConnectionManager {
             ),
           );
           onServiceDead?.call();
+          return;
         }
       }
 


### PR DESCRIPTION
## Summary

- **Fix 1 (Android 16):** `FlutterEngineHelper.kt:62` — disable `automaticallyRegisterPlugins` on background FGS engine. The default `FlutterEngine(context)` constructor triggered `GeneratedPluginRegistrant.registerWith(engine)`, registering all 25+ app plugins (including `AudioSessionPlugin`, `FlutterWebRTCPlugin`) on the FGS engine. On Android 16 `FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING`, audio resource init in `onAttachedToEngine` prevents `signalingServiceCallbackDispatcher` from ever running — the Dart isolate stays silent, all 6 `synchroniseIsolate` attempts fail with "Unable to establish connection on channel", and the 30s startup watchdog kills the FGS. Passing `false` as the fifth constructor argument disables auto-registration; only the two Pigeon channels registered manually in `onStartCommand` are needed.

- **Fix 2 (pushBound recovery gap):** `hub_connection_manager.dart` — add `noPortTimeout: Duration` (default 15s) and `emptyPortPolls` counter to `_initLoop`. Previously the `else` branch (no hub port found) only reset `consecutiveStaleAcks = 0` and looped forever — `onServiceDead` was never called, leaving `signalingClientStatus` stuck in `connecting`. Now after 15s of absent port, `SignalingConnectionFailed` is emitted and `onServiceDead` is called, triggering `_onHubServiceDead` → `_startService`. Counter resets when a port is found.

## Affected devices

| Device | Android | Root cause fixed |
|--------|---------|-----------------|
| Google Pixel 9 | 16 | Fix 1 — Dart isolate never started |
| Samsung SM-A505FN | 11 | Fix 2 — recovery gap after OS kill |

## Test plan

- [ ] Android 16 (Pixel 9): open app in `pushBound` mode — confirm `signalingServiceCallbackDispatcher: background isolate starting` appears in logcat; confirm `synchroniseIsolate` succeeds; confirm no `WebtritSignalingServicePlugin attached` on FGS engine
- [ ] Samsung Android 11: kill FGS externally — confirm `signalingClientStatus` exits `connecting` within ~15s
- [ ] Happy path: normal app launch on Android 10–15 — confirm signaling connects as before
- [ ] `noPortTimeout` watchdog fires only once per recovery cycle (no repeated rapid-fire)