### PR TITLE
fix(user-media-builder): detach pooled tracks before stream dispose to prevent native eviction

### DIFF
--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -105,11 +105,29 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
     final lease = _borrowedStreams.remove(stream.id);
 
     if (lease != null) {
+      // Detach pooled tracks from the stream before disposing it.
+      // On iOS and Android, streamDispose iterates stream.audioTracks /
+      // stream.videoTracks and removes each from the native localTracks
+      // registry. If a track is still referenced by another active call
+      // (references > 1), removing it from the stream first prevents
+      // streamDispose from evicting it — mediaStreamRemoveTrack does not
+      // touch localTracks, only the stream's own track list.
+      await _detachIfStillPooled(stream, lease.audioTrackId, _audioTrack);
+      await _detachIfStillPooled(stream, lease.videoTrackId, _videoTrack);
       await _releaseAudioTrack(lease.audioTrackId);
       await _releaseVideoTrack(lease.videoTrackId);
     }
 
     await stream.dispose();
+  }
+
+  Future<void> _detachIfStillPooled(MediaStream stream, String? trackId, _PooledTrack? pooled) async {
+    if (trackId == null || pooled == null || pooled.track.id != trackId) return;
+    // references <= 1 means this is the last holder — _releaseAudioTrack /
+    // _releaseVideoTrack will stop and dispose the track anyway, so there
+    // is no need to detach it from the stream beforehand.
+    if (pooled.references <= 1) return;
+    await stream.removeTrack(pooled.track);
   }
 
   Future<MediaStream> _acquirePooledStream({required bool resolvedVideo, bool? frontCamera}) async {

--- a/test/features/call/utils/user_media_builder_test.dart
+++ b/test/features/call/utils/user_media_builder_test.dart
@@ -33,6 +33,7 @@ class _TestMediaStreamFactory {
         videoTracks.add(track);
       }
     });
+    when(() => stream.removeTrack(any())).thenAnswer((_) async {});
     when(() => stream.dispose()).thenAnswer((_) async {});
 
     streams.add(stream);
@@ -135,6 +136,27 @@ void main() {
       verify(() => videoTrack.stop()).called(1);
       verify(() => audioSourceStream.dispose()).called(1);
       verify(() => videoSourceStream.dispose()).called(1);
+    });
+
+    test('detaches pooled tracks from stream before dispose when another borrower exists', () async {
+      final subject = builder();
+      final stream1 = await subject.build(video: true);
+      final stream2 = await subject.build(video: true);
+
+      // Releasing stream1 while stream2 still holds refs — tracks must be
+      // detached from stream1 so streamDispose does not evict them from the
+      // native localTracks registry.
+      await subject.release(stream1);
+
+      final localStream1 = localStreamFactory.streams[0];
+      verify(() => localStream1.removeTrack(audioTrack)).called(1);
+      verify(() => localStream1.removeTrack(videoTrack)).called(1);
+
+      // Releasing the last borrower — detach is skipped (tracks are stopped anyway).
+      await subject.release(stream2);
+
+      final localStream2 = localStreamFactory.streams[1];
+      verifyNever(() => localStream2.removeTrack(any()));
     });
   });
 


### PR DESCRIPTION
## Problem

WT-1398 Part 2 — root cause fix.

When a consultation call ends, `DefaultUserMediaBuilder.release()` calls `stream.dispose()` directly. On both iOS (`streamDispose` in `FlutterWebRTCPlugin.m`) and Android (`streamDispose` in `MethodCallHandlerImpl.java`), this iterates `stream.audioTracks` / `stream.videoTracks` and removes each track ID from the native `localTracks` registry.

If the same track is still referenced by the main call (pool `references > 1`), its entry in `localTracks` gets evicted. The next call attempt then does `addTrack` → `trackForId` returns `nil` → `PlatformException(mediaStreamAddTrack, Track is nil)`.

## Fix

Added `_detachIfStillPooled` to `release()`:
- Calls `stream.removeTrack(pooled.track)` **before** `dispose()` when `references > 1`
- `mediaStreamRemoveTrack` (both platforms) removes the track only from the stream's own track list — it does **not** touch `localTracks`
- So `streamDispose` no longer sees the track and skips eviction
- When `references <= 1` the track is being stopped and disposed anyway, so detach is skipped
