### PR TITLE
fix(call): add callId key to CallInfo to force recreate on call change (WT-1302)

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -187,6 +187,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                           children: [
                                             for (final activeCall in activeCalls)
                                               CallInfo(
+                                                key: ValueKey(activeCall.callId),
                                                 transfering: activeTransfer is Transfering,
                                                 requestToAttendedTransfer: false,
                                                 inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,


### PR DESCRIPTION
## Summary

- Add `key: ValueKey(activeCall.callId)` to `CallInfo` widget instantiation in the `for` loop inside `call_active_scaffold.dart`
- Eliminates stale widget state when the same `CallInfo` widget is reused across different calls

## Root cause

Without a `key`, Flutter uses positional matching when reconciling the widget tree. When two consecutive calls arrive while the screen is locked (Flutter paused), the intermediate `activeCalls: []` state is never rendered — `CallInfo` is not disposed and recreated. Instead, `didUpdateWidget` fires on the existing instance.

PR #1177 fixed the `duration` leak via `_durationTimerCancel()`, but only when `acceptedTime` actually changes between calls. Adding a `key` makes the fix unconditional: Flutter always disposes and recreates `CallInfo` when the `callId` changes, regardless of lifecycle state or which props changed.

## Fix

```dart
for (final activeCall in activeCalls)
  CallInfo(
    key: ValueKey(activeCall.callId), // <- added
    ...
  ),
```

## Test plan

- [ ] Call 1: answer, talk ~20s, end call (remote side)
- [ ] Screen stays locked — Call 2 arrives immediately after
- [ ] Incoming screen shows **"Incoming call"**, not a stale timer value
- [ ] Call 2: accept — timer starts from `0:00`
- [ ] Normal call flow (answer, talk, end) unaffected
- [ ] Multi-call / attended transfer flow unaffected

Closes WT-1302