### PR TITLE
fix(signaling): eliminate FGS restart crash during logout teardown

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -80,6 +80,7 @@ class WebtritSignalingService implements SignalingModule {
 
   StreamSubscription<SignalingModuleEvent>? _serviceEventsSub;
   bool _isConnected = false;
+  bool _isDisposed = false;
 
   /// True while [connect] has been called but a terminal event
   /// ([SignalingConnected], [SignalingDisconnected], [SignalingConnectionFailed])
@@ -104,8 +105,9 @@ class WebtritSignalingService implements SignalingModule {
 
   /// Starts the signaling service and initiates a WebSocket connection.
   ///
-  /// Idempotent: no-op when a start is already in progress ([_startPending])
-  /// or the hub is already connected ([_isConnected]).
+  /// No-op when the service has been disposed ([_isDisposed]), a start is
+  /// already in progress ([_startPending]), or the hub is already connected
+  /// ([_isConnected]).
   ///
   /// ## Self-healing on stuck start
   ///
@@ -135,7 +137,7 @@ class WebtritSignalingService implements SignalingModule {
   /// has no effect during normal operation.
   @override
   void connect() {
-    if (_startPending || _isConnected) return;
+    if (_isDisposed || _startPending || _isConnected) return;
     _startPending = true;
     _startPendingTimer?.cancel();
     _startPendingTimer = Timer(_startPendingTimeout, () {
@@ -185,6 +187,7 @@ class WebtritSignalingService implements SignalingModule {
 
   @override
   Future<void> dispose() async {
+    _isDisposed = true;
     _requestQueue.failAll(NotConnectedException('WebtritSignalingService is disposed'));
     await _serviceEventsSub?.cancel();
     _serviceEventsSub = null;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -251,8 +251,14 @@ class SignalingForegroundService : Service() {
                    StorageDelegate.getTenantId(applicationContext).isNotEmpty() &&
                    StorageDelegate.getToken(applicationContext).isNotEmpty() &&
                    StorageDelegate.getCallbackDispatcher(applicationContext) != 0L) {
-            // persistent mode -- enqueue a fast restart in case the OS doesn't honour START_STICKY
-            SignalingRestartWorker.enqueue(applicationContext, delayMillis = 1_000)
+            // persistent mode -- enqueue a fast restart in case the OS doesn't honour START_STICKY.
+            // REPLACE resets any accumulated backoff: task removal is a UI action, not a
+            // connection failure, so an immediate retry is appropriate.
+            SignalingRestartWorker.enqueue(
+                applicationContext,
+                delayMillis = 1_000,
+                policy = androidx.work.ExistingWorkPolicy.REPLACE,
+            )
         }
     }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -116,6 +116,18 @@ class SignalingForegroundService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "SignalingForegroundService onStartCommand")
+
+        // Path 4 guard: stopService() arrived in the Pigeon FIFO queue before this
+        // service's H.CREATE_SERVICE ran (main thread was overloaded). The plugin
+        // deferred the stop because calling context.stopService() at that point would
+        // crash — the service had not yet called startForeground(). onCreate() already
+        // called startForeground() so we can stop safely now without a crash.
+        if (WebtritSignalingServicePlugin.consumeStopRequested()) {
+            Log.w(TAG, "onStartCommand: deferred stop detected — stopping after startForeground()")
+            gracefulStop { stopSelf() }
+            return START_NOT_STICKY
+        }
+
         getLock(applicationContext).acquire(10 * 60 * 1000L)
 
         // Fast path: engine already exists — attach if needed and wire Pigeon immediately.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingRestartWorker.kt
@@ -3,6 +3,7 @@ package com.webtrit.signaling_service
 import android.content.Context
 import android.os.Build
 import android.util.Log
+import androidx.work.BackoffPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
@@ -29,17 +30,26 @@ class SignalingRestartWorker(
 ) : Worker(context, workerParams) {
 
     override fun doWork(): Result = try {
-        if (!SignalingForegroundService.isRunning &&
-            !StorageDelegate.isPushBound(applicationContext) &&
+        if (SignalingForegroundService.isRunning) {
+            Log.d(TAG, "SignalingRestartWorker: FGS already running — nothing to do")
+            return Result.success()
+        }
+        if (!StorageDelegate.isPushBound(applicationContext) &&
             StorageDelegate.getCoreUrl(applicationContext).isNotEmpty() &&
             StorageDelegate.getTenantId(applicationContext).isNotEmpty() &&
             StorageDelegate.getToken(applicationContext).isNotEmpty() &&
             StorageDelegate.getCallbackDispatcher(applicationContext) != 0L
         ) {
-            Log.w(TAG, "SignalingRestartWorker: restarting persistent FGS")
+            Log.w(TAG, "SignalingRestartWorker: restarting persistent FGS (attempt ${runAttemptCount + 1})")
             SignalingForegroundService.start(applicationContext)
+            // Return retry so WorkManager applies exponential backoff for the next check.
+            // If the FGS stays up, the next run finds isRunning==true and returns success.
+            // If it dies again (core still unreachable), the delay grows: 15s→30s→60s→...→5h,
+            // preventing the overnight restart churn that leads to OS-level throttling on Xiaomi.
+            Result.retry()
+        } else {
+            Result.success()
         }
-        Result.success()
     } catch (e: Exception) {
         // ForegroundServiceStartNotAllowedException is expected on Android 12+ when the process
         // has left the BFGS window. Log at warning level (transient) and schedule a retry.
@@ -57,13 +67,18 @@ class SignalingRestartWorker(
         private const val TAG = "SignalingRestartWorker"
         private const val WORK_TAG = "signaling_fgs_restart"
 
-        fun enqueue(context: Context, delayMillis: Long = 15_000) {
+        fun enqueue(
+            context: Context,
+            delayMillis: Long = 15_000,
+            policy: ExistingWorkPolicy = ExistingWorkPolicy.KEEP,
+        ) {
             val request = OneTimeWorkRequestBuilder<SignalingRestartWorker>()
                 .addTag(WORK_TAG)
                 .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 15, TimeUnit.SECONDS)
                 .build()
             WorkManager.getInstance(context)
-                .enqueueUniqueWork(WORK_TAG, ExistingWorkPolicy.REPLACE, request)
+                .enqueueUniqueWork(WORK_TAG, policy, request)
         }
 
         fun remove(context: Context) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.Keep
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import java.util.concurrent.atomic.AtomicBoolean
 
 // NOTE: PSignalingServiceHostApi and PSignalingServiceFlutterApi are generated
 // by running:  dart run pigeon --input pigeons/signaling.messages.dart
@@ -77,8 +78,8 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
     }
 
     override fun startService(mode: PSignalingServiceMode) {
-        Log.d(TAG, "startService mode=$mode isRunning=${SignalingForegroundService.isRunning} instance=${SignalingForegroundService.instance != null} _stopRequested=$_stopRequested")
-        _stopRequested = false
+        Log.d(TAG, "startService mode=$mode isRunning=${SignalingForegroundService.isRunning} instance=${SignalingForegroundService.instance != null} _stopRequested=${_stopRequested.get()}")
+        _stopRequested.set(false)
         StorageDelegate.saveMode(context, mode)
         Log.d(TAG, "startService: calling startForegroundService()")
         SignalingForegroundService.start(context)
@@ -102,7 +103,7 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
             // ForegroundServiceDidNotStartInTimeException. Set the flag instead;
             // onStartCommand checks it and stops cleanly after startForeground() has run.
             Log.w(TAG, "stopService: service not yet started — deferring stop via _stopRequested")
-            _stopRequested = true
+            _stopRequested.set(true)
         }
     }
 
@@ -144,16 +145,15 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
         /// directly would crash with ForegroundServiceDidNotStartInTimeException because
         /// the service never got to call startForeground(). The deferred stop is picked
         /// up by [SignalingForegroundService.onStartCommand] after startForeground() runs.
-        @Volatile
-        private var _stopRequested = false
+        ///
+        /// AtomicBoolean used for atomic getAndSet — both writer (stopService via Pigeon)
+        /// and reader (onStartCommand) run on the main thread, but AtomicBoolean makes
+        /// the intent explicit and avoids relying on @Volatile for the read-modify-write.
+        private val _stopRequested = AtomicBoolean(false)
 
-        /// Reads and clears [_stopRequested] atomically.
+        /// Atomically reads and clears [_stopRequested].
         /// Called by [SignalingForegroundService.onStartCommand].
-        internal fun consumeStopRequested(): Boolean {
-            val was = _stopRequested
-            _stopRequested = false
-            return was
-        }
+        internal fun consumeStopRequested(): Boolean = _stopRequested.getAndSet(false)
 
         /// Returns true when [e] is [ForegroundServiceStartNotAllowedException] (API 31+).
         ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -77,9 +77,12 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
     }
 
     override fun startService(mode: PSignalingServiceMode) {
-        Log.d(TAG, "startService mode=$mode")
+        Log.d(TAG, "startService mode=$mode isRunning=${SignalingForegroundService.isRunning} instance=${SignalingForegroundService.instance != null} _stopRequested=$_stopRequested")
+        _stopRequested = false
         StorageDelegate.saveMode(context, mode)
+        Log.d(TAG, "startService: calling startForegroundService()")
         SignalingForegroundService.start(context)
+        Log.d(TAG, "startService: startForegroundService() returned")
     }
 
     override fun stopService() {
@@ -89,8 +92,17 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
         val service = SignalingForegroundService.instance
         if (service != null) {
             service.gracefulStop { SignalingForegroundService.stop(context) }
-        } else {
+        } else if (SignalingForegroundService.isRunning) {
             SignalingForegroundService.stop(context)
+        } else {
+            // startForegroundService() was called but onCreate() hasn't run yet.
+            // The Pigeon queue delivered stopService() before H.CREATE_SERVICE ran on the
+            // main thread (e.g. main thread was overloaded). Calling stop() here would
+            // bring down a service that never called startForeground() →
+            // ForegroundServiceDidNotStartInTimeException. Set the flag instead;
+            // onStartCommand checks it and stops cleanly after startForeground() has run.
+            Log.w(TAG, "stopService: service not yet started — deferring stop via _stopRequested")
+            _stopRequested = true
         }
     }
 
@@ -126,6 +138,22 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
 
     companion object {
         private const val TAG = "WebtritSignalingServicePlugin"
+
+        /// True when [stopService] was called while [SignalingForegroundService.onCreate]
+        /// had not yet run. In that window, calling [SignalingForegroundService.stop]
+        /// directly would crash with ForegroundServiceDidNotStartInTimeException because
+        /// the service never got to call startForeground(). The deferred stop is picked
+        /// up by [SignalingForegroundService.onStartCommand] after startForeground() runs.
+        @Volatile
+        private var _stopRequested = false
+
+        /// Reads and clears [_stopRequested] atomically.
+        /// Called by [SignalingForegroundService.onStartCommand].
+        internal fun consumeStopRequested(): Boolean {
+            val was = _stopRequested
+            _stopRequested = false
+            return was
+        }
 
         /// Returns true when [e] is [ForegroundServiceStartNotAllowedException] (API 31+).
         ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -266,6 +266,10 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
   Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
     _logger.fine('_startService mode=$mode');
+    if (_isStopped) {
+      _logger.warning('_startService: aborted — service already stopped');
+      return;
+    }
     final dispatcherHandle = PluginUtilities.getCallbackHandle(signalingServiceCallbackDispatcher);
     if (dispatcherHandle == null) {
       throw StateError(

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -92,6 +92,20 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   /// chosen mode is used instead of reverting to the stale parameter.
   SignalingServiceMode? _currentMode;
 
+  /// Set to `true` by [stopService] and [dispose] to prevent [_onHubServiceDead]
+  /// from restarting the foreground service after an intentional stop.
+  ///
+  /// Without this guard, stopping the FGS during logout causes the hub to lose
+  /// its port in [IsolateNameServer], which triggers [_onHubServiceDead]. That
+  /// callback calls [_startService] directly — bypassing [WebtritSignalingService]
+  /// and its own [_isDisposed] check — and starts a new FGS. If the logout
+  /// teardown then calls [stopService] on the new FGS before it reaches
+  /// [startForeground], the OS throws [ForegroundServiceDidNotStartInTimeException].
+  ///
+  /// Reset to `false` in [start] so the service can be restarted after a new
+  /// login session.
+  bool _isStopped = false;
+
   @override
   Stream<SignalingModuleEvent> get events {
     return Stream.multi((sink) {
@@ -108,6 +122,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.persistent,
   }) async {
+    _isStopped = false;
     _currentConfig = config;
     // Use the mode from the last explicit start/updateMode call so that
     // reconnect calls (which always pass the initial mode) do not revert
@@ -164,6 +179,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
   @override
   Future<void> dispose() async {
+    _isStopped = true;
     _logger.info('dispose');
     await _hubManager.tearDown();
 
@@ -212,6 +228,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
   @override
   Future<void> stopService() async {
+    _isStopped = true;
     _logger.info('stopService');
     await _hostApi.stopService();
   }
@@ -229,6 +246,10 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   }
 
   Future<void> _onHubServiceDead() async {
+    if (_isStopped) {
+      _logger.info('_onHubServiceDead: service intentionally stopped, skipping restart');
+      return;
+    }
     _logger.warning('_onHubServiceDead: hub service dead, restarting');
     final config = _currentConfig;
     final mode = _currentMode;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -291,6 +291,16 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       _hostApi.saveTrustedCertificates(_encodeTrustedCertificates(config.trustedCertificates)),
     ]);
 
+    // Guard: stopService() or dispose() may have been called while the
+    // credential saves above were in flight (the await yields the event loop,
+    // allowing concurrent teardown to set _isStopped). Abort before calling
+    // startForegroundService() to avoid ForegroundServiceDidNotStartInTimeException —
+    // the crash that fires when the service is stopped before it calls startForeground().
+    if (_isStopped) {
+      _logger.warning('_startService: aborted — service stopped during credential save');
+      return;
+    }
+
     // Start the service only after all credentials are persisted so that
     // synchronizeIsolate() reads correct data on the first attempt.
     await _hostApi.startService(signalingModeToNative(mode));


### PR DESCRIPTION
## What and why

During logout teardown and after extended core outages, the app crashes with a fatal
`ForegroundServiceDidNotStartInTimeException`. Two independent root causes are fixed here.

---

## Root cause 1 — FGS restart during logout teardown (Scenario B)

When the core restarts and invalidates tokens, `notifyNetworkAvailable` fires
and schedules a 1 s reconnect timer. If that timer overlaps with the logout
sequence triggered by the 401 response, one of four races can reach
`startForegroundService()` after teardown has already issued `stopService()`.
The result is always the same fatal exception.

| Path | Trigger | Layer |
|------|---------|-------|
| 1 | `stopService()` → hub port gone → `_onHubServiceDead()` restarts FGS, bypassing `_isDisposed` | Dart |
| 2 | Reconnect timer fires after `dispose()`, `start()` resets `_isStopped` | Dart |
| 3 | Timer fires before `stopService()`; `Future.wait` yields the event loop and `stopService()` runs during the yield | Dart |
| 4 | `Future.wait` completes before `stopService()`; both messages already in the Kotlin Pigeon FIFO; `H.CREATE_SERVICE` arrives behind `stopService` in the overloaded main-thread queue | Kotlin |

Paths 1–3 are closed with synchronous flag checks in Dart before any
`startForegroundService()` call is made. Path 4 cannot be prevented from the
Dart side — the fix is deferred to `onStartCommand()`, which runs after
`startForeground()` has already been called in `onCreate()`.

---

## Root cause 2 — overnight restart churn on Xiaomi persistent mode (Scenario A)

App in persistent mode with the core unreachable. `SignalingRestartWorker`
previously returned `Result.success()` and re-enqueued with
`ExistingWorkPolicy.REPLACE` on every `onDestroy`, resetting the delay to a
fixed 15 s each cycle. Over 8 hours this produced ~640 restart attempts.
After extended churn, Xiaomi HyperOS throttled process creation — the next
`startForegroundService()` call timed out before `Service.onCreate()` could
run, triggering the same fatal exception.

**Fix:** `doWork()` now returns `Result.retry()` after each restart attempt so
WorkManager applies exponential backoff (15 s → 30 s → 60 s → … → 5 h cap).
`onDestroy` enqueues with `ExistingWorkPolicy.KEEP` so accumulated backoff is
preserved across watchdog cycles. `onTaskRemoved` keeps `REPLACE` — task
removal is a UI action, so an immediate restart is appropriate.

When the user opens the app, `connect()` starts the FGS directly without
going through WorkManager, so there is no UX impact from the longer delays.

---

## Changes

**Dart — `signaling_service.dart`**
- `_isDisposed = true` as first statement of `dispose()`
- `connect()` returns early when `_isDisposed`

**Dart — `plugin.dart`**
- `_isStopped = true` as first statement of `stopService()` and `dispose()`; reset in `start()` for re-login
- `_onHubServiceDead()` returns early when `_isStopped`
- `_startService()`: early `_isStopped` guard before `Future.wait` (skips Binder calls) and after (prevents `startForegroundService()`)

**Kotlin — `WebtritSignalingServicePlugin.kt`**
- `stopService()`: when `instance == null && !isRunning`, sets `_stopRequested` (`AtomicBoolean`) instead of calling `context.stopService()`
- `startService()`: clears `_stopRequested` for re-login

**Kotlin — `SignalingForegroundService.kt`**
- `onStartCommand()`: checks `consumeStopRequested()` before wake lock; stops cleanly if true
- `onTaskRemoved()`: passes `ExistingWorkPolicy.REPLACE` explicitly

**Kotlin — `SignalingRestartWorker.kt`**
- `doWork()`: returns `Result.retry()` after restart attempt; `Result.success()` when already running
- `enqueue()`: adds `setBackoffCriteria(EXPONENTIAL, 15 s)`; default policy changed to `KEEP`

---

## Observed crash

```
Fatal Exception: android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException
  Context.startForegroundService() did not then call Service.startForeground()
```

**Scenario B:** Samsung SM-A505FN (Android 11) — logout while reconnect timer in flight  
**Scenario A:** Xiaomi 25028RN03Y (Android 15, HyperOS) — persistent mode, core down overnight

---

## How to verify

**Scenario B:** Connect to a core that invalidates tokens on restart. Kill and restart
the core so a network-recovery event fires a reconnect timer, then a 401 triggers
logout within ~1 s. Before: crash. After: logout completes cleanly.

**Scenario A:** Run the app in persistent mode against an unreachable core for an
extended period. Before: hundreds of restart cycles, eventual crash on Xiaomi.
After: restart attempts grow from 15 s to several minutes between tries.