### PR TITLE
fix(WT-1369): incoming call stuck in Preparing after wifi reconnect

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2917,6 +2917,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
     }
 
+    // TODO(WT-1369): Both HandshakeProcessor and this block iterate
+    // stateHandshake.lines and inspect IncomingCallEvent entries. The overlap
+    // exists because HandshakeProcessor receives only activeCallIds (a Set of
+    // strings) and cannot inspect ActiveCall.incomingOffer. A cleaner design
+    // would pass richer call state into HandshakeProcessor (or introduce a
+    // dedicated ReplayOfferAction) so this second pass can be removed.
+    // For now the separation is intentional: HandshakeProcessor stays stateless
+    // and easy to unit-test; this block handles the BLoC-state-dependent part.
+
     // ---------------------------------------------------------------------------
     // Handshake offer delivery for push-registered calls without an SDP offer
     //

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2899,32 +2899,36 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     }
 
     // ---------------------------------------------------------------------------
-    // Handshake offer delivery for calls answered before WebSocket was ready
+    // Handshake offer delivery for push-registered calls without an SDP offer
     //
-    // When the user answers from a lock-screen notification, native callkeep
-    // marks the connection as answered immediately — before the WebSocket has
-    // reconnected. The BLoC call therefore reaches [incomingSubmittedAnswer] or
-    // [incomingPerformingStarted] without ever receiving an [IncomingCallEvent],
-    // so [ActiveCall.incomingOffer] stays null.
+    // A push notification creates an [ActiveCall] with status [incomingFromPush]
+    // before the WebSocket is available. The SDP offer normally arrives via a
+    // live [IncomingCallEvent] on the WebSocket. When the WebSocket is down at
+    // push arrival time (e.g. wifi reconnect), that live event is never received
+    // and [ActiveCall.incomingOffer] stays null.
     //
-    // Once the WebSocket connects, the server includes the original
+    // Once the WebSocket reconnects, the server includes the original
     // [IncomingCallEvent] (with the SDP offer) inside the [StateHandshake].
     // [HandshakeProcessor] intentionally skips it — the call is already in
     // [activeCallIds], so no action is emitted (deduplication guard).
     //
+    // This leaves the call without an offer regardless of when the user answers:
+    //   - Handshake before answer: call is [incomingFromPush], offer never stored,
+    //     answer then enters wait loop and times out.
+    //   - Answer before handshake: call reaches [incomingSubmittedAnswer] /
+    //     [incomingPerformingStarted], handshake arrives but guard still skips it.
+    //
     // [__onCallPerformEventAnswered] needs [incomingOffer] to build the peer
-    // connection. Without it the code waits on a stream that never emits and
-    // times out after 10 s. To cover this gap, the handshake lines are scanned
-    // here: any [IncomingCallEvent] that carries a jsep offer for a call that
-    // is still waiting for one is routed through [_handleSignalingEvent].
-    // [__onCallSignalingEventIncoming] then stores the offer in [ActiveCall]
-    // and the answer path proceeds normally.
+    // connection and times out after 10 s without it. To cover this gap the
+    // handshake lines are scanned here: any [IncomingCallEvent] that carries a
+    // jsep offer for a call that is still waiting for one is routed through
+    // [_handleSignalingEvent]. [__onCallSignalingEventIncoming] then stores the
+    // offer in [ActiveCall] and the answer path proceeds normally.
     //
     // [__onCallSignalingEventIncoming] reports the call to callkeep a second
     // time and receives [callIdAlreadyExistsAndAnswered], which it handles
-    // gracefully. The second [CallControlEvent.answered] it dispatches is
-    // dropped by the [canPerformAnswer] guard because the status is already
-    // [incomingPerformingStarted].
+    // gracefully. Any second [CallControlEvent.answered] it dispatches is
+    // dropped by the [canPerformAnswer] guard.
     // ---------------------------------------------------------------------------
     for (final line in stateHandshake.lines) {
       if (line == null) continue;
@@ -2940,6 +2944,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         if (call.incomingOffer != null) continue;
 
         final isWaitingForOffer =
+            call.processingStatus == CallProcessingStatus.incomingFromPush ||
             call.processingStatus == CallProcessingStatus.incomingSubmittedAnswer ||
             call.processingStatus == CallProcessingStatus.incomingPerformingStarted;
         if (!isWaitingForOffer) continue;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2899,29 +2899,32 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     }
 
     // ---------------------------------------------------------------------------
