### PR TITLE
fix(WT-1393): restore call when blind transfer target declines

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1432,10 +1432,22 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> __onCallSignalingEventNotifyRefer(_CallSignalingEventNotifyRefer event, Emitter<CallState> emit) async {
     _logger.fine('_CallSignalingEventNotifyRefer: $event');
     if (event.subscriptionState != SubscriptionState.terminated) return;
-    if (event.state != ReferNotifyState.ok) return;
 
-    // Verifies if the original call line is currently active in the state
-    if (state.activeCalls.any((it) => it.callId == event.callId)) add(CallControlEvent.ended(event.callId));
+    if (event.state == ReferNotifyState.ok) {
+      // Transfer succeeded — end the original call (A is now connected via C)
+      if (state.activeCalls.any((it) => it.callId == event.callId)) add(CallControlEvent.ended(event.callId));
+    } else {
+      // Transfer failed (e.g. C declined) — restore the original call
+      final callId = event.callId;
+      if (state.activeCalls.any((it) => it.callId == callId)) {
+        _logger.warning(
+          '__onCallSignalingEventNotifyRefer: transfer failed (state=${event.state}), restoring call $callId',
+        );
+        emit(state.copyWithMappedActiveCall(callId, (activeCall) => activeCall.copyWith(transfer: null)));
+        await callkeep.setHeld(callId, onHold: false);
+        submitNotification(BlindTransferFailedNotification());
+      }
+    }
   }
 
   Future<void> __onCallSignalingEventNotifyUnknown(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1433,20 +1433,23 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _logger.fine('_CallSignalingEventNotifyRefer: $event');
     if (event.subscriptionState != SubscriptionState.terminated) return;
 
-    if (event.state == ReferNotifyState.ok) {
-      // Transfer succeeded — end the original call (A is now connected via C)
-      if (state.activeCalls.any((it) => it.callId == event.callId)) add(CallControlEvent.ended(event.callId));
-    } else {
-      // Transfer failed (e.g. C declined) — restore the original call
-      final callId = event.callId;
-      if (state.activeCalls.any((it) => it.callId == callId)) {
-        _logger.warning(
-          '__onCallSignalingEventNotifyRefer: transfer failed (state=${event.state}), restoring call $callId',
-        );
-        emit(state.copyWithMappedActiveCall(callId, (activeCall) => activeCall.copyWith(transfer: null)));
-        await callkeep.setHeld(callId, onHold: false);
-        submitNotification(BlindTransferFailedNotification());
-      }
+    switch (event.state) {
+      case ReferAccepted():
+        if (state.activeCalls.any((it) => it.callId == event.callId)) {
+          add(CallControlEvent.ended(event.callId));
+        }
+      case ReferFailed():
+        final callId = event.callId;
+        if (state.activeCalls.any((it) => it.callId == callId)) {
+          _logger.warning(
+            '__onCallSignalingEventNotifyRefer: transfer failed (${event.state}), restoring call $callId',
+          );
+          emit(state.copyWithMappedActiveCall(callId, (activeCall) => activeCall.copyWith(transfer: null)));
+          await callkeep.setHeld(callId, onHold: false);
+          submitNotification(BlindTransferFailedNotification());
+        }
+      case ReferProvisional():
+        break;
     }
   }
 

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -198,6 +198,13 @@ final class ActiveLineBlindTransferWarningNotification extends MessageNotificati
   }
 }
 
