### PR TITLE
fix(WT-1398): distinguish stale track error from permission denial

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2166,7 +2166,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
       add(_ResetStateEvent.completeCall(event.callId, endReason: CallkeepEndCallReason.failed));
 
-      submitNotification(const CallUserMediaErrorNotification());
+      if (e is UserMediaTrackSetupError) {
+        submitNotification(const CallMediaTrackSetupErrorNotification());
+      } else {
+        submitNotification(const CallUserMediaErrorNotification());
+      }
       return;
     }
 

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -82,6 +82,18 @@ final class CallUserMediaErrorNotification extends MessageNotification {
   }
 }
 
+final class CallMediaTrackSetupErrorNotification extends MessageNotification {
+  const CallMediaTrackSetupErrorNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.notifications_errorSnackBar_callMediaTrackSetup;
+  }
+
+  @override
+  SnackBarAction? action(BuildContext context) => null;
+}
+
 @Deprecated.instantiate('will be removed, (see [app/notifications/models/notification.dart] for details)')
 final class CallSdpConfigurationErrorNotification extends ErrorNotification {
   CallSdpConfigurationErrorNotification();

--- a/lib/features/call/utils/call_error_reporter.dart
+++ b/lib/features/call/utils/call_error_reporter.dart
@@ -45,6 +45,10 @@ class DefaultCallErrorReporter implements CallErrorReporter {
       submitNotification(const CallServiceBusyLineNotification());
       return;
     }
+    if (error is UserMediaTrackSetupError) {
+      submitNotification(const CallMediaTrackSetupErrorNotification());
+      return;
+    }
     if (error is UserMediaError) {
       submitNotification(const CallUserMediaErrorNotification());
       return;

--- a/lib/features/call/utils/call_error_reporter.dart
+++ b/lib/features/call/utils/call_error_reporter.dart
@@ -46,6 +46,7 @@ class DefaultCallErrorReporter implements CallErrorReporter {
       return;
     }
     if (error is UserMediaTrackSetupError) {
+      _logger.warning('[$context] MediaStreamAddTrack failed (stale track): $error', error, stack);
       submitNotification(const CallMediaTrackSetupErrorNotification());
       return;
     }

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
@@ -140,6 +141,9 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
       await stream?.dispose();
 
       if (e is UserMediaError) rethrow;
+      if (e is PlatformException && e.code == 'mediaStreamAddTrack') {
+        throw UserMediaTrackSetupError(e.toString());
+      }
       throw UserMediaError(e.toString());
     }
   }