-    // Pre-answer offer replay
+    // Handshake offer delivery for calls answered before WebSocket was ready
     //
-    // Race condition: the user can tap "Answer" on the native call UI (lock-screen
-    // notification or Telecom/CallKit overlay) *before* the WebSocket reconnects.
-    // When that happens the following sequence occurs:
+    // When the user answers from a lock-screen notification, native callkeep
+    // marks the connection as answered immediately — before the WebSocket has
+    // reconnected. The BLoC call therefore reaches [incomingSubmittedAnswer] or
+    // [incomingPerformingStarted] without ever receiving an [IncomingCallEvent],
+    // so [ActiveCall.incomingOffer] stays null.
     //
-    //   1. Native callkeep marks the connection as answered and the BLoC call
-    //      advances to [incomingSubmittedAnswer] / [incomingPerformingStarted].
-    //   2. The WebSocket reconnects and the server replays the call state via a
-    //      [StateHandshake] that contains an [IncomingCallEvent] with the SDP offer.
-    //   3. [HandshakeProcessor] sees the call already in [activeCallIds] and emits
-    //      no action for it (deduplication guard) — the offer is discarded.
-    //   4. [__onCallPerformEventAnswered] waits up to 10 s for [incomingOffer] to
-    //      become non-null, then throws [TimeoutException: Timed out waiting for offer].
+    // Once the WebSocket connects, the server includes the original
+    // [IncomingCallEvent] (with the SDP offer) inside the [StateHandshake].
+    // [HandshakeProcessor] intentionally skips it — the call is already in
+    // [activeCallIds], so no action is emitted (deduplication guard).
     //
-    // Fix: after HandshakeProcessor runs, scan the handshake lines for any
-    // [IncomingCallEvent] whose call is locally waiting for an offer. If found,
-    // route the event through [_handleSignalingEvent] so that the existing
-    // [__onCallSignalingEventIncoming] handler stores the SDP offer and unblocks
-    // the wait loop. The subsequent [callIdAlreadyExistsAndAnswered] branch in
-    // [__onCallSignalingEventIncoming] handles the duplicate callkeep report
-    // gracefully — the second [CallControlEvent.answered] it dispatches is dropped
-    // by the [canPerformAnswer] guard (status is already [incomingPerformingStarted]).
+    // [__onCallPerformEventAnswered] needs [incomingOffer] to build the peer
+    // connection. Without it the code waits on a stream that never emits and
+    // times out after 10 s. To cover this gap, the handshake lines are scanned
+    // here: any [IncomingCallEvent] that carries a jsep offer for a call that
+    // is still waiting for one is routed through [_handleSignalingEvent].
+    // [__onCallSignalingEventIncoming] then stores the offer in [ActiveCall]
+    // and the answer path proceeds normally.
+    //
+    // [__onCallSignalingEventIncoming] reports the call to callkeep a second
+    // time and receives [callIdAlreadyExistsAndAnswered], which it handles
+    // gracefully. The second [CallControlEvent.answered] it dispatches is
+    // dropped by the [canPerformAnswer] guard because the status is already
+    // [incomingPerformingStarted].
     // ---------------------------------------------------------------------------
     for (final line in stateHandshake.lines) {
       if (line == null) continue;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1018,10 +1018,18 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     ActiveCall? activeCall = state.retrieveActiveCall(event.callId);
 
     if (activeCall != null) {
+      // Preserve an already-stored offer when the server re-delivers the
+      // IncomingCallEvent without a jsep (e.g. a state-sync message after
+      // reconnect that omits the SDP). Overwriting with null here would
+      // silently clear the offer and cause __onCallPerformEventAnswered to
+      // time out waiting for it.
+      final resolvedOffer = event.jsep ?? activeCall.incomingOffer;
+
       if (event.jsep == null && activeCall.incomingOffer != null) {
-        _logger.warning(
-          '__onCallSignalingEventIncoming: incoming event has jsep=null but call already has offer — '
-          'overwriting with null! callId=${event.callId} status=${activeCall.processingStatus}',
+        _logger.info(
+          '__onCallSignalingEventIncoming: keeping existing offer — '
+          'incoming event has no jsep '
+          'callId=${event.callId} status=${activeCall.processingStatus}',
         );
       }
       if (event.jsep != null && activeCall.incomingOffer != null) {
@@ -1036,7 +1044,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         displayName: displayName,
         video: video,
         transfer: transfer,
-        incomingOffer: event.jsep,
+        incomingOffer: resolvedOffer,
       );
       emit(state.copyWithMappedActiveCall(event.callId, (_) => activeCall!));
     } else {
@@ -2865,6 +2873,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
                 ),
               )
               ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived hangupRequest error'));
+          // Early return is intentional: HangupSignalingAction means the
+          // entire session is being torn down. Offer-replay for other calls
+          // is deferred to the next handshake cycle after the hang-up settles.
           return;
 
         case DeclineSignalingAction():
@@ -2877,6 +2888,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
                 ),
               )
               ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived declineRequest error'));
