### PR TITLE
fix(call): fix iOS disconnecting freeze when network is unavailable

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2425,9 +2425,18 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             line: activeCall.line,
             callId: activeCall.callId,
           );
-          await _signalingModule.execute(hangupRequest)?.catchError((e, s) {
-            callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
-          });
+          final hangupFuture = _signalingModule.execute(hangupRequest);
+          if (state.callServiceState.networkStatus != NetworkStatus.none) {
+            await hangupFuture?.catchError((e, s) {
+              callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
+            });
+          } else {
+            // Network is unavailable — the queued hangup will retry and eventually fail.
+            // Skip the await to prevent blocking UI in disconnecting state for ~30s.
+            hangupFuture?.catchError((e, s) {
+              callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
+            }).ignore();
+          }
         }
       }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2405,9 +2405,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           line: activeCall.line,
           callId: activeCall.callId,
         );
-        await _signalingModule.execute(declineRequest)?.catchError((e, s) {
-          callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
-        });
+        final declineFuture = _signalingModule.execute(declineRequest);
+        if (state.callServiceState.networkStatus != NetworkStatus.none) {
+          await declineFuture?.catchError((e, s) {
+            callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
+          });
+        } else {
+          declineFuture?.catchError((e, s) {
+            callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
+          }).ignore();
+        }
       } else {
         // Skip hangup when a blind transfer is in Transfering state (server started to process it).
         // In this state the SIP dialog may already be closed server-side via REFER; sending hangup

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -529,9 +529,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           .toList();
       for (final call in disconnectingCalls) {
         _logger.info('_onConnectivityResultChanged: force-terminating disconnecting call ${call.callId}');
-        await _peerConnectionManager.disposePeerConnection(call.callId);
-        await _releaseLocalStream(call.localStream);
-        emit(state.copyWithPopActiveCall(call.callId));
+        add(_ResetStateEvent.completeCall(call.callId));
       }
     } else {
       _reconnectController.notifyNetworkAvailable();

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -520,6 +520,19 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _logger.fine('_onConnectivityResultChanged: $connectivityResult');
     if (connectivityResult == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
+
+      // Force-terminate calls stuck in disconnecting when network goes down.
+      // The queued hangup request cannot complete without connectivity; terminating
+      // locally prevents the UI from freezing in disconnecting state until reconnect.
+      final disconnectingCalls = state.activeCalls
+          .where((c) => c.processingStatus == CallProcessingStatus.disconnecting)
+          .toList();
+      for (final call in disconnectingCalls) {
+        _logger.info('_onConnectivityResultChanged: force-terminating disconnecting call ${call.callId}');
+        await _peerConnectionManager.disposePeerConnection(call.callId);
+        await _releaseLocalStream(call.localStream);
+        emit(state.copyWithPopActiveCall(call.callId));
+      }
     } else {
       _reconnectController.notifyNetworkAvailable();
 


### PR DESCRIPTION
## Summary

- Force-terminate calls stuck in `disconnecting` state when `ConnectivityResult.none` is detected — covers the case where network drops while a hangup is already in progress
- Skip `await` on the hangup/decline signaling request when `networkStatus == NetworkStatus.none` — covers the case where user taps hangup/decline after network is already down, preventing a ~30s UI freeze caused by `SignalingRequestQueue` retrying 3×10s

## Root cause

Two scenarios both lead to the same symptom — UI frozen on "Disconnecting, please hold on" for 30–40s:

1. **Network drops while call is in `disconnecting`**: the queued hangup can't complete, but the call stays in `disconnecting` until reconnect
2. **User taps hangup while network is already down**: `await _signalingModule.execute(hangupRequest)` blocks ~30s while the queue retries before failing

## Changes

- `_onConnectivityResultChanged`: dispatch `_ResetStateEvent.completeCall` for any `disconnecting` calls when network goes away — uses the centralized cleanup path which also calls `callkeep.reportEndCall`
- `_onCallPerformEventEndedImpl`: check `networkStatus` before awaiting the hangup/decline request — fire-and-forget when offline so `disposePeerConnection` + `copyWithPopActiveCall` run immediately

## Known limitation (Android) — needs separate investigation

On Android, after a call is terminated locally while offline, the signaling server still holds the call. When connectivity is restored and signaling reconnects, the server sends a handshake that includes the terminated call.

The `HandshakeProcessor` has two guards for this:
1. `stateDisconnected` connection check → should send `HangupSignalingAction`, but by handshake time the Android CallKeep connection is already fully cleaned up (`null`), not in `stateDisconnected`
2. `connection == null` orphan check → explicitly skips incoming calls (`earliestCallEvent is! IncomingCallEvent`) to avoid incorrectly declining unanswered incoming calls

For accepted incoming calls hung up while offline, neither guard fires — the call falls through to `RestoreCallAction` and is incorrectly re-presented to the user as an active call.

Outgoing calls and the iOS path need separate verification.

**Needs a dedicated fix:** distinguish "app restart, restore the call" from "user explicitly hung up while offline, send hangup on reconnect" — likely via an in-memory set of locally terminated call IDs that is checked before `HandshakeProcessor.process`.

## Test plan

- [ ] Normal call hangup (network up) — hangup completes normally, no regression
- [ ] Hangup while network is down — call terminates immediately without freeze
- [ ] Network drops while call is in disconnecting — call terminates immediately
- [ ] Decline unanswered incoming call while network is down — no freeze