### PR TITLE
fix(contacts): use permission status check instead of request() in _onStarted

### DIFF
--- a/lib/blocs/local_contacts_sync/local_contacts_sync_bloc.dart
+++ b/lib/blocs/local_contacts_sync/local_contacts_sync_bloc.dart
@@ -60,7 +60,7 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
       return;
     }
 
-    final permissionGranted = await requestContactPermission();
+    final permissionGranted = await isContactsPermissionGranted();
     if (isClosed) return;
     if (!permissionGranted) {
       emit(const LocalContactsSyncPermissionFailure());

--- a/test/blocs/local_contacts_sync_bloc_test.dart
+++ b/test/blocs/local_contacts_sync_bloc_test.dart
@@ -87,9 +87,9 @@ void main() {
       );
 
       blocTest<LocalContactsSyncBloc, LocalContactsSyncState>(
-        'emits LocalContactsSyncPermissionFailure when permission request is denied',
+        'emits LocalContactsSyncPermissionFailure when permission is not granted',
         build: () {
-          requestPermissionResult = false;
+          contactsPermissionGranted = false;
           return buildBloc();
         },
         act: (bloc) => bloc.add(const LocalContactsSyncStarted()),


### PR DESCRIPTION
## Summary

Fixes WT-1343: contacts not loading on ZTE Blade A36 (Z2472, MyOS 15, Android 15).

- `_onStarted` was calling `requestContactPermission()` → `Permission.contacts.request()`, which on ZTE MyOS 15 returns a non-granted status even when permission is already granted (OEM behavior)
- Changed to `isContactsPermissionGranted()` → `Permission.contacts.status.isGranted` (read-only check)
- `_onRefreshed` already used the correct check; `_onStarted` is now aligned with it
- `PermissionsScreen` handles the permission dialog upfront — `_onStarted` only needs to verify the status

## Root cause evidence

Log analysis across 8 sessions on the ZTE device showed `_initContactsSubscription` was always triggered from `_onRefreshed` context, never from `_onStarted`. Since the two handlers differ only in which permission check they use, this confirms `Permission.contacts.request()` consistently fails on this OEM while `Permission.contacts.status` correctly reports granted.

## Changes

- `lib/blocs/local_contacts_sync/local_contacts_sync_bloc.dart` — one-line change in `_onStarted`
- `test/blocs/local_contacts_sync_bloc_test.dart` — updated test to match new status-check behavior

## Test plan

- [ ] Verify contacts load on first app launch after granting permission
- [ ] Verify `LocalContactsSyncPermissionFailure` still emitted when permission is not granted
- [ ] Run `flutter test test/blocs/local_contacts_sync_bloc_test.dart`