### PR TITLE
fix(call): prevent local thumbnail disappearing when callee enables video

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1305,11 +1305,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             );
 
             if (localStream?.getVideoTracks().firstOrNull?.enabled == false) {
-              emit(
-                state.copyWithMappedActiveCall(event.callId, (activeCall) {
-                  return activeCall.copyWith(localStream: localStream, video: false);
-                }),
-              );
+              final currentCall = state.retrieveActiveCall(event.callId);
+              if (currentCall != null && !currentCall.video) {
+                emit(
+                  state.copyWithMappedActiveCall(event.callId, (activeCall) {
+                    return activeCall.copyWith(localStream: localStream, video: false);
+                  }),
+                );
+              }
             }
           }
         });

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1251,6 +1251,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             );
           } else {
             final localStream = activeCall.localStream;
+            // Capture before policy applier runs — policy applier may add a disabled
+            // video track to satisfy the m=video line, which would otherwise look like
+            // the caller had video. hadLocalVideo=true means the caller already enabled
+            // their camera and we must NOT reset the video flag after renegotiation.
+            final hadLocalVideo = localStream?.getVideoTracks().any((t) => t.enabled) ?? false;
             if (localStream != null) {
               await peerConnectionPolicyApplier?.apply(
                 peerConnection,
@@ -1304,15 +1309,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
               ),
             );
 
-            if (localStream?.getVideoTracks().firstOrNull?.enabled == false) {
-              final currentCall = state.retrieveActiveCall(event.callId);
-              if (currentCall != null && !currentCall.video) {
-                emit(
-                  state.copyWithMappedActiveCall(event.callId, (activeCall) {
-                    return activeCall.copyWith(localStream: localStream, video: false);
-                  }),
-                );
-              }
+            if (!hadLocalVideo && localStream?.getVideoTracks().firstOrNull?.enabled == false) {
+              emit(
+                state.copyWithMappedActiveCall(event.callId, (activeCall) {
+                  return activeCall.copyWith(localStream: localStream, video: false);
+                }),
+              );
             }
           }
         });

--- a/lib/features/call/utils/peer_connection_policy_applier.dart
+++ b/lib/features/call/utils/peer_connection_policy_applier.dart
@@ -79,12 +79,22 @@ class ModifyWithSettingsPeerConnectionPolicyApplier implements PeerConnectionPol
         return;
       }
 
+      // After a glare-rollback the video sender is removed from the peer connection,
+      // but the user's active camera track remains in localStream. Re-add it as-is
+      // (enabled=true) so the call continues with video — never disable it.
+      final activeTrack = localStream.getVideoTracks().where((t) => t.enabled).firstOrNull;
+      if (activeTrack != null) {
+        _logger.fine('Active local video track found in stream after rollback, re-adding to peer connection');
+        await peerConnection.addTrack(activeTrack, localStream);
+        return;
+      }
+
       final localVideoTrack = await _userMediaBuilder.ensureVideoTrack(localStream, frontCamera: frontCamera);
 
       // Add the video track to the peer connection, disabled initially
       if (localVideoTrack != null) {
         localVideoTrack.enabled = false;
-        peerConnection.addTrack(localVideoTrack, localStream);
+        await peerConnection.addTrack(localVideoTrack, localStream);
         _logger.fine('Added inactive local video track to peer connection');
       }
     }

--- a/lib/features/call/utils/peer_connection_policy_applier.dart
+++ b/lib/features/call/utils/peer_connection_policy_applier.dart
@@ -79,12 +79,12 @@ class ModifyWithSettingsPeerConnectionPolicyApplier implements PeerConnectionPol
         return;
       }
 
-      // After a glare-rollback the video sender is removed from the peer connection,
-      // but the user's active camera track remains in localStream. Re-add it as-is
-      // (enabled=true) so the call continues with video — never disable it.
+      // The video sender may be absent (e.g. after a glare-rollback or error recovery)
+      // while the caller's active camera track is still in localStream. Re-add it as-is
+      // to preserve the active video — never disable a track the caller already enabled.
       final activeTrack = localStream.getVideoTracks().where((t) => t.enabled).firstOrNull;
       if (activeTrack != null) {
-        _logger.fine('Active local video track found in stream after rollback, re-adding to peer connection');
+        _logger.fine('Active local video track found in stream, re-adding to peer connection');
         await peerConnection.addTrack(activeTrack, localStream);
         return;
       }


### PR DESCRIPTION
## Root cause

Commit `fb076cc56` introduced a guard that emits `video: false` when the policy applier inserts a disabled video track into `localStream` to satisfy the SDP `m=video` line. The guard was incorrectly checking `!currentCall.video` (which reflects the remote JSEP, not the caller's local state), so it fired even when the caller had already enabled their camera — causing `isCameraActive` to drop and `DraggableThumbnail` to disappear.

This affected the **audio → video upgrade** flow specifically:
1. Call starts as audio-only
2. Caller enables camera → `video: true`, thumbnail appears
3. Callee sends a re-INVITE with video → policy applier adds disabled track to `localStream`
4. Guard fires, emits `video: false` → thumbnail disappears

## Fix

- **`call_bloc.dart`** — capture `hadLocalVideo` (whether an enabled video track existed in `localStream`) **before** the policy applier runs. Use this flag in the guard: if `hadLocalVideo == true`, the caller already had an active camera and the disabled-track reset is skipped entirely.

- **`peer_connection_policy_applier.dart`** — skip inserting a new disabled track if `localStream` already contains an enabled video track (caller's active camera). This avoids adding a redundant disabled track alongside the already-present active one.

## Test scenario

1. Caller A calls Callee B (audio-only)
2. A enables camera → thumbnail appears for A
3. B enables camera → thumbnail must remain visible for A ✓

## Files changed

- `lib/features/call/bloc/call_bloc.dart`
- `lib/features/call/utils/peer_connection_policy_applier.dart`