+final class BlindTransferFailedNotification extends MessageNotification {
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.notifications_errorSnackBar_blindTransferFailed;
+  }
+}
+
 final class CallErrorRegisteringSelfManagedPhoneAccountNotification extends ErrorNotification {
   const CallErrorRegisteringSelfManagedPhoneAccountNotification();
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2232,6 +2232,12 @@ abstract class AppLocalizations {
   /// **'You are already on the line with the recipient you are trying to blind transfer to'**
   String get notifications_errorSnackBar_activeLineBlindTransferWarning;
 
+  /// Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Transfer failed, returning to active call'**
+  String get notifications_errorSnackBar_blindTransferFailed;
+
   /// Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -699,6 +699,8 @@ class AppLocalizationsMapper {
       'notifications_errorSnackBar_activeLineBlindTransferWarning':
           localizations
               .notifications_errorSnackBar_activeLineBlindTransferWarning,
+      'notifications_errorSnackBar_blindTransferFailed':
+          localizations.notifications_errorSnackBar_blindTransferFailed,
       'notifications_errorSnackBar_appOffline':
           localizations.notifications_errorSnackBar_appOffline,
       'notifications_errorSnackBar_appOnline':

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1195,6 +1195,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'You are already on the line with the recipient you are trying to blind transfer to';
 
   @override
+  String get notifications_errorSnackBar_blindTransferFailed => 'Transfer failed, returning to active call';
+
+  @override
   String get notifications_errorSnackBar_appOffline => 'Your application is currently offline';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1207,6 +1207,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Sei già in linea con il destinatario a cui stai cercando di trasferire alla cieca';
 
   @override
+  String get notifications_errorSnackBar_blindTransferFailed => 'Trasferimento fallito, ritorno alla chiamata attiva';
+
+  @override
   String get notifications_errorSnackBar_appOffline => 'La tua apllicazione è offline';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1213,6 +1213,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Ви вже на лінії з одержувачем, до якого намагаєтеся здійснити безумовний переказ';
 
   @override
+  String get notifications_errorSnackBar_blindTransferFailed =>
+      'Переадресація не вдалась, повертаємо до активного дзвінка';
+
+  @override
   String get notifications_errorSnackBar_appOffline => 'Ваш застосунок зараз офлайн.';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -999,6 +999,10 @@
   "@notifications_errorSnackBar_activeLineBlindTransferWarning": {
     "description": "Shown in a notification or snackbar when a user tries to perform a blind transfer to a recipient they are already on the line with. Condition: the active call is with the same recipient as the blind transfer target."
   },
+  "notifications_errorSnackBar_blindTransferFailed": "Transfer failed, returning to active call",
+  "@notifications_errorSnackBar_blindTransferFailed": {
+    "description": "Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen."
+  },
   "notifications_errorSnackBar_appOffline": "Your application is currently offline",
   "@notifications_errorSnackBar_appOffline": {
     "description": "Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -999,6 +999,10 @@
   "@notifications_errorSnackBar_activeLineBlindTransferWarning": {
     "description": "Shown in a notification or snackbar when a user tries to perform a blind transfer to a recipient they are already on the line with. Condition: the active call is with the same recipient as the blind transfer target."
   },
+  "notifications_errorSnackBar_blindTransferFailed": "Trasferimento fallito, ritorno alla chiamata attiva",
+  "@notifications_errorSnackBar_blindTransferFailed": {
+    "description": "Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen."
+  },
   "notifications_errorSnackBar_appOffline": "La tua apllicazione è offline",
   "@notifications_errorSnackBar_appOffline": {
     "description": "Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -999,6 +999,10 @@
   "@notifications_errorSnackBar_activeLineBlindTransferWarning": {
     "description": "Shown in a notification or snackbar when a user tries to perform a blind transfer to a recipient they are already on the line with. Condition: the active call is with the same recipient as the blind transfer target."
   },
+  "notifications_errorSnackBar_blindTransferFailed": "Переадресація не вдалась, повертаємо до активного дзвінка",
+  "@notifications_errorSnackBar_blindTransferFailed": {
+    "description": "Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen."
+  },
   "notifications_errorSnackBar_appOffline": "Ваш застосунок зараз офлайн.",
   "@notifications_errorSnackBar_appOffline": {
     "description": "Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions."

--- a/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
@@ -35,7 +35,82 @@ sealed class NotifyEvent extends CallEvent {
   }
 }
 
-enum ReferNotifyState { trying, ok, unknown }
+// ---------------------------------------------------------------------------
+// ReferNotifyState — sealed class preserving the SIP response code
+// ---------------------------------------------------------------------------
+
+sealed class ReferNotifyState {
+  const ReferNotifyState();
+
+  factory ReferNotifyState.fromContent(String content) {
+    final match = RegExp(r'SIP/2\.0\s+(\d{3})\s*(.*)').firstMatch(content.trim());
+    if (match == null) return const ReferFailed(sipCode: null, reason: null);
+
+    final code = int.parse(match.group(1)!);
+    final reason = match.group(2)!.trim();
+
+    return switch (code) {
+      >= 100 && < 200 => ReferProvisional(sipCode: code, reason: reason),
+      >= 200 && < 300 => const ReferAccepted(),
+      _ => ReferFailed(sipCode: code, reason: reason),
+    };
+  }
+}
+
+/// Transfer is in progress — target is ringing (1xx provisional).
+final class ReferProvisional extends ReferNotifyState {
+  const ReferProvisional({required this.sipCode, required this.reason});
+
+  final int sipCode;
+  final String reason;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ReferProvisional && sipCode == other.sipCode && reason == other.reason;
+
+  @override
+  int get hashCode => Object.hash(sipCode, reason);
+
+  @override
+  String toString() => 'ReferProvisional($sipCode $reason)';
+}
+
+/// Transfer succeeded — target accepted (2xx).
+final class ReferAccepted extends ReferNotifyState {
+  const ReferAccepted();
+
+  @override
+  bool operator ==(Object other) => other is ReferAccepted;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'ReferAccepted()';
+}
+
+/// Transfer failed — target rejected (3xx–6xx) or content was malformed.
+/// [sipCode] is null only when the NOTIFY body could not be parsed.
+final class ReferFailed extends ReferNotifyState {
+  const ReferFailed({required this.sipCode, required this.reason});
+
+  final int? sipCode;
+  final String? reason;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ReferFailed && sipCode == other.sipCode && reason == other.reason;
+
+  @override
+  int get hashCode => Object.hash(sipCode, reason);
+
+  @override
+  String toString() => sipCode != null ? 'ReferFailed($sipCode $reason)' : 'ReferFailed(malformed)';
+}
+
+// ---------------------------------------------------------------------------
+// ReferNotifyEvent
+// ---------------------------------------------------------------------------
 
 class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
   const ReferNotifyEvent({
@@ -55,20 +130,16 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
     'notify': notifyValue,
     if (subscriptionState != null) 'subscription_state': subscriptionState!.name,
     'content': switch (state) {
-      ReferNotifyState.trying => 'SIP/2.0 100 Trying',
-      ReferNotifyState.ok => 'SIP/2.0 200 OK',
-      ReferNotifyState.unknown => '',
+      ReferProvisional(:final sipCode, :final reason) => 'SIP/2.0 $sipCode $reason',
+      ReferAccepted() => 'SIP/2.0 200 OK',
+      ReferFailed(:final sipCode?, :final reason?) => 'SIP/2.0 $sipCode $reason',
+      ReferFailed() => '',
     },
   };
 
   @override
   factory ReferNotifyEvent.fromJson(Map<String, dynamic> json) {
     final contentStr = json['content'] as String;
-    final state = switch (contentStr) {
-      String s when s.startsWith('SIP/2.0 100') => ReferNotifyState.trying,
-      String s when s.contains('200 OK') => ReferNotifyState.ok,
-      _ => ReferNotifyState.unknown,
-    };
 
     return ReferNotifyEvent(
       transaction: json['transaction'],
@@ -77,7 +148,7 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
           : null,
-      state: state,
+      state: ReferNotifyState.fromContent(contentStr),
     );
   }
 
@@ -90,6 +161,10 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
         'subscriptionState: $subscriptionState, state: $state}';
   }
 }
+
+// ---------------------------------------------------------------------------
+// UnknownNotifyEvent
+// ---------------------------------------------------------------------------
 
 class UnknownNotifyEvent extends NotifyEvent with EquatableMixin {
   const UnknownNotifyEvent({

--- a/packages/webtrit_signaling/test/src/events/call/notify_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/notify_event_test.dart
@@ -15,8 +15,10 @@ void main() {
     });
   }
 
+  // --- ReferProvisional (1xx) ---
+
   testFromJson(
-    '$NotifyEvent fromJson 1',
+    'ReferNotifyEvent: 100 Trying → ReferProvisional',
     json.decode(r'''
     {
       "transaction": "transaction 1",
@@ -35,12 +37,12 @@ void main() {
       line: 0,
       callId: 'qwerty',
       subscriptionState: SubscriptionState.active,
-      state: ReferNotifyState.trying,
+      state: const ReferProvisional(sipCode: 100, reason: 'Trying'),
     ),
   );
 
   testFromJson(
-    '$NotifyEvent fromJson 2',
+    'ReferNotifyEvent: 100 Trying without transaction → ReferProvisional',
     json.decode(r'''
     {
       "line": 0,
@@ -57,11 +59,135 @@ void main() {
       line: 0,
       callId: 'qwerty',
       subscriptionState: SubscriptionState.active,
-      state: ReferNotifyState.trying,
+      state: const ReferProvisional(sipCode: 100, reason: 'Trying'),
     ),
   );
 
-  test('$NotifyEvent fromJson error', () {
+  // --- ReferAccepted (2xx) ---
+
+  testFromJson(
+    'ReferNotifyEvent: 200 OK → ReferAccepted',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 200 OK"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferAccepted(),
+    ),
+  );
+
+  // --- ReferFailed (non-2xx) ---
+
+  testFromJson(
+    'ReferNotifyEvent: 603 Decline → ReferFailed',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 603 Decline"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: 603, reason: 'Decline'),
+    ),
+  );
+
+  testFromJson(
+    'ReferNotifyEvent: 486 Busy Here → ReferFailed',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 486 Busy Here"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: 486, reason: 'Busy Here'),
+    ),
+  );
+
+  testFromJson(
+    'ReferNotifyEvent: 480 Temporarily Unavailable → ReferFailed',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 480 Temporarily Unavailable"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: 480, reason: 'Temporarily Unavailable'),
+    ),
+  );
+
+  testFromJson(
+    'ReferNotifyEvent: empty content → ReferFailed (malformed)',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": ""
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: null, reason: null),
+    ),
+  );
+
+  test('NotifyEvent fromJson error on empty event', () {
     expect(() => NotifyEvent.fromJson(json.decode(eventJsonEmpty) as Map<String, dynamic>), throwsA(isArgumentError));
   });
 }


### PR DESCRIPTION
## Summary

- Fixes WT-1393: transferor (B) stuck on processing screen indefinitely when transfer target (C) declines a blind transfer
- Replaces `ReferNotifyState` enum with a sealed class hierarchy that preserves the SIP response code
- Adds exhaustive `switch` handler in `CallBloc` — `ReferFailed` now clears Transfer state, unholds the call, and shows a snackbar

## Changes

**`fix(call): restore call when blind transfer target declines`**
- `__onCallSignalingEventNotifyRefer`: exhaustive switch on `ReferNotifyState` sealed class
  - `ReferAccepted` → end original call (C connected via transfer)
  - `ReferFailed` → clear transfer state, unhold call, show `BlindTransferFailedNotification`
  - `ReferProvisional` → no-op (C still ringing)
- Added `BlindTransferFailedNotification` + l10n strings (EN / UK / IT)

**`refactor(signaling): replace ReferNotifyState enum with sealed class`**
- `ReferNotifyState` → sealed class with `ReferProvisional(sipCode, reason)`, `ReferAccepted()`, `ReferFailed(sipCode?, reason?)`
- `ReferNotifyState.fromContent()`: parses `SIP/2.0 603 Decline` → `ReferFailed(sipCode: 603, reason: "Decline")`
- Tests expanded: 100 Trying, 200 OK, 603 Decline, 486 Busy Here, 480 Unavailable, malformed (8/8 passing)

## Root Cause

`__onCallSignalingEventNotifyRefer` had a hard guard `if (event.state != ReferNotifyState.ok) return;`. The server sends `SIP/2.0 603 Decline` in the NOTIFY `message/sipfrag` body when C declines. The old `ReferNotifyState` enum mapped every non-2xx code to `unknown`, so the handler returned early — Transfer state was never cleared, call was never unheld, no feedback shown.

## Test Results

- Unit tests: 8/8 passing (sealed class parsing)
- Verified on testenv-domain-05 (correct PortaSwitch): `603 Decline` NOTIFY → unhold request sent within 89ms → call with A restored ✅
- SIP trace logs confirm domain-05 does NOT send BYE to B when C declines (B-A call stays alive)

## Note on domain-12

testenv-domain-12 has two server-side bugs (sends `200 OK` instead of `603 Decline` + sends BYE to B on decline). This client fix does not help domain-12 without a separate PortaSwitch config fix.

## YouTrack

https://youtrack.portaone.com/issue/WT-1393