### PR TITLE
fix(WT-1393): restore call when blind transfer target declines

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1472,10 +1472,22 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> __onCallSignalingEventNotifyRefer(_CallSignalingEventNotifyRefer event, Emitter<CallState> emit) async {
     _logger.fine('_CallSignalingEventNotifyRefer: $event');
     if (event.subscriptionState != SubscriptionState.terminated) return;
-    if (event.state != ReferNotifyState.ok) return;
 
-    // Verifies if the original call line is currently active in the state
-    if (state.activeCalls.any((it) => it.callId == event.callId)) add(CallControlEvent.ended(event.callId));
+    if (event.state == ReferNotifyState.ok) {
+      // Transfer succeeded — end the original call (A is now connected via C)
+      if (state.activeCalls.any((it) => it.callId == event.callId)) add(CallControlEvent.ended(event.callId));
+    } else {
+      // Transfer failed (e.g. C declined) — restore the original call
+      final callId = event.callId;
+      if (state.activeCalls.any((it) => it.callId == callId)) {
+        _logger.warning(
+          '__onCallSignalingEventNotifyRefer: transfer failed (state=${event.state}), restoring call $callId',
+        );
+        emit(state.copyWithMappedActiveCall(callId, (activeCall) => activeCall.copyWith(transfer: null)));
+        await callkeep.setHeld(callId, onHold: false);
+        submitNotification(BlindTransferFailedNotification());
+      }
+    }
   }
 
   Future<void> __onCallSignalingEventNotifyUnknown(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1447,6 +1447,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final transfer = Transfer.transfering(
       fromAttendedTransfer: prev is AttendedTransferTransferSubmitted,
       fromBlindTransfer: prev is BlindTransferTransferSubmitted,
+      toNumber: prev is BlindTransferTransferSubmitted ? prev.toNumber : null,
     );
 
     final callUpdate = call.copyWith(transfer: transfer);
@@ -1477,6 +1478,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       case ReferAccepted():
         if (state.activeCalls.any((it) => it.callId == event.callId)) {
           add(CallControlEvent.ended(event.callId));
+        } else {
+          _logger.fine('__onCallSignalingEventNotifyRefer: ReferAccepted for unknown call ${event.callId}, ignoring');
         }
       case ReferFailed():
         final callId = event.callId;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1473,20 +1473,23 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _logger.fine('_CallSignalingEventNotifyRefer: $event');
     if (event.subscriptionState != SubscriptionState.terminated) return;
 
-    if (event.state == ReferNotifyState.ok) {
-      // Transfer succeeded — end the original call (A is now connected via C)
-      if (state.activeCalls.any((it) => it.callId == event.callId)) add(CallControlEvent.ended(event.callId));
-    } else {
-      // Transfer failed (e.g. C declined) — restore the original call
-      final callId = event.callId;
-      if (state.activeCalls.any((it) => it.callId == callId)) {
-        _logger.warning(
-          '__onCallSignalingEventNotifyRefer: transfer failed (state=${event.state}), restoring call $callId',
-        );
-        emit(state.copyWithMappedActiveCall(callId, (activeCall) => activeCall.copyWith(transfer: null)));
-        await callkeep.setHeld(callId, onHold: false);
-        submitNotification(BlindTransferFailedNotification());
-      }
+    switch (event.state) {
+      case ReferAccepted():
+        if (state.activeCalls.any((it) => it.callId == event.callId)) {
+          add(CallControlEvent.ended(event.callId));
+        }
+      case ReferFailed():
+        final callId = event.callId;
+        if (state.activeCalls.any((it) => it.callId == callId)) {
+          _logger.warning(
+            '__onCallSignalingEventNotifyRefer: transfer failed (${event.state}), restoring call $callId',
+          );
+          emit(state.copyWithMappedActiveCall(callId, (activeCall) => activeCall.copyWith(transfer: null)));
+          await callkeep.setHeld(callId, onHold: false);
+          submitNotification(BlindTransferFailedNotification());
+        }
+      case ReferProvisional():
+        break;
     }
   }
 

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -248,6 +248,13 @@ final class ActiveLineBlindTransferWarningNotification extends MessageNotificati
   }
 }
 
