### PR TITLE
fix(api): map 401 token_invalid to UnauthorizedException — auto-logout on server restart (WT-1386)

### DIFF
--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -156,6 +156,18 @@ class WebtritApiClient {
             );
           }
 
+          // Map 401 token_invalid to UnauthorizedException so the existing SessionGuard
+          // chain triggers logout when the server invalidates all tokens (e.g. after restart).
+          if (httpResponse.statusCode == 401 && error?.code == 'token_invalid') {
+            throw UnauthorizedException(
+              url: tenantUrl,
+              requestId: xRequestId,
+              statusCode: httpResponse.statusCode,
+              token: token,
+              error: error,
+            );
+          }
+
           // Map 422 with code="refresh_token_invalid" to UnauthorizedException.
           // This ensures higher layers can handle expired/invalid sessions in a unified way
           // (e.g., trigger global logout or token refresh).

--- a/packages/webtrit_api/test/webtrit_api_client_unauthorized_exception_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_client_unauthorized_exception_test.dart
@@ -56,5 +56,67 @@ void main() {
       verify(() => mockHttpClient.send(any())).called(1);
       verifyNoMoreInteractions(mockHttpClient);
     });
+
+    test('throws on 401 with code "token_invalid"', () async {
+      when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+        return _jsonResponse({'code': 'token_invalid', 'message': 'Token is invalid'}, 401);
+      });
+
+      expect(
+        () => apiClient.getUserInfo(token),
+        throwsA(
+          isA<UnauthorizedException>()
+              .having((e) => e.statusCode, 'statusCode', 401)
+              .having((e) => e.error?.code, 'error.code', 'token_invalid'),
+        ),
+      );
+
+      verify(() => mockHttpClient.send(any())).called(1);
+      verifyNoMoreInteractions(mockHttpClient);
+    });
+  });
+
+  group('SessionMissingException', () {
+    late MockHttpClient mockHttpClient;
+    late WebtritApiClient apiClient;
+
+    setUp(() {
+      mockHttpClient = MockHttpClient();
+      apiClient = WebtritApiClient.inner(Uri.parse(baseUri), tenantId, httpClient: mockHttpClient);
+    });
+
+    tearDown(() {
+      apiClient.close();
+      reset(mockHttpClient);
+    });
+
+    test('throws on 401 with code "session_missing"', () async {
+      when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+        return _jsonResponse({'code': 'session_missing', 'message': 'Session not found'}, 401);
+      });
+
+      expect(
+        () => apiClient.getUserInfo(token),
+        throwsA(
+          isA<SessionMissingException>()
+              .having((e) => e.statusCode, 'statusCode', 401)
+              .having((e) => e.error?.code, 'error.code', 'session_missing'),
+        ),
+      );
+
+      verify(() => mockHttpClient.send(any())).called(1);
+      verifyNoMoreInteractions(mockHttpClient);
+    });
+
+    test('does not throw UnauthorizedException on 401 with code "session_missing"', () async {
+      when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+        return _jsonResponse({'code': 'session_missing', 'message': 'Session not found'}, 401);
+      });
+
+      expect(
+        () => apiClient.getUserInfo(token),
+        throwsA(isNot(isA<UnauthorizedException>())),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

- `401 token_invalid` response from the server was falling through to `RequestFailure` instead of being recognized as an auth failure
- Added mapping in `WebtritApiClient` to throw `UnauthorizedException` for `401/token_invalid`, consistent with how `session_missing` and `refresh_token_invalid` are handled
- Unblocks the existing `SessionGuard → RouterLogoutSessionGuard → AppLogoutRequested` chain for repositories that already have a guard wired (4 of 11)

## Root cause (from WT-1386)

When the core server restarts and invalidates all tokens, it returns `401 {"code": "token_invalid"}`. Previously this produced a `RequestFailure` that no repository caught as an auth error — `PollingService` swallowed it as a warning and the user stayed stuck in an authenticated state with silently broken UI.

## Files changed

- `packages/webtrit_api/lib/src/webtrit_api_client.dart` — minimal fix: add `token_invalid` → `UnauthorizedException` mapping

## Scope

This is the **minimal fix** (Layer 1 only). Full fix (centralized `onAuthError` callback covering all 11 repositories) is tracked as a follow-up in WT-1386.

## Test plan

- [ ] Simulate server restart / token invalidation → verify app triggers logout
- [ ] Verify `401 session_missing` still throws `SessionMissingException` (no regression)
- [ ] Verify `422 refresh_token_invalid` still throws `UnauthorizedException` (no regression)

Fixes: https://youtrack.portaone.com/issue/WT-1386