### PR TITLE
fix(WT-1369): handle incoming call handshake when callLogs.length > 1

### DIFF
--- a/lib/features/call/utils/handshake_processor.dart
+++ b/lib/features/call/utils/handshake_processor.dart
@@ -61,8 +61,9 @@ final class RestoreCallAction extends HandshakeAction {
 
 /// Deliver an unanswered [IncomingCallEvent] to the BLoC signaling handler.
 ///
-/// Emitted when the line's [callLogs] contains a single [CallEventLog] carrying
-/// an [IncomingCallEvent] -the call has not been answered yet.
+/// Emitted when the line has not been terminated, has no [AcceptedEvent], the
+/// earliest call log entry is an [IncomingCallEvent], and the call is not yet
+/// tracked in BLoC state.
 final class HandleIncomingCallAction extends HandshakeAction {
   const HandleIncomingCallAction({required this.event});
 
@@ -93,7 +94,7 @@ final class EndLocalCallAction extends HandshakeAction {
 ///   the latest event is not [HangupEvent]/[MissedCallEvent] -> [HangupSignalingAction].
 /// - If the log contains an [AcceptedEvent] (non-terminated call, not yet in BLoC) -> [RestoreCallAction]
 ///   (covers both incoming and outgoing calls; [AcceptedEvent] may not be the newest entry after re-INVITE).
-/// - If only a single unanswered [IncomingCallEvent] is present -> [HandleIncomingCallAction].
+/// - If the earliest log is an unanswered [IncomingCallEvent] (not terminated, not accepted, not in BLoC) -> [HandleIncomingCallAction].
 ///
 /// **Loop C -orphaned local connections:**
 /// - For each local Callkeep connection whose call ID is absent from the handshake
@@ -183,11 +184,11 @@ class HandshakeProcessor {
         continue;
       }
 
-      if (activeLine.callLogs.length == 1) {
-        final singleCallLog = activeLine.callLogs.first;
-        if (singleCallLog is CallEventLog && singleCallLog.callEvent is IncomingCallEvent) {
-          actions.add(HandleIncomingCallAction(event: singleCallLog.callEvent as IncomingCallEvent));
-        }
+      if (!isTerminated &&
+          acceptedLogEntry == null &&
+          earliestCallEvent is IncomingCallEvent &&
+          !activeCallIds.contains(activeLine.callId)) {
+        actions.add(HandleIncomingCallAction(event: earliestCallEvent));
       }
     }
 

--- a/lib/features/call/utils/handshake_processor.dart
+++ b/lib/features/call/utils/handshake_processor.dart
@@ -184,6 +184,22 @@ class HandshakeProcessor {
         continue;
       }
 
+      // Unanswered incoming call: deliver the IncomingCallEvent to the BLoC so
+      // it can set up the call state and surface the ringing UI.
+      //
+      // earliestCallEvent (not callEvent/latest) identifies the call direction
+      // because SIP UAs — notably iOS CallKit — append RingingEvent or
+      // ProceedingEvent almost immediately after the call is placed. By the time
+      // a WebSocket reconnect completes and a new StateHandshake arrives, the
+      // server log already contains multiple entries (e.g. [RingingEvent,
+      // IncomingCallEvent]). Using the latest entry would misidentify those calls.
+      //
+      // Guard rationale:
+      // - !isTerminated           : skip calls the server already ended.
+      // - acceptedLogEntry == null: accepted calls are handled by RestoreCallAction above.
+      // - earliestCallEvent is IncomingCallEvent: confirms the call is incoming, not outgoing.
+      // - !activeCallIds.contains : skip calls already tracked in BLoC state to avoid
+      //   re-triggering the incoming-call flow for an already-ringing call.
       if (!isTerminated &&
           acceptedLogEntry == null &&
           earliestCallEvent is IncomingCallEvent &&

--- a/test/features/call/bloc/handshake_processor_test.dart
+++ b/test/features/call/bloc/handshake_processor_test.dart
@@ -30,6 +30,10 @@ ProceedingEvent _makeProceedingEvent({int? line = _kLine, String callId = _kCall
   return ProceedingEvent(line: line, callId: callId, code: 180);
 }
 
+RingingEvent _makeRingingEvent({int? line = _kLine, String callId = _kCallId}) {
+  return RingingEvent(line: line, callId: callId);
+}
+
 Line _makeLine({String callId = _kCallId, required List<CallLog> callLogs}) {
   return Line(callId: callId, callLogs: callLogs);
 }
@@ -78,8 +82,8 @@ void main() {
   // Unanswered incoming call (single CallEventLog)
   // -------------------------------------------------------------------------
 
-  group('single unanswered IncomingCallEvent', () {
-    test('returns HandleIncomingCallAction', () async {
+  group('unanswered incoming call', () {
+    test('returns HandleIncomingCallAction for single IncomingCallEvent', () async {
       final line = _makeLine(callLogs: [CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent())]);
 
       final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
@@ -88,6 +92,47 @@ void main() {
       expect(actions.first, isA<HandleIncomingCallAction>());
       final a = actions.first as HandleIncomingCallAction;
       expect(a.event.callId, _kCallId);
+    });
+
+    // Regression: WT-1369 — iOS CallKit sends 180 Ringing almost immediately,
+    // so by the time a WebSocket reconnect completes the server log already has
+    // [RingingEvent (latest), IncomingCallEvent (earliest)] (length=2).
+    // The old callLogs.length == 1 guard silently skipped this case.
+    test('returns HandleIncomingCallAction when RingingEvent prepended (iPhone 180-Ringing)', () async {
+      final line = _makeLine(callLogs: [
+        CallEventLog(timestamp: 2000, callEvent: _makeRingingEvent()),
+        CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
+      ]);
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
+
+      expect(actions, hasLength(1));
+      expect(actions.first, isA<HandleIncomingCallAction>());
+      final a = actions.first as HandleIncomingCallAction;
+      expect(a.event.callId, _kCallId);
+    });
+
+    test('returns HandleIncomingCallAction when ProceedingEvent prepended', () async {
+      final line = _makeLine(callLogs: [
+        CallEventLog(timestamp: 2000, callEvent: _makeProceedingEvent()),
+        CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
+      ]);
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
+
+      expect(actions, hasLength(1));
+      expect(actions.first, isA<HandleIncomingCallAction>());
+    });
+
+    test('skips HandleIncomingCallAction when callId already in activeCallIds', () async {
+      final line = _makeLine(callLogs: [
+        CallEventLog(timestamp: 2000, callEvent: _makeRingingEvent()),
+        CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
+      ]);
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {_kCallId});
+
+      expect(actions.whereType<HandleIncomingCallAction>(), isEmpty);
     });
   });
 


### PR DESCRIPTION
## Problem

When an incoming call arrives from iPhone (or any SIP UA that sends `180 Ringing` immediately), the app fails to answer the call — stuck in `incomingPerformingStarted` with `incomingOffer: null`, timing out after 10 s.

## Root cause

On app resume after a push notification, `notifyAppResumed()` triggers a forced WebSocket reconnect (intentional — bypasses stale `isConnected` state, see #1134). The reconnect emits `SignalingConnecting` → `_callEventHistory.clear()` in the hub → the `IncomingCallEvent` is lost from the replay buffer.

The new `StateHandshake` carries the call state from the server, but by then iPhone has already sent `180 Ringing`, so:

```
callLogs = [RingingEvent (latest), IncomingCallEvent (earliest)]  // length = 2
```

`HandshakeProcessor` had `callLogs.length == 1` as the guard for `HandleIncomingCallAction` — this silently fails for length > 1 and `incomingOffer` is never set.

## Fix

Replace the length guard with semantic conditions already computed in the same loop:

```dart
// Before
if (activeLine.callLogs.length == 1) { ... }

// After
if (!isTerminated &&
    acceptedLogEntry == null &&
    earliestCallEvent is IncomingCallEvent &&
    !activeCallIds.contains(activeLine.callId)) {
  actions.add(HandleIncomingCallAction(event: earliestCallEvent));
}
```

All conditions reuse variables already computed above — no extra traversals.

## Why "called from iPhone" matters

iOS CallKit sends `180 Ringing` within ~100 ms of the call being placed. Android SIP clients typically do not. By the time the WebSocket reconnects (~1–2 s after app resume), the server's `callLogs` already has length ≥ 2 for iPhone callers.