### PR TITLE
chore: suppress deprecated_subclass warnings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,8 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "build/**"
+  errors:
+    deprecated_subclass: ignore
     
 formatter:
   page_width: 120


### PR DESCRIPTION
## Summary
- Adds `deprecated_subclass: ignore` to `analysis_options.yaml`
- Suppresses IDE and `flutter analyze` warnings for subclasses of `ErrorNotification` which is annotated with `@Deprecated.subclass(...)`
- Affects only own-package deprecations (`lib/features/call/models/notification.dart`)

## Test plan
- [x] `flutter analyze` produces no `deprecated_subclass` warnings