### PR TITLE
fix(signaling): throw WebtritSignalingTransactionTimeoutException from Hub execute timeout

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -124,7 +124,7 @@ class SignalingHubClient {
 
   /// Routes a [Request] through the hub's WebSocket connection.
   ///
-  /// Throws [TimeoutException] if no reply arrives within [_executeTimeout].
+  /// Throws [WebtritSignalingTransactionTimeoutException] if no reply arrives within [_executeTimeout].
   /// This handles the edge case where the subscriber unsubscribes between
   /// sending the exec command and the hub sending a reply -- without a timeout
   /// the completer would hang indefinitely.
@@ -139,7 +139,11 @@ class SignalingHubClient {
       _executeTimeout,
       onTimeout: () {
         _pendingExecutions.remove(corrId);
-        throw TimeoutException('Hub execute timed out for corr=$corrId', _executeTimeout);
+        // Throw WebtritSignalingTransactionTimeoutException so callers (e.g.
+        // __onCallPerformEventAnswered) can treat this the same as a signaling-
+        // layer timeout: the server may have received the request but the
+        // response was lost — sending a decline would kill an active call.
+        throw const WebtritSignalingTransactionTimeoutException(0, 'hub-execute-timeout');
       },
     );
   }


### PR DESCRIPTION
## Problem

`SignalingHubClient.execute()` had a 15s safety timer that threw `dart:async TimeoutException` on expiry. On Android, all signaling requests go through the Hub layer, so this was the exception callers actually received.

`call_bloc.dart` (`__onCallPerformEventAnswered`) guards against queuing a stale decline:

```dart
if (e is WebtritSignalingTransactionTerminateByDisconnectException ||
    e is WebtritSignalingTransactionTimeoutException) {
  return; // skip decline
}
```

`TimeoutException` is not `WebtritSignalingTransactionTimeoutException` — the guard never matched on Android. The decline was always queued.

## Fix

Throw `WebtritSignalingTransactionTimeoutException` from the Hub safety timer so the existing guard in `call_bloc.dart` catches it correctly on Android.

## Why the Hub has its own timer

`WebtritSignalingClient` has a 10s transaction timeout and **retries**. During retry the Hub waits for a reply indefinitely without its own guard — hence the 15s safety net. Both timers exist for different reasons but must throw the same exception type.

Related: WT-1397