### PR TITLE
fix(call): do not queue decline when accept transaction times out (WT-1397)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2468,7 +2468,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // If the WS was already closed when the answer flow failed, the server-side
       // call session is gone — sending DeclineRequest on the reconnected WS would
       // target a stale call and trigger another 4610 close.
-      if (e is WebtritSignalingTransactionTerminateByDisconnectException) {
+      //
+      // A transaction timeout (retries exhausted while the network was degraded)
+      // is treated the same way: the server may have already processed the accept
+      // SDP and promoted the call to connected state, so sending decline would
+      // silently kill an active call. The handshake processor handles the correct
+      // action on the next reconnect — restoring the call if the server accepted
+      // it, or re-delivering the incoming call event if it did not.
+      if (e is WebtritSignalingTransactionTerminateByDisconnectException ||
+          e is WebtritSignalingTransactionTimeoutException) {
         callErrorReporter.handle(e, stackTrace, '__onCallPerformEventAnswered error:');
         return;
       }


### PR DESCRIPTION
## Root cause (WT-1397)

```
1. User answers incoming call → accept SDP sent
2. Network is degraded → accept retries exhaust (WebtritSignalingTransactionTimeoutException)
3. call_bloc queues a decline in SharedPreferences
4. Signaling reconnects → HandshakeProcessor replays the queued decline
5. Server (which DID receive the accept) terminates the active call
→ Call drops silently; user answered but gets nothing
```

## Fix

`call_bloc.dart`: treat `WebtritSignalingTransactionTimeoutException` the same as
`WebtritSignalingTransactionTerminateByDisconnectException` when the accept transaction
fails — do not queue a decline.

Both exceptions mean the client lost the acknowledgement, not that the accept failed.
The server may have already processed the accept SDP even though no acknowledgement
was received. Queuing a decline in either case silently kills an active call on the
next reconnect.

On reconnect the HandshakeProcessor already handles the correct outcome:
- server has `AcceptedEvent` → `RestoreCallAction` → call restored
- server has no `AcceptedEvent` → `HandleIncomingCallAction` → call rings again
