### PR TITLE
fix(signaling): opportunistic reconnect on network restore in background (WT-1373)

### DIFF
--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -97,9 +97,9 @@ class SignalingReconnectController {
   // Set to true by notifyNetworkAvailable and consumed by the first timer that
   // fires after it. Allows a one-shot opportunistic reconnect when the network
   // is restored while the app is backgrounded with no known active calls —
-  // the case where FCM TTL=0 push was dropped during the offline window and
+  // the case where an FCM push was dropped during the offline window and
   // the only way to discover a pending incoming call is to reconnect and read
-  // the handshake state from Core (WT-1373).
+  // the handshake state from Core.
   bool _networkJustRestored = false;
 
   /// Last value passed to [_onConnectionPresenceChanged].
@@ -308,7 +308,7 @@ class SignalingReconnectController {
           _logger.info('_scheduleReconnect: skipped - app not active and no active calls');
           return;
         }
-        _logger.info('_scheduleReconnect: network-restore opportunistic reconnect (WT-1373)');
+        _logger.info('_scheduleReconnect: network-restore opportunistic reconnect');
       }
       if (!force && !_networkActive) {
         _logger.info('_scheduleReconnect: skipped - network unavailable');

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -299,7 +299,8 @@ class SignalingReconnectController {
       _logger.info(
         '_scheduleReconnect timer fired after $delay - '
         'appActive=$_appActive networkActive=$_networkActive '
-        'force=$force connected=${_module.isConnected}',
+        'force=$force connected=${_module.isConnected} '
+        'networkJustRestored=$networkJustRestored',
       );
 
       if (!force && !_appActive && !_hasActiveCalls) {

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -94,6 +94,14 @@ class SignalingReconnectController {
   bool _hasActiveCalls = false;
   bool _disposed = false;
 
+  // Set to true by notifyNetworkAvailable and consumed by the first timer that
+  // fires after it. Allows a one-shot opportunistic reconnect when the network
+  // is restored while the app is backgrounded with no known active calls —
+  // the case where FCM TTL=0 push was dropped during the offline window and
+  // the only way to discover a pending incoming call is to reconnect and read
+  // the handshake state from Core (WT-1373).
+  bool _networkJustRestored = false;
+
   /// Last value passed to [_onConnectionPresenceChanged].
   /// Starts as `true` (assumed available) to avoid a spurious "available"
   /// callback on the first [SignalingConnected] event.
@@ -185,6 +193,7 @@ class SignalingReconnectController {
   void notifyNetworkAvailable() {
     _logger.fine('notifyNetworkAvailable');
     _networkActive = true;
+    _networkJustRestored = true;
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
   }
 
@@ -283,6 +292,10 @@ class SignalingReconnectController {
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(delay, () {
       if (_disposed) return;
+
+      final networkJustRestored = _networkJustRestored;
+      _networkJustRestored = false;
+
       _logger.info(
         '_scheduleReconnect timer fired after $delay - '
         'appActive=$_appActive networkActive=$_networkActive '
@@ -290,8 +303,11 @@ class SignalingReconnectController {
       );
 
       if (!force && !_appActive && !_hasActiveCalls) {
-        _logger.info('_scheduleReconnect: skipped - app not active and no active calls');
-        return;
+        if (!networkJustRestored) {
+          _logger.info('_scheduleReconnect: skipped - app not active and no active calls');
+          return;
+        }
+        _logger.info('_scheduleReconnect: network-restore opportunistic reconnect (WT-1373)');
       }
       if (!force && !_networkActive) {
         _logger.info('_scheduleReconnect: skipped - network unavailable');

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -852,16 +852,16 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // WT-1373: opportunistic reconnect on network restore in background
+  // Opportunistic reconnect on network restore in background
   // -------------------------------------------------------------------------
 
-  group('SignalingReconnectController - WT-1373 network-restore opportunistic reconnect', () {
-    // Core scenario from the bug: app is backgrounded with no active calls,
-    // network drops and restores while a call is pending on the server.
-    // FCM push (TTL=0) was discarded during the offline window, so no
-    // notifyForceReconnect arrives. The controller must still reconnect once
-    // to read Core's handshake state and surface the pending call.
-    test('reconnects once when network is restored in background with no active calls (WT-1373)', () {
+  group('SignalingReconnectController - network-restore opportunistic reconnect', () {
+    // App is backgrounded with no active calls, network drops and restores
+    // while a call is pending on the server. FCM push was discarded during
+    // the offline window, so no notifyForceReconnect arrives. The controller
+    // must still reconnect once to read Core's handshake state and surface
+    // the pending call.
+    test('reconnects once when network is restored in background with no active calls', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -888,7 +888,7 @@ void main() {
     // the _networkJustRestored flag, subsequent failure-driven timers must
     // respect the background-skip guard as normal. Without this guarantee the
     // fix would silently turn into persistent-mode reconnection.
-    test('opportunistic reconnect is one-shot — subsequent failures skip in background (WT-1373)', () {
+    test('opportunistic reconnect is one-shot — subsequent failures skip in background', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -888,6 +888,29 @@ void main() {
     // the _networkJustRestored flag, subsequent failure-driven timers must
     // respect the background-skip guard as normal. Without this guarantee the
     // fix would silently turn into persistent-mode reconnection.
+    test('no duplicate connect when module is already connected at timer fire time', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = true;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyAppPaused(hasActiveCalls: false);
+        controller.notifyNetworkUnavailable();
+        controller.notifyNetworkAvailable();
+
+        // Timer fires: networkJustRestored=true bypasses the appActive guard,
+        // but isConnected guard applies — no duplicate connect() call.
+        async.elapse(kSignalingClientFastReconnectDelay);
+        expect(
+          module.connectCalls,
+          0,
+          reason: 'already connected — opportunistic reconnect must not call connect() again',
+        );
+      });
+    });
+
     test('opportunistic reconnect is one-shot — subsequent failures skip in background', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -852,6 +852,69 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // WT-1373: opportunistic reconnect on network restore in background
+  // -------------------------------------------------------------------------
+
+  group('SignalingReconnectController - WT-1373 network-restore opportunistic reconnect', () {
+    // Core scenario from the bug: app is backgrounded with no active calls,
+    // network drops and restores while a call is pending on the server.
+    // FCM push (TTL=0) was discarded during the offline window, so no
+    // notifyForceReconnect arrives. The controller must still reconnect once
+    // to read Core's handshake state and surface the pending call.
+    test('reconnects once when network is restored in background with no active calls (WT-1373)', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = false;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        // App goes to background, signaling disconnects intentionally.
+        controller.notifyAppPaused(hasActiveCalls: false);
+        expect(module.disconnectCalls, 1);
+
+        // Network drops and restores while offline (e.g. WiFi toggle).
+        controller.notifyNetworkUnavailable();
+        controller.notifyNetworkAvailable();
+
+        // Must connect after the fast-reconnect delay.
+        expect(module.connectCalls, 0);
+        async.elapse(kSignalingClientFastReconnectDelay);
+        expect(module.connectCalls, 1);
+      });
+    });
+
+    // The opportunistic reconnect is one-shot: after the first timer consumes
+    // the _networkJustRestored flag, subsequent failure-driven timers must
+    // respect the background-skip guard as normal. Without this guarantee the
+    // fix would silently turn into persistent-mode reconnection.
+    test('opportunistic reconnect is one-shot — subsequent failures skip in background (WT-1373)', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = false;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyAppPaused(hasActiveCalls: false);
+        controller.notifyNetworkUnavailable();
+        controller.notifyNetworkAvailable();
+
+        // First timer: opportunistic reconnect fires.
+        async.elapse(kSignalingClientFastReconnectDelay);
+        expect(module.connectCalls, 1);
+
+        // Connection attempt fails — schedules the next reconnect timer.
+        module.emit(_failed(delay: kSignalingClientReconnectDelay));
+
+        // Second timer: flag already consumed, background skip applies again.
+        async.elapse(kSignalingClientReconnectDelay);
+        expect(module.connectCalls, 1, reason: 'background skip must apply after opportunistic flag is consumed');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // dispose() safety
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

When the device briefly goes offline while an incoming call arrives, the call is silently missed even after connectivity is restored.

Two independent issues combine to create a dead zone:

1. **FCM TTL=0 (Core default)** — the push notification is discarded by FCM during the offline window. Without the push, `notifyForceReconnect` is never called.
2. **`SignalingReconnectController` skips reconnect in background with no active calls** — when network is restored, the controller fires its timer but exits with `skipped - app not active and no active calls`. No WS reconnect happens, so Core never delivers the `incoming_call` event.

**Reproduced** via ADB script: WiFi disabled → call placed → WiFi restored → reconnect skipped → call missed.

## Fix

Introduces `_networkJustRestored` flag in `SignalingReconnectController`:

- Set to `true` in `notifyNetworkAvailable()`
- Consumed by the first `_scheduleReconnect` timer that fires after it
- When the flag is set, the background-skip guard is bypassed **once**, allowing a single opportunistic WS reconnect to read Core's handshake state

**One-shot by design** — after the flag is consumed, subsequent failure-driven timers respect the background-skip guard as normal, so this does not degrade into persistent-mode reconnection.

**Self-cleaning** — if the handshake comes back with no pending calls, the existing `notifyHasActiveCalls(false) + !_appActive → _disconnect()` path tears down the connection immediately.

