### PR TITLE
fix(diag): add diagnostic logs for WT-1369 incoming push call offer-wait failure

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2164,7 +2164,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       /// and main [IncomingEvent] with offer wasnt received yet
       ///
       if (call.incomingOffer == null) {
-        _logger.info('__onCallPerformEventAnswered: wait for offer');
+        _logger.info(
+          '__onCallPerformEventAnswered: wait for offer '
+          'signalingConnected=${_signalingModule.isConnected}',
+        );
 
         // Signaling may still be disconnected when answering from push while the app was in background.
         // Trigger reconnect immediately so the offer can arrive — don't wait for AppLifecycleState.resumed.
@@ -2177,11 +2180,24 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         await stream
             .firstWhere((s) {
               final activeCall = s.retrieveActiveCall(event.callId);
+              if (activeCall?.incomingOffer == null) {
+                _logger.fine(
+                  '__onCallPerformEventAnswered: offer still pending '
+                  'status=${activeCall?.processingStatus} '
+                  'signalingConnected=${_signalingModule.isConnected} '
+                  'elapsed=${DateTime.now().difference(offerWaitStart).inMilliseconds}ms',
+                );
+              }
               return activeCall?.incomingOffer != null;
             })
             .timeout(
               const Duration(seconds: 10),
               onTimeout: () {
+                _logger.warning(
+                  '__onCallPerformEventAnswered: offer wait timed out — '
+                  'signalingConnected=${_signalingModule.isConnected} '
+                  'elapsed=${DateTime.now().difference(offerWaitStart).inMilliseconds}ms',
+                );
                 throw TimeoutException('Timed out waiting for offer');
               },
             );

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -127,6 +127,10 @@ class SignalingHub {
   /// Removes the hub from [IsolateNameServer], cancels all subscriptions,
   /// and closes the receive port. After [dispose] the hub must not be used.
   Future<void> dispose() async {
+    _logger.warning(
+      'Hub disposing — cancelling event forwarding to ${_subscribers.length} subscriber(s); '
+      'pending calls in history: ${_callEventHistory.length}',
+    );
     IsolateNameServer.removePortNameMapping(kSignalingHubPortName);
     await _moduleSubscription?.cancel();
     _receivePort.close();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -188,7 +188,14 @@ class SignalingModuleImpl implements SignalingModule {
   /// Clears the session buffer on each call.
   @override
   void connect() {
-    if (_disposed || _connectToken != null) return;
+    if (_disposed) {
+      _logger.fine('connect: skipped — disposed');
+      return;
+    }
+    if (_connectToken != null) {
+      _logger.fine('connect: skipped — already connecting or connected');
+      return;
+    }
     final token = _connectToken = Object();
     _eventBuffer.clear();
     unawaited(_connectAsync(token));


### PR DESCRIPTION
## Summary

Adds diagnostic logging to help reproduce and pinpoint WT-1369 — incoming push call stuck in `incomingPerformingStarted` / offer-wait timeout.

- **SignalingHub.dispose()**: upgraded from `fine` to `warning` log, includes subscriber count and pending call-history count — makes it visible when the hub tears down while a call is active
- **SignalingModuleImpl.connect()**: split the silent `if (_disposed || _connectToken != null) return` into two explicit `fine` log lines so logs distinguish "already connected" from "disposed"
- **CallBloc offer-wait path**: log WS connected status at wait-start; periodic `fine` log every state change (status + WS connected + elapsed ms); `warning` log at timeout with WS status and elapsed time

## Motivation

In the WT-1369 log all 13 state snapshots show `incomingOffer: null` — `IncomingCallEvent` never reached CallBloc. The new `SignalingHub.dispose()` warning will confirm whether the hub was torn down mid-call. The offer-wait logs will show exactly when WS went dead relative to the timeout.

## Test plan

- [ ] Reproduce WT-1369 scenario: answer incoming push call while app is backgrounded
- [ ] Verify `Hub disposing` WARNING appears in logcat with correct subscriber/call counts
- [ ] Verify `offer wait timed out` WARNING includes `signalingConnected=false` when WS is dead
- [ ] Happy path: normal incoming push call answers correctly with no regressions