@@ -267,6 +271,15 @@ class UserMediaError implements Exception {
 
   @override
   String toString() => 'UserMediaError: $message';
+}
+
+/// Thrown when a native media track cannot be added to a local stream.
+///
+/// Distinct from [UserMediaError]: the cause is a stale or invalidated native
+/// track reference, not a permission denial. Does not warrant showing
+/// "check permissions" to the user.
+final class UserMediaTrackSetupError extends UserMediaError {
+  UserMediaTrackSetupError(super.message);
 }
 
 class _PooledTrack {

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2298,6 +2298,12 @@ abstract class AppLocalizations {
   /// **'No idle lines to initiate the call'**
   String get notifications_errorSnackBar_callUndefinedLine;
 
+  /// Shown when a call fails due to an internal media track error, not a permission denial. Typical cause: a native audio/video track reference was invalidated after a previous call was cleaned up. No action to open Settings.
+  ///
+  /// In en, this message translates to:
+  /// **'Call setup failed, please try again'**
+  String get notifications_errorSnackBar_callMediaTrackSetup;
+
   /// Shown in a notification or snackbar when the app cannot access camera or microphone required for a call. Context: occurs when getUserMedia or platform permission check fails; typical causes include the user denying camera/microphone permission, OS-level restriction or revoked permission, missing runtime permission (Android), or the device hardware being busy or unavailable.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1231,6 +1231,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notifications_errorSnackBar_callUndefinedLine => 'No idle lines to initiate the call';
 
   @override
+  String get notifications_errorSnackBar_callMediaTrackSetup => 'Call setup failed, please try again';
+
+  @override
   String get notifications_errorSnackBar_callUserMedia => 'No access to media input, please check app permissions';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1247,6 +1247,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get notifications_errorSnackBar_callUndefinedLine => 'Nessuna linea disponibile per avviare una chiamata';
 
   @override
+  String get notifications_errorSnackBar_callMediaTrackSetup => 'Configurazione chiamata fallita, riprova';
+
+  @override
   String get notifications_errorSnackBar_callUserMedia =>
       'Nessun accesso al server multimediale, controlla le autorizzazioni dell\'app';
 

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1251,6 +1251,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get notifications_errorSnackBar_callUndefinedLine => 'Немає вільних ліній для ініціювання дзвінка';
 
   @override
+  String get notifications_errorSnackBar_callMediaTrackSetup => 'Не вдалося налаштувати дзвінок, спробуйте ще раз';
+
+  @override
   String get notifications_errorSnackBar_callUserMedia =>
       'Немає доступу до медіа-входу, будь ласка, перевірте дозволи застосунку';
 

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1043,6 +1043,10 @@
   "@notifications_errorSnackBar_callUndefinedLine": {
     "description": "Shown in a snackbar when the user attempts to start a call but there is no outbound line available. Context: occurs at call initiation when no SIP/VoIP line is assigned or registered, all lines are disabled or busy, or the line was removed/disabled by an administrator; typical causes: unassigned or unregistered SIP line, account/line disabled, or concurrent channel limits."
   },
+  "notifications_errorSnackBar_callMediaTrackSetup": "Call setup failed, please try again",
+  "@notifications_errorSnackBar_callMediaTrackSetup": {
+    "description": "Shown when a call fails due to an internal media track error, not a permission denial. Typical cause: a native audio/video track reference was invalidated after a previous call was cleaned up. No action to open Settings."
+  },
   "notifications_errorSnackBar_callUserMedia": "No access to media input, please check app permissions",
   "@notifications_errorSnackBar_callUserMedia": {
     "description": "Shown in a notification or snackbar when the app cannot access camera or microphone required for a call. Context: occurs when getUserMedia or platform permission check fails; typical causes include the user denying camera/microphone permission, OS-level restriction or revoked permission, missing runtime permission (Android), or the device hardware being busy or unavailable."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1043,6 +1043,10 @@
   "@notifications_errorSnackBar_callUndefinedLine": {
     "description": "Shown in a snackbar when the user attempts to start a call but there is no outbound line available. Context: occurs at call initiation when no SIP/VoIP line is assigned or registered, all lines are disabled or busy, or the line was removed/disabled by an administrator; typical causes: unassigned or unregistered SIP line, account/line disabled, or concurrent channel limits."
   },
+  "notifications_errorSnackBar_callMediaTrackSetup": "Configurazione chiamata fallita, riprova",
+  "@notifications_errorSnackBar_callMediaTrackSetup": {
+    "description": "Shown when a call fails due to an internal media track error, not a permission denial. Typical cause: a native audio/video track reference was invalidated after a previous call was cleaned up. No action to open Settings."
+  },
   "notifications_errorSnackBar_callUserMedia": "Nessun accesso al server multimediale, controlla le autorizzazioni dell'app",
   "@notifications_errorSnackBar_callUserMedia": {
     "description": "Shown in a notification or snackbar when the app cannot access camera or microphone required for a call. Context: occurs when getUserMedia or platform permission check fails; typical causes include the user denying camera/microphone permission, OS-level restriction or revoked permission, missing runtime permission (Android), or the device hardware being busy or unavailable."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1043,6 +1043,10 @@
   "@notifications_errorSnackBar_callUndefinedLine": {
     "description": "Shown in a snackbar when the user attempts to start a call but there is no outbound line available. Context: occurs at call initiation when no SIP/VoIP line is assigned or registered, all lines are disabled or busy, or the line was removed/disabled by an administrator; typical causes: unassigned or unregistered SIP line, account/line disabled, or concurrent channel limits."
   },
+  "notifications_errorSnackBar_callMediaTrackSetup": "Не вдалося налаштувати дзвінок, спробуйте ще раз",
+  "@notifications_errorSnackBar_callMediaTrackSetup": {
+    "description": "Shown when a call fails due to an internal media track error, not a permission denial. Typical cause: a native audio/video track reference was invalidated after a previous call was cleaned up. No action to open Settings."
+  },
   "notifications_errorSnackBar_callUserMedia": "Немає доступу до медіа-входу, будь ласка, перевірте дозволи застосунку",
   "@notifications_errorSnackBar_callUserMedia": {
     "description": "Shown in a notification or snackbar when the app cannot access camera or microphone required for a call. Context: occurs when getUserMedia or platform permission check fails; typical causes include the user denying camera/microphone permission, OS-level restriction or revoked permission, missing runtime permission (Android), or the device hardware being busy or unavailable."


### PR DESCRIPTION
## Summary

- Introduces `UserMediaTrackSetupError extends UserMediaError` — thrown specifically when `PlatformException.code == 'mediaStreamAddTrack'` in `DefaultUserMediaBuilder._acquirePooledStream`
- Adds `CallMediaTrackSetupErrorNotification` with message "Call setup failed, please try again" and no `openAppSettings` action
- Handles the new type in `CallBloc.__onCallPerformEventStarted` and `DefaultCallErrorReporter` before the existing `UserMediaError` check (subclass must precede parent)
- Adds l10n strings for EN / UK / IT

## Context

WT-1398: when a consultation call is declined and retried, the pooled native audio/video track may be invalidated during cleanup of the first call. The resulting `PlatformException(mediaStreamAddTrack: Track is nil)` was previously shown to the user as **"No access to media input, please check app permissions"** with a "Check" button that opens Settings — misleading because permissions are not the cause.

This fix corrects the user-facing message. The underlying pool root cause (track invalidated by `stream.dispose()` in iOS flutter-webrtc) is tracked separately.

Covers both iOS ("Track is nil") and Android ("track is null") — same `PlatformException.code = 'mediaStreamAddTrack'` on both platforms (see also WT-1389).
