### PR TITLE
fix(fgs): migrate background engine to sibling-isolate spawn

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,8 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "build/**"
+  errors:
+    deprecated_subclass: ignore
     
 formatter:
   page_width: 120

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import android.util.Log
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.embedding.engine.dart.DartExecutor.DartCallback
+import io.flutter.embedding.engine.FlutterEngineGroup
+import io.flutter.embedding.engine.dart.DartExecutor.DartEntrypoint
 import io.flutter.view.FlutterCallbackInformation
 
 class FlutterEngineHelper(
@@ -64,28 +65,34 @@ class FlutterEngineHelper(
             }
 
             hasInvalidHandle = false
-            Log.d(TAG, "executeDartCallback: handle=$callbackHandle " +
+            Log.d(TAG, "makeEngine: handle=$callbackHandle " +
                 "library=${callbackInformation.callbackLibraryPath} " +
                 "function=${callbackInformation.callbackName}")
-            // automaticallyRegisterPlugins=false: prevents GeneratedPluginRegistrant from
-            // registering all app plugins (AudioSessionPlugin, FlutterWebRTCPlugin, etc.)
-            // on this background FGS engine. On Android 16 REMOTE_MESSAGING services,
-            // audio/hardware init in onAttachedToEngine can block the Dart VM from running
-            // the background entry point. Only the two Pigeon channels set up manually
-            // in onStartCommand are needed here.
-            // FlutterJNI is obtained via FlutterInjector so DI overrides are respected,
-            // matching the internal behaviour of the 1-arg FlutterEngine constructor.
-            backgroundEngine = FlutterEngine(context.applicationContext, null, FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI(), null, false).also { engine ->
-                val dartCallback = DartCallback(
-                    context.assets,
-                    flutterLoader.findAppBundlePath(),
-                    callbackInformation,
-                )
-                engine.dartExecutor.executeDartCallback(dartCallback)
-                engine.serviceControlSurface.attachToService(service, null, true)
-                isEngineAttached = true
-                Log.d(TAG, "FlutterEngine initialized and attached successfully")
-            }
+
+            // Use FlutterEngineGroup so the background isolate shares the process-wide Dart
+            // VM rather than attempting to spawn an independent root isolate via
+            // executeDartCallback. On some Samsung Android 13 devices, executeDartCallback
+            // silently fails to start the Dart isolate when the main FlutterEngine is already
+            // running in the same process (multi-engine conflict at the Dart VM level).
+            // FlutterEngineGroup.createAndRunEngine uses FlutterJNI.spawn() for all but the
+            // first engine, which creates a proper child isolate that reliably starts alongside
+            // the main engine's isolate.
+            // Options.setAutomaticallyRegisterPlugins(false) keeps audio/hardware plugins from
+            // blocking the Dart VM on Android 16+ REMOTE_MESSAGING services.
+            val dartEntrypoint = DartEntrypoint(
+                flutterLoader.findAppBundlePath(),
+                callbackInformation.callbackName,
+            )
+            val options = FlutterEngineGroup.Options(context.applicationContext)
+                .setDartEntrypoint(dartEntrypoint)
+                .setAutomaticallyRegisterPlugins(false)
+            backgroundEngine = getOrCreateEngineGroup(context)
+                .createAndRunEngine(options)
+                .also { engine ->
+                    engine.serviceControlSurface.attachToService(service, null, true)
+                    isEngineAttached = true
+                    Log.d(TAG, "FlutterEngine initialized and attached successfully")
+                }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize FlutterEngine", e)
         }
@@ -107,5 +114,15 @@ class FlutterEngineHelper(
 
     companion object {
         private const val TAG = "FlutterEngineHelper"
+
+        @Volatile
+        private var engineGroup: FlutterEngineGroup? = null
+
+        // Double-checked locking: engineGroup is written once and only read afterwards,
+        // so the volatile + synchronized pair is safe without a full lock on every read.
+        private fun getOrCreateEngineGroup(context: Context): FlutterEngineGroup =
+            engineGroup ?: synchronized(this) {
+                engineGroup ?: FlutterEngineGroup(context.applicationContext).also { engineGroup = it }
+            }
     }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -143,11 +143,11 @@ class FlutterEngineHelper(
             parent,
             context,
             entrypoint,
-            null,  // initialRoute
-            null,  // dartEntrypointArgs
-            null,  // platformViewsController
-            false, // automaticallyRegisterPlugins
-            false, // waitForRestorationData
+            null,                        // initialRoute
+            null,                        // dartEntrypointArgs
+            PlatformViewsController(),   // must be non-null — FlutterEngine constructor dereferences it
+            false,                       // automaticallyRegisterPlugins
+            false,                       // waitForRestorationData
         ) as FlutterEngine
     }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -13,6 +13,7 @@ class FlutterEngineHelper(
     private val context: Context,
     private val callbackHandle: Long,
     private val service: android.app.Service,
+    private val mainEngineProvider: () -> FlutterEngine?,
 ) {
     var backgroundEngine: FlutterEngine? = null
         private set
@@ -92,7 +93,7 @@ class FlutterEngineHelper(
             //
             // FlutterEngine.spawn() is package-private; reflection is used to reach it
             // from outside io.flutter.embedding.engine.
-            val mainEngine = WebtritSignalingServicePlugin.mainFlutterEngine
+            val mainEngine = mainEngineProvider()
             backgroundEngine = if (mainEngine != null && mainEngine.dartExecutor.isExecutingDart) {
                 Log.d(TAG, "Spawning background engine from main engine (sibling isolate)")
                 spawnFromEngine(mainEngine, dartEntrypoint)

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -6,6 +6,7 @@ import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterEngineGroup
 import io.flutter.embedding.engine.dart.DartExecutor.DartEntrypoint
+import io.flutter.plugin.platform.PlatformViewsController
 import io.flutter.view.FlutterCallbackInformation
 
 class FlutterEngineHelper(
@@ -69,31 +70,44 @@ class FlutterEngineHelper(
                 "library=${callbackInformation.callbackLibraryPath} " +
                 "function=${callbackInformation.callbackName}")
 
-            // Use FlutterEngineGroup so the background isolate shares the process-wide Dart
-            // VM rather than attempting to spawn an independent root isolate via
-            // executeDartCallback. On some Samsung Android 13 devices, executeDartCallback
-            // silently fails to start the Dart isolate when the main FlutterEngine is already
-            // running in the same process (multi-engine conflict at the Dart VM level).
-            // FlutterEngineGroup.createAndRunEngine uses FlutterJNI.spawn() for all but the
-            // first engine, which creates a proper child isolate that reliably starts alongside
-            // the main engine's isolate.
-            // Options.setAutomaticallyRegisterPlugins(false) keeps audio/hardware plugins from
-            // blocking the Dart VM on Android 16+ REMOTE_MESSAGING services.
             val dartEntrypoint = DartEntrypoint(
                 flutterLoader.findAppBundlePath(),
                 callbackInformation.callbackLibraryPath,
                 callbackInformation.callbackName,
             )
-            val options = FlutterEngineGroup.Options(context.applicationContext)
-                .setDartEntrypoint(dartEntrypoint)
-                .setAutomaticallyRegisterPlugins(false)
-            backgroundEngine = getOrCreateEngineGroup(context)
-                .createAndRunEngine(options)
-                .also { engine ->
-                    engine.serviceControlSurface.attachToService(service, null, true)
-                    isEngineAttached = true
-                    Log.d(TAG, "FlutterEngine initialized and attached successfully")
-                }
+
+            // If the main engine is running, spawn a child isolate from it.
+            //
+            // FlutterEngineGroup.createAndRunEngine uses FlutterJNI.spawn() only for
+            // non-first engines. For the first engine it falls back to
+            // executeDartEntrypoint, which calls Dart_LookupLibrary("package:...") on a
+            // fresh isolate group — this lookup fails in AOT mode because package URIs are
+            // not registered in a newly created group. Spawn from the main engine bypasses
+            // that lookup: it creates a sibling isolate in the existing Dart VM where the
+            // library table is already populated.
+            //
+            // When no main engine is present (e.g. push-notification cold start), the
+            // FlutterEngineGroup fallback is safe: there is no existing root isolate so
+            // executeDartEntrypoint can create one without conflict.
+            //
+            // FlutterEngine.spawn() is package-private; reflection is used to reach it
+            // from outside io.flutter.embedding.engine.
+            val mainEngine = WebtritSignalingServicePlugin.mainFlutterEngine
+            backgroundEngine = if (mainEngine != null && mainEngine.dartExecutor.isExecutingDart) {
+                Log.d(TAG, "Spawning background engine from main engine (sibling isolate)")
+                spawnFromEngine(mainEngine, dartEntrypoint)
+            } else {
+                Log.d(TAG, "No active main engine — creating via FlutterEngineGroup (root isolate)")
+                getOrCreateEngineGroup(context).createAndRunEngine(
+                    FlutterEngineGroup.Options(context.applicationContext)
+                        .setDartEntrypoint(dartEntrypoint)
+                        .setAutomaticallyRegisterPlugins(false)
+                )
+            }.also { engine ->
+                engine.serviceControlSurface.attachToService(service, null, true)
+                isEngineAttached = true
+                Log.d(TAG, "FlutterEngine initialized and attached successfully")
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize FlutterEngine", e)
         }
@@ -111,6 +125,30 @@ class FlutterEngineHelper(
         backgroundEngine = null
         isEngineAttached = false
         Log.d(TAG, "FlutterEngine detached and destroyed")
+    }
+
+    private fun spawnFromEngine(parent: FlutterEngine, entrypoint: DartEntrypoint): FlutterEngine {
+        val spawnMethod = FlutterEngine::class.java.getDeclaredMethod(
+            "spawn",
+            Context::class.java,
+            DartEntrypoint::class.java,
+            String::class.java,
+            List::class.java,
+            PlatformViewsController::class.java,
+            Boolean::class.javaPrimitiveType,
+            Boolean::class.javaPrimitiveType,
+        )
+        spawnMethod.isAccessible = true
+        return spawnMethod.invoke(
+            parent,
+            context,
+            entrypoint,
+            null,  // initialRoute
+            null,  // dartEntrypointArgs
+            null,  // platformViewsController
+            false, // automaticallyRegisterPlugins
+            false, // waitForRestorationData
+        ) as FlutterEngine
     }
 
     companion object {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -81,6 +81,7 @@ class FlutterEngineHelper(
             // blocking the Dart VM on Android 16+ REMOTE_MESSAGING services.
             val dartEntrypoint = DartEntrypoint(
                 flutterLoader.findAppBundlePath(),
+                callbackInformation.callbackLibraryPath,
                 callbackInformation.callbackName,
             )
             val options = FlutterEngineGroup.Options(context.applicationContext)

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -95,8 +95,20 @@ class FlutterEngineHelper(
             // from outside io.flutter.embedding.engine.
             val mainEngine = mainEngineProvider()
             backgroundEngine = if (mainEngine != null && mainEngine.dartExecutor.isExecutingDart) {
-                Log.d(TAG, "Spawning background engine from main engine (sibling isolate)")
-                spawnFromEngine(mainEngine, dartEntrypoint)
+                try {
+                    Log.d(TAG, "Spawning background engine from main engine (sibling isolate)")
+                    spawnFromEngine(mainEngine, dartEntrypoint)
+                } catch (e: ReflectiveOperationException) {
+                    // spawn() is package-private and its signature may change across Flutter
+                    // upgrades. Fall back to FlutterEngineGroup so the service does not enter
+                    // a WorkManager restart loop on a signature mismatch.
+                    Log.e(TAG, "spawn() reflection failed — falling back to FlutterEngineGroup", e)
+                    getOrCreateEngineGroup(context).createAndRunEngine(
+                        FlutterEngineGroup.Options(context.applicationContext)
+                            .setDartEntrypoint(dartEntrypoint)
+                            .setAutomaticallyRegisterPlugins(false)
+                    )
+                }
             } else {
                 Log.d(TAG, "No active main engine — creating via FlutterEngineGroup (root isolate)")
                 getOrCreateEngineGroup(context).createAndRunEngine(
@@ -128,6 +140,8 @@ class FlutterEngineHelper(
         Log.d(TAG, "FlutterEngine detached and destroyed")
     }
 
+    // Verified against flutter_embedding 3.32.4 (FlutterEngine.java).
+    // Re-verify after any Flutter SDK upgrade: search for 'fun spawn' in FlutterEngine.java.
     private fun spawnFromEngine(parent: FlutterEngine, entrypoint: DartEntrypoint): FlutterEngine {
         val spawnMethod = FlutterEngine::class.java.getDeclaredMethod(
             "spawn",
@@ -146,15 +160,24 @@ class FlutterEngineHelper(
             entrypoint,
             null,                        // initialRoute
             null,                        // dartEntrypointArgs
-            PlatformViewsController(),   // must be non-null — FlutterEngine constructor dereferences it
+            // Must be non-null: FlutterEngine constructor calls getRegistry() on this at
+            // line 392 without a null check. This instance is intentionally not attached
+            // to any surface — the background engine runs headless inside a Service.
+            PlatformViewsController(),
             false,                       // automaticallyRegisterPlugins
             false,                       // waitForRestorationData
-        ) as FlutterEngine
+        ) as? FlutterEngine
+            ?: throw IllegalStateException("FlutterEngine.spawn() returned null")
     }
 
     companion object {
         private const val TAG = "FlutterEngineHelper"
 
+        // Process-lifetime singleton: FlutterEngineGroup is designed to be reused across
+        // multiple createAndRunEngine calls. Persisting it means repeated FGS restarts
+        // (crashes, WorkManager retries) share the same group, which is correct — each
+        // call creates a new engine/isolate inside the existing group rather than
+        // re-initialising the Dart VM from scratch.
         @Volatile
         private var engineGroup: FlutterEngineGroup? = null
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHelper.kt
@@ -94,15 +94,16 @@ class FlutterEngineHelper(
             // FlutterEngine.spawn() is package-private; reflection is used to reach it
             // from outside io.flutter.embedding.engine.
             val mainEngine = mainEngineProvider()
-            backgroundEngine = if (mainEngine != null && mainEngine.dartExecutor.isExecutingDart) {
+            val engine = if (mainEngine != null && mainEngine.dartExecutor.isExecutingDart) {
                 try {
                     Log.d(TAG, "Spawning background engine from main engine (sibling isolate)")
                     spawnFromEngine(mainEngine, dartEntrypoint)
-                } catch (e: ReflectiveOperationException) {
-                    // spawn() is package-private and its signature may change across Flutter
-                    // upgrades. Fall back to FlutterEngineGroup so the service does not enter
-                    // a WorkManager restart loop on a signature mismatch.
-                    Log.e(TAG, "spawn() reflection failed — falling back to FlutterEngineGroup", e)
+                } catch (e: Exception) {
+                    // Catches ReflectiveOperationException (signature mismatch after Flutter
+                    // upgrade) and IllegalStateException (spawn() returned null). Both are
+                    // non-fatal: fall back to FlutterEngineGroup so the service does not enter
+                    // a WorkManager restart loop.
+                    Log.e(TAG, "spawn() failed — falling back to FlutterEngineGroup", e)
                     getOrCreateEngineGroup(context).createAndRunEngine(
                         FlutterEngineGroup.Options(context.applicationContext)
                             .setDartEntrypoint(dartEntrypoint)
@@ -116,11 +117,15 @@ class FlutterEngineHelper(
                         .setDartEntrypoint(dartEntrypoint)
                         .setAutomaticallyRegisterPlugins(false)
                 )
-            }.also { engine ->
-                engine.serviceControlSurface.attachToService(service, null, true)
-                isEngineAttached = true
-                Log.d(TAG, "FlutterEngine initialized and attached successfully")
             }
+            // Assign backgroundEngine only after a successful attach so that
+            // detachAndDestroyEngine() always has a reference to clean up. If
+            // attachToService() throws, the engine is not stored and the outer
+            // catch handles cleanup — no leak.
+            engine.serviceControlSurface.attachToService(service, null, true)
+            isEngineAttached = true
+            backgroundEngine = engine
+            Log.d(TAG, "FlutterEngine initialized and attached successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize FlutterEngine", e)
         }
@@ -167,7 +172,7 @@ class FlutterEngineHelper(
             false,                       // automaticallyRegisterPlugins
             false,                       // waitForRestorationData
         ) as? FlutterEngine
-            ?: throw IllegalStateException("FlutterEngine.spawn() returned null")
+            ?: throw IllegalStateException("FlutterEngine.spawn() returned null — caught by caller fallback")
     }
 
     companion object {
@@ -178,6 +183,8 @@ class FlutterEngineHelper(
         // (crashes, WorkManager retries) share the same group, which is correct — each
         // call creates a new engine/isolate inside the existing group rather than
         // re-initialising the Dart VM from scratch.
+        // Note: if the group itself enters a bad internal state the only recovery path
+        // is a process restart — there is no mechanism to replace it mid-process.
         @Volatile
         private var engineGroup: FlutterEngineGroup? = null
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHolder.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHolder.kt
@@ -1,0 +1,16 @@
+package com.webtrit.signaling_service
+
+import io.flutter.embedding.engine.FlutterEngine
+
+/// Holds a reference to whichever [FlutterEngine] most recently attached
+/// [WebtritSignalingServicePlugin]. Used by [FlutterEngineHelper] to spawn
+/// the background isolate as a sibling of an already-running Dart VM instead
+/// of creating a new root isolate (which fails in AOT when a VM already exists).
+///
+/// Any engine — main UI engine, push-notification handler engine, or any other —
+/// that registers the plugin qualifies. The only requirement at spawn time is
+/// that [FlutterEngine.dartExecutor.isExecutingDart] returns true.
+internal object FlutterEngineHolder {
+    @Volatile
+    var runningEngine: FlutterEngine? = null
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHolder.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/FlutterEngineHolder.kt
@@ -10,6 +10,13 @@ import io.flutter.embedding.engine.FlutterEngine
 /// Any engine — main UI engine, push-notification handler engine, or any other —
 /// that registers the plugin qualifies. The only requirement at spawn time is
 /// that [FlutterEngine.dartExecutor.isExecutingDart] returns true.
+///
+/// Thread safety: [runningEngine] is read and written only from
+/// [WebtritSignalingServicePlugin.onAttachedToEngine] /
+/// [WebtritSignalingServicePlugin.onDetachedFromEngine], both of which run on
+/// the main thread. [FlutterEngineHelper.initializeFlutterEngine] also reads it
+/// on the main thread (posted via Handler). @Volatile covers the rare case
+/// where another thread reads before the main-thread write is visible.
 internal object FlutterEngineHolder {
     @Volatile
     var runningEngine: FlutterEngine? = null

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -557,9 +557,11 @@ class SignalingForegroundService : Service() {
         /// How long [gracefulStop] waits for an isolate ACK before forcing the stop.
         private const val _gracefulStopTimeoutMs = 3000L
 
-        /// Mirrors Drift's completer.future.timeout(30s): if no successful sync is
-        /// received within this window, the service stops so WorkManager can retry.
-        private const val _startupWatchdogTimeoutMs = 30_000L
+        /// If no successful sync is received within this window, the service stops
+        /// so WorkManager / HubConnectionManager can retry. With the spawn-from-main-engine
+        /// path, the isolate starts in 1-3s; 10s gives enough margin for loaded devices
+        /// while reducing user-visible wait time from ~30s to ~10s on failure.
+        private const val _startupWatchdogTimeoutMs = 10_000L
 
         @Volatile var isRunning = false
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -110,7 +110,10 @@ class SignalingForegroundService : Service() {
         Log.d(TAG, "SignalingForegroundService onCreate")
         instance = this
         val callbackHandle = StorageDelegate.getCallbackDispatcher(applicationContext)
-        flutterEngineHelper = FlutterEngineHelper(applicationContext, callbackHandle, this)
+        flutterEngineHelper = FlutterEngineHelper(
+            applicationContext, callbackHandle, this,
+            mainEngineProvider = { FlutterEngineHolder.runningEngine },
+        )
         isRunning = true
     }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -32,11 +32,13 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         context = binding.applicationContext
+        mainFlutterEngine = binding.flutterEngine
         PSignalingServiceHostApi.setUp(binding.binaryMessenger, this)
         Log.d(TAG, "WebtritSignalingServicePlugin attached")
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        if (mainFlutterEngine === binding.flutterEngine) mainFlutterEngine = null
         PSignalingServiceHostApi.setUp(binding.binaryMessenger, null)
         Log.d(TAG, "WebtritSignalingServicePlugin detached")
     }
@@ -139,6 +141,12 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
 
     companion object {
         private const val TAG = "WebtritSignalingServicePlugin"
+
+        /// The main app [FlutterEngine], set in [onAttachedToEngine] and cleared in
+        /// [onDetachedFromEngine]. Used by [FlutterEngineHelper] to spawn the background
+        /// engine as a child isolate instead of creating a new root isolate.
+        @Volatile
+        internal var mainFlutterEngine: io.flutter.embedding.engine.FlutterEngine? = null
 
         /// True when [stopService] was called while [SignalingForegroundService.onCreate]
         /// had not yet run. In that window, calling [SignalingForegroundService.stop]

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -32,13 +32,13 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         context = binding.applicationContext
-        mainFlutterEngine = binding.flutterEngine
+        FlutterEngineHolder.runningEngine = binding.flutterEngine
         PSignalingServiceHostApi.setUp(binding.binaryMessenger, this)
         Log.d(TAG, "WebtritSignalingServicePlugin attached")
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        if (mainFlutterEngine === binding.flutterEngine) mainFlutterEngine = null
+        if (FlutterEngineHolder.runningEngine === binding.flutterEngine) FlutterEngineHolder.runningEngine = null
         PSignalingServiceHostApi.setUp(binding.binaryMessenger, null)
         Log.d(TAG, "WebtritSignalingServicePlugin detached")
     }
@@ -141,12 +141,6 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
 
     companion object {
         private const val TAG = "WebtritSignalingServicePlugin"
-
-        /// The main app [FlutterEngine], set in [onAttachedToEngine] and cleared in
-        /// [onDetachedFromEngine]. Used by [FlutterEngineHelper] to spawn the background
-        /// engine as a child isolate instead of creating a new root isolate.
-        @Volatile
-        internal var mainFlutterEngine: io.flutter.embedding.engine.FlutterEngine? = null
 
         /// True when [stopService] was called while [SignalingForegroundService.onCreate]
         /// had not yet run. In that window, calling [SignalingForegroundService.stop]

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub_connection_manager.dart
@@ -36,7 +36,7 @@ class HubConnectionManager {
     this.pingInterval = const Duration(seconds: 15),
     this.pongTimeout = const Duration(seconds: 2),
     this.stalePortThreshold = 3,
-    this.noPortTimeout = const Duration(seconds: 15),
+    this.noPortTimeout = const Duration(seconds: 8),
     this.onServiceDead,
   }) : _onEvent = onEvent,
        _onError = onError,


### PR DESCRIPTION
Re-opening #1191 as draft for further investigation and testing.

Original fix: spawn background engine as sibling isolate from main engine to avoid root-isolate conflict in AOT mode.