### PR TITLE
fix(signaling): handle unknown/provisional SIP dialog states without crashing [WT-1380]

### DIFF
--- a/packages/webtrit_signaling/lib/src/events/global/dialog_info.dart
+++ b/packages/webtrit_signaling/lib/src/events/global/dialog_info.dart
@@ -2,7 +2,7 @@ import 'package:equatable/equatable.dart';
 
 enum SignalingDialogDirection { initiator, recipient }
 
-enum SignalingDialogState { proceeding, early, confirmed, terminated, unknown }
+enum SignalingDialogState { trying, proceeding, early, confirmed, terminated, unknown }
 
 class SignalingDialogInfo extends Equatable {
   const SignalingDialogInfo({
@@ -39,9 +39,11 @@ class SignalingDialogInfo extends Equatable {
     return SignalingDialogInfo(
       id: json['id'],
       entityNumber: json['entity_number'],
-      state: SignalingDialogState.values.byName(json['state']),
+      state: SignalingDialogState.values.asNameMap()[json['state'] as String?] ?? SignalingDialogState.unknown,
       callId: json['call_id'],
-      direction: json['direction'] != null ? SignalingDialogDirection.values.byName(json['direction']) : null,
+      direction: json['direction'] != null
+          ? SignalingDialogDirection.values.asNameMap()[json['direction'] as String]
+          : null,
       localTag: json['local_tag'],
       localNumber: json['local_number'],
       localDisplayName: json['local_display_name'],

--- a/packages/webtrit_signaling/test/src/events/global/dialog_info_test.dart
+++ b/packages/webtrit_signaling/test/src/events/global/dialog_info_test.dart
@@ -1,0 +1,75 @@
+import 'package:test/test.dart';
+
+import 'package:webtrit_signaling/src/events/global/dialog_info.dart';
+
+void main() {
+  Map<String, dynamic> baseJson({required String state, String? direction}) => {
+    'id': 'dlg-1',
+    'entity_number': '124111',
+    'state': state,
+    'call_id': 'abc123',
+    'direction': direction,
+    'arrival_version': '1',
+    'arrival_time': '2026-04-19T16:07:00.000000Z',
+  };
+
+  group('SignalingDialogState parsing', () {
+    test('parses "trying" → SignalingDialogState.trying', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'trying'));
+      expect(info.state, SignalingDialogState.trying);
+    });
+
+    test('parses "proceeding" → SignalingDialogState.proceeding', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'proceeding'));
+      expect(info.state, SignalingDialogState.proceeding);
+    });
+
+    test('parses "early" → SignalingDialogState.early', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'early'));
+      expect(info.state, SignalingDialogState.early);
+    });
+
+    test('parses "confirmed" → SignalingDialogState.confirmed', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'confirmed'));
+      expect(info.state, SignalingDialogState.confirmed);
+    });
+
+    test('parses "terminated" → SignalingDialogState.terminated', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'terminated'));
+      expect(info.state, SignalingDialogState.terminated);
+    });
+
+    test('unknown future state falls back to SignalingDialogState.unknown', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'some_future_state'));
+      expect(info.state, SignalingDialogState.unknown);
+    });
+
+    test('null state falls back to SignalingDialogState.unknown', () {
+      final json = baseJson(state: 'placeholder')..['state'] = null;
+      final info = SignalingDialogInfo.fromJson(json);
+      expect(info.state, SignalingDialogState.unknown);
+    });
+  });
+
+  group('SignalingDialogDirection parsing', () {
+    test('parses "initiator" → SignalingDialogDirection.initiator', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'confirmed', direction: 'initiator'));
+      expect(info.direction, SignalingDialogDirection.initiator);
+    });
+
+    test('parses "recipient" → SignalingDialogDirection.recipient', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'confirmed', direction: 'recipient'));
+      expect(info.direction, SignalingDialogDirection.recipient);
+    });
+
+    test('unknown direction falls back to null', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'confirmed', direction: 'unknown_direction'));
+      expect(info.direction, isNull);
+    });
+
+    test('null direction → null', () {
+      final info = SignalingDialogInfo.fromJson(baseJson(state: 'confirmed'));
+      expect(info.direction, isNull);
+    });
+  });
+}

--- a/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
+++ b/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:test/test.dart';
 
 import 'package:webtrit_signaling/src/events/events.dart';
