### PR TITLE
feat: call terminate queuee (WT-1347)

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -528,6 +528,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         presenceInfoRepository: context.read<PresenceInfoRepository>(),
                         dialogInfoRepository: context.read<DialogInfoRepository>(),
                         presenceSettingsRepository: context.read<PresenceSettingsRepository>(),
+                        queuedTerminationRequestsRepository: context.read<QueuedTerminationRequestsRepository>(),
                         userRepository: context.read<UserRepository>(),
                         submitNotification: (n) => notificationsBloc.add(NotificationsSubmitted(n)),
                         callkeep: _callkeep,

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -48,6 +48,7 @@ class _AppState extends State<App> {
         systemInfoRepository: context.read<SystemInfoRepository>(),
         registerStatusRepository: context.read<RegisterStatusRepository>(),
         presenceSettingsRepository: context.read<PresenceSettingsRepository>(),
+        queuedTerminationRequestsRepository: context.read<QueuedTerminationRequestsRepository>(),
         activeMainFlavorRepository: context.read<ActiveMainFlavorRepository>(),
         activeRecentsVisibilityFilterRepository: context.read<ActiveRecentsVisibilityFilterRepository>(),
         activeContactSourceTypeRepository: context.read<ActiveContactSourceTypeRepository>(),

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -56,20 +56,6 @@ typedef SignalingSessionInvalidatedCallback = void Function();
 
 const _getUserMediaPushKitTimeout = Duration(seconds: 8);
 
-enum _QueuedTerminationRequestType { hangup, decline }
-
-class _QueuedTerminationRequest {
-  const _QueuedTerminationRequest.hangup({required this.line, required this.callId})
-    : type = _QueuedTerminationRequestType.hangup;
-
-  const _QueuedTerminationRequest.decline({required this.line, required this.callId})
-    : type = _QueuedTerminationRequestType.decline;
-
-  final _QueuedTerminationRequestType type;
-  final int? line;
-  final String callId;
-}
-
 class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver implements CallkeepDelegate {
   final CallLogsRepository callLogsRepository;
   final UserRepository userRepository;
@@ -77,6 +63,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final PresenceInfoRepository presenceInfoRepository;
   final DialogInfoRepository dialogInfoRepository;
   final PresenceSettingsRepository presenceSettingsRepository;
+  final QueuedTerminationRequestsRepository queuedTerminationRequestsRepository;
   final Function(Notification) submitNotification;
 
   /// Callback invoked when the signaling client reports a critical session error
@@ -109,7 +96,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   late final PeerConnectionManager _peerConnectionManager;
   final Map<String, RenegotiationHandler> _renegotiationHandlers = {};
-  final Map<String, _QueuedTerminationRequest> _queuedTerminationRequests = {};
   late final HandshakeProcessor _handshakeProcessor;
 
   final _callkeepSound = WebtritCallkeepSound();
@@ -120,6 +106,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required this.presenceInfoRepository,
     required this.dialogInfoRepository,
     required this.presenceSettingsRepository,
+    required this.queuedTerminationRequestsRepository,
     required this.onSessionInvalidated,
     required this.userRepository,
     required this.submitNotification,
@@ -219,7 +206,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     callkeep.setDelegate(null);
 
     WidgetsBinding.instance.removeObserver(this);
-
     navigator.mediaDevices.ondevicechange = null;
 
     await _connectivityChangedSubscription?.cancel();
@@ -240,7 +226,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     await _peerConnectionManager.dispose();
 
     _clearRenegotiationHandlers();
-    _queuedTerminationRequests.clear();
 
     await super.close();
   }
@@ -936,7 +921,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
       try {
         await _dispatchTerminationRequest(
-          request: _QueuedTerminationRequest.decline(line: event.line, callId: event.callId),
+          request: QueuedTerminationRequest(
+            type: QueuedTerminationRequestType.decline,
+            line: event.line,
+            callId: event.callId,
+          ),
           source: '__onCallSignalingEventIncoming',
         );
       } catch (e, s) {
@@ -1010,7 +999,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       );
       try {
         await _dispatchTerminationRequest(
-          request: _QueuedTerminationRequest.decline(line: event.line, callId: event.callId),
+          request: QueuedTerminationRequest(
+            type: QueuedTerminationRequestType.decline,
+            line: event.line,
+            callId: event.callId,
+          ),
           source: '__onCallSignalingEventIncoming',
         );
       } catch (e, s) {
@@ -2389,7 +2382,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // the inner catch — that means the caller already hung up server-side.
 
       _dispatchTerminationRequest(
-        request: _QueuedTerminationRequest.decline(line: call.line, callId: call.callId),
+        request: QueuedTerminationRequest(
+          type: QueuedTerminationRequestType.decline,
+          line: call.line,
+          callId: call.callId,
+        ),
         source: '__onCallPerformEventAnswered',
       );
     }
@@ -2436,7 +2433,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     await state.performOnActiveCall(event.callId, (activeCall) async {
       if (activeCall.isIncoming && !activeCall.wasAccepted) {
         await _dispatchTerminationRequest(
-          request: _QueuedTerminationRequest.decline(line: activeCall.line, callId: activeCall.callId),
+          request: QueuedTerminationRequest(
+            type: QueuedTerminationRequestType.decline,
+            line: activeCall.line,
+            callId: activeCall.callId,
+          ),
           source: '_onCallPerformEventEndedImpl',
         ).timeout(Duration(seconds: 1), onTimeout: () {});
       } else {
@@ -2450,7 +2451,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
         if (!isBlindTransferInTransferingState) {
           await _dispatchTerminationRequest(
-            request: _QueuedTerminationRequest.hangup(line: activeCall.line, callId: activeCall.callId),
+            request: QueuedTerminationRequest(
+              type: QueuedTerminationRequestType.hangup,
+              line: activeCall.line,
+              callId: activeCall.callId,
+            ),
             source: '_onCallPerformEventEndedImpl',
           ).timeout(Duration(seconds: 1), onTimeout: () {});
         }
@@ -2811,6 +2816,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   // SignalingModule event handlers (called from stream subscription in constructor)
 
   void _handleHandshakeReceived(StateHandshake stateHandshake) async {
+    List<Line?> mainLines = stateHandshake.lines;
+    Line? guestLine = stateHandshake.guestLine;
+
     add(
       _HandshakeSignalingEventState(registration: stateHandshake.registration, linesCount: stateHandshake.lines.length),
     );
@@ -2818,31 +2826,30 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _assignInitialPresence(stateHandshake.presenceInfos);
     _assignInitialDialogs(stateHandshake.dialogInfos);
 
+    // Send enqueued termination requests that was made when socket was disconnected
+    // and remove their callIds from active lines to prevent recovery attempts
+    final queuedTerminationRequests = queuedTerminationRequestsRepository.getAll;
+    for (final trq in queuedTerminationRequests.entries) {
+      try {
+        await _executeTerminationRequest(trq.value);
+      } catch (e, s) {
+        _logger.warning('_handleHandshakeReceived - _executeTerminationRequest failed', e, s);
+      } finally {
+        var mainIndex = mainLines.indexWhere((line) => line?.callId == trq.value.callId);
+        if (mainIndex != -1) mainLines[mainIndex] = null;
+        if (guestLine?.callId == trq.value.callId) guestLine = null;
+      }
+    }
+    queuedTerminationRequestsRepository.clear();
+
     // Hang up all active calls that are not associated with any line
     // or guest line, indicating that they are no longer valid.
     //
     // This is needed to drop or retain calls after reconnecting to the signaling server.
     // If you have troubles with line position mismatch replace the activeLineCallIds
     // computation with: https://gist.github.com/digiboridev/f7f1020731e8f247b5891983433bd159
-    Set<String> activeLineCallIds = [
-      ...stateHandshake.lines,
-      stateHandshake.guestLine,
-    ].whereType<Line>().map((line) => line.callId).toSet();
+    Set<String> activeLineCallIds = [...mainLines, guestLine].whereType<Line>().map((line) => line.callId).toSet();
     _logger.info('_handleHandshakeReceived: activeLineCallIds=$activeLineCallIds');
-
-    // Send enqueued termination requests that was made when socket was disconnected
-    // and remove their callIds from activeLineCallIds to prevent recovery attempts
-    for (final trq in _queuedTerminationRequests.entries) {
-      try {
-        await _executeTerminationRequest(trq.value);
-      } catch (e, s) {
-        _queuedTerminationRequests.remove(trq.key);
-        callErrorReporter.handle(e, s, '_handleHandshakeReceived queued termination error');
-      } finally {
-        _queuedTerminationRequests.remove(trq.key);
-        activeLineCallIds.remove(trq.value.callId);
-      }
-    }
 
     for (final activeCall in state.callsToTerminate(activeLineCallIds)) {
       _peerConnectionManager.conditionalCompleteError(activeCall.callId, 'Active call Request Terminated');
@@ -2857,8 +2864,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     }
 
     final actions = await _handshakeProcessor.process(
-      lines: stateHandshake.lines,
-      guestLine: stateHandshake.guestLine,
+      lines: mainLines,
+      guestLine: guestLine,
       activeCallIds: state.activeCalls.map((c) => c.callId).toSet(),
     );
 
@@ -3492,32 +3499,24 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
   }
 
-  String _terminationRequestQueueKey(_QueuedTerminationRequest request) {
-    return '${request.type.name}:${request.callId}';
-  }
-
-  void _queueTerminationRequest(_QueuedTerminationRequest request, String source) {
-    _queuedTerminationRequests[_terminationRequestQueueKey(request)] = request;
-    _logger.warning('$source: queued ${request.type.name} request callId=${request.callId} line=${request.line}');
-  }
-
-  Future<void> _dispatchTerminationRequest({required _QueuedTerminationRequest request, required String source}) async {
+  /// Attempts to execute a termination request immediately.
+  /// If it fails due to connectivity issues, the request is queued for later retry.
+  ///
+  /// The [source] parameter is used for logging to indicate where the request originated.
+  Future<void> _dispatchTerminationRequest({required QueuedTerminationRequest request, required String source}) async {
+    /// Put upfront in the repository to ensure it's recorded even if the app is killed before the async operation completes.
+    queuedTerminationRequestsRepository.put(request);
     try {
       await _executeTerminationRequest(request);
-    } on NotConnectedException {
-      _queueTerminationRequest(request, source);
-    } on WebtritSignalingTransactionTimeoutException {
-      _queueTerminationRequest(request, source);
-    } on WebtritSignalingTransactionTerminateByDisconnectException {
-      _queueTerminationRequest(request, source);
+      queuedTerminationRequestsRepository.remove(request);
     } catch (e, s) {
-      callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
+      _logger.warning('_dispatchTerminationRequest failed, request queued for retry. source=$source', e, s);
     }
   }
 
-  Future<void> _executeTerminationRequest(_QueuedTerminationRequest request) async {
+  Future<void> _executeTerminationRequest(QueuedTerminationRequest request) async {
     switch (request.type) {
-      case _QueuedTerminationRequestType.hangup:
+      case QueuedTerminationRequestType.hangup:
         await _signalingModule.execute(
           HangupRequest(
             transaction: WebtritSignalingClient.generateTransactionId(),
@@ -3525,7 +3524,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             callId: request.callId,
           ),
         );
-      case _QueuedTerminationRequestType.decline:
+      case QueuedTerminationRequestType.decline:
         await _signalingModule.execute(
           DeclineRequest(
             transaction: WebtritSignalingClient.generateTransactionId(),

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -56,6 +56,20 @@ typedef SignalingSessionInvalidatedCallback = void Function();
 
 const _getUserMediaPushKitTimeout = Duration(seconds: 8);
 
+enum _QueuedTerminationRequestType { hangup, decline }
+
+class _QueuedTerminationRequest {
+  const _QueuedTerminationRequest.hangup({required this.line, required this.callId})
+    : type = _QueuedTerminationRequestType.hangup;
+
+  const _QueuedTerminationRequest.decline({required this.line, required this.callId})
+    : type = _QueuedTerminationRequestType.decline;
+
+  final _QueuedTerminationRequestType type;
+  final int? line;
+  final String callId;
+}
+
 class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver implements CallkeepDelegate {
   final CallLogsRepository callLogsRepository;
   final UserRepository userRepository;
@@ -95,6 +109,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   late final PeerConnectionManager _peerConnectionManager;
   final Map<String, RenegotiationHandler> _renegotiationHandlers = {};
+  final Map<String, _QueuedTerminationRequest> _queuedTerminationRequests = {};
   late final HandshakeProcessor _handshakeProcessor;
 
   final _callkeepSound = WebtritCallkeepSound();
@@ -225,6 +240,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     await _peerConnectionManager.dispose();
 
     _clearRenegotiationHandlers();
+    _queuedTerminationRequests.clear();
 
     await super.close();
   }
@@ -918,13 +934,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _logger.info(
         '__onCallSignalingEventIncoming: received incoming call with existing callId but different line - callId: ${event.callId}, probably call to myself or transfer to myself',
       );
-      final declineRequest = DeclineRequest(
-        transaction: WebtritSignalingClient.generateTransactionId(),
-        line: event.line,
-        callId: event.callId,
-      );
       try {
-        await _signalingModule.execute(declineRequest);
+        await _dispatchTerminationRequest(
+          request: _QueuedTerminationRequest.decline(line: event.line, callId: event.callId),
+          source: '__onCallSignalingEventIncoming',
+        );
       } catch (e, s) {
         callErrorReporter.handle(e, s, '__onCallSignalingEventIncoming declineRequest error');
       }
@@ -994,17 +1008,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         '__onCallSignalingEventIncoming: reportNewIncomingCall error=$error '
         '(callId: ${event.callId}, line: ${event.line}) — sending decline',
       );
-      await _signalingModule
-          .execute(
-            DeclineRequest(
-              transaction: WebtritSignalingClient.generateTransactionId(),
-              line: event.line,
-              callId: event.callId,
-            ),
-          )
-          ?.catchError((e, s) {
-            callErrorReporter.handle(e, s, '__onCallSignalingEventIncoming declineRequest error');
-          });
+      try {
+        await _dispatchTerminationRequest(
+          request: _QueuedTerminationRequest.decline(line: event.line, callId: event.callId),
+          source: '__onCallSignalingEventIncoming',
+        );
+      } catch (e, s) {
+        callErrorReporter.handle(e, s, '__onCallSignalingEventIncoming declineRequest error');
+      }
       return;
     }
 
@@ -2376,20 +2387,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // For non-disconnect errors (e.g. UserMediaError, SDP errors) the server line
       // may still be alive. Send DeclineRequest to clean it up, and handle 4610 in
       // the inner catch — that means the caller already hung up server-side.
-      try {
-        final declineId = WebtritSignalingClient.generateTransactionId();
-        await _signalingModule.execute(DeclineRequest(transaction: declineId, line: call.line, callId: call.callId));
-        callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
-      } catch (declineError, _) {
-        if (declineError is WebtritSignalingTransactionTerminateByDisconnectException &&
-            declineError.closeCode == SignalingDisconnectCode.requestCallIdError.code) {
-          _logger.warning(
-            '__onCallPerformEventAnswered: DeclineRequest rejected with 4610 callId=${event.callId} — call already terminated server-side, ignoring',
-          );
-          return;
-        }
-        callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
-      }
+
+      _dispatchTerminationRequest(
+        request: _QueuedTerminationRequest.decline(line: call.line, callId: call.callId),
+        source: '__onCallPerformEventAnswered',
+      );
     }
   }
 
@@ -2433,14 +2435,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     await state.performOnActiveCall(event.callId, (activeCall) async {
       if (activeCall.isIncoming && !activeCall.wasAccepted) {
-        final declineRequest = DeclineRequest(
-          transaction: WebtritSignalingClient.generateTransactionId(),
-          line: activeCall.line,
-          callId: activeCall.callId,
-        );
-        await _signalingModule.execute(declineRequest)?.catchError((e, s) {
-          callErrorReporter.handle(e, s, '__onCallPerformEventEnded declineRequest error');
-        });
+        await _dispatchTerminationRequest(
+          request: _QueuedTerminationRequest.decline(line: activeCall.line, callId: activeCall.callId),
+          source: '_onCallPerformEventEndedImpl',
+        ).timeout(Duration(seconds: 1), onTimeout: () {});
       } else {
         // Skip hangup when a blind transfer is in Transfering state (server started to process it).
         // In this state the SIP dialog may already be closed server-side via REFER; sending hangup
@@ -2451,14 +2449,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         };
 
         if (!isBlindTransferInTransferingState) {
-          final hangupRequest = HangupRequest(
-            transaction: WebtritSignalingClient.generateTransactionId(),
-            line: activeCall.line,
-            callId: activeCall.callId,
-          );
-          await _signalingModule.execute(hangupRequest)?.catchError((e, s) {
-            callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
-          });
+          await _dispatchTerminationRequest(
+            request: _QueuedTerminationRequest.hangup(line: activeCall.line, callId: activeCall.callId),
+            source: '_onCallPerformEventEndedImpl',
+          ).timeout(Duration(seconds: 1), onTimeout: () {});
         }
       }
 
@@ -2830,10 +2824,25 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // This is needed to drop or retain calls after reconnecting to the signaling server.
     // If you have troubles with line position mismatch replace the activeLineCallIds
     // computation with: https://gist.github.com/digiboridev/f7f1020731e8f247b5891983433bd159
-    final activeLineCallIds = [
+    Set<String> activeLineCallIds = [
       ...stateHandshake.lines,
       stateHandshake.guestLine,
     ].whereType<Line>().map((line) => line.callId).toSet();
+    _logger.info('_handleHandshakeReceived: activeLineCallIds=$activeLineCallIds');
+
+    // Send enqueued termination requests that was made when socket was disconnected
+    // and remove their callIds from activeLineCallIds to prevent recovery attempts
+    for (final trq in _queuedTerminationRequests.entries) {
+      try {
+        await _executeTerminationRequest(trq.value);
+      } catch (e, s) {
+        _queuedTerminationRequests.remove(trq.key);
+        callErrorReporter.handle(e, s, '_handleHandshakeReceived queued termination error');
+      } finally {
+        _queuedTerminationRequests.remove(trq.key);
+        activeLineCallIds.remove(trq.value.callId);
+      }
+    }
 
     for (final activeCall in state.callsToTerminate(activeLineCallIds)) {
       _peerConnectionManager.conditionalCompleteError(activeCall.callId, 'Active call Request Terminated');
@@ -2845,24 +2854,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           reason: 'Request Terminated',
         ),
       );
-    }
-
-    // Retry HangupRequest for calls that were being terminated when signaling dropped.
-    // If a call is locally disconnecting AND the server still lists it in activeLineCallIds,
-    // the hangup was lost mid-flight — resend it now so the server-side leg is torn down.
-    for (final activeCall in state.activeCalls) {
-      if (activeCall.processingStatus != CallProcessingStatus.disconnecting) continue;
-      if (!activeLineCallIds.contains(activeCall.callId)) continue;
-      _signalingModule
-          .execute(
-            HangupRequest(
-              transaction: WebtritSignalingClient.generateTransactionId(),
-              line: activeCall.line,
-              callId: activeCall.callId,
-            ),
-          )
-          ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived pendingHangup retry error'))
-          .ignore();
     }
 
     final actions = await _handshakeProcessor.process(
@@ -3499,6 +3490,50 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         },
       ),
     );
+  }
+
+  String _terminationRequestQueueKey(_QueuedTerminationRequest request) {
+    return '${request.type.name}:${request.callId}';
+  }
+
+  void _queueTerminationRequest(_QueuedTerminationRequest request, String source) {
+    _queuedTerminationRequests[_terminationRequestQueueKey(request)] = request;
+    _logger.warning('$source: queued ${request.type.name} request callId=${request.callId} line=${request.line}');
+  }
+
+  Future<void> _dispatchTerminationRequest({required _QueuedTerminationRequest request, required String source}) async {
+    try {
+      await _executeTerminationRequest(request);
+    } on NotConnectedException {
+      _queueTerminationRequest(request, source);
+    } on WebtritSignalingTransactionTimeoutException {
+      _queueTerminationRequest(request, source);
+    } on WebtritSignalingTransactionTerminateByDisconnectException {
+      _queueTerminationRequest(request, source);
+    } catch (e, s) {
+      callErrorReporter.handle(e, s, '__onCallPerformEventEnded hangupRequest error');
+    }
+  }
+
+  Future<void> _executeTerminationRequest(_QueuedTerminationRequest request) async {
+    switch (request.type) {
+      case _QueuedTerminationRequestType.hangup:
+        await _signalingModule.execute(
+          HangupRequest(
+            transaction: WebtritSignalingClient.generateTransactionId(),
+            line: request.line,
+            callId: request.callId,
+          ),
+        );
+      case _QueuedTerminationRequestType.decline:
+        await _signalingModule.execute(
+          DeclineRequest(
+            transaction: WebtritSignalingClient.generateTransactionId(),
+            line: request.line,
+            callId: request.callId,
+          ),
+        );
+    }
   }
 
   void _addToRecents(ActiveCall activeCall) {

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -672,9 +672,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // user turn off all network interfaces >> __onPeerConnectionEventIceConnectionStateChanged >> RTCIceConnectionStateFailed >> peerConnection.restartIce() >> onRenegotiationNeeded >> _safeRenegotiate >> if(!signalingConnected) return;
     // user turn on network interfaces >> _onSignalingClientEventConnected >> safeRenegotiate
     for (final call in state.activeCalls.where((c) => c.processingStatus == CallProcessingStatus.connected)) {
-      // Skip calls that are being torn down — sending UpdateRequest for a
-      // disconnecting call would keep the server-side leg alive unnecessarily.
-      if (call.processingStatus == CallProcessingStatus.disconnecting) continue;
       _logger.warning('__onSignalingClientEventConnected: triggering safe renegotiation for call ${call.callId}');
       _safeRenegotiate(call.callId, call.line);
     }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -671,7 +671,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // Important to do in case if there was connection loss for a while and then webrtc detects network loss and restarts ice e.g
     // user turn off all network interfaces >> __onPeerConnectionEventIceConnectionStateChanged >> RTCIceConnectionStateFailed >> peerConnection.restartIce() >> onRenegotiationNeeded >> _safeRenegotiate >> if(!signalingConnected) return;
     // user turn on network interfaces >> _onSignalingClientEventConnected >> safeRenegotiate
-    for (final call in state.activeCalls) {
+    for (final call in state.activeCalls.where((c) => c.processingStatus == CallProcessingStatus.connected)) {
       // Skip calls that are being torn down — sending UpdateRequest for a
       // disconnecting call would keep the server-side leg alive unnecessarily.
       if (call.processingStatus == CallProcessingStatus.disconnecting) continue;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -129,7 +129,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }) : super(const CallState()) {
     _signalingModule = signalingModule;
     _peerConnectionManager = peerConnectionManager;
-    _handshakeProcessor = HandshakeProcessor(callkeepConnections: callkeepConnections);
+    _handshakeProcessor = HandshakeProcessor(
+      callkeepConnections: callkeepConnections,
+      queuedTerminationRequestsRepository: queuedTerminationRequestsRepository,
+    );
 
     _reconnectController = SignalingReconnectController(
       signalingModule: signalingModule,
@@ -2816,9 +2819,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   // SignalingModule event handlers (called from stream subscription in constructor)
 
   void _handleHandshakeReceived(StateHandshake stateHandshake) async {
-    List<Line?> mainLines = stateHandshake.lines;
-    Line? guestLine = stateHandshake.guestLine;
-
     add(
       _HandshakeSignalingEventState(registration: stateHandshake.registration, linesCount: stateHandshake.lines.length),
     );
@@ -2826,29 +2826,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _assignInitialPresence(stateHandshake.presenceInfos);
     _assignInitialDialogs(stateHandshake.dialogInfos);
 
-    // Send enqueued termination requests that was made when socket was disconnected
-    // and remove their callIds from active lines to prevent recovery attempts
-    final queuedTerminationRequests = queuedTerminationRequestsRepository.getAll;
-    for (final trq in queuedTerminationRequests.entries) {
-      try {
-        await _executeTerminationRequest(trq.value);
-      } catch (e, s) {
-        _logger.warning('_handleHandshakeReceived - _executeTerminationRequest failed', e, s);
-      } finally {
-        var mainIndex = mainLines.indexWhere((line) => line?.callId == trq.value.callId);
-        if (mainIndex != -1) mainLines[mainIndex] = null;
-        if (guestLine?.callId == trq.value.callId) guestLine = null;
-      }
-    }
-    queuedTerminationRequestsRepository.clear();
-
     // Hang up all active calls that are not associated with any line
     // or guest line, indicating that they are no longer valid.
     //
     // This is needed to drop or retain calls after reconnecting to the signaling server.
     // If you have troubles with line position mismatch replace the activeLineCallIds
     // computation with: https://gist.github.com/digiboridev/f7f1020731e8f247b5891983433bd159
-    Set<String> activeLineCallIds = [...mainLines, guestLine].whereType<Line>().map((line) => line.callId).toSet();
+    Set<String> activeLineCallIds = [
+      ...stateHandshake.lines,
+      stateHandshake.guestLine,
+    ].whereType<Line>().map((line) => line.callId).toSet();
     _logger.info('_handleHandshakeReceived: activeLineCallIds=$activeLineCallIds');
 
     for (final activeCall in state.callsToTerminate(activeLineCallIds)) {
@@ -2864,8 +2851,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     }
 
     final actions = await _handshakeProcessor.process(
-      lines: mainLines,
-      guestLine: guestLine,
+      lines: stateHandshake.lines,
+      guestLine: stateHandshake.guestLine,
       activeCallIds: state.activeCalls.map((c) => c.callId).toSet(),
     );
 

--- a/lib/features/call/utils/handshake_processor.dart
+++ b/lib/features/call/utils/handshake_processor.dart
@@ -1,6 +1,9 @@
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+
 /// Actions returned by [HandshakeProcessor.process] describing what the BLoC
 /// should do after processing the signaling [StateHandshake].
 sealed class HandshakeAction {
@@ -100,12 +103,19 @@ final class EndLocalCallAction extends HandshakeAction {
 /// - For each local Callkeep connection whose call ID is absent from the handshake
 ///   lines -> [EndLocalCallAction].
 ///
-/// [HangupSignalingAction] and [DeclineSignalingAction] are always returned as the
-/// sole action -the processor exits early to match the original `return` semantics.
+/// When queued terminations exist in the repository, they are emitted first as
+/// regular [HangupSignalingAction]/[DeclineSignalingAction] entries, removed
+/// from the repository immediately, and excluded from subsequent handshake-line
+/// processing.
+///
+/// If a terminal disconnected-state action is produced during line traversal,
+/// the processor exits early to match the original `return` semantics, while
+/// preserving any already-collected queued actions.
 class HandshakeProcessor {
-  HandshakeProcessor({required this.callkeepConnections});
+  HandshakeProcessor({required this.callkeepConnections, required this.queuedTerminationRequestsRepository});
 
   final CallkeepConnections callkeepConnections;
+  final QueuedTerminationRequestsRepository queuedTerminationRequestsRepository;
 
   Future<List<HandshakeAction>> process({
     required List<Line?> lines,
@@ -113,7 +123,27 @@ class HandshakeProcessor {
     required Set<String> activeCallIds,
   }) async {
     final actions = <HandshakeAction>[];
-    final allLines = [...lines, guestLine].whereType<Line>().toList();
+
+    /// Prepare termination queue actions
+    final queuedTerminationCallIds = <String>{};
+    final queuedTerminationRequests = queuedTerminationRequestsRepository.getAll;
+
+    for (final request in queuedTerminationRequests.values) {
+      switch (request.type) {
+        case QueuedTerminationRequestType.hangup:
+          actions.add(HangupSignalingAction(line: request.line, callId: request.callId));
+        case QueuedTerminationRequestType.decline:
+          actions.add(DeclineSignalingAction(line: request.line, callId: request.callId));
+      }
+      queuedTerminationRequestsRepository.remove(request);
+      queuedTerminationCallIds.add(request.callId);
+    }
+
+    /// Prepare callkeep connections actions
+    final allLines = [
+      ...lines,
+      guestLine,
+    ].whereType<Line>().where((line) => !queuedTerminationCallIds.contains(line.callId)).toList();
     final localConnections = await callkeepConnections.getConnections();
 
     for (final activeLine in allLines) {
@@ -134,9 +164,9 @@ class HandshakeProcessor {
 
         if (connection?.state == CallkeepConnectionState.stateDisconnected) {
           if (callEvent is IncomingCallEvent) {
-            return [DeclineSignalingAction(line: callEvent.line, callId: callEvent.callId)];
+            return [...actions, DeclineSignalingAction(line: callEvent.line, callId: callEvent.callId)];
           } else if (callEvent is! HangupEvent && callEvent is! MissedCallEvent) {
-            return [HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
+            return [...actions, HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
           }
         } else if (connection == null &&
             !activeCallIds.contains(activeLine.callId) &&
@@ -160,7 +190,7 @@ class HandshakeProcessor {
           //
           // On iOS getConnection() always returns null, so activeCallIds is the
           // decisive guard: calls that are still active in BLoC are not affected.
-          return [HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
+          return [...actions, HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
         }
       }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -105,6 +105,7 @@ class RootApp extends StatelessWidget {
 
           final registerStatusRepository = RegisterStatusRepositoryPrefsImpl(prefs);
           final presenceSettingsRepository = PresenceSettingsRepositoryPrefsImpl(prefs, presenceDeviceName);
+          final queuedTerminationRequestsRepository = QueuedTerminationRequestsRepositoryPrefsImpl(prefs);
           final activeMainFlavorRepository = ActiveMainFlavorRepositoryPrefsImpl(prefs);
           final userAgreementStatusRepository = UserAgreementStatusRepositoryPrefsImpl(prefs);
           final activeRecentsVisibilityFilterRepository = ActiveRecentsVisibilityFilterRepositoryPrefsImpl(prefs);
@@ -129,6 +130,7 @@ class RootApp extends StatelessWidget {
               RepositoryProvider.value(value: AppAnalyticsRepository(instance: FirebaseAnalytics.instance)),
               RepositoryProvider<RegisterStatusRepository>.value(value: registerStatusRepository),
               RepositoryProvider<PresenceSettingsRepository>.value(value: presenceSettingsRepository),
+              RepositoryProvider<QueuedTerminationRequestsRepository>.value(value: queuedTerminationRequestsRepository),
               RepositoryProvider<ActiveMainFlavorRepository>.value(value: activeMainFlavorRepository),
               RepositoryProvider<SessionRepository>.value(value: instanceRegistry.get<SessionRepository>()),
               RepositoryProvider<UserAgreementStatusRepository>.value(value: userAgreementStatusRepository),

--- a/lib/mappers/json/json.dart
+++ b/lib/mappers/json/json.dart
@@ -4,6 +4,7 @@ export 'encoding_settings_mapper.dart';
 export 'ice_settings_mapper.dart';
 export 'negotiation_settings_mapper.dart';
 export 'presence_settings_mapper.dart';
+export 'queued_termination_request_mapper.dart';
 export 'system_info_mapper.dart';
 export 'user_info_mapper.dart';
 export 'video_capturing_settings_mapper.dart';

--- a/lib/mappers/json/queued_termination_request_mapper.dart
+++ b/lib/mappers/json/queued_termination_request_mapper.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:webtrit_phone/models/models.dart';
+
+class QueuedTerminationRequestJsonMapper {
+  static String toJson(Map<String, QueuedTerminationRequest> data) => jsonEncode(toMap(data));
+
+  static Map<String, QueuedTerminationRequest> fromJson(String json) {
+    try {
+      final decoded = jsonDecode(json);
+      if (decoded is! Map) return {};
+      return fromMap(decoded);
+    } catch (_) {
+      return {};
+    }
+  }
+
+  static Map<String, dynamic> toMap(Map<String, QueuedTerminationRequest> data) {
+    return data.map((key, value) => MapEntry(key, requestToMap(value)));
+  }
+
+  static Map<String, QueuedTerminationRequest> fromMap(Map<dynamic, dynamic> map) {
+    final restored = <String, QueuedTerminationRequest>{};
+    for (final entry in map.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      if (key is! String || value is! Map) continue;
+      final request = requestFromMap(value);
+      if (request == null) continue;
+      restored[key] = request;
+    }
+    return restored;
+  }
+
+  static Map<String, dynamic> requestToMap(QueuedTerminationRequest data) {
+    return {'type': data.type.name, 'callId': data.callId, 'line': data.line};
+  }
+
+  static QueuedTerminationRequest? requestFromMap(Map<dynamic, dynamic> map) {
+    final callId = map['callId'];
+    final typeName = map['type'];
+    if (callId is! String || typeName is! String) return null;
+
+    final lineValue = map['line'];
+    final int? line = switch (lineValue) {
+      int value => value,
+      double value => value.toInt(),
+      _ => null,
+    };
+
+    try {
+      final type = QueuedTerminationRequestType.values.byName(typeName);
+      return QueuedTerminationRequest(type: type, callId: callId, line: line);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+mixin QueuedTerminationRequestJsonMapperMixin {
+  String queuedTerminationRequestsToJson(Map<String, QueuedTerminationRequest> data) {
+    return QueuedTerminationRequestJsonMapper.toJson(data);
+  }
+
+  Map<String, QueuedTerminationRequest> queuedTerminationRequestsFromJson(String json) {
+    return QueuedTerminationRequestJsonMapper.fromJson(json);
+  }
+
+  Map<String, dynamic> queuedTerminationRequestsToMap(Map<String, QueuedTerminationRequest> data) {
+    return QueuedTerminationRequestJsonMapper.toMap(data);
+  }
+
+  Map<String, QueuedTerminationRequest> queuedTerminationRequestsFromMap(Map<dynamic, dynamic> map) {
+    return QueuedTerminationRequestJsonMapper.fromMap(map);
+  }
+
+  Map<String, dynamic> queuedTerminationRequestToMap(QueuedTerminationRequest data) {
+    return QueuedTerminationRequestJsonMapper.requestToMap(data);
+  }
+
+  QueuedTerminationRequest? queuedTerminationRequestFromMap(Map<dynamic, dynamic> map) {
+    return QueuedTerminationRequestJsonMapper.requestFromMap(map);
+  }
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -36,6 +36,7 @@ export 'metrics/metrics.dart';
 export 'negotiation_settings.dart';
 export 'peer_connection_settings.dart';
 export 'presence/presence.dart';
+export 'queued_termination_request.dart';
 export 'recent.dart';
 export 'recents_visibility_filter.dart';
 export 'rtp_codec_profile.dart';

--- a/lib/models/queued_termination_request.dart
+++ b/lib/models/queued_termination_request.dart
@@ -1,0 +1,11 @@
+enum QueuedTerminationRequestType { hangup, decline }
+
+class QueuedTerminationRequest {
+  const QueuedTerminationRequest({required this.type, required this.callId, required this.line});
+
+  final QueuedTerminationRequestType type;
+  final String callId;
+  final int? line;
+
+  String get key => '${type.name}:$callId';
+}

--- a/lib/repositories/queued_termination_requests/queued_termination_requests_repository.dart
+++ b/lib/repositories/queued_termination_requests/queued_termination_requests_repository.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:webtrit_phone/data/data.dart';
+
+import 'package:webtrit_phone/mappers/mappers.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+abstract interface class QueuedTerminationRequestsRepository {
+  Map<String, QueuedTerminationRequest> get getAll;
+
+  void put(QueuedTerminationRequest request);
+
+  void remove(QueuedTerminationRequest request);
+
+  Future<void> clear();
+}
+
+class QueuedTerminationRequestsRepositoryPrefsImpl
+    with QueuedTerminationRequestJsonMapperMixin
+    implements QueuedTerminationRequestsRepository {
+  QueuedTerminationRequestsRepositoryPrefsImpl(this._appPreferences);
+
+  static const _prefsKey = 'queued-termination-requests';
+
+  final AppPreferences _appPreferences;
+
+  Map<String, QueuedTerminationRequest>? _cache;
+
+  @override
+  Map<String, QueuedTerminationRequest> get getAll {
+    return Map.unmodifiable(_getCachedRequests());
+  }
+
+  @override
+  void put(QueuedTerminationRequest request) {
+    final cache = _getCachedRequests();
+    cache[request.key] = request;
+    _persist(cache);
+  }
+
+  @override
+  void remove(QueuedTerminationRequest request) {
+    final cache = _getCachedRequests();
+    cache.remove(request.key);
+    _persist(cache);
+  }
+
+  @override
+  Future<void> clear() async {
+    _cache = {};
+    await _appPreferences.remove(_prefsKey);
+  }
+
+  Map<String, QueuedTerminationRequest> _getCachedRequests() {
+    final cached = _cache;
+    if (cached != null) return cached;
+
+    final raw = _appPreferences.getString(_prefsKey);
+    if (raw == null) {
+      _cache = {};
+      return _cache!;
+    }
+
+    _cache = queuedTerminationRequestsFromJson(raw);
+    return _cache!;
+  }
+
+  void _persist(Map<String, QueuedTerminationRequest> requests) {
+    unawaited(_appPreferences.setString(_prefsKey, queuedTerminationRequestsToJson(requests)));
+  }
+}

--- a/lib/repositories/repositories.dart
+++ b/lib/repositories/repositories.dart
@@ -30,6 +30,7 @@ export 'private_gateway_repository/private_gateway_repository.dart';
 export 'push_notifications/local_push_repository.dart';
 export 'push_notifications/remote_push_repository.dart';
 export 'push_tokens/push_tokens_repository.dart';
+export 'queued_termination_requests/queued_termination_requests_repository.dart';
 export 'recents/recents_repository.dart';
 export 'register_status/register_status_repository.dart';
 export 'route_state/route_state.dart';

--- a/lib/resolvers/user_session_cleanup_resolver.dart
+++ b/lib/resolvers/user_session_cleanup_resolver.dart
@@ -19,6 +19,7 @@ class RepositoryUserSessionCleanupResolver implements UserSessionCleanupResolver
     required this.systemInfoRepository,
     required this.registerStatusRepository,
     required this.presenceSettingsRepository,
+    required this.queuedTerminationRequestsRepository,
     required this.activeMainFlavorRepository,
     required this.activeRecentsVisibilityFilterRepository,
     required this.activeContactSourceTypeRepository,
@@ -38,6 +39,7 @@ class RepositoryUserSessionCleanupResolver implements UserSessionCleanupResolver
   final SystemInfoRepository systemInfoRepository;
   final RegisterStatusRepository registerStatusRepository;
   final PresenceSettingsRepository presenceSettingsRepository;
+  final QueuedTerminationRequestsRepository queuedTerminationRequestsRepository;
   final ActiveMainFlavorRepository activeMainFlavorRepository;
   final ActiveRecentsVisibilityFilterRepository activeRecentsVisibilityFilterRepository;
   final ActiveContactSourceTypeRepository activeContactSourceTypeRepository;
@@ -63,6 +65,7 @@ class RepositoryUserSessionCleanupResolver implements UserSessionCleanupResolver
       systemInfoRepository.clear().suppressError('systemInfoRepository'),
       registerStatusRepository.clear().suppressError('registerStatusRepository'),
       presenceSettingsRepository.clear().suppressError('presenceSettingsRepository'),
+      queuedTerminationRequestsRepository.clear().suppressError('queuedTerminationRequestsRepository'),
       activeMainFlavorRepository.clear().suppressError('activeMainFlavorRepository'),
       activeRecentsVisibilityFilterRepository.clear().suppressError('activeRecentsVisibilityFilterRepository'),
       activeContactSourceTypeRepository.clear().suppressError('activeContactSourceTypeRepository'),

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/lib/src/plugin.dart
@@ -98,7 +98,7 @@ class WebtritSignalingServiceIos extends SignalingServicePlatform {
   Future<void> execute(Request request) async {
     final module = _module;
     if (module == null || !module.isConnected) {
-      throw StateError('SignalingModule not ready -- call start() first');
+      throw NotConnectedException('SignalingServiceIos: not connected');
     }
     await module.execute(request)!;
   }

--- a/test/features/call/bloc/handshake_processor_test.dart
+++ b/test/features/call/bloc/handshake_processor_test.dart
@@ -4,12 +4,16 @@ import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
 import 'package:webtrit_phone/features/call/utils/handshake_processor.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
 class MockCallkeepConnections extends Mock implements CallkeepConnections {}
+
+class MockQueuedTerminationRequestsRepository extends Mock implements QueuedTerminationRequestsRepository {}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -45,21 +49,39 @@ CallkeepConnection _makeConnection({
   return CallkeepConnection(callId: callId, state: state, disconnectCause: null);
 }
 
+QueuedTerminationRequest _makeQueuedTerminationRequest({
+  QueuedTerminationRequestType type = QueuedTerminationRequestType.decline,
+  String callId = _kCallId,
+  int? line = _kLine,
+}) {
+  return QueuedTerminationRequest(type: type, callId: callId, line: line);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 void main() {
   late MockCallkeepConnections mockConnections;
+  late MockQueuedTerminationRequestsRepository mockQueuedTerminationRequestsRepository;
   late HandshakeProcessor processor;
+
+  setUpAll(() {
+    registerFallbackValue(_makeQueuedTerminationRequest());
+  });
 
   setUp(() {
     mockConnections = MockCallkeepConnections();
-    processor = HandshakeProcessor(callkeepConnections: mockConnections);
+    mockQueuedTerminationRequestsRepository = MockQueuedTerminationRequestsRepository();
+    processor = HandshakeProcessor(
+      callkeepConnections: mockConnections,
+      queuedTerminationRequestsRepository: mockQueuedTerminationRequestsRepository,
+    );
 
     // Default: no local connections, no connection for any callId.
     when(() => mockConnections.getConnections()).thenAnswer((_) async => []);
     when(() => mockConnections.getConnection(any())).thenAnswer((_) async => null);
+    when(() => mockQueuedTerminationRequestsRepository.getAll).thenReturn(<String, QueuedTerminationRequest>{});
   });
 
   // -------------------------------------------------------------------------
@@ -99,10 +121,12 @@ void main() {
     // [RingingEvent (latest), IncomingCallEvent (earliest)] (length=2).
     // The old callLogs.length == 1 guard silently skipped this case.
     test('returns HandleIncomingCallAction when RingingEvent prepended (iPhone 180-Ringing)', () async {
-      final line = _makeLine(callLogs: [
-        CallEventLog(timestamp: 2000, callEvent: _makeRingingEvent()),
-        CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
-      ]);
+      final line = _makeLine(
+        callLogs: [
+          CallEventLog(timestamp: 2000, callEvent: _makeRingingEvent()),
+          CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
+        ],
+      );
 
       final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
 
@@ -113,10 +137,12 @@ void main() {
     });
 
     test('returns HandleIncomingCallAction when ProceedingEvent prepended', () async {
-      final line = _makeLine(callLogs: [
-        CallEventLog(timestamp: 2000, callEvent: _makeProceedingEvent()),
-        CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
-      ]);
+      final line = _makeLine(
+        callLogs: [
+          CallEventLog(timestamp: 2000, callEvent: _makeProceedingEvent()),
+          CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
+        ],
+      );
 
       final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
 
@@ -125,10 +151,12 @@ void main() {
     });
 
     test('skips HandleIncomingCallAction when callId already in activeCallIds', () async {
-      final line = _makeLine(callLogs: [
-        CallEventLog(timestamp: 2000, callEvent: _makeRingingEvent()),
-        CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
-      ]);
+      final line = _makeLine(
+        callLogs: [
+          CallEventLog(timestamp: 2000, callEvent: _makeRingingEvent()),
+          CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent()),
+        ],
+      );
 
       final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {_kCallId});
 
@@ -483,6 +511,39 @@ void main() {
 
       expect(actions, hasLength(1));
       expect(actions.first, isA<HandleIncomingCallAction>());
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // queued termination requests
+  // -------------------------------------------------------------------------
+
+  group('queued termination requests', () {
+    test('returns regular signaling actions for queued requests', () async {
+      final queued = {
+        'decline:call-1': _makeQueuedTerminationRequest(callId: 'call-1', type: QueuedTerminationRequestType.decline),
+        'hangup:call-2': _makeQueuedTerminationRequest(callId: 'call-2', type: QueuedTerminationRequestType.hangup),
+      };
+      when(() => mockQueuedTerminationRequestsRepository.getAll).thenReturn(queued);
+
+      final actions = await processor.process(lines: [], guestLine: null, activeCallIds: {});
+
+      expect(actions.whereType<DeclineSignalingAction>().map((a) => a.callId).toSet(), {'call-1'});
+      expect(actions.whereType<HangupSignalingAction>().map((a) => a.callId).toSet(), {'call-2'});
+      verify(() => mockQueuedTerminationRequestsRepository.remove(any())).called(2);
+    });
+
+    test('filters queued callIds from handshake line processing', () async {
+      final line = _makeLine(callLogs: [CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent())]);
+      when(() => mockQueuedTerminationRequestsRepository.getAll).thenReturn(<String, QueuedTerminationRequest>{
+        'decline:${line.callId}': _makeQueuedTerminationRequest(callId: line.callId),
+      });
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {});
+
+      expect(actions.whereType<DeclineSignalingAction>(), hasLength(1));
+      expect(actions.whereType<HandleIncomingCallAction>(), isEmpty);
+      verify(() => mockQueuedTerminationRequestsRepository.remove(any())).called(1);
     });
   });
 }

--- a/test/models/queued_termination_request_mapper_test.dart
+++ b/test/models/queued_termination_request_mapper_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/mappers/mappers.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+void main() {
+  group('QueuedTerminationRequestJsonMapper', () {
+    final request = QueuedTerminationRequest(type: QueuedTerminationRequestType.decline, callId: 'call-42', line: 7);
+
+    test('roundtrips request map through json', () {
+      final source = <String, QueuedTerminationRequest>{request.key: request};
+
+      final encoded = QueuedTerminationRequestJsonMapper.toJson(source);
+      final decoded = QueuedTerminationRequestJsonMapper.fromJson(encoded);
+
+      expect(decoded.length, 1);
+      expect(decoded[request.key]?.type, QueuedTerminationRequestType.decline);
+      expect(decoded[request.key]?.callId, 'call-42');
+      expect(decoded[request.key]?.line, 7);
+    });
+
+    test('fromJson returns empty map for invalid json input', () {
+      expect(QueuedTerminationRequestJsonMapper.fromJson('{bad-json'), isEmpty);
+    });
+
+    test('fromMap filters invalid items and parses valid double line values', () {
+      final map = <dynamic, dynamic>{
+        'decline:call-42': {'type': 'decline', 'callId': 'call-42', 'line': 9.0},
+        123: {'type': 'hangup', 'callId': 'call-x', 'line': 1},
+        'missing-type': {'callId': 'call-y', 'line': 2},
+      };
+
+      final decoded = QueuedTerminationRequestJsonMapper.fromMap(map);
+
+      expect(decoded.length, 1);
+      expect(decoded['decline:call-42']?.type, QueuedTerminationRequestType.decline);
+      expect(decoded['decline:call-42']?.line, 9);
+    });
+  });
+}

--- a/test/models/queued_termination_request_test.dart
+++ b/test/models/queued_termination_request_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/models/models.dart';
+
+void main() {
+  group('QueuedTerminationRequest', () {
+    test('key is derived from type and callId', () {
+      final request = QueuedTerminationRequest(type: QueuedTerminationRequestType.hangup, callId: 'call-100', line: 1);
+
+      expect(request.key, 'hangup:call-100');
+    });
+
+    test('same callId with different type produces different keys', () {
+      final hangup = QueuedTerminationRequest(type: QueuedTerminationRequestType.hangup, callId: 'call-100', line: 1);
+      final decline = QueuedTerminationRequest(type: QueuedTerminationRequestType.decline, callId: 'call-100', line: 1);
+
+      expect(hangup.key, isNot(decline.key));
+    });
+  });
+}

--- a/test/repository/queued_termination_requests_repository_test.dart
+++ b/test/repository/queued_termination_requests_repository_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/mappers/mappers.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+
+import '../mocks/mocks.dart';
+
+void main() {
+  const prefsKey = 'queued-termination-requests';
+
+  group('QueuedTerminationRequestsRepositoryPrefsImpl', () {
+    late MockAppPreferences appPreferences;
+    late QueuedTerminationRequestsRepositoryPrefsImpl repository;
+
+    final hangupRequest = QueuedTerminationRequest(
+      type: QueuedTerminationRequestType.hangup,
+      callId: 'call-1',
+      line: 1,
+    );
+    final declineRequest = QueuedTerminationRequest(
+      type: QueuedTerminationRequestType.decline,
+      callId: 'call-2',
+      line: 2,
+    );
+
+    setUp(() {
+      appPreferences = MockAppPreferences();
+      repository = QueuedTerminationRequestsRepositoryPrefsImpl(appPreferences);
+    });
+
+    test('getAll returns empty map when prefs is empty', () {
+      expect(repository.getAll, isEmpty);
+    });
+
+    test('put stores request in cache and persistence layer', () {
+      repository.put(hangupRequest);
+
+      final all = repository.getAll;
+      expect(all.length, 1);
+      expect(all[hangupRequest.key]?.type, QueuedTerminationRequestType.hangup);
+      expect(all[hangupRequest.key]?.callId, 'call-1');
+      expect(all[hangupRequest.key]?.line, 1);
+      expect(appPreferences.getString(prefsKey), isNotNull);
+    });
+
+    test('remove deletes request by key', () {
+      repository.put(hangupRequest);
+      repository.put(declineRequest);
+
+      repository.remove(hangupRequest);
+
+      final all = repository.getAll;
+      expect(all.length, 1);
+      expect(all.containsKey(hangupRequest.key), isFalse);
+      expect(all.containsKey(declineRequest.key), isTrue);
+    });
+
+    test('clear removes all requests and deletes persisted key', () async {
+      repository.put(hangupRequest);
+
+      await repository.clear();
+
+      expect(repository.getAll, isEmpty);
+      expect(appPreferences.getString(prefsKey), isNull);
+    });
+
+    test('getAll returns unmodifiable map snapshot', () {
+      repository.put(hangupRequest);
+
+      final all = repository.getAll;
+      expect(
+        () => all['new'] = QueuedTerminationRequest(
+          type: QueuedTerminationRequestType.decline,
+          callId: 'call-3',
+          line: null,
+        ),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('hydrates queued requests from valid json in preferences', () {
+      final payload = QueuedTerminationRequestJsonMapper.toJson({
+        hangupRequest.key: hangupRequest,
+        declineRequest.key: declineRequest,
+      });
+
+      final hydratedPrefs = MockAppPreferences(initialData: {prefsKey: payload});
+      final hydratedRepo = QueuedTerminationRequestsRepositoryPrefsImpl(hydratedPrefs);
+
+      final all = hydratedRepo.getAll;
+      expect(all.length, 2);
+      expect(all[hangupRequest.key]?.type, QueuedTerminationRequestType.hangup);
+      expect(all[declineRequest.key]?.type, QueuedTerminationRequestType.decline);
+    });
+
+    test('returns empty map on malformed persisted json', () {
+      final malformedPrefs = MockAppPreferences(initialData: {prefsKey: '{invalid'});
+      final malformedRepo = QueuedTerminationRequestsRepositoryPrefsImpl(malformedPrefs);
+
+      expect(malformedRepo.getAll, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
### Feature Description

This feature makes queued call termination recovery part of the handshake decision engine.

When the app reconnects, any offline termination intents (hangup/decline) stored in the queued termination repository are now handled directly by HandshakeProcessor, converted into standard signaling actions, and consumed from the repository immediately.

### Why This Was Added

During signaling outages, termination requests can’t always be sent in real time.  
Without replay on reconnect, server state and local state may diverge (for example, stale ringing or stale active calls on server side).

This change ensures those pending terminations are picked up on handshake and replayed through the same HangupSignalingAction / DeclineSignalingAction flow already used by normal disconnected-call reconciliation.

### How It Works

1. HandshakeProcessor starts by loading all queued termination requests from the repository.
2. Each queued request is mapped to a regular signaling action:
   - hangup -> HangupSignalingAction
   - decline -> DeclineSignalingAction
3. Each queued request is removed from the repository immediately (consume-on-read behavior), regardless of later execution result.
4. Call IDs from queued requests are excluded from handshake line processing to avoid duplicate/contradicting actions for the same call.
5. Processor then continues normal handshake analysis:
   - disconnected connection guards
   - restore accepted calls
   - unanswered incoming handling
   - orphan local connection cleanup
6. CallBloc executes returned actions using existing signaling execution paths.

### Behavioral Notes

- The queue now behaves as best-effort consume-on-handshake.
- Requests are deleted as soon as they are transformed into actions, not after successful signaling execution.
- Existing early-return semantics for HangupSignalingAction / DeclineSignalingAction are preserved.

### What Was Refactored

- Queue ownership moved from CallBloc into HandshakeProcessor.
- Dedicated queued action type is no longer needed; standard Hangup/Decline actions are used.
- Queue deletion logic was removed from BLoC handshake loop and centralized in processor.
