### PR TITLE
fix(signaling): ignore late server ACK for already-timed-out transactions

### DIFF
--- a/packages/webtrit_signaling/AGENTS.md
+++ b/packages/webtrit_signaling/AGENTS.md
@@ -73,7 +73,6 @@ All extend `WebtritSignalingException`:
 - `WebtritSignalingTransactionException` ← abstract base for transaction errors
   - `WebtritSignalingTransactionTimeoutException` — no response within 10 s timeout
     - `WebtritSignalingKeepaliveTransactionTimeoutException` — keepalive timed out
-  - `WebtritSignalingTransactionUnavailableException` — transaction slot unavailable
   - `WebtritSignalingTransactionTerminateException` ← abstract base for terminations
     - `WebtritSignalingTransactionTerminateByDisconnectException` — in-flight transaction cancelled because socket closed
 

--- a/packages/webtrit_signaling/lib/src/exceptions.dart
+++ b/packages/webtrit_signaling/lib/src/exceptions.dart
@@ -65,10 +65,6 @@ class WebtritSignalingKeepaliveTransactionTimeoutException extends WebtritSignal
   const WebtritSignalingKeepaliveTransactionTimeoutException(super.id, super.transactionId);
 }
 
-class WebtritSignalingTransactionUnavailableException extends WebtritSignalingTransactionException {
-  const WebtritSignalingTransactionUnavailableException(super.id, super.transactionId);
-}
-
 abstract class WebtritSignalingTransactionTerminateException extends WebtritSignalingTransactionException {
   const WebtritSignalingTransactionTerminateException(super.id, super.transactionId);
 }

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -206,7 +206,14 @@ class WebtritSignalingClient {
       if (transaction != null) {
         transaction.handleResponse(responseJson);
       } else {
-        _onError(WebtritSignalingTransactionUnavailableException(_id, transactionId), StackTrace.current);
+        // Late server response for a transaction that already timed out and was
+        // removed from the map. This can happen under network congestion when
+        // the server ACK arrives after the client's timeout has fired.
+        // Treating this as a connection error would cause a false-positive
+        // SignalingConnectionFailed and an unnecessary reconnect — ignore it.
+        _logger.warning(
+          '$_id _onMessage: received response for unknown transactionId=$transactionId — ignoring late response',
+        );
       }
     } else if (messageJson.containsKey(Event.typeKey)) {
       final eventJson = messageJson;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -24,7 +24,6 @@ const _executeErrorTypeWebtritSignalingUnknownResponse = 'webtrit_signaling_unkn
 const _executeErrorTypeWebtritSignalingTransactionTimeout = 'webtrit_signaling_transaction_timeout';
 const _executeErrorTypeWebtritSignalingBadState = 'webtrit_signaling_bad_state';
 const _executeErrorTypeWebtritSignalingKeepaliveTransactionTimeout = 'webtrit_signaling_keepalive_transaction_timeout';
-const _executeErrorTypeWebtritSignalingTransactionUnavailable = 'webtrit_signaling_transaction_unavailable';
 const _executeErrorTypeWebtritSignalingTransactionTerminateByDisconnect =
     'webtrit_signaling_transaction_terminate_by_disconnect';
 const _executeErrorIdKey = 'id';
@@ -187,13 +186,6 @@ Object? _encodeExecuteError(Object? error) {
       _executeErrorStateErrorMessageKey: error.error.message.toString(),
     };
   }
