### PR TITLE
fix(WT-1350): audio stuck in speaker after video disabled on iOS

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1640,6 +1640,22 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (currentVideoTrack != null) {
       currentVideoTrack.enabled = event.enabled;
       emit(state.copyWithMappedActiveCall(event.callId, (call) => call.copyWith(video: event.enabled)));
+      if (!event.enabled) {
+        // When video was enabled, user_media_builder called
+        // _configureAppleAudio(hasVideo: true), which set the shared
+        // RTCAudioSessionConfiguration.webRTCConfiguration.mode singleton to
+        // AVAudioSessionModeVideoChat. That value persists: a subsequent
+        // setSpeakerphoneOn(false) reads the same singleton and re-applies
+        // VideoChat mode, which forces speaker routing regardless of the port
+        // override. Explicitly resetting the singleton to VoiceChat first
+        // means setSpeakerphoneOn(false) applies the correct mode and clears
+        // the port override, routing audio back to the earpiece.
+        if (Platform.isIOS) {
+          await Helper.setAppleAudioConfiguration(AppleAudioConfiguration(appleAudioMode: AppleAudioMode.voiceChat));
+          await Helper.setSpeakerphoneOn(false);
+        }
+        await callkeep.reportUpdateCall(event.callId, hasVideo: false);
+      }
       return;
     }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -97,6 +97,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final Map<String, RenegotiationHandler> _renegotiationHandlers = {};
   late final HandshakeProcessor _handshakeProcessor;
 
