### PR TITLE
fix(signaling): use callbackName instead of non-existent callbackEntrypointFunctionName

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -66,8 +66,7 @@ class FlutterEngineHelper(
             hasInvalidHandle = false
             Log.d(TAG, "executeDartCallback: handle=$callbackHandle " +
                 "library=${callbackInformation.callbackLibraryPath} " +
-                "function=${callbackInformation.callbackEntrypointFunctionName} " +
-                "class=${callbackInformation.callbackEntrypointFunctionClass}")
+                "function=${callbackInformation.callbackName}")
             // automaticallyRegisterPlugins=false: prevents GeneratedPluginRegistrant from
             // registering all app plugins (AudioSessionPlugin, FlutterWebRTCPlugin, etc.)
             // on this background FGS engine. On Android 16 REMOTE_MESSAGING services,


### PR DESCRIPTION
## Problem

`FlutterCallbackInformation` on Android does not have `callbackEntrypointFunctionName` or `callbackEntrypointFunctionClass` — those are iOS-specific fields. The diagnostic log added in #1187 caused a compilation error:

```
Unresolved reference 'callbackEntrypointFunctionName'
Unresolved reference 'callbackEntrypointFunctionClass'
```

## Fix

Replace with the correct Android field `callbackName`.

Before:
```kotlin
Log.d(TAG, "executeDartCallback: handle=$callbackHandle " +
    "library=${callbackInformation.callbackLibraryPath} " +
    "function=${callbackInformation.callbackEntrypointFunctionName} " +
    "class=${callbackInformation.callbackEntrypointFunctionClass}")
```

After:
```kotlin
Log.d(TAG, "executeDartCallback: handle=$callbackHandle " +
    "library=${callbackInformation.callbackLibraryPath} " +
    "function=${callbackInformation.callbackName}")
```

## Related

Followup fix for #1187.