### PR TITLE
fix(signaling): self-healing timer to recover from stuck _startPending

### DIFF
--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -15,6 +15,13 @@ const kCallRoutingStateTimeout = Duration(seconds: 10);
 const kSignalingClientReconnectDelay = Duration(seconds: 3);
 const kSignalingClientFastReconnectDelay = Duration(seconds: 1);
 
+/// How long [WebtritSignalingService.connect] waits for a terminal event
+/// (Connected / Disconnected / ConnectionFailed) before resetting
+/// [_startPending] and retrying. Covers the case where the background isolate
+/// accepts the connect command but never sends a response — e.g. a WebSocket
+/// upgrade that hangs at the OS/TCP level without timing out.
+const kSignalingStartPendingTimeout = Duration(seconds: 30);
+
 const kPeerConnectionRetrieveTimeout = Duration(seconds: 5);
 
 const kCompatibilityVerifyRepeatDelay = Duration(seconds: 2);

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -106,6 +106,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
         trustedCertificates: context.read<AppCertificates>().trustedCertificates,
       ),
       mode: context.read<IncomingCallTypeRepository>().getIncomingCallType().toSignalingServiceMode(),
+      startPendingTimeout: kSignalingStartPendingTimeout,
     )..connect();
 
     final notificationsBloc = context.read<NotificationsBloc>();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -51,20 +51,22 @@ class WebtritSignalingService implements SignalingModule {
   WebtritSignalingService({
     required SignalingServiceConfig config,
     SignalingServiceMode mode = SignalingServiceMode.persistent,
+    Duration startPendingTimeout = const Duration(seconds: 30),
   }) : _config = config,
-       _mode = mode {
+       _mode = mode,
+       _startPendingTimeout = startPendingTimeout {
     _serviceEventsSub = SignalingServicePlatform.instance.events.listen((event) {
       switch (event) {
         case SignalingConnected():
           _isConnected = true;
-          _startPending = false;
+          _clearStartPending();
           unawaited(
             _requestQueue.flush(execute: SignalingServicePlatform.instance.execute, isActive: () => _isConnected),
           );
         case SignalingDisconnected():
         case SignalingConnectionFailed():
           _isConnected = false;
-          _startPending = false;
+          _clearStartPending();
         default:
           break;
       }
@@ -73,6 +75,7 @@ class WebtritSignalingService implements SignalingModule {
 
   final SignalingServiceConfig _config;
   final SignalingServiceMode _mode;
+  final Duration _startPendingTimeout;
   final _requestQueue = SignalingRequestQueue();
 
   StreamSubscription<SignalingModuleEvent>? _serviceEventsSub;
@@ -87,20 +90,70 @@ class WebtritSignalingService implements SignalingModule {
   /// the loop from completing on Android.
   bool _startPending = false;
 
+  /// Fires [_startPendingTimeout] after [connect] is called if no terminal
+  /// event arrives. Resets [_startPending] and retries [connect] to recover
+  /// from a background isolate that accepted the connect command but stopped
+  /// sending events (e.g. a TCP-level hang with no OS timeout).
+  Timer? _startPendingTimer;
+
   @override
   Stream<SignalingModuleEvent> get events => SignalingServicePlatform.instance.events;
 
   @override
   bool get isConnected => _isConnected;
 
+  /// Starts the signaling service and initiates a WebSocket connection.
+  ///
+  /// Idempotent: no-op when a start is already in progress ([_startPending])
+  /// or the hub is already connected ([_isConnected]).
+  ///
+  /// ## Self-healing on stuck start
+  ///
+  /// [_startPending] is set to `true` on entry and cleared only when a terminal
+  /// event ([SignalingConnected], [SignalingDisconnected], [SignalingConnectionFailed])
+  /// arrives from the background isolate. In practice two failure modes can
+  /// prevent that event from ever arriving:
+  ///
+  /// 1. **TCP-level hang**: the background isolate starts a WebSocket upgrade
+  ///    whose TCP connect stalls (e.g. a middlebox drops SYN packets silently).
+  ///    Android's default TCP timeout can exceed 10 minutes, so no OS error is
+  ///    delivered within a reasonable time and the isolate never emits a failure
+  ///    event.
+  ///
+  /// 2. **Background-isolate state mismatch**: after the app resumes from
+  ///    background the [SignalingReconnectController] calls [connect] via a
+  ///    one-shot [_reconnectTimer]. If [_startPending] is already `true` from a
+  ///    prior background attempt that stalled, the call is silently discarded.
+  ///    [SignalingReconnectController] has no periodic timer — it reschedules
+  ///    only on terminal events or external lifecycle notifications — so the
+  ///    reconnect loop goes silent until the next user-visible lifecycle change.
+  ///
+  /// To recover without waiting for an external trigger, a [_startPendingTimer]
+  /// is armed on every [connect] call. If [_startPendingTimeout] elapses with
+  /// no terminal event, [_startPending] is reset and [connect] is retried.
+  /// The timer is cancelled immediately when a terminal event arrives, so it
+  /// has no effect during normal operation.
   @override
   void connect() {
     if (_startPending || _isConnected) return;
     _startPending = true;
+    _startPendingTimer?.cancel();
+    _startPendingTimer = Timer(_startPendingTimeout, () {
+      _logger.warning('connect: no terminal event after $_startPendingTimeout — resetting and retrying');
+      _startPending = false;
+      _startPendingTimer = null;
+      connect();
+    });
     SignalingServicePlatform.instance.start(_config, mode: _mode).catchError((Object e, StackTrace s) {
       _logger.severe('connect: start() failed', e, s);
-      _startPending = false;
+      _clearStartPending();
     });
+  }
+
+  void _clearStartPending() {
+    _startPending = false;
+    _startPendingTimer?.cancel();
+    _startPendingTimer = null;
   }
 
   /// No-op -- intentional. The service stays connected while the app is
@@ -136,7 +189,7 @@ class WebtritSignalingService implements SignalingModule {
     await _serviceEventsSub?.cancel();
     _serviceEventsSub = null;
     _isConnected = false;
-    _startPending = false;
+    _clearStartPending();
     await SignalingServicePlatform.instance.dispose();
   }
 


### PR DESCRIPTION
## Summary

- `_startPending` could get stuck `true` if the background isolate accepted a connect command but never emitted a terminal event (TCP-level hang with no OS timeout, or reconnect loop going silent after a backgrounded stall)
- Added `_startPendingTimer` that resets `_startPending` and retries `connect()` after `kSignalingStartPendingTimeout` (30 s) if no `SignalingConnected` / `SignalingDisconnected` / `SignalingConnectionFailed` arrives
- Extracted `_clearStartPending()` helper to cancel the timer and clear the flag atomically — used in all existing clear sites (`SignalingConnected`, `SignalingDisconnected`, `SignalingConnectionFailed`, `start()` catchError, `dispose()`)
- `startPendingTimeout` is injected via constructor (default 30 s) and wired from `kSignalingStartPendingTimeout` constant in `main_shell.dart`

## Test plan

- [ ] Normal connect path: timer is cancelled on first `SignalingConnected` — no effect
- [ ] Simulate stuck isolate (block WebSocket upgrade): verify `connect()` retries after 30 s and eventually connects
- [ ] App resumes from background with stale `_startPending = true`: verify self-heal fires and reconnect resumes
- [ ] `dispose()` called while timer is running: verify timer is cancelled and no retry fires after dispose