### PR TITLE
fix(signaling): reset _syncSucceeded before reconnect sync to restore retries

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -139,6 +139,15 @@ class SignalingForegroundService : Service() {
                 // Send a sync so the FGS Dart isolate can reconnect the WebSocket if it
                 // dropped while the app was backgrounded (e.g. screen unlock in PUSH_BOUND).
                 // The watchdog is not re-armed: the isolate is already initialised.
+                //
+                // Reset _syncSucceeded so timer-based retries work correctly.
+                // After a successful initial sync _syncSucceeded == true, which causes
+                // every retry runnable to evaluate !_syncSucceeded == false and return
+                // immediately — leaving a single Pigeon message as the only attempt.
+                // If that message is dropped (e.g. under memory pressure on MIUI) no
+                // reconnect fires. Resetting here restores the full retry cycle.
+                _syncSucceeded = false
+                cancelSyncRetries()
                 synchronizeIsolate()
             }
             return if (StorageDelegate.isPushBound(applicationContext)) START_NOT_STICKY else START_STICKY


### PR DESCRIPTION
## Summary

- `_syncSucceeded` was never reset in the `alreadyWired` reconnect path of `SignalingForegroundService.onStartCommand`
- After a successful initial startup sync, `_syncSucceeded == true` caused every timer-based retry runnable in `synchronizeIsolate` to short-circuit (`if (!_syncSucceeded) return`)
- This left only a single Pigeon message with no fallback for the reconnect signal
- On MIUI/Xiaomi under memory pressure, that single message is silently dropped — the FGS Dart isolate never receives the reconnect trigger, and the WebSocket stays permanently dead

**Fix:** add `_syncSucceeded = false` + `cancelSyncRetries()` before `synchronizeIsolate()` in the `alreadyWired` block, restoring the full 6-attempt retry cycle for every reconnect.

## Root cause chain

1. Server closes WebSocket with code 4610 (stale in-flight transaction)
2. `SignalingReconnectController` schedules reconnect after 3 s
3. `WebtritSignalingServiceAndroid.start()` → `startService()` → `onStartCommand`
4. Engine already running → `alreadyWired == true` → `wireUpPigeon` skips re-wiring ✓ (correct)
5. `synchronizeIsolate()` called — but `_syncSucceeded == true` from prior startup
6. All 5 retry runnables evaluate `!_syncSucceeded == false` → immediate no-op
7. One Pigeon message sent, dropped on MIUI → FGS isolate never reconnects

## Relation to PR #1181

PR #1181 (safety reconnect timer in FGS Dart isolate) is a defence-in-depth layer that catches failures **after** the Pigeon message is sent. This PR fixes the **cause**: restoring the retry cycle so the message is actually delivered reliably.

Together both PRs create two independent reconnect paths:
- Kotlin retries the Pigeon sync up to 6× (this PR)
- FGS Dart fires a safety timer if all retries fail (PR #1181)

## Test plan

- [x] Reproduce 4610 disconnect scenario (rapid successive calls) on Xiaomi/MIUI device
- [x] Confirm signaling reconnects within `baseDelay + safetyReconnectGrace` after 4610 close
- [x] Confirm no regression on non-MIUI devices (Pixel, Samsung) for normal reconnect
- [x] Confirm `synchronizeIsolate` logs show retry attempts on reconnect (not just attempt 1)