-  if (error is WebtritSignalingTransactionUnavailableException) {
-    return {
-      _executeErrorTypeKey: _executeErrorTypeWebtritSignalingTransactionUnavailable,
-      _executeErrorIdKey: error.id,
-      _executeErrorTransactionIdKey: error.transactionId,
-    };
-  }
   if (error is WebtritSignalingTransactionTerminateByDisconnectException) {
     return {
       _executeErrorTypeKey: _executeErrorTypeWebtritSignalingTransactionTerminateByDisconnect,
@@ -265,13 +257,6 @@ Object? _decodeExecuteError(Object? encodedError) {
         return Exception('Malformed webtrit_signaling_bad_state execute payload: $map');
       }
       return WebtritSignalingBadStateException(id, StateError(stateErrorMessage));
-    case _executeErrorTypeWebtritSignalingTransactionUnavailable:
-      final id = map[_executeErrorIdKey] as int?;
-      final transactionId = map[_executeErrorTransactionIdKey] as String?;
-      if (id == null || transactionId == null) {
-        return Exception('Malformed webtrit_signaling_transaction_unavailable execute payload: $map');
-      }
-      return WebtritSignalingTransactionUnavailableException(id, transactionId);
     case _executeErrorTypeWebtritSignalingTransactionTerminateByDisconnect:
       final id = map[_executeErrorIdKey] as int?;
       final transactionId = map[_executeErrorTransactionIdKey] as String?;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/hub/signaling_hub_codec_test.dart
@@ -335,7 +335,6 @@ void main() {
         const WebtritSignalingTransactionTimeoutException(5, 'tx-timeout'),
         WebtritSignalingBadStateException(6, StateError('invalid state')),
         const WebtritSignalingKeepaliveTransactionTimeoutException(7, 'tx-keepalive'),
-        const WebtritSignalingTransactionUnavailableException(8, 'tx-unavailable'),
         const WebtritSignalingTransactionTerminateByDisconnectException(9, 'tx-disconnect', 1001, 'closed'),
       ];
 
@@ -368,9 +367,6 @@ void main() {
           case WebtritSignalingBadStateException source:
             final target = reconstructed as WebtritSignalingBadStateException;
             expect(target.error.message, source.error.message);
-          case WebtritSignalingTransactionUnavailableException source:
-            final target = reconstructed as WebtritSignalingTransactionUnavailableException;
-            expect(target.transactionId, source.transactionId);
           case WebtritSignalingTransactionTerminateByDisconnectException source:
             final target = reconstructed as WebtritSignalingTransactionTerminateByDisconnectException;
             expect(target.transactionId, source.transactionId);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -320,11 +320,6 @@ Matcher _matchesSignalingException(WebtritSignalingException expected) {
       case (WebtritSignalingBadStateException source, WebtritSignalingBadStateException target):
         return target.error.message.toString() == source.error.message.toString();
       case (
-        WebtritSignalingTransactionUnavailableException source,
-        WebtritSignalingTransactionUnavailableException target,
-      ):
-        return target.transactionId == source.transactionId;
-      case (
         WebtritSignalingTransactionTerminateByDisconnectException source,
         WebtritSignalingTransactionTerminateByDisconnectException target,
       ):
@@ -697,7 +692,6 @@ void main() {
         const WebtritSignalingTransactionTimeoutException(5, 'tx-timeout'),
         WebtritSignalingBadStateException(6, StateError('invalid state')),
         const WebtritSignalingKeepaliveTransactionTimeoutException(7, 'tx-keepalive'),
-        const WebtritSignalingTransactionUnavailableException(8, 'tx-unavailable'),
         const WebtritSignalingTransactionTerminateByDisconnectException(9, 'tx-disconnect', 1001, 'closed'),
       ];
 


### PR DESCRIPTION
## Problem

When a signaling transaction (e.g. `AcceptRequest`) times out after 15 s, the client removes it from the `_transactions` map and tears down the call. If the server responds after the timeout 

```
_onError(WebtritSignalingTransactionUnavailableException)
  → SignalingModuleImpl._onError
  → SignalingConnectionFailed  ← false-positive
  → SignalingReconnectController: unnecessary reconnect
  → Crashlytics entry
```

## Root cause

`WebtritSignalingClient._onMessage` treated any response for an unknown `transactionId` as a fatal connection error. A late ACK from the server is not a connection error — it is an expected outcome when the server is slow under load or network congestion.

## Fix

Two changes:

1. Replace the `_onError` call in the `else` branch of `_onMessage` with a `_logger.warning`. A late response is now a no-op: the signaling connection stays alive, no reconnect is triggered, and no Crashlytics entry is generated.

2. Remove `WebtritSignalingTransactionUnavailableException` — the class, its hub codec encode/decode branches, the wire-format constant, and all test references.

## Impact

- Signaling connection survives a late server ACK after transaction timeout
- No false-positive `SignalingConnectionFailed` events
- No unnecessary reconnect that could disrupt other active calls or delay the next incoming call
