### PR TITLE
fix(fgs): register callkeep bootstrap API on FGS engine — fixes incoming calls in persistent mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
     </queries>
     <application
         android:label="@string/APP_NAME"
-        android:name="${applicationName}"
+        android:name=".WebtritApplication"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
         android:extractNativeLibs="true"

--- a/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
@@ -1,0 +1,18 @@
+package com.webtrit.app
+
+import android.app.Application
+import com.webtrit.callkeep.BackgroundPushNotificationIsolateBootstrapApi
+import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateBootstrapApi
+import com.webtrit.signaling_service.SignalingForegroundService
+
+class WebtritApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        SignalingForegroundService.onFgsEngineReady = { context, messenger ->
+            PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(
+                messenger,
+                BackgroundPushNotificationIsolateBootstrapApi(context),
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
@@ -5,9 +5,41 @@ import com.webtrit.callkeep.BackgroundPushNotificationIsolateBootstrapApi
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateBootstrapApi
 import com.webtrit.signaling_service.SignalingForegroundService
 
+/// App-level initialization that wires together two independent Flutter plugins:
+/// [webtrit_signaling_service_android] and [webtrit_callkeep_android].
+///
+/// ## Why Kotlin, not Dart
+///
+/// The FGS (Foreground Service) engine is created with [automaticallyRegisterPlugins=false]
+/// to prevent audio/WebRTC plugins from doing hardware initialization on a background engine.
+/// As a consequence, [WebtritCallkeepPlugin.onAttachedToEngine] is never called for the FGS
+/// engine, so [PHostBackgroundPushNotificationIsolateBootstrapApi] — the Pigeon HOST API that
+/// the FGS Dart isolate uses to trigger ringing in persistent mode — is not registered on the
+/// FGS engine's binary messenger.
+///
+/// This registration is a native-only operation ([BinaryMessenger] channel setup); it cannot
+/// be initiated from Dart. Doing it via a Pigeon round-trip from Dart would introduce a timing
+/// risk: the FGS can start (and receive an incoming call) before Dart has had a chance to make
+/// that call. [Application.onCreate] runs before any Flutter engine or Service, making it the
+/// earliest and safest place for this wiring.
+///
+/// ## Initialization split between Dart and Kotlin
+///
+/// | What                              | Where            | When                        |
+/// |-----------------------------------|------------------|-----------------------------|
+/// | Signaling config (coreUrl, token) | Dart → Pigeon    | User logs in                |
+/// | FGS start/stop                    | Dart → Pigeon    | App lifecycle               |
+/// | Sync of FGS state to Dart isolate | Kotlin → Pigeon  | FGS engine ready            |
+/// | Callkeep channel on FGS engine    | Kotlin (here)    | Before first FGS start      |
+/// | Incoming call ring/notification   | FGS Dart → Pigeon| Incoming WebSocket event    |
+///
+/// The [onFgsEngineReady] callback is the seam between the two libraries at the app level,
+/// keeping [webtrit_signaling_service_android] and [webtrit_callkeep_android] decoupled.
 class WebtritApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        // Register callkeep's background isolate bootstrap API on the FGS engine's messenger.
+        // Called inside SignalingForegroundService.wireUpPigeon() when the FGS engine is ready.
         SignalingForegroundService.onFgsEngineReady = { context, messenger ->
             PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(
                 messenger,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -195,7 +195,11 @@ class SignalingForegroundService : Service() {
             return
         }
         Log.d(TAG, "wireUpPigeon: registering Pigeon channels on FGS engine")
-        onFgsEngineReady?.invoke(applicationContext, engine.dartExecutor.binaryMessenger)
+        try {
+            onFgsEngineReady?.invoke(applicationContext, engine.dartExecutor.binaryMessenger)
+        } catch (e: Exception) {
+            Log.e(TAG, "wireUpPigeon: onFgsEngineReady hook threw — continuing without it", e)
+        }
         PSignalingServiceHostApi.setUp(engine.dartExecutor.binaryMessenger, FgsHostApiHandler())
         isolateFlutterApi = PSignalingServiceFlutterApi(engine.dartExecutor.binaryMessenger)
     }
@@ -567,6 +571,7 @@ class SignalingForegroundService : Service() {
         ///         messenger, BackgroundPushNotificationIsolateBootstrapApi(context))
         /// }
         /// ```
+        @Volatile
         var onFgsEngineReady: ((Context, BinaryMessenger) -> Unit)? = null
     }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -15,6 +15,7 @@ import android.util.Log
 import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
+import io.flutter.plugin.common.BinaryMessenger
 
 /// Foreground service that manages the background Flutter engine for signaling.
 ///
@@ -194,6 +195,7 @@ class SignalingForegroundService : Service() {
             return
         }
         Log.d(TAG, "wireUpPigeon: registering Pigeon channels on FGS engine")
+        onFgsEngineReady?.invoke(applicationContext, engine.dartExecutor.binaryMessenger)
         PSignalingServiceHostApi.setUp(engine.dartExecutor.binaryMessenger, FgsHostApiHandler())
         isolateFlutterApi = PSignalingServiceFlutterApi(engine.dartExecutor.binaryMessenger)
     }
@@ -551,5 +553,20 @@ class SignalingForegroundService : Service() {
         fun stop(context: Context) {
             context.stopService(Intent(context, SignalingForegroundService::class.java))
         }
+
+        /// Optional callback invoked on the main thread inside [wireUpPigeon], immediately
+        /// before the two built-in Pigeon channels are registered on the FGS engine.
+        ///
+        /// Use this to register additional Pigeon HOST APIs on the FGS engine without
+        /// coupling [SignalingForegroundService] to other plugins.
+        ///
+        /// Example — registering webtrit_callkeep's bootstrap API (set in Application.onCreate):
+        /// ```kotlin
+        /// SignalingForegroundService.onFgsEngineReady = { context, messenger ->
+        ///     PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(
+        ///         messenger, BackgroundPushNotificationIsolateBootstrapApi(context))
+        /// }
+        /// ```
+        var onFgsEngineReady: ((Context, BinaryMessenger) -> Unit)? = null
     }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -63,6 +63,19 @@ class SignalingHub {
   /// and would cause the buffer to grow unboundedly over a long session.
   final List<List<dynamic>> _sessionBuffer = [];
 
+  /// Last encoded registration-state protocol event in the current session.
+  ///
+  /// The initial [StateHandshake] always carries [RegistrationStatus.unregistered]
+  /// because SIP REGISTER hasn't completed yet. The server then sends a
+  /// [RegisteredEvent] (or similar) as a protocol event, which is normally
+  /// excluded from [_sessionBuffer]. Without this field, a late subscriber
+  /// (e.g. the main app opening after the FGS has been running) would only see
+  /// the initial unregistered handshake and get stuck at "Unregistered".
+  ///
+  /// Cleared on each [SignalingConnecting] (new WebSocket session).
+  /// Replaced on each registration state transition event.
+  List<dynamic>? _lastRegistrationEvent;
+
   /// callId → ordered list of encoded [SignalingProtocolEvent]s for that call.
   ///
   /// Tracks the lifecycle of each incoming call that arrived during the current
@@ -120,6 +133,7 @@ class SignalingHub {
     _subscribers.clear();
     _sessionBuffer.clear();
     _callEventHistory.clear();
+    _lastRegistrationEvent = null;
     _logger.fine('Hub disposed');
   }
 
@@ -127,15 +141,26 @@ class SignalingHub {
     if (event is SignalingConnecting) {
       _sessionBuffer.clear();
       _callEventHistory.clear();
+      _lastRegistrationEvent = null;
     }
     final encoded = encodeHubEvent(event);
     if (event is! SignalingProtocolEvent) {
       _sessionBuffer.add(encoded);
     } else {
       _updateCallHistory(event.event, encoded);
+      if (_isRegistrationEvent(event.event)) {
+        _lastRegistrationEvent = encoded;
+      }
     }
     _broadcast(encoded);
   }
+
+  bool _isRegistrationEvent(Event event) =>
+      event is RegisteredEvent ||
+      event is UnregisteredEvent ||
+      event is RegisteringEvent ||
+      event is RegistrationFailedEvent ||
+      event is UnregisteringEvent;
 
   /// Updates [_callEventHistory] based on a protocol event.
   ///
@@ -244,6 +269,15 @@ class SignalingHub {
     // Replay current session buffer so the new subscriber gets the full connection state.
     for (final event in List<List<dynamic>>.from(_sessionBuffer)) {
       cmd.replyPort.send(event);
+    }
+    // Replay the last registration state transition so the subscriber doesn't
+    // get stuck at the initial "unregistered" status from the StateHandshake.
+    // The initial handshake always carries unregistered because SIP REGISTER
+    // hasn't completed yet; the subsequent RegisteredEvent (a protocol event)
+    // is not in [_sessionBuffer], so late subscribers would miss it without this.
+    final regEvent = _lastRegistrationEvent;
+    if (regEvent != null) {
+      cmd.replyPort.send(regEvent);
     }
     // Replay the full event history for each active in-session call.
     // Protocol events are not stored in [_sessionBuffer], so without this


### PR DESCRIPTION
## Changes

### 1. Fix: replay last registration event to late subscribers

**Problem:** On devices without Google services (Huawei/Xiaomi persistent mode), reopening the app causes registration status stuck at **Unregistered**.

**Root cause:** The initial `StateHandshake` always carries `registration=unregistered` (SIP REGISTER not yet complete). The subsequent `RegisteredEvent` is a `SignalingProtocolEvent` — excluded from `_sessionBuffer` by design. Late subscriber (main app reopened) receives only the buffered `Handshake(unregistered)` and never sees `RegisteredEvent`.

**Fix:** Track `_lastRegistrationEvent` in `SignalingHub`; replay it to new subscribers after the session buffer.

---

### 2. Fix: register callkeep bootstrap API on FGS engine via onFgsEngineReady hook

Registers the callkeep bootstrap channel on the FGS Flutter engine so incoming calls can trigger callkeep UI while the app is in persistent background mode.

---

> Includes fix from #1161 (FGS WebSocket reconnect after screen unlock in PUSH_BOUND mode).