+          // Early return mirrors HangupSignalingAction: the incoming call is
+          // being declined server-side, so offer-replay is not applicable.
           return;
 
         case RestoreCallAction():
@@ -2919,20 +2932,28 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     //     [incomingPerformingStarted], handshake arrives but guard still skips it.
     //
     // [__onCallPerformEventAnswered] needs [incomingOffer] to build the peer
-    // connection and times out after 10 s without it. To cover this gap the
-    // handshake lines are scanned here: any [IncomingCallEvent] that carries a
-    // jsep offer for a call that is still waiting for one is routed through
-    // [_handleSignalingEvent]. [__onCallSignalingEventIncoming] then stores the
-    // offer in [ActiveCall] and the answer path proceeds normally.
+    // connection and times out after 10 s without it. To cover this gap, all
+    // handshake lines (including [guestLine]) are scanned: any [IncomingCallEvent]
+    // that carries a jsep offer for a call that is still waiting for one is routed
+    // through [_handleSignalingEvent]. [__onCallSignalingEventIncoming] then stores
+    // the offer in [ActiveCall] and the answer path proceeds normally.
     //
     // [__onCallSignalingEventIncoming] reports the call to callkeep a second
     // time and receives [callIdAlreadyExistsAndAnswered], which it handles
     // gracefully. Any second [CallControlEvent.answered] it dispatches is
     // dropped by the [canPerformAnswer] guard.
+    //
+    // Only the first [IncomingCallEvent] with a jsep per line is replayed
+    // (break after match) to avoid dispatching the same offer more than once
+    // in the unlikely case a call log contains duplicate entries.
+    //
+    // Note: this block is unreachable when [HangupSignalingAction] or
+    // [DeclineSignalingAction] triggers an early return above. Those cases
+    // tear down the session entirely, making offer-replay irrelevant.
     // ---------------------------------------------------------------------------
