### PR TITLE
fix(signaling): add safety reconnect fallback when main isolate sync fails

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -232,6 +232,8 @@ class SignalingForegroundIsolateManager {
         _logger.info('IsolateManager: connecting...');
       case SignalingConnected():
         _logger.info('IsolateManager: connected');
+        _reconnectTimer?.cancel();
+        _reconnectTimer = null;
       case SignalingConnectionFailed(:final error, :final recommendedReconnectDelay):
         _logger.warning('IsolateManager: connection failed -- $error');
         if (!(_hub?.hasSubscribers ?? false)) {
@@ -239,8 +241,13 @@ class SignalingForegroundIsolateManager {
           // Reconnect locally; when the app opens and subscribes, the main isolate
           // takes over reconnect decisions via SignalingReconnectController.
           _scheduleReconnect(recommendedReconnectDelay);
+        } else {
+          // Main isolate handles reconnect via SignalingReconnectController.
+          // Schedule a safety fallback in case the sync round-trip (startService →
+          // onStartCommand → synchronizeIsolate → Pigeon → handleStatus) fails to
+          // reach this isolate. Cancelled by _start() when the sync arrives normally.
+          _scheduleSafetyReconnect(recommendedReconnectDelay);
         }
-      // else: delegated to SignalingReconnectController in the main isolate.
       case SignalingHandshakeReceived(:final handshake):
         _logger.info('IsolateManager: handshake lines=${handshake.lines}');
       case SignalingProtocolEvent(:final event):
@@ -253,8 +260,13 @@ class SignalingForegroundIsolateManager {
         if (!(_hub?.hasSubscribers ?? false)) {
           // No main-isolate subscriber — app is closed (persistent-service mode).
           _scheduleReconnect(recommendedReconnectDelay);
+        } else {
+          // Main isolate handles reconnect via SignalingReconnectController.
+          // Schedule a safety fallback in case the sync round-trip (startService →
+          // onStartCommand → synchronizeIsolate → Pigeon → handleStatus) fails to
+          // reach this isolate. Cancelled by _start() when the sync arrives normally.
+          _scheduleSafetyReconnect(recommendedReconnectDelay);
         }
-      // else: delegated to SignalingReconnectController in the main isolate.
       default:
         break;
     }
@@ -314,6 +326,33 @@ class SignalingForegroundIsolateManager {
       _reconnectTimer = null;
       if (_started && !(_signalingModule?.isConnected ?? false)) {
         _logger.info('IsolateManager: auto-reconnecting (persistent mode)');
+        _signalingModule?.connect();
+      }
+    });
+  }
+
+  /// Schedules a safety fallback reconnect for use when [SignalingHub.hasSubscribers]
+  /// is true (app foreground).
+  ///
+  /// The main isolate's [SignalingReconnectController] drives reconnect via a
+  /// round-trip: startService → onStartCommand → synchronizeIsolate (Pigeon) →
+  /// handleStatus → _start. If any step in that chain fails (e.g. Pigeon message
+  /// dropped on MIUI, pendingSync queue stuck), no reconnect ever fires.
+  ///
+  /// This timer fires [baseDelay] + 2 s after the disconnect, giving the main
+  /// isolate's path priority. When the normal path works, [_start] cancels
+  /// [_reconnectTimer] before this window expires. A second [connect] call on
+  /// an already-in-progress attempt is a no-op due to [SignalingModuleImpl]'s
+  /// [_connectToken] guard, so double-reconnects are not possible.
+  void _scheduleSafetyReconnect(Duration? baseDelay) {
+    if (baseDelay == null) return;
+    final safetyDelay = baseDelay + const Duration(seconds: 2);
+    _reconnectTimer?.cancel();
+    _logger.info('IsolateManager: scheduling safety reconnect in ${safetyDelay.inMilliseconds} ms');
+    _reconnectTimer = Timer(safetyDelay, () {
+      _reconnectTimer = null;
+      if (_started && !(_signalingModule?.isConnected ?? false)) {
+        _logger.warning('IsolateManager: safety reconnect triggered — main isolate sync did not arrive');
         _signalingModule?.connect();
       }
     });

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/signaling_foreground_isolate_manager.dart
@@ -45,6 +45,7 @@ class SignalingForegroundIsolateManager {
     this.moduleFactoryHandle = 0,
     this.isPushBound = false,
     this.pushBoundNoSubscriberGrace = const Duration(seconds: 10),
+    this.safetyReconnectGrace = const Duration(seconds: 2),
     @visibleForTesting SignalingModuleFactory? moduleFactory,
     @visibleForTesting SignalingHubFactory? hubFactory,
     @visibleForTesting VoidCallback? stopServiceOverride,
@@ -93,6 +94,15 @@ class SignalingForegroundIsolateManager {
   /// the service continues normally. Exposed as a constructor parameter so it
   /// can be overridden in tests without sleeping.
   final Duration pushBoundNoSubscriberGrace;
+
+  /// Extra time added on top of [recommendedReconnectDelay] before the safety
+  /// reconnect fires when the main isolate's sync does not arrive.
+  ///
+  /// Defaults to 2 s, which gives the main isolate's round-trip path
+  /// (startService → onStartCommand → synchronizeIsolate → Pigeon → handleStatus)
+  /// enough headroom to cancel the timer before it fires. Exposed as a
+  /// constructor parameter so tests can use small values without sleeping.
+  final Duration safetyReconnectGrace;
 
   /// Overrides handle-based [SignalingModule] creation in tests.
   final SignalingModuleFactory? _testModuleFactory;
@@ -339,15 +349,16 @@ class SignalingForegroundIsolateManager {
   /// handleStatus → _start. If any step in that chain fails (e.g. Pigeon message
   /// dropped on MIUI, pendingSync queue stuck), no reconnect ever fires.
   ///
-  /// This timer fires [baseDelay] + 2 s after the disconnect, giving the main
-  /// isolate's path priority. When the normal path works, [_start] cancels
-  /// [_reconnectTimer] before this window expires. A second [connect] call on
-  /// an already-in-progress attempt is a no-op due to [SignalingModuleImpl]'s
-  /// [_connectToken] guard, so double-reconnects are not possible.
+  /// This timer fires [baseDelay] + [safetyReconnectGrace] after the disconnect,
+  /// giving the main isolate's path priority. When the normal path works, [_start]
+  /// cancels [_reconnectTimer] before this window expires. A redundant [connect]
+  /// call while the module is already connected is prevented by the
+  /// [!isConnected] guard in the timer callback.
   void _scheduleSafetyReconnect(Duration? baseDelay) {
     if (baseDelay == null) return;
-    final safetyDelay = baseDelay + const Duration(seconds: 2);
+    final safetyDelay = baseDelay + safetyReconnectGrace;
     _reconnectTimer?.cancel();
+    _reconnectTimer = null;
     _logger.info('IsolateManager: scheduling safety reconnect in ${safetyDelay.inMilliseconds} ms');
     _reconnectTimer = Timer(safetyDelay, () {
       _reconnectTimer = null;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/isolate/signaling_foreground_isolate_manager_test.dart
@@ -139,6 +139,22 @@ SignalingForegroundIsolateManager _makeManager(_FakeSignalingModule module) {
   );
 }
 
+/// Creates a manager (with subscribers) where [safetyReconnectGrace] is small
+/// enough to test the safety fallback without real-time sleeping.
+SignalingForegroundIsolateManager _makeManagerWithSafetyGrace(
+  _FakeSignalingModule module, {
+  Duration grace = const Duration(milliseconds: 20),
+}) {
+  return SignalingForegroundIsolateManager(
+    coreUrl: 'wss://example.com',
+    tenantId: 'tenant',
+    token: 'tok',
+    safetyReconnectGrace: grace,
+    moduleFactory: (_) => module,
+    hubFactory: _FakeSignalingHub.new, // hasSubscribers defaults to true
+  );
+}
+
 /// Creates a manager where the hub reports NO subscribers (app is closed —
 /// persistent-service mode). The background isolate must auto-reconnect
 /// independently in this configuration.
@@ -503,6 +519,113 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 150));
 
       expect(stopCalls, isEmpty, reason: 'persistent mode must not schedule cleanup timer');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Safety reconnect — fallback when main isolate sync does not arrive
+  // -------------------------------------------------------------------------
+
+  // When hasSubscribers is true (app open), reconnect decisions normally belong
+  // to SignalingReconnectController. If the sync round-trip (startService →
+  // onStartCommand → synchronizeIsolate → Pigeon → handleStatus) fails silently
+  // (e.g. Pigeon dropped on MIUI), the safety timer fires after
+  // recommendedReconnectDelay + safetyReconnectGrace and reconnects directly.
+
+  group('SignalingForegroundIsolateManager -- safety reconnect (main isolate fallback)', () {
+    test('safety timer fires and reconnects when main isolate sync never arrives (disconnect)', () async {
+      final module = _FakeSignalingModule();
+      // Use a tiny grace so the test completes quickly.
+      final manager = _makeManagerWithSafetyGrace(module, grace: const Duration(milliseconds: 20));
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      // WebSocket drops — reconnect delay 50ms, safety fires at 50+20=70ms.
+      module.simulateDisconnectWithDelay(const Duration(milliseconds: 50));
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1); // no immediate reconnect
+
+      // Wait past safety window — safety timer fires.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(module.connectCount, 2, reason: 'safety timer must fire and reconnect');
+    });
+
+    test('safety timer fires and reconnects when main isolate sync never arrives (connection failed)', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerWithSafetyGrace(module, grace: const Duration(milliseconds: 20));
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      module.simulateConnectionFailed(const Duration(milliseconds: 50));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(module.connectCount, 2, reason: 'safety timer must fire after connection failed');
+    });
+
+    test('safety timer is cancelled when _start() arrives via main isolate sync', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerWithSafetyGrace(module, grace: const Duration(milliseconds: 50));
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      module.simulateDisconnectWithDelay(const Duration(milliseconds: 20));
+      await Future<void>.delayed(Duration.zero);
+
+      // Main isolate sync arrives before safety window — cancels timer and reconnects.
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 2);
+
+      // Wait past safety deadline — must not fire a second reconnect.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(module.connectCount, 2, reason: 'safety timer must be cancelled by _start()');
+    });
+
+    test('safety timer is cancelled on SignalingConnected (connection restored by other means)', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerWithSafetyGrace(module, grace: const Duration(milliseconds: 50));
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      module.simulateDisconnectWithDelay(const Duration(milliseconds: 20));
+      await Future<void>.delayed(Duration.zero);
+
+      // Simulate the main isolate reconnecting via hub command (not handleStatus),
+      // which causes _FakeSignalingModule.connect() to emit SignalingConnected.
+      module.connect(); // emits SignalingConnected internally
+      await Future<void>.delayed(Duration.zero);
+
+      final countAfterReconnect = module.connectCount;
+
+      // Safety timer must have been cancelled by the SignalingConnected event.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(module.connectCount, countAfterReconnect, reason: 'safety timer must be cancelled on SignalingConnected');
+    });
+
+    test('safety timer does NOT fire when delay is null (server says do not reconnect)', () async {
+      final module = _FakeSignalingModule();
+      final manager = _makeManagerWithSafetyGrace(module, grace: const Duration(milliseconds: 20));
+      addTearDown(() => manager.handleStatus(enabled: false));
+
+      await manager.handleStatus(enabled: true);
+      await Future<void>.delayed(Duration.zero);
+      expect(module.connectCount, 1);
+
+      // code 1002 → recommendedReconnectDelay == null → no safety timer.
+      module.simulateDisconnect1002();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(module.connectCount, 1, reason: 'null delay must suppress the safety timer too');
     });
   });
 