+final class BlindTransferFailedNotification extends MessageNotification {
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.notifications_errorSnackBar_blindTransferFailed;
+  }
+}
+
 @Deprecated.instantiate('will be removed, (see [app/notifications/models/notification.dart] for details)')
 final class CallErrorRegisteringSelfManagedPhoneAccountNotification extends ErrorNotification {
   CallErrorRegisteringSelfManagedPhoneAccountNotification();

--- a/lib/features/call/models/transfer.dart
+++ b/lib/features/call/models/transfer.dart
@@ -21,8 +21,11 @@ class Transfer with _$Transfer {
       AttendedTransferTransferSubmitted;
 
   /// Represents state when server has started to process the transfer
-  const factory Transfer.transfering({required bool fromAttendedTransfer, required bool fromBlindTransfer}) =
-      Transfering;
+  const factory Transfer.transfering({
+    required bool fromAttendedTransfer,
+    required bool fromBlindTransfer,
+    String? toNumber,
+  }) = Transfering;
 
   /// Represents state when server has successfully processed
   /// attended transfer with full flow e.g `refer` or accept request

--- a/lib/features/call/models/transfer.freezed.dart
+++ b/lib/features/call/models/transfer.freezed.dart
@@ -134,13 +134,13 @@ return inviteToAttendedTransfer(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  blindTransferInitiated,TResult Function( String toNumber)?  blindTransferTransferSubmitted,TResult Function( String replaceCallId)?  attendedTransferTransferSubmitted,TResult Function( bool fromAttendedTransfer,  bool fromBlindTransfer)?  transfering,TResult Function( String referId,  String referTo,  String referredBy)?  attendedTransferConfirmationRequested,TResult Function( String replaceCallId,  String referredBy)?  inviteToAttendedTransfer,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  blindTransferInitiated,TResult Function( String toNumber)?  blindTransferTransferSubmitted,TResult Function( String replaceCallId)?  attendedTransferTransferSubmitted,TResult Function( bool fromAttendedTransfer,  bool fromBlindTransfer,  String? toNumber)?  transfering,TResult Function( String referId,  String referTo,  String referredBy)?  attendedTransferConfirmationRequested,TResult Function( String replaceCallId,  String referredBy)?  inviteToAttendedTransfer,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case BlindTransferInitiated() when blindTransferInitiated != null:
 return blindTransferInitiated();case BlindTransferTransferSubmitted() when blindTransferTransferSubmitted != null:
 return blindTransferTransferSubmitted(_that.toNumber);case AttendedTransferTransferSubmitted() when attendedTransferTransferSubmitted != null:
 return attendedTransferTransferSubmitted(_that.replaceCallId);case Transfering() when transfering != null:
-return transfering(_that.fromAttendedTransfer,_that.fromBlindTransfer);case AttendedTransferConfirmationRequested() when attendedTransferConfirmationRequested != null:
+return transfering(_that.fromAttendedTransfer,_that.fromBlindTransfer,_that.toNumber);case AttendedTransferConfirmationRequested() when attendedTransferConfirmationRequested != null:
 return attendedTransferConfirmationRequested(_that.referId,_that.referTo,_that.referredBy);case InviteToAttendedTransfer() when inviteToAttendedTransfer != null:
 return inviteToAttendedTransfer(_that.replaceCallId,_that.referredBy);case _:
   return orElse();
@@ -160,13 +160,13 @@ return inviteToAttendedTransfer(_that.replaceCallId,_that.referredBy);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  blindTransferInitiated,required TResult Function( String toNumber)  blindTransferTransferSubmitted,required TResult Function( String replaceCallId)  attendedTransferTransferSubmitted,required TResult Function( bool fromAttendedTransfer,  bool fromBlindTransfer)  transfering,required TResult Function( String referId,  String referTo,  String referredBy)  attendedTransferConfirmationRequested,required TResult Function( String replaceCallId,  String referredBy)  inviteToAttendedTransfer,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  blindTransferInitiated,required TResult Function( String toNumber)  blindTransferTransferSubmitted,required TResult Function( String replaceCallId)  attendedTransferTransferSubmitted,required TResult Function( bool fromAttendedTransfer,  bool fromBlindTransfer,  String? toNumber)  transfering,required TResult Function( String referId,  String referTo,  String referredBy)  attendedTransferConfirmationRequested,required TResult Function( String replaceCallId,  String referredBy)  inviteToAttendedTransfer,}) {final _that = this;
 switch (_that) {
 case BlindTransferInitiated():
 return blindTransferInitiated();case BlindTransferTransferSubmitted():
 return blindTransferTransferSubmitted(_that.toNumber);case AttendedTransferTransferSubmitted():
 return attendedTransferTransferSubmitted(_that.replaceCallId);case Transfering():
-return transfering(_that.fromAttendedTransfer,_that.fromBlindTransfer);case AttendedTransferConfirmationRequested():
+return transfering(_that.fromAttendedTransfer,_that.fromBlindTransfer,_that.toNumber);case AttendedTransferConfirmationRequested():
 return attendedTransferConfirmationRequested(_that.referId,_that.referTo,_that.referredBy);case InviteToAttendedTransfer():
 return inviteToAttendedTransfer(_that.replaceCallId,_that.referredBy);case _:
   throw StateError('Unexpected subclass');
@@ -185,13 +185,13 @@ return inviteToAttendedTransfer(_that.replaceCallId,_that.referredBy);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  blindTransferInitiated,TResult? Function( String toNumber)?  blindTransferTransferSubmitted,TResult? Function( String replaceCallId)?  attendedTransferTransferSubmitted,TResult? Function( bool fromAttendedTransfer,  bool fromBlindTransfer)?  transfering,TResult? Function( String referId,  String referTo,  String referredBy)?  attendedTransferConfirmationRequested,TResult? Function( String replaceCallId,  String referredBy)?  inviteToAttendedTransfer,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  blindTransferInitiated,TResult? Function( String toNumber)?  blindTransferTransferSubmitted,TResult? Function( String replaceCallId)?  attendedTransferTransferSubmitted,TResult? Function( bool fromAttendedTransfer,  bool fromBlindTransfer,  String? toNumber)?  transfering,TResult? Function( String referId,  String referTo,  String referredBy)?  attendedTransferConfirmationRequested,TResult? Function( String replaceCallId,  String referredBy)?  inviteToAttendedTransfer,}) {final _that = this;
 switch (_that) {
 case BlindTransferInitiated() when blindTransferInitiated != null:
 return blindTransferInitiated();case BlindTransferTransferSubmitted() when blindTransferTransferSubmitted != null:
 return blindTransferTransferSubmitted(_that.toNumber);case AttendedTransferTransferSubmitted() when attendedTransferTransferSubmitted != null:
 return attendedTransferTransferSubmitted(_that.replaceCallId);case Transfering() when transfering != null:
-return transfering(_that.fromAttendedTransfer,_that.fromBlindTransfer);case AttendedTransferConfirmationRequested() when attendedTransferConfirmationRequested != null:
+return transfering(_that.fromAttendedTransfer,_that.fromBlindTransfer,_that.toNumber);case AttendedTransferConfirmationRequested() when attendedTransferConfirmationRequested != null:
 return attendedTransferConfirmationRequested(_that.referId,_that.referTo,_that.referredBy);case InviteToAttendedTransfer() when inviteToAttendedTransfer != null:
 return inviteToAttendedTransfer(_that.replaceCallId,_that.referredBy);case _:
   return null;
@@ -369,11 +369,12 @@ as String,
 
 
 class Transfering extends Transfer {
-  const Transfering({required this.fromAttendedTransfer, required this.fromBlindTransfer}): super._();
+  const Transfering({required this.fromAttendedTransfer, required this.fromBlindTransfer, this.toNumber}): super._();
   
 
  final  bool fromAttendedTransfer;
  final  bool fromBlindTransfer;
+ final  String? toNumber;
 
 /// Create a copy of Transfer
 /// with the given fields replaced by the non-null parameter values.
@@ -385,16 +386,16 @@ $TransferingCopyWith<Transfering> get copyWith => _$TransferingCopyWithImpl<Tran
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Transfering&&(identical(other.fromAttendedTransfer, fromAttendedTransfer) || other.fromAttendedTransfer == fromAttendedTransfer)&&(identical(other.fromBlindTransfer, fromBlindTransfer) || other.fromBlindTransfer == fromBlindTransfer));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Transfering&&(identical(other.fromAttendedTransfer, fromAttendedTransfer) || other.fromAttendedTransfer == fromAttendedTransfer)&&(identical(other.fromBlindTransfer, fromBlindTransfer) || other.fromBlindTransfer == fromBlindTransfer)&&(identical(other.toNumber, toNumber) || other.toNumber == toNumber));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,fromAttendedTransfer,fromBlindTransfer);
+int get hashCode => Object.hash(runtimeType,fromAttendedTransfer,fromBlindTransfer,toNumber);
 
 @override
 String toString() {
-  return 'Transfer.transfering(fromAttendedTransfer: $fromAttendedTransfer, fromBlindTransfer: $fromBlindTransfer)';
+  return 'Transfer.transfering(fromAttendedTransfer: $fromAttendedTransfer, fromBlindTransfer: $fromBlindTransfer, toNumber: $toNumber)';
 }
 
 
@@ -405,7 +406,7 @@ abstract mixin class $TransferingCopyWith<$Res> implements $TransferCopyWith<$Re
   factory $TransferingCopyWith(Transfering value, $Res Function(Transfering) _then) = _$TransferingCopyWithImpl;
 @useResult
 $Res call({
- bool fromAttendedTransfer, bool fromBlindTransfer
+ bool fromAttendedTransfer, bool fromBlindTransfer, String? toNumber
 });
 
 
@@ -422,11 +423,12 @@ class _$TransferingCopyWithImpl<$Res>
 
 /// Create a copy of Transfer
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? fromAttendedTransfer = null,Object? fromBlindTransfer = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? fromAttendedTransfer = null,Object? fromBlindTransfer = null,Object? toNumber = freezed,}) {
   return _then(Transfering(
 fromAttendedTransfer: null == fromAttendedTransfer ? _self.fromAttendedTransfer : fromAttendedTransfer // ignore: cast_nullable_to_non_nullable
 as bool,fromBlindTransfer: null == fromBlindTransfer ? _self.fromBlindTransfer : fromBlindTransfer // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,toNumber: freezed == toNumber ? _self.toNumber : toNumber // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2232,6 +2232,12 @@ abstract class AppLocalizations {
   /// **'You are already on the line with the recipient you are trying to blind transfer to'**
   String get notifications_errorSnackBar_activeLineBlindTransferWarning;
 
+  /// Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Transfer failed, returning to active call'**
+  String get notifications_errorSnackBar_blindTransferFailed;
+
   /// Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -699,6 +699,8 @@ class AppLocalizationsMapper {
       'notifications_errorSnackBar_activeLineBlindTransferWarning':
           localizations
               .notifications_errorSnackBar_activeLineBlindTransferWarning,
+      'notifications_errorSnackBar_blindTransferFailed':
+          localizations.notifications_errorSnackBar_blindTransferFailed,
       'notifications_errorSnackBar_appOffline':
           localizations.notifications_errorSnackBar_appOffline,
       'notifications_errorSnackBar_appOnline':

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1195,6 +1195,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'You are already on the line with the recipient you are trying to blind transfer to';
 
   @override
+  String get notifications_errorSnackBar_blindTransferFailed => 'Transfer failed, returning to active call';
+
+  @override
   String get notifications_errorSnackBar_appOffline => 'Your application is currently offline';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1207,6 +1207,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Sei già in linea con il destinatario a cui stai cercando di trasferire alla cieca';
 
   @override
+  String get notifications_errorSnackBar_blindTransferFailed => 'Trasferimento fallito, ritorno alla chiamata attiva';
+
+  @override
   String get notifications_errorSnackBar_appOffline => 'La tua apllicazione è offline';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1213,6 +1213,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Ви вже на лінії з одержувачем, до якого намагаєтеся здійснити безумовний переказ';
 
   @override
+  String get notifications_errorSnackBar_blindTransferFailed =>
+      'Переадресація не вдалась, повертаємо до активного дзвінка';
+
+  @override
   String get notifications_errorSnackBar_appOffline => 'Ваш застосунок зараз офлайн.';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -999,6 +999,10 @@
   "@notifications_errorSnackBar_activeLineBlindTransferWarning": {
     "description": "Shown in a notification or snackbar when a user tries to perform a blind transfer to a recipient they are already on the line with. Condition: the active call is with the same recipient as the blind transfer target."
   },
+  "notifications_errorSnackBar_blindTransferFailed": "Transfer failed, returning to active call",
+  "@notifications_errorSnackBar_blindTransferFailed": {
+    "description": "Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen."
+  },
   "notifications_errorSnackBar_appOffline": "Your application is currently offline",
   "@notifications_errorSnackBar_appOffline": {
     "description": "Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -999,6 +999,10 @@
   "@notifications_errorSnackBar_activeLineBlindTransferWarning": {
     "description": "Shown in a notification or snackbar when a user tries to perform a blind transfer to a recipient they are already on the line with. Condition: the active call is with the same recipient as the blind transfer target."
   },
+  "notifications_errorSnackBar_blindTransferFailed": "Trasferimento fallito, ritorno alla chiamata attiva",
+  "@notifications_errorSnackBar_blindTransferFailed": {
+    "description": "Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen."
+  },
   "notifications_errorSnackBar_appOffline": "La tua apllicazione è offline",
   "@notifications_errorSnackBar_appOffline": {
     "description": "Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -999,6 +999,10 @@
   "@notifications_errorSnackBar_activeLineBlindTransferWarning": {
     "description": "Shown in a notification or snackbar when a user tries to perform a blind transfer to a recipient they are already on the line with. Condition: the active call is with the same recipient as the blind transfer target."
   },
+  "notifications_errorSnackBar_blindTransferFailed": "Переадресація не вдалась, повертаємо до активного дзвінка",
+  "@notifications_errorSnackBar_blindTransferFailed": {
+    "description": "Shown when a blind transfer fails because the transfer target declined. The original call is restored and the user is returned to the active call screen."
+  },
   "notifications_errorSnackBar_appOffline": "Ваш застосунок зараз офлайн.",
   "@notifications_errorSnackBar_appOffline": {
     "description": "Shown in a notification or snackbar when the application is offline. Condition: the app loses connection to the server or network and cannot perform online actions."

--- a/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/notify_event.dart
@@ -35,7 +35,82 @@ sealed class NotifyEvent extends CallEvent {
   }
 }
 
-enum ReferNotifyState { trying, ok, unknown }
+// ---------------------------------------------------------------------------
+// ReferNotifyState — sealed class preserving the SIP response code
+// ---------------------------------------------------------------------------
+
+sealed class ReferNotifyState {
+  const ReferNotifyState();
+
+  factory ReferNotifyState.fromContent(String content) {
+    final match = RegExp(r'SIP/2\.0\s+(\d{3})\s*(.*)').firstMatch(content.trim());
+    if (match == null) return const ReferFailed(sipCode: null, reason: null);
+
+    final code = int.parse(match.group(1)!);
+    final reason = match.group(2)!.trim();
+
+    return switch (code) {
+      >= 100 && < 200 => ReferProvisional(sipCode: code, reason: reason),
+      >= 200 && < 300 => const ReferAccepted(),
+      _ => ReferFailed(sipCode: code, reason: reason),
+    };
+  }
+}
+
+/// Transfer is in progress — target is ringing (1xx provisional).
+final class ReferProvisional extends ReferNotifyState {
+  const ReferProvisional({required this.sipCode, required this.reason});
+
+  final int sipCode;
+  final String reason;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ReferProvisional && sipCode == other.sipCode && reason == other.reason;
+
+  @override
+  int get hashCode => Object.hash(sipCode, reason);
+
+  @override
+  String toString() => 'ReferProvisional($sipCode $reason)';
+}
+
+/// Transfer succeeded — target accepted (2xx).
+final class ReferAccepted extends ReferNotifyState {
+  const ReferAccepted();
+
+  @override
+  bool operator ==(Object other) => other is ReferAccepted;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'ReferAccepted()';
+}
+
+/// Transfer failed — target rejected (3xx–6xx) or content was malformed.
+/// [sipCode] is null only when the NOTIFY body could not be parsed.
+final class ReferFailed extends ReferNotifyState {
+  const ReferFailed({required this.sipCode, required this.reason});
+
+  final int? sipCode;
+  final String? reason;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ReferFailed && sipCode == other.sipCode && reason == other.reason;
+
+  @override
+  int get hashCode => Object.hash(sipCode, reason);
+
+  @override
+  String toString() => sipCode != null ? 'ReferFailed($sipCode $reason)' : 'ReferFailed(malformed)';
+}
+
+// ---------------------------------------------------------------------------
+// ReferNotifyEvent
+// ---------------------------------------------------------------------------
 
 class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
   const ReferNotifyEvent({
@@ -55,20 +130,16 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
     'notify': notifyValue,
     if (subscriptionState != null) 'subscription_state': subscriptionState!.name,
     'content': switch (state) {
-      ReferNotifyState.trying => 'SIP/2.0 100 Trying',
-      ReferNotifyState.ok => 'SIP/2.0 200 OK',
-      ReferNotifyState.unknown => '',
+      ReferProvisional(:final sipCode, :final reason) => 'SIP/2.0 $sipCode $reason',
+      ReferAccepted() => 'SIP/2.0 200 OK',
+      ReferFailed(:final sipCode?, :final reason?) => 'SIP/2.0 $sipCode $reason',
+      ReferFailed() => '',
     },
   };
 
   @override
   factory ReferNotifyEvent.fromJson(Map<String, dynamic> json) {
     final contentStr = json['content'] as String;
-    final state = switch (contentStr) {
-      String s when s.startsWith('SIP/2.0 100') => ReferNotifyState.trying,
-      String s when s.contains('200 OK') => ReferNotifyState.ok,
-      _ => ReferNotifyState.unknown,
-    };
 
     return ReferNotifyEvent(
       transaction: json['transaction'],
@@ -77,7 +148,7 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
       subscriptionState: json['subscription_state'] != null
           ? SubscriptionState.values.byName(json['subscription_state'])
           : null,
-      state: state,
+      state: ReferNotifyState.fromContent(contentStr),
     );
   }
 
@@ -90,6 +161,10 @@ class ReferNotifyEvent extends NotifyEvent with EquatableMixin {
         'subscriptionState: $subscriptionState, state: $state}';
   }
 }
+
+// ---------------------------------------------------------------------------
+// UnknownNotifyEvent
+// ---------------------------------------------------------------------------
 
 class UnknownNotifyEvent extends NotifyEvent with EquatableMixin {
   const UnknownNotifyEvent({

--- a/packages/webtrit_signaling/test/src/events/call/notify_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/notify_event_test.dart
@@ -15,8 +15,10 @@ void main() {
     });
   }
 
+  // --- ReferProvisional (1xx) ---
+
   testFromJson(
-    '$NotifyEvent fromJson 1',
+    'ReferNotifyEvent: 100 Trying → ReferProvisional',
     json.decode(r'''
     {
       "transaction": "transaction 1",
@@ -35,12 +37,12 @@ void main() {
       line: 0,
       callId: 'qwerty',
       subscriptionState: SubscriptionState.active,
-      state: ReferNotifyState.trying,
+      state: const ReferProvisional(sipCode: 100, reason: 'Trying'),
     ),
   );
 
   testFromJson(
-    '$NotifyEvent fromJson 2',
+    'ReferNotifyEvent: 100 Trying without transaction → ReferProvisional',
     json.decode(r'''
     {
       "line": 0,
@@ -57,11 +59,135 @@ void main() {
       line: 0,
       callId: 'qwerty',
       subscriptionState: SubscriptionState.active,
-      state: ReferNotifyState.trying,
+      state: const ReferProvisional(sipCode: 100, reason: 'Trying'),
     ),
   );
 
-  test('$NotifyEvent fromJson error', () {
+  // --- ReferAccepted (2xx) ---
+
+  testFromJson(
+    'ReferNotifyEvent: 200 OK → ReferAccepted',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 200 OK"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferAccepted(),
+    ),
+  );
+
+  // --- ReferFailed (non-2xx) ---
+
+  testFromJson(
+    'ReferNotifyEvent: 603 Decline → ReferFailed',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 603 Decline"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: 603, reason: 'Decline'),
+    ),
+  );
+
+  testFromJson(
+    'ReferNotifyEvent: 486 Busy Here → ReferFailed',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 486 Busy Here"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: 486, reason: 'Busy Here'),
+    ),
+  );
+
+  testFromJson(
+    'ReferNotifyEvent: 480 Temporarily Unavailable → ReferFailed',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": "SIP/2.0 480 Temporarily Unavailable"
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: 480, reason: 'Temporarily Unavailable'),
+    ),
+  );
+
+  testFromJson(
+    'ReferNotifyEvent: empty content → ReferFailed (malformed)',
+    json.decode(r'''
+    {
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "event": "notify",
+      "notify": "refer",
+      "subscription_state": "terminated",
+      "content_type": "message/sipfrag",
+      "content": ""
+    }
+    ''')
+        as Map<String, dynamic>,
+    ReferNotifyEvent(
+      transaction: 'transaction 1',
+      line: 0,
+      callId: 'qwerty',
+      subscriptionState: SubscriptionState.terminated,
+      state: const ReferFailed(sipCode: null, reason: null),
+    ),
+  );
+
+  test('NotifyEvent fromJson error on empty event', () {
     expect(() => NotifyEvent.fromJson(json.decode(eventJsonEmpty) as Map<String, dynamic>), throwsA(isArgumentError));
   });
 }


### PR DESCRIPTION
## Summary

Fixes WT-1393: transferor (B) stuck on processing screen indefinitely when transfer target (C) declines a blind transfer.

- Replaces `ReferNotifyState` enum with a sealed class hierarchy that preserves the SIP response code
- Adds exhaustive `switch` handler in `CallBloc` — `ReferFailed` now clears Transfer state, unholds the call, and shows a snackbar
- Preserves `toNumber` through the `Transfering` state transition

## Changes

**`fix(call): restore call when blind transfer target declines`**
- `__onCallSignalingEventNotifyRefer`: exhaustive switch on `ReferNotifyState` sealed class
  - `ReferAccepted` → end original call (C connected via transfer)
  - `ReferFailed` → clear transfer state, unhold call, show `BlindTransferFailedNotification`
  - `ReferProvisional` → no-op (C still ringing)
- Added `BlindTransferFailedNotification` + l10n strings (EN / UK / IT)

**`refactor(signaling): replace ReferNotifyState enum with sealed class`**
- `ReferNotifyState` → sealed class with `ReferProvisional(sipCode, reason)`, `ReferAccepted()`, `ReferFailed(sipCode?, reason?)`
- `ReferNotifyState.fromContent()`: parses `SIP/2.0 603 Decline` → `ReferFailed(sipCode: 603, reason: "Decline")`
- Tests: 100 Trying, 200 OK, 603 Decline, 486 Busy Here, 480 Unavailable, malformed (8/8 passing)

**`refactor(call): preserve toNumber in Transfering state and log ReferAccepted miss`**
- `Transfer.transfering` now carries optional `toNumber`, propagated from `BlindTransferTransferSubmitted` on `TransferringEvent`
- `ReferAccepted` case: logs `fine` when callId is not found in `activeCalls` instead of silently dropping

## Root Cause

`__onCallSignalingEventNotifyRefer` had a hard guard `if (event.state != ReferNotifyState.ok) return;`. The server sends `SIP/2.0 603 Decline` in the NOTIFY `message/sipfrag` body when C declines. The old `ReferNotifyState` enum mapped every non-2xx code to `unknown`, so the handler returned early — Transfer state was never cleared, call was never unheld, no feedback shown.
