### PR TITLE
fix: reconnect renegotiate only connected

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -672,9 +672,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // user turn off all network interfaces >> __onPeerConnectionEventIceConnectionStateChanged >> RTCIceConnectionStateFailed >> peerConnection.restartIce() >> onRenegotiationNeeded >> _safeRenegotiate >> if(!signalingConnected) return;
     // user turn on network interfaces >> _onSignalingClientEventConnected >> safeRenegotiate
     for (final call in state.activeCalls.where((c) => c.processingStatus == CallProcessingStatus.connected)) {
-      // Skip calls that are being torn down — sending UpdateRequest for a
-      // disconnecting call would keep the server-side leg alive unnecessarily.
-      if (call.processingStatus == CallProcessingStatus.disconnecting) continue;
       _logger.warning('__onSignalingClientEventConnected: triggering safe renegotiation for call ${call.callId}');
       _safeRenegotiate(call.callId, call.line);
     }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -671,7 +671,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // Important to do in case if there was connection loss for a while and then webrtc detects network loss and restarts ice e.g
     // user turn off all network interfaces >> __onPeerConnectionEventIceConnectionStateChanged >> RTCIceConnectionStateFailed >> peerConnection.restartIce() >> onRenegotiationNeeded >> _safeRenegotiate >> if(!signalingConnected) return;
     // user turn on network interfaces >> _onSignalingClientEventConnected >> safeRenegotiate
-    for (final call in state.activeCalls) {
+    for (final call in state.activeCalls.where((c) => c.processingStatus == CallProcessingStatus.connected)) {
       // Skip calls that are being torn down — sending UpdateRequest for a
       // disconnecting call would keep the server-side leg alive unnecessarily.
       if (call.processingStatus == CallProcessingStatus.disconnecting) continue;


### PR DESCRIPTION
 Only iterate over active calls with a `processingStatus` of `connected` when forcing renegotiation on reconnection, ensuring that calls not yet connected or disconnecting are excluded from this process. (`lib/features/call/bloc/call_bloc.dart`)