-    for (final line in stateHandshake.lines) {
-      if (line == null) continue;
+    final linesToScan = [...stateHandshake.lines, stateHandshake.guestLine].whereType<Line>();
 
+    for (final line in linesToScan) {
       for (final log in line.callLogs) {
         if (log is! CallEventLog) continue;
         final callEvent = log.callEvent;
@@ -2949,11 +2970,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             call.processingStatus == CallProcessingStatus.incomingPerformingStarted;
         if (!isWaitingForOffer) continue;
 
-        _logger.warning(
-          '_handleHandshakeReceived: replaying offer for pre-answered call — '
+        _logger.info(
+          '_handleHandshakeReceived: replaying offer for push-registered call — '
           'callId=${line.callId} status=${call.processingStatus}',
         );
         _handleSignalingEvent(callEvent);
+        break; // one offer per line is sufficient; avoid duplicate dispatches
       }
     }
   }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1018,6 +1018,18 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     ActiveCall? activeCall = state.retrieveActiveCall(event.callId);
 
     if (activeCall != null) {
+      if (event.jsep == null && activeCall.incomingOffer != null) {
+        _logger.warning(
+          '__onCallSignalingEventIncoming: incoming event has jsep=null but call already has offer — '
+          'overwriting with null! callId=${event.callId} status=${activeCall.processingStatus}',
+        );
+      }
+      if (event.jsep != null && activeCall.incomingOffer != null) {
+        _logger.info(
+          '__onCallSignalingEventIncoming: replacing existing offer with new one '
+          'callId=${event.callId} status=${activeCall.processingStatus}',
+        );
+      }
       activeCall = activeCall.copyWith(
         line: event.line,
         handle: handle,
@@ -1047,6 +1059,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // typically happens on android from terminated or background state,
     // on ios it produce second call of [__onCallPerformEventAnswered] or [__onCallPerformEventEnded]
     // so make sure to guard it from race conditions
+    _logger.warning(
+      '__onCallSignalingEventIncoming: callId=${event.callId} '
+      'callAlreadyExists=$callAlreadyExists '
+      'callAlreadyAnswered=$callAlreadyAnswered '
+      'callAlreadyTerminated=$callAlreadyTerminated '
+      'hasOffer=${event.jsep != null} '
+      'status=${state.retrieveActiveCall(event.callId)?.processingStatus}',
+    );
+
     await Future.delayed(Duration.zero); // Defer execution to avoid exceptions like CallkeepCallRequestError.internal.
     if (callAlreadyAnswered) add(CallControlEvent.answered(event.callId));
     if (callAlreadyTerminated) add(CallControlEvent.ended(event.callId));
@@ -2827,6 +2848,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       activeCallIds: state.activeCalls.map((c) => c.callId).toSet(),
     );
 
+    _logger.warning(
+      '_handleHandshakeReceived: HandshakeProcessor actions=${actions.map((a) => a.runtimeType).toList()} '
+      'activeCalls=${state.activeCalls.map((c) => '${c.callId}:${c.processingStatus}').toList()}',
+    );
+
     for (final action in actions) {
       switch (action) {
         case HangupSignalingAction():
@@ -2942,6 +2968,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         CallkeepIncomingCallError.callIdAlreadyExists,
         CallkeepIncomingCallError.callIdAlreadyExistsAndAnswered,
       };
+
+      _logger.warning(
+        '_onRestoreAcceptedCall: reportNewIncomingCall result=$reportError '
+        'callId=${event.callId} hasOffer=${incomingOffer != null} '
+        'alreadyAnswered=${reportError == CallkeepIncomingCallError.callIdAlreadyExistsAndAnswered}',
+      );
+
       if (!acceptableReportErrors.contains(reportError)) {
         _logger.warning('_onRestoreAcceptedCall: reportNewIncomingCall returned $reportError, aborting');
         add(_ResetStateEvent.completeCall(event.callId));

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2876,6 +2876,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           // Early return is intentional: HangupSignalingAction means the
           // entire session is being torn down. Offer-replay for other calls
           // is deferred to the next handshake cycle after the hang-up settles.
+          _logger.info(
+            '_handleHandshakeReceived: HangupSignalingAction — skipping offer-replay, callId=${action.callId}',
+          );
           return;
 
         case DeclineSignalingAction():
@@ -2890,6 +2893,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
               ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived declineRequest error'));
           // Early return mirrors HangupSignalingAction: the incoming call is
           // being declined server-side, so offer-replay is not applicable.
+          _logger.info(
+            '_handleHandshakeReceived: DeclineSignalingAction — skipping offer-replay, callId=${action.callId}',
+          );
           return;
 
         case RestoreCallAction():

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2897,6 +2897,57 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           await callkeep.endCall(action.callId);
       }
     }
+
+    // ---------------------------------------------------------------------------
+    // Pre-answer offer replay
+    //
+    // Race condition: the user can tap "Answer" on the native call UI (lock-screen
+    // notification or Telecom/CallKit overlay) *before* the WebSocket reconnects.
+    // When that happens the following sequence occurs:
+    //
+    //   1. Native callkeep marks the connection as answered and the BLoC call
+    //      advances to [incomingSubmittedAnswer] / [incomingPerformingStarted].
+    //   2. The WebSocket reconnects and the server replays the call state via a
+    //      [StateHandshake] that contains an [IncomingCallEvent] with the SDP offer.
+    //   3. [HandshakeProcessor] sees the call already in [activeCallIds] and emits
+    //      no action for it (deduplication guard) — the offer is discarded.
+    //   4. [__onCallPerformEventAnswered] waits up to 10 s for [incomingOffer] to
+    //      become non-null, then throws [TimeoutException: Timed out waiting for offer].
+    //
+    // Fix: after HandshakeProcessor runs, scan the handshake lines for any
+    // [IncomingCallEvent] whose call is locally waiting for an offer. If found,
+    // route the event through [_handleSignalingEvent] so that the existing
+    // [__onCallSignalingEventIncoming] handler stores the SDP offer and unblocks
+    // the wait loop. The subsequent [callIdAlreadyExistsAndAnswered] branch in
+    // [__onCallSignalingEventIncoming] handles the duplicate callkeep report
+    // gracefully — the second [CallControlEvent.answered] it dispatches is dropped
+    // by the [canPerformAnswer] guard (status is already [incomingPerformingStarted]).
+    // ---------------------------------------------------------------------------
+    for (final line in stateHandshake.lines) {
+      if (line == null) continue;
+
+      for (final log in line.callLogs) {
+        if (log is! CallEventLog) continue;
+        final callEvent = log.callEvent;
+        if (callEvent is! IncomingCallEvent) continue;
+        if (callEvent.jsep == null) continue;
+
+        final call = state.retrieveActiveCall(line.callId);
+        if (call == null) continue;
+        if (call.incomingOffer != null) continue;
+
+        final isWaitingForOffer =
+            call.processingStatus == CallProcessingStatus.incomingSubmittedAnswer ||
+            call.processingStatus == CallProcessingStatus.incomingPerformingStarted;
+        if (!isWaitingForOffer) continue;
+
+        _logger.warning(
+          '_handleHandshakeReceived: replaying offer for pre-answered call — '
+          'callId=${line.callId} status=${call.processingStatus}',
+        );
+        _handleSignalingEvent(callEvent);
+      }
+    }
   }
 
   Future<void> _onRestoreAcceptedCall(_RestoreAcceptedCall event, Emitter<CallState> emit) async {


### PR DESCRIPTION
## Problem

When a user receives an incoming call while the app is in the background and the network connection was recently interrupted (e.g. wifi toggle), the call gets stuck on the **Preparing** screen after tapping Answer and drops after ~10 seconds.

**What happens:**

On a stable connection, the call arrives together with the data needed to establish the audio/video session (SDP offer). When the network drops and reconnects, the app receives a push notification first — before the server connection is restored. By the time the connection comes back, the server resends all the necessary data in a batch. However, the app saw that the call was already registered from the push notification and skipped the batch — including the offer needed to complete the answer.

Without that data, the answer path waits up to 10 seconds, fails, and the call is dropped.

## Fix

After processing the server batch, the app now checks whether any active call is still missing the offer data. If found, the offer is retrieved from the batch and the answer proceeds normally.

Two timing variants are covered:
- Batch arrives **before** the user taps Answer
- Batch arrives **after** the user taps Answer

## How to reproduce

1. Put the app in the background
2. Run `adb shell svc wifi disable && adb shell svc wifi enable`
3. Call the device a few seconds after wifi reconnects
4. Tap Answer from the lock screen — call should now connect

## Related

Closes WT-1369