+  bool _userSelectedSpeaker = false;
+
   final _callkeepSound = WebtritCallkeepSound();
 
   CallBloc({
@@ -382,6 +384,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   ///   retains the speaker route from a previous, unrelated session.
   void _onFirstCallStarted() {
     _logger.info(() => 'Lifecycle: First call started');
+    _userSelectedSpeaker = false;
     if (Platform.isIOS) Helper.setSpeakerphoneOn(false);
   }
 
@@ -394,6 +397,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   ///   back to A2DP (media profile), fixing degraded audio in YouTube/music after calls.
   void _onLastCallEnded() {
     _logger.info(() => 'Lifecycle: Last call ended');
+    _userSelectedSpeaker = false;
     if (Platform.isIOS) Helper.setSpeakerphoneOn(false);
     if (Platform.isAndroid) Helper.clearAndroidCommunicationDevice();
   }
@@ -1650,7 +1654,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         // override. Explicitly resetting the singleton to VoiceChat first
         // means setSpeakerphoneOn(false) applies the correct mode and clears
         // the port override, routing audio back to the earpiece.
-        if (Platform.isIOS) {
+        // The reset is skipped when the user explicitly chose the speaker so
+        // their preference is preserved after turning the camera off.
+        if (Platform.isIOS && !_userSelectedSpeaker) {
           await Helper.setAppleAudioConfiguration(AppleAudioConfiguration(appleAudioMode: AppleAudioMode.voiceChat));
           await Helper.setSpeakerphoneOn(false);
         }
@@ -1696,8 +1702,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         callkeep.setAudioDevice(event.callId, event.device.toCallkeep());
       } else if (Platform.isIOS) {
         if (event.device.type == CallAudioDeviceType.speaker) {
+          _userSelectedSpeaker = true;
           Helper.setSpeakerphoneOn(true);
         } else {
+          _userSelectedSpeaker = false;
           Helper.setSpeakerphoneOn(false);
           final deviceId = event.device.id;
           if (deviceId != null) Helper.selectAudioInput(deviceId);

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -97,8 +97,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final Map<String, RenegotiationHandler> _renegotiationHandlers = {};
   late final HandshakeProcessor _handshakeProcessor;
 
-  bool _userSelectedSpeaker = false;
-
   final _callkeepSound = WebtritCallkeepSound();
 
   CallBloc({
@@ -384,7 +382,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   ///   retains the speaker route from a previous, unrelated session.
   void _onFirstCallStarted() {
     _logger.info(() => 'Lifecycle: First call started');
-    _userSelectedSpeaker = false;
     if (Platform.isIOS) Helper.setSpeakerphoneOn(false);
   }
 
@@ -397,7 +394,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   ///   back to A2DP (media profile), fixing degraded audio in YouTube/music after calls.
   void _onLastCallEnded() {
     _logger.info(() => 'Lifecycle: Last call ended');
-    _userSelectedSpeaker = false;
     if (Platform.isIOS) Helper.setSpeakerphoneOn(false);
     if (Platform.isAndroid) Helper.clearAndroidCommunicationDevice();
   }
@@ -1656,7 +1652,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         // the port override, routing audio back to the earpiece.
         // The reset is skipped when the user explicitly chose the speaker so
         // their preference is preserved after turning the camera off.
-        if (Platform.isIOS && !_userSelectedSpeaker) {
+        if (Platform.isIOS && state.audioDevice?.type != CallAudioDeviceType.speaker) {
           await Helper.setAppleAudioConfiguration(AppleAudioConfiguration(appleAudioMode: AppleAudioMode.voiceChat));
           await Helper.setSpeakerphoneOn(false);
         }
@@ -1702,10 +1698,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         callkeep.setAudioDevice(event.callId, event.device.toCallkeep());
       } else if (Platform.isIOS) {
         if (event.device.type == CallAudioDeviceType.speaker) {
-          _userSelectedSpeaker = true;
           Helper.setSpeakerphoneOn(true);
         } else {
-          _userSelectedSpeaker = false;
           Helper.setSpeakerphoneOn(false);
           final deviceId = event.device.id;
           if (deviceId != null) Helper.selectAudioInput(deviceId);

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -234,9 +234,10 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   Future<void> _configureAppleAudio({required bool hasVideo}) async {
     if (kIsWeb) return;
 
-    await Helper.setAppleAudioConfiguration(
-      AppleAudioConfiguration(appleAudioMode: hasVideo ? AppleAudioMode.videoChat : AppleAudioMode.voiceChat),
-    );
+    // Always use VoiceChat so enabling video does not automatically switch
+    // the audio output to the speaker. The user can turn on the speaker
+    // manually if needed.
+    await Helper.setAppleAudioConfiguration(AppleAudioConfiguration(appleAudioMode: AppleAudioMode.voiceChat));
   }
 
   String _nextStreamLabel() => 'user_media_${DateTime.now().microsecondsSinceEpoch}';


### PR DESCRIPTION
## Summary

Fixes iOS audio routing stuck in speaker mode after video is disabled (WT-1350).

**Root cause**: \`_configureAppleAudio(hasVideo: true)\` sets the shared \`RTCAudioSessionConfiguration.webRTCConfiguration.mode\` singleton to \`AVAudioSessionModeVideoChat\`. That value persists: a subsequent \`setSpeakerphoneOn(false)\` reads the same singleton and re-applies \`VideoChat\` mode, which forces speaker routing regardless of the port override — effectively cancelling itself.

**Fix**:
- \`user_media_builder.dart\`: \`_configureAppleAudio\` always sets \`VoiceChat\` mode so the singleton is never left in \`VideoChat\` state regardless of video presence
- \`call_bloc.dart\`: when video is disabled, reset the singleton to \`VoiceChat\` and call \`setSpeakerphoneOn(false)\` to route back to earpiece; skip the reset if the user explicitly selected speaker so their preference is preserved

## Known remaining behavior

When video is enabled mid-call (either local camera or remote side), iOS CallKit can automatically switch audio to speaker via \`reportUpdateCall(hasVideo: true)\`. This happens asynchronously (~250–750ms after renegotiation) through a CallKit-internal audio session reconfiguration that does not go through \`didActivateAudioSession\`, so it cannot be intercepted at the native level without blocking the \`hasVideo\` signal to the system (which would break the video call UI badge).

This behavior is partially consistent with industry apps (FaceTime auto-enables speaker on video; WhatsApp/Telegram do not). The current fix prevents speaker from getting stuck — routing back to earpiece when video is turned off — which is the core of WT-1350.

## Future refactoring

Audio device logic is currently spread across 5 locations in \`call_bloc.dart\` with inline \`Platform.isIOS/Android\` conditionals. A planned \`AudioDeviceHandler\` abstraction (following the existing \`RenegotiationHandler\` / \`PeerConnectionPolicyApplier\` pattern) would:
- Encapsulate all platform-specific audio routing behind a clean interface
- Move \`_userSelectedSpeaker\` intent tracking into the handler
- Enable a reactive fix for the auto-speaker on video-enable case without polluting BLoC state

## Changes

- \`user_media_builder.dart\` — \`_configureAppleAudio\` always sets \`VoiceChat\`, removing the \`VideoChat\` singleton side-effect on video enable
- \`call_bloc.dart\` — camera-off path resets singleton + earpiece; preserves speaker if user selected it

## Test plan

- [ ] Start a video call on iOS — audio should stay on earpiece (no auto-speaker)
- [ ] Turn off camera mid-call — audio routes back to earpiece
- [ ] Turn off camera while speaker is active — speaker is preserved
- [ ] Manually toggle speaker on/off works correctly through the entire call
- [ ] Audio-only call — no regression in speaker/earpiece behavior

YouTrack: [WT-1350](https://youtrack.portaone.com/issue/WT-1350)