### PR TITLE
fix(call): skip ICE restart for calls without initialized PeerConnection (WT-1401)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -558,7 +558,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           );
           continue;
         }
-        _logger.info('_onConnectivityResultChanged: restarting ICE for call ${activeCall.callId} ');
+        _logger.info(
+          '_onConnectivityResultChanged: restarting ICE for call ${activeCall.callId} (status: ${activeCall.processingStatus})',
+        );
         final pc = await _peerConnectionManager.retrieve(activeCall.callId);
         pc?.restartIce();
       }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -552,7 +552,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       //  - in double network scenario (e.g already has mobile network, but also connected to wifi)
       //    it helps to switch to better network instead of staying on old until rtp breaks.
       for (var activeCall in state.activeCalls) {
-        if (!activeCall.processingStatus.hasPeerConnectionReady) continue;
+        if (!activeCall.processingStatus.hasPeerConnectionReady) {
+          _logger.info(
+            '_onConnectivityResultChanged: skipping ICE restart for call ${activeCall.callId} — PC not ready (status: ${activeCall.processingStatus})',
+          );
+          continue;
+        }
         _logger.info('_onConnectivityResultChanged: restarting ICE for call ${activeCall.callId} ');
         final pc = await _peerConnectionManager.retrieve(activeCall.callId);
         pc?.restartIce();

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -552,6 +552,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       //  - in double network scenario (e.g already has mobile network, but also connected to wifi)
       //    it helps to switch to better network instead of staying on old until rtp breaks.
       for (var activeCall in state.activeCalls) {
+        if (!activeCall.processingStatus.hasPeerConnectionReady) continue;
         _logger.info('_onConnectivityResultChanged: restarting ICE for call ${activeCall.callId} ');
         final pc = await _peerConnectionManager.retrieve(activeCall.callId);
         pc?.restartIce();

--- a/lib/features/call/models/processing_status.dart
+++ b/lib/features/call/models/processing_status.dart
@@ -26,4 +26,11 @@ enum CallProcessingStatus {
     CallProcessingStatus.outgoingInitializingMedia,
     CallProcessingStatus.outgoingOfferPreparing,
   }.contains(this);
+
+  bool get hasPeerConnectionReady => const {
+    CallProcessingStatus.outgoingOfferSent,
+    CallProcessingStatus.outgoingRinging,
+    CallProcessingStatus.connected,
+    CallProcessingStatus.disconnecting,
+  }.contains(this);
 }

--- a/lib/features/call/models/processing_status.dart
+++ b/lib/features/call/models/processing_status.dart
@@ -31,6 +31,5 @@ enum CallProcessingStatus {
     CallProcessingStatus.outgoingOfferSent,
     CallProcessingStatus.outgoingRinging,
     CallProcessingStatus.connected,
-    CallProcessingStatus.disconnecting,
   }.contains(this);
 }

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -214,7 +214,6 @@ void main() {
       CallProcessingStatus.outgoingOfferSent,
       CallProcessingStatus.outgoingRinging,
       CallProcessingStatus.connected,
-      CallProcessingStatus.disconnecting,
     };
 
     for (final status in CallProcessingStatus.values) {

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -206,6 +206,25 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // CallProcessingStatus.hasPeerConnectionReady
+  // ---------------------------------------------------------------------------
+
+  group('CallProcessingStatus.hasPeerConnectionReady', () {
+    const readyStates = {
+      CallProcessingStatus.outgoingOfferSent,
+      CallProcessingStatus.outgoingRinging,
+      CallProcessingStatus.connected,
+      CallProcessingStatus.disconnecting,
+    };
+
+    for (final status in CallProcessingStatus.values) {
+      test('$status → ${readyStates.contains(status)}', () {
+        expect(status.hasPeerConnectionReady, readyStates.contains(status));
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
   // Transfer state machine
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `hasPeerConnectionReady` getter to `CallProcessingStatus` — returns `true` only for states where `PeerConnectionManager.complete()` is guaranteed to have been called (`outgoingOfferSent`, `outgoingRinging`, `connected`, `disconnecting`)
- Guards `_onConnectivityResultChanged` ICE restart loop with this check — calls without a ready PC are skipped with an INFO log instead of blocking 5 s and throwing `TimeoutException`

## Problem

`_onConnectivityResultChanged` called `PeerConnectionManager.retrieve()` unconditionally for all active calls. For calls in pre-PC states (e.g. `outgoingConnectingToSignaling`) the completer was never completed — `retrieve()` blocked for 5 s, threw `TimeoutException` with rethrow, which broke the entire handler loop: remaining calls never got ICE restart and the `emit()` at the bottom never ran.
