### PR TITLE
fix(call): reset call timer on new incoming call (WT-1302)

### DIFF
--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -87,6 +87,7 @@ class _CallInfoState extends State<CallInfo> {
   void _durationTimerCancel() {
     durationTimer?.cancel();
     durationTimer = null;
+    duration = null;
   }
 
   void _durationTic(DateTime acceptedTime) {


### PR DESCRIPTION
## Summary

- `CallInfo._durationTimerCancel()` now resets `duration = null` alongside cancelling the `Timer`
- Prevents stale timer value from previous call leaking into next call's UI

## Root cause

When a call ends while the screen is locked, Flutter is paused — the intermediate `activeCalls: []` state is never rendered. `CallInfo` widget is not disposed/recreated. When the next call arrives, `didUpdateWidget` fires with `acceptedTime` changing to `null`, `_durationTimerCancel()` stops the timer but `duration` retained the value from the previous call (e.g. `20s`).

`_buildStatusMessage` checks `duration == null` to decide whether to show `"Incoming call"` or the formatted timer. With stale `duration != null` it incorrectly showed `"0:20"` instead of `"Incoming call"`.

## Fix

```dart
void _durationTimerCancel() {
  durationTimer?.cancel();
  durationTimer = null;
  duration = null; // <- added
}
```

## Test plan

- [x] Call 1: answer, talk ~20s, end call (callee side)
- [x] Call 2: arrives immediately after on locked/paused device — incoming screen shows **"Incoming call"**, not `"0:20"`
- [x] Call 2: accept — timer starts from `0:00`
- [x] Normal call flow (answer, talk, end) unaffected

Closes WT-1302