### PR TITLE
fix(signaling): replace bare FlutterJNI() with FlutterInjector factory

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.Log
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.embedding.engine.FlutterJNI
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback
 import io.flutter.view.FlutterCallbackInformation
 
@@ -63,12 +62,12 @@ class FlutterEngineHelper(
             // automaticallyRegisterPlugins=false: prevents GeneratedPluginRegistrant from
             // registering all app plugins (AudioSessionPlugin, FlutterWebRTCPlugin, etc.)
             // on this background FGS engine. On Android 16 REMOTE_MESSAGING services,
-            // audio/hardware init in onAttachedToEngine blocks the Dart VM from running
+            // audio/hardware init in onAttachedToEngine can block the Dart VM from running
             // the background entry point. Only the two Pigeon channels set up manually
             // in onStartCommand are needed here.
-            // FlutterJNI() is passed explicitly — the parameter is @NonNull in the Flutter
-            // Java API; relying on null handling would bypass the annotation contract.
-            backgroundEngine = FlutterEngine(context.applicationContext, null, FlutterJNI(), null, false).also { engine ->
+            // FlutterJNI is obtained via FlutterInjector so DI overrides are respected,
+            // matching the internal behaviour of the 1-arg FlutterEngine constructor.
+            backgroundEngine = FlutterEngine(context.applicationContext, null, FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI(), null, false).also { engine ->
                 val dartCallback = DartCallback(
                     context.assets,
                     flutterLoader.findAppBundlePath(),


### PR DESCRIPTION
## Problem

PR #1155 introduced a regression: following a reviewer suggestion, the `FlutterEngine` constructor was changed to pass an explicit `FlutterJNI()` instance. A bare `FlutterJNI()` is uninitialized — passing it to the engine causes the Dart VM to fail silently on Android 15 (and likely other versions). The background isolate entry point (`signalingServiceCallbackDispatcher`) never runs, the Pigeon handler is never registered, and every sync attempt fails with "Unable to establish connection on channel: PSignalingServiceFlutterApi.onSynchronize".

## Root cause

`FlutterJNI()` creates a raw, unattached JNI wrapper. The Flutter engine internals require a properly initialized instance, which `FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI()` provides — this mirrors the internal behaviour of the 1-arg `FlutterEngine(context)` constructor and respects any DI overrides.

## Fix

Replace `FlutterJNI()` with `FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI()` in `FlutterEngineHelper.kt` (signaling service). Remove the now-unnecessary `import io.flutter.embedding.engine.FlutterJNI`. Update the comment to accurately describe the approach.

## Evidence

All test phones deployed from develop after #1155 merged showed `connection error` status. Logcat from Xiaomi Android 15 confirmed:
- No `signalingServiceCallbackDispatcher` startup log
- No `notifyIsolateReady` log
- No `FlutterEngine initialized and attached successfully`
- `no hub port for 15s` → watchdog fires → `SignalingClientStatus.failure`

## Test plan

- [ ] Deploy to Android 15 device — confirm `signalingServiceCallbackDispatcher` runs and call connects
- [ ] Deploy to Android 16 device — confirm FGS starts and Dart isolate runs without audio plugin blocking
- [ ] Verify `FlutterEngine initialized and attached successfully` appears in logcat

Fixes regression from #1155.