### PR TITLE
chore(signaling): diagnostic logs for silent executeDartCallback failure (WT-1373)

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -64,6 +64,10 @@ class FlutterEngineHelper(
             }
 
             hasInvalidHandle = false
+            Log.d(TAG, "executeDartCallback: handle=$callbackHandle " +
+                "library=${callbackInformation.callbackLibraryPath} " +
+                "function=${callbackInformation.callbackEntrypointFunctionName} " +
+                "class=${callbackInformation.callbackEntrypointFunctionClass}")
             // automaticallyRegisterPlugins=false: prevents GeneratedPluginRegistrant from
             // registering all app plugins (AudioSessionPlugin, FlutterWebRTCPlugin, etc.)
             // on this background FGS engine. On Android 16 REMOTE_MESSAGING services,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/isolate/entry_point.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
 import 'package:logging_appenders/logging_appenders.dart';
@@ -18,6 +19,7 @@ final _logger = Logger('SignalingEntryPoint');
 /// [PSignalingServiceHostApi.initializeServiceCallback].
 @pragma('vm:entry-point')
 void signalingServiceCallbackDispatcher() {
+  debugPrint('[FGS-ISOLATE] signalingServiceCallbackDispatcher: entry');
   hierarchicalLoggingEnabled = true;
   Logger.root.level = Level.ALL;
   PrintAppender(formatter: const ColorFormatter()).attachToLogger(Logger.root);


### PR DESCRIPTION
## Problem

On Samsung SM-M325FV Android 13, `signalingServiceCallbackDispatcher` never executes after FGS restart in `pushBound` mode. This manifests as 8+ consecutive cycles of:

```
FlutterEngine initialized and attached successfully
wireUpPigeon: registering Pigeon channels on FGS engine
synchronizeIsolate attempt=1/6
[NEVER] signalingServiceCallbackDispatcher: background isolate starting
attempt 1 failed: Unable to establish connection on channel: PSignalingServiceFlutterApi.onSynchronize
```

`executeDartCallback` is called without a Java exception, but the Dart isolate never starts. The failure is silent at the JNI layer. Previous fixes (thread starvation, bare FlutterJNI, auto-plugin registration) do not address this.

## This PR

Two temporary canary logs to narrow down the root cause:

**`FlutterEngineHelper.kt`** — logs the AOT symbol that Dart VM will attempt to execute:
```
executeDartCallback: handle=<N> library=<path> function=<name> class=<class>
```
Confirms whether `callbackEntrypointFunctionName` resolves to `signalingServiceCallbackDispatcher` or something unexpected.

**`entry_point.dart`** — `debugPrint` as the absolute first instruction, bypassing the Logger:
```
[FGS-ISOLATE] signalingServiceCallbackDispatcher: entry
```
If this line appears → isolate starts but something after it fails.
If this line is absent → failure is confirmed before any Dart code runs (JNI/AOT level).

## Next steps

After capturing a new logcat on the affected device, these logs will give the definitive answer. This branch will be closed and replaced with the actual fix.

## Affected files

- `webtrit_signaling_service_android/android/.../FlutterEngineHelper.kt`
- `webtrit_signaling_service_android/lib/src/isolate/entry_point.dart`