### PR TITLE
fix: use inProgress color for SessionStatus.inProgress

### DIFF
--- a/lib/extensions/session_status.dart
+++ b/lib/extensions/session_status.dart
@@ -41,7 +41,7 @@ extension SessionStatusColor on SessionStatus {
       case SessionStatus.connectIssue:
         return callStatusStyles?.connectIssue ?? colorScheme.error;
       case SessionStatus.inProgress:
-        return callStatusStyles?.ready ?? colorScheme.secondary;
+        return callStatusStyles?.inProgress ?? colorScheme.secondary;
       case SessionStatus.ready:
         return callStatusStyles?.ready ?? colorScheme.tertiary;
       case SessionStatus.pushTokenError:


### PR DESCRIPTION
## Summary

- `SessionStatus.inProgress` was reading `callStatusStyles?.ready` instead of `callStatusStyles?.inProgress`, causing both `inProgress` and `ready` statuses to render with the same color when a theme config is applied
- Fixed in `lib/extensions/session_status.dart:44`
- `CallStatusStyle` and `CallStatusStyleFactory` already had the `inProgress` field correctly defined — only the color extension was wrong

## Affected components

- `MainAppBar` — circle border indicator
- `SessionStatusListTile` — circle avatar indicator

## Test plan

- [ ] Open settings screen and observe `SessionStatusListTile` during reconnection (`inProgress`) — color should differ from `ready` (established)
- [ ] Observe `MainAppBar` indicator during the same transition
- [ ] Verify with a themed config that overrides `inProgress` and `ready` colors separately