### PR DESCRIPTION
## Summary

- After a server-side WebSocket close (e.g. code 4610), the FGS isolate delegated reconnect entirely to the main isolate via a 7-step round-trip (`startService → onStartCommand → synchronizeIsolate → Pigeon → handleStatus → _start → connect`). If any step failed silently (Pigeon message dropped on MIUI, `pendingSync` queue stuck), no reconnect ever fired.
- Added `_scheduleSafetyReconnect`: fires `baseDelay + 2s` after disconnect. When the normal path works, `_start()` cancels the timer before it fires. When it doesn't, the FGS isolate reconnects directly via `_signalingModule.connect()`.
- Double-reconnect is not possible: a second `connect()` call is a no-op due to `SignalingModuleImpl._connectToken` guard.

## Root cause

Bug observed on Samsung SM-M325FV (Android 13 / MIUI) after rapid consecutive calls triggered a stale `updating_call` transaction, causing the server to close WebSocket with code 4610. Full analysis: `bugs/WT-pending/2026-04-21-signaling-no-reconnect-after-4610.md`

## Test plan

- [ ] Normal reconnect still works (safety timer is cancelled by `_start()`)
- [ ] After 4610 disconnect, WebSocket reconnects within 5s
- [ ] No double-reconnect observed in logs
- [ ] Persistent mode unaffected (no-subscribers path unchanged)