### PR TITLE
fix(signaling): skip FGS restart in pushBound mode to prevent ForegroundServiceStartNotAllowedException

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -55,6 +55,15 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   WebtritSignalingServiceAndroid.forTesting({BinaryMessenger? binaryMessenger})
     : _hostApi = PSignalingServiceHostApi(binaryMessenger: binaryMessenger);
 
+  @visibleForTesting
+  void initStateForTesting({required SignalingServiceConfig config, required SignalingServiceMode mode}) {
+    _currentConfig = config;
+    _currentMode = mode;
+  }
+
+  @visibleForTesting
+  Future<void> triggerOnServiceDeadForTesting() => _onHubServiceDead();
+
   static WebtritSignalingServiceAndroid? _instance;
 
   /// Registers this class as the default [SignalingServicePlatform] instance.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -250,13 +250,17 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       _logger.info('_onHubServiceDead: service intentionally stopped, skipping restart');
       return;
     }
-    _logger.warning('_onHubServiceDead: hub service dead, restarting');
     final config = _currentConfig;
     final mode = _currentMode;
     if (config == null || mode == null) {
       _logger.warning('_onHubServiceDead: no config/mode available, cannot restart');
       return;
     }
+    if (mode == SignalingServiceMode.pushBound) {
+      _logger.info('_onHubServiceDead: pushBound mode — FCM push will trigger restart');
+      return;
+    }
+    _logger.warning('_onHubServiceDead: hub service dead, restarting');
     try {
       await _startService(config, mode);
     } catch (e, st) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ssl_certificates/ssl_certificates.dart';
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
 
 import 'package:webtrit_signaling_service_android/src/plugin.dart';
 
@@ -51,6 +53,89 @@ void main() {
       await plugin.dispose();
 
       expect(stopCalled, isFalse);
+    });
+  });
+
+  group('WebtritSignalingServiceAndroid -- _onHubServiceDead()', () {
+    const startServiceChannel =
+        'dev.flutter.pigeon.webtrit_signaling_service_android'
+        '.PSignalingServiceHostApi.startService';
+
+    const testConfig = SignalingServiceConfig(
+      coreUrl: 'https://example.com',
+      tenantId: 'tenant',
+      token: 'token',
+      trustedCertificates: TrustedCertificates.empty,
+    );
+
+    late WebtritSignalingServiceAndroid plugin;
+
+    setUp(() {
+      plugin = WebtritSignalingServiceAndroid.forTesting();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        startServiceChannel,
+        null,
+      );
+    });
+
+    test('does not call startService in pushBound mode', () async {
+      plugin.initStateForTesting(config: testConfig, mode: SignalingServiceMode.pushBound);
+
+      var startCalled = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(startServiceChannel, (
+        message,
+      ) async {
+        startCalled = true;
+        return const StandardMessageCodec().encodeMessage(<Object?>[null]);
+      });
+
+      await plugin.triggerOnServiceDeadForTesting();
+
+      expect(startCalled, isFalse);
+    });
+
+    test('does not call startService when _isStopped is true', () async {
+      const stopServiceChannel =
+          'dev.flutter.pigeon.webtrit_signaling_service_android'
+          '.PSignalingServiceHostApi.stopService';
+
+      plugin.initStateForTesting(config: testConfig, mode: SignalingServiceMode.persistent);
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        stopServiceChannel,
+        (message) async => const StandardMessageCodec().encodeMessage(<Object?>[null]),
+      );
+      await plugin.stopService();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(stopServiceChannel, null);
+
+      var startCalled = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(startServiceChannel, (
+        message,
+      ) async {
+        startCalled = true;
+        return const StandardMessageCodec().encodeMessage(<Object?>[null]);
+      });
+
+      await plugin.triggerOnServiceDeadForTesting();
+
+      expect(startCalled, isFalse);
+    });
+
+    test('does not call startService when config is null', () async {
+      var startCalled = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(startServiceChannel, (
+        message,
+      ) async {
+        startCalled = true;
+        return const StandardMessageCodec().encodeMessage(<Object?>[null]);
+      });
+
+      await plugin.triggerOnServiceDeadForTesting();
+
+      expect(startCalled, isFalse);
     });
   });
 


### PR DESCRIPTION
## Problem

In `pushBound` mode, when the FGS is killed (expected — `onTaskRemoved` → `stopSelf()`), `HubConnectionManager` detects the dead hub and calls `_onHubServiceDead`. That callback unconditionally called `_startService`, which invokes `startForegroundService()` from the background. Android 12+ throws `ForegroundServiceStartNotAllowedException` because the app has no foreground exemption at that point.

Result: signaling stuck in `failure` state until the user manually opens the app.

## Root Cause

`_onHubServiceDead` did not check `_currentMode` before attempting a restart. In `pushBound` mode the FGS dying is by design — the next incoming call arrives via FCM push, which restarts the FGS through the push isolate (`WebtritSignalingService.connect()` → `start()`).

## Fix

Added an early return in `_onHubServiceDead` when mode is `pushBound`:

```dart
if (mode == SignalingServiceMode.pushBound) {
  _logger.info('_onHubServiceDead: pushBound mode — FCM push will trigger restart');
  return;
}
```

## Why This Is Safe

- **pushBound recovery path**: FCM push → push isolate → `WebtritSignalingService.connect()` → `start()` → FGS restarts. The push isolate is a separate Dart isolate; `failure` state in the main isolate does not block it.
- **Activity open**: `SignalingReconnectController` handles restart independently when `_appActive = true` — unaffected by this change.
- **persistent mode**: FGS isolate has its own `_scheduleReconnect` logic independent of `_onHubServiceDead` — unaffected.

## Tested

Reproduced `ForegroundServiceStartNotAllowedException` on Xiaomi 25028RN03Y (Android 15) via ADB scenario: app backgrounded → FGS stopped → hub dead detection → restart attempt from background.

Relates to: WT-1302