+import 'package:webtrit_signaling/src/events/global/dialog_info.dart';
 import 'package:webtrit_signaling/src/handshakes/handshakes.dart';
 
 void main() {
@@ -65,5 +66,92 @@ void main() {
 
   test('$StateHandshake fromJson', () {
     expect(StateHandshake.fromJson(json.decode(stateHandshakeJson) as Map<String, dynamic>), equals(stateHandshake));
+  });
+
+  test('$StateHandshake fromJson with dialog_infos state "trying" does not throw', () {
+    final jsonWithTrying =
+        json.decode('''
+    {
+      "handshake": "state",
+      "keepalive_interval": 30000,
+      "timestamp": 1662114679648,
+      "registration": {"status": "registered"},
+      "lines": [null, null],
+      "dialog_infos": [{
+        "id": "dlg-1",
+        "entity_number": "124111",
+        "state": "trying",
+        "call_id": "abc123",
+        "direction": "recipient",
+        "arrival_version": "1",
+        "arrival_time": "2026-04-19T16:07:00.000000Z"
+      }],
+      "presence_infos": [],
+      "guest_line": {"call_id": null, "call_logs": []}
+    }
+    ''')
+            as Map<String, dynamic>;
+
+    expect(() => StateHandshake.fromJson(jsonWithTrying), returnsNormally);
+
+    final result = StateHandshake.fromJson(jsonWithTrying);
+    expect(result.dialogInfos.length, equals(1));
+    expect(result.dialogInfos.first.state, equals(SignalingDialogState.trying));
+  });
+
+  test('$StateHandshake fromJson with unknown dialog_infos state falls back to unknown', () {
+    final jsonWithUnknown =
+        json.decode('''
+    {
+      "handshake": "state",
+      "keepalive_interval": 30000,
+      "timestamp": 1662114679648,
+      "registration": {"status": "registered"},
+      "lines": [null, null],
+      "dialog_infos": [{
+        "id": "dlg-2",
+        "entity_number": "124111",
+        "state": "some_future_state",
+        "call_id": null,
+        "direction": null,
+        "arrival_version": "1",
+        "arrival_time": "2026-04-19T16:07:00.000000Z"
+      }],
+      "presence_infos": [],
+      "guest_line": {"call_id": null, "call_logs": []}
+    }
+    ''')
+            as Map<String, dynamic>;
+
+    final result = StateHandshake.fromJson(jsonWithUnknown);
+    expect(result.dialogInfos.first.state, equals(SignalingDialogState.unknown));
+  });
+
+  test('$StateHandshake fromJson with null dialog_infos state falls back to unknown', () {
+    final jsonWithNull =
+        json.decode('''
+    {
+      "handshake": "state",
+      "keepalive_interval": 30000,
+      "timestamp": 1662114679648,
+      "registration": {"status": "registered"},
+      "lines": [null, null],
+      "dialog_infos": [{
+        "id": "dlg-3",
+        "entity_number": "124111",
+        "state": null,
+        "call_id": null,
+        "direction": null,
+        "arrival_version": "1",
+        "arrival_time": "2026-04-19T16:07:00.000000Z"
+      }],
+      "presence_infos": [],
+      "guest_line": {"call_id": null, "call_logs": []}
+    }
+    ''')
+            as Map<String, dynamic>;
+
+    final result = StateHandshake.fromJson(jsonWithNull);
+    expect(result.dialogInfos.first.state, equals(SignalingDialogState.unknown));
   });
 }

--- a/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
+++ b/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:test/test.dart';
 
 import 'package:webtrit_signaling/src/events/events.dart';
-import 'package:webtrit_signaling/src/events/global/dialog_info.dart';
 import 'package:webtrit_signaling/src/handshakes/handshakes.dart';
 
 void main() {


### PR DESCRIPTION
## Problem

When PortaSwitch backend is unresponsive (WT-1381), an active SIP dialog can remain in `"trying"` state for an extended period. The signaling server forwards this in the `StateHandshake` `dialog_infos` field. `SignalingDialogInfo.fromJson` used `byName()` which throws `ArgumentError` for any unrecognised value — including `"trying"`.

This caused a crash on **every** reconnect for the entire call duration:

```
ArgumentError: Invalid argument (name): No enum value with that name: "trying"
  #1  SignalingDialogInfo.fromJson     (dialog_info.dart:42)
  #9  StateHandshake.fromJson          (state_handshake.dart:167)
  #10 WebtritSignalingClient._onMessage
→ SignalingModuleImpl._onError → disconnect → reconnect in 3s → same crash → loop
```

**User-visible effect (WT-1380, iOS LTE, idle phone):**
- Signaling disconnect/reconnect loop every ~3 s for the whole call
- `StateHandshake` never fully parsed → offer-replay mechanism never ran → `incomingOffer` stayed `null` → call initialisation blocked for ~44 min until backend recovered
- "Connection error" in UI, all buttons non-functional except Hangup
- Audio still worked because WebRTC RTP is independent of the signaling WebSocket
- "Connecting to the core failed" shown after hangup

The same `byName()` pattern existed for `SignalingDialogDirection`, creating the same risk for unknown direction values.

## Changes

**`packages/webtrit_signaling/lib/src/events/global/dialog_info.dart`**
- Add `trying` to `SignalingDialogState` — valid SIP provisional state (RFC 4235)
- Replace `byName()` with `asNameMap()[...] ?? unknown` for `state` — null and any unknown future value fall back to `unknown` without throwing
- Replace `byName()` with `asNameMap()[...]` for `direction` — unknown value returns `null` without throwing

**`packages/webtrit_signaling/test/src/events/global/dialog_info_test.dart`** *(new)*
- All known `SignalingDialogState` values parse correctly (regression)
- `"trying"` → `SignalingDialogState.trying`
- Unknown future state → `SignalingDialogState.unknown`
- `null` state → `SignalingDialogState.unknown`
- Known `SignalingDialogDirection` values parse correctly
- Unknown direction → `null`

**`packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart`**
- `StateHandshake.fromJson` with `dialog_infos[].state = "trying"` — does not throw, parses to `SignalingDialogState.trying`
- `StateHandshake.fromJson` with unknown state — parses to `SignalingDialogState.unknown`
- `StateHandshake.fromJson` with `null` state — parses to `SignalingDialogState.unknown`

## Related

- WT-1380 — 'Connection error' after accepting incoming call on iOS
- WT-1381 — PortaSwitch backend unresponsive (root trigger for "trying" state in dialog_infos)