### PR TITLE
fix(signaling): reconnect FGS WebSocket after screen unlock in PUSH_BOUND mode

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -119,7 +119,15 @@ class SignalingForegroundService : Service() {
 
         // Fast path: engine already exists — attach if needed and wire Pigeon immediately.
         if (flutterEngineHelper.attachExistingIfNeeded()) {
+            val alreadyWired = _isolateFlutterApi != null
             wireUpPigeon()
+            if (alreadyWired) {
+                // Service was already running when startService() was called again.
+                // Send a sync so the FGS Dart isolate can reconnect the WebSocket if it
+                // dropped while the app was backgrounded (e.g. screen unlock in PUSH_BOUND).
+                // The watchdog is not re-armed: the isolate is already initialised.
+                synchronizeIsolate()
+            }
             return if (StorageDelegate.isPushBound(applicationContext)) START_NOT_STICKY else START_STICKY
         }
 


### PR DESCRIPTION
## Problem

After locking the screen for ~60s and unlocking, the UI shows **"Connection in progress"** indefinitely — on all devices in PUSH_BOUND mode.

## Root cause

When the screen is locked, `notifyAppPaused()` sets `_appActive = false` and calls `disconnect()` — which is an intentional no-op (WebSocket stays in FGS). After ~60s the server closes the idle connection. `SignalingDisconnected` arrives, `_isConnected = false`. `SignalingReconnectController` schedules a reconnect but skips it because `_appActive = false`.

On screen unlock, `notifyAppResumed()` fires → 1s timer → `_module.connect()` → `WebtritSignalingService.connect()` → `_startService()` → Kotlin `startService(PUSH_BOUND)`.

Kotlin's `onStartCommand` takes the **fast path** (engine already running): calls `wireUpPigeon()`, which returns immediately with `"wireUpPigeon: already wired"`. **`synchronizeIsolate()` is never called** — the FGS Dart isolate never receives a reconnect signal. WebSocket stays disconnected.

Meanwhile `_startPending = true` and no terminal event ever arrives, so all further `connect()` calls are no-ops.

## Fix

Capture whether pigeon was already wired before `wireUpPigeon()`. When it was, call `synchronizeIsolate()` so the FGS Dart isolate receives `onSynchronize(enabled=true)`, which triggers `_start()` → `_signalingModule?.connect()` if the WebSocket is disconnected. The startup watchdog is not re-armed because the isolate is already initialised. Idempotent: if the WebSocket is already connected `_start()` is a no-op.

## Test plan

- [ ] Lock phone for 60+ seconds (PUSH_BOUND mode)
- [ ] Unlock — status should recover to "Connected" within 1-2s
- [ ] Verify no regression: incoming calls still work after unlock
- [ ] Verify no regression: persistent mode unaffected