### PR TITLE
fix(signaling): align hub execute timeout with full retry cycle

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_client.dart
@@ -10,6 +10,15 @@ import '../constants.dart';
 import 'signaling_hub_codec.dart';
 import 'signaling_hub_command.dart';
 
+// The hub execute timeout must cover the full _executeWithRetry budget:
+// transactionTimeout × (maxRetryCount + 1) + a small overhead buffer.
+// This ensures the hub timeout only fires when the background isolate stops
+// responding entirely (hub death), not during a normal retry cycle.
+Duration _defaultHubExecuteTimeout({
+  Duration transactionTimeout = WebtritSignalingClient.defaultExecuteTransactionTimeoutDuration,
+  int maxRetryCount = SignalingRequestQueue.defaultMaxRetryCount,
+}) => transactionTimeout * (maxRetryCount + 1) + const Duration(seconds: 5);
+
 final _logger = Logger('SignalingHubClient');
 
 /// Client-side counterpart of [SignalingHub].
@@ -35,9 +44,11 @@ class SignalingHubClient {
     required SendPort hubPort,
     required Duration pingInterval,
     required Duration pongTimeout,
+    required Duration executeTimeout,
   }) : _hubPort = hubPort,
        _pingInterval = pingInterval,
-       _pongTimeout = pongTimeout;
+       _pongTimeout = pongTimeout,
+       _executeTimeout = executeTimeout;
 
   /// Returns a [SignalingHubClient] connected to the hub, or null when no
   /// hub is currently registered in [IsolateNameServer].
@@ -45,6 +56,7 @@ class SignalingHubClient {
     String consumerId, {
     Duration pingInterval = const Duration(seconds: 15),
     Duration pongTimeout = const Duration(seconds: 2),
+    Duration? executeTimeout,
   }) {
     final port = IsolateNameServer.lookupPortByName(kSignalingHubPortName);
     if (port == null) return null;
@@ -53,6 +65,7 @@ class SignalingHubClient {
       hubPort: port,
       pingInterval: pingInterval,
       pongTimeout: pongTimeout,
+      executeTimeout: executeTimeout ?? _defaultHubExecuteTimeout(),
     );
   }
 
@@ -60,6 +73,7 @@ class SignalingHubClient {
   final SendPort _hubPort;
   final Duration _pingInterval;
   final Duration _pongTimeout;
+  final Duration _executeTimeout;
   final ReceivePort _receivePort = ReceivePort();
   final _controller = StreamController<SignalingModuleEvent>.broadcast();
   final Map<String, Completer<void>> _pendingExecutions = {};
@@ -208,10 +222,6 @@ class SignalingHubClient {
       _controller.add(event);
     }
   }
-
-  // Slightly longer than WebtritSignalingClient's internal 10 s transaction timeout
-  // so the signaling layer reports the error before this fires.
-  static const _executeTimeout = Duration(seconds: 15);
 
   static int _counter = 0;
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -859,9 +859,12 @@ void main() {
     });
 
     test('incorrect timeout (old behaviour) fires mid-retry when background takes full cycle', () async {
-      // Reproduces the original bug: executeTimeout was only slightly above
-      // transactionTimeout, so it fired between the first attempt timing out
-      // and the first retry completing.
+      // Simulates the observable effect of the original bug: the hub timeout
+      // fires because the background takes as long as the full retry cycle.
+      // The fake client delays execution directly rather than throwing
+      // WebtritSignalingTransactionTimeoutException, so no real retry happens
+      // here — but the proportional invariant (hubTimeout < fullRetryCycle)
+      // that caused the bug is preserved.
       fakeClient.executeDelay = fullRetryCycle;
 
       final client = await _subscribeClient('exec-align-3', executeTimeout: incorrectHubTimeout);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -218,6 +218,7 @@ class _FakeSignalingClient extends Fake implements WebtritSignalingClient {
   bool disconnected = false;
   final List<Request> executed = [];
   Object? executeError;
+  Duration? executeDelay;
 
   @override
   void listen({
@@ -236,6 +237,7 @@ class _FakeSignalingClient extends Fake implements WebtritSignalingClient {
 
   @override
   Future<void> execute(Request request, [Duration? timeout]) async {
+    if (executeDelay != null) await Future<void>.delayed(executeDelay!);
     if (executeError != null) throw executeError!;
     executed.add(request);
   }
@@ -287,8 +289,8 @@ Future<T> _waitFor<T extends SignalingModuleEvent>(Stream<SignalingModuleEvent> 
 
 /// Creates a [SignalingHubClient], awaits the sub-ack, and returns it ready
 /// for use.
-Future<SignalingHubClient> _subscribeClient(String consumerId) async {
-  final client = SignalingHubClient.tryConnect(consumerId);
+Future<SignalingHubClient> _subscribeClient(String consumerId, {Duration? executeTimeout}) async {
+  final client = SignalingHubClient.tryConnect(consumerId, executeTimeout: executeTimeout);
   expect(client, isNotNull, reason: 'Hub must be registered before subscribing');
   final ackFuture = client!.awaitAck(timeout: const Duration(seconds: 2));
   client.start();
@@ -784,6 +786,99 @@ void main() {
       fakeClient.injectDisconnect(1000, 'done');
       await _waitFor<SignalingDisconnected>(hubModule.events);
       expect(hubModule.isConnected, isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Hub execute timeout alignment
+  //
+  // Uses scaled-down durations so tests run fast while preserving the
+  // proportional invariant:
+  //   hubExecuteTimeout >= transactionTimeout × (maxRetryCount + 1)
+  //
+  // transactionTimeout = 50 ms, maxRetryCount = 2
+  // full retry cycle   = 50 ms × 3 = 150 ms
+  // correct timeout    = 150 ms + 20 ms buffer = 170 ms
+  // old (wrong) timeout = 55 ms — just above transactionTimeout, fires mid-retry
+  // -------------------------------------------------------------------------
+
+  group('execute timeout alignment —', () {
+    // Scaled-down durations for fast execution.
+    const transactionTimeout = Duration(milliseconds: 50);
+    const maxRetryCount = 2;
+    final fullRetryCycle = transactionTimeout * (maxRetryCount + 1); // 150 ms
+    final correctHubTimeout = fullRetryCycle + const Duration(milliseconds: 20); // 170 ms
+    final incorrectHubTimeout = transactionTimeout + const Duration(milliseconds: 5); // 55 ms
+
+    late _FakeSignalingClient fakeClient;
+    late _SignalingModule module;
+    late SignalingHub hub;
+
+    setUp(() async {
+      fakeClient = _FakeSignalingClient();
+      module = _buildModule(fakeClient);
+      hub = SignalingHub(module);
+      hub.start();
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    tearDown(() async {
+      fakeClient.executeDelay = null;
+      await hub.dispose();
+      await module.dispose();
+    });
+
+    test('hub timeout fires when background takes longer than executeTimeout', () async {
+      fakeClient.executeDelay = incorrectHubTimeout + const Duration(milliseconds: 50);
+
+      final client = await _subscribeClient('exec-align-1', executeTimeout: incorrectHubTimeout);
+      addTearDown(client.dispose);
+
+      fakeClient.injectHandshake(_kHandshake);
+
+      await expectLater(
+        client.execute(HangupRequest(transaction: 'tx-align-1', line: 0, callId: 'align-1')),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test('hub timeout does not fire when executeTimeout covers full retry cycle', () async {
+      // Background responds within the full retry cycle duration.
+      fakeClient.executeDelay = fullRetryCycle - const Duration(milliseconds: 10);
+
+      final client = await _subscribeClient('exec-align-2', executeTimeout: correctHubTimeout);
+      addTearDown(client.dispose);
+
+      fakeClient.injectHandshake(_kHandshake);
+
+      await expectLater(
+        client.execute(HangupRequest(transaction: 'tx-align-2', line: 0, callId: 'align-2')),
+        completes,
+      );
+    });
+
+    test('incorrect timeout (old behaviour) fires mid-retry when background takes full cycle', () async {
+      // Reproduces the original bug: executeTimeout was only slightly above
+      // transactionTimeout, so it fired between the first attempt timing out
+      // and the first retry completing.
+      fakeClient.executeDelay = fullRetryCycle;
+
+      final client = await _subscribeClient('exec-align-3', executeTimeout: incorrectHubTimeout);
+      addTearDown(client.dispose);
+
+      fakeClient.injectHandshake(_kHandshake);
+
+      await expectLater(
+        client.execute(HangupRequest(transaction: 'tx-align-3', line: 0, callId: 'align-3')),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test('tryConnect accepts custom executeTimeout', () async {
+      final client = SignalingHubClient.tryConnect('exec-align-4', executeTimeout: const Duration(seconds: 60));
+      expect(client, isNotNull);
+      addTearDown(() => client!.dispose());
     });
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -12,7 +12,9 @@ final _logger = Logger('SignalingRequestQueue');
 /// Handles per-request timeouts, execution retries on
 /// [WebtritSignalingTransactionTimeoutException], and bulk failure on dispose.
 class SignalingRequestQueue {
-  SignalingRequestQueue({this.requestTimeout = const Duration(seconds: 30), this.maxRetryCount = 3});
+  static const defaultMaxRetryCount = 3;
+
+  SignalingRequestQueue({this.requestTimeout = const Duration(seconds: 30), this.maxRetryCount = defaultMaxRetryCount});
 
   final Duration requestTimeout;
   final int maxRetryCount;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_request_queue.dart
@@ -12,7 +12,7 @@ final _logger = Logger('SignalingRequestQueue');
 /// Handles per-request timeouts, execution retries on
 /// [WebtritSignalingTransactionTimeoutException], and bulk failure on dispose.
 class SignalingRequestQueue {
-  static const defaultMaxRetryCount = 3;
+  static const int defaultMaxRetryCount = 3;
 
   SignalingRequestQueue({this.requestTimeout = const Duration(seconds: 30), this.maxRetryCount = defaultMaxRetryCount});
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_request_queue_test.dart
@@ -235,4 +235,20 @@ void main() {
       expect(queue.isEmpty, isTrue);
     });
   });
+
+  group('SignalingRequestQueue.defaultMaxRetryCount —', () {
+    test('defaultMaxRetryCount equals 3', () {
+      expect(SignalingRequestQueue.defaultMaxRetryCount, 3);
+    });
+
+    test('default constructor uses defaultMaxRetryCount', () {
+      final queue = SignalingRequestQueue();
+      expect(queue.maxRetryCount, SignalingRequestQueue.defaultMaxRetryCount);
+    });
+
+    test('custom maxRetryCount is respected', () {
+      final queue = SignalingRequestQueue(maxRetryCount: 1);
+      expect(queue.maxRetryCount, 1);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- `SignalingHubClient._executeTimeout` was hardcoded to 15 s, but `SignalingRequestQueue._executeWithRetry` retries up to `maxRetryCount` (3) times on `WebtritSignalingTransactionTimeoutException`, making the real background budget `transactionTimeout × (maxRetryCount + 1) = 40 s`. The hub timeout fired at T+15 s mid-retry, causing the main isolate to receive `TimeoutException` and treat the request as failed (e.g. `wasAccepted == false` → premature `DeclineRequest`).

- `_executeTimeout` is now derived from `_defaultHubExecuteTimeout()` — a top-level function that computes `transactionTimeout × (maxRetryCount + 1) + 5 s` using the same constants as `WebtritSignalingClient` and `SignalingRequestQueue`, so it stays in sync automatically. The default becomes 45 s.

- `SignalingRequestQueue.defaultMaxRetryCount = 3` is extracted as a `static const int` — single source of truth used by both `_defaultHubExecuteTimeout()` and the queue constructor default.

- `SignalingHubClient.tryConnect()` accepts an optional `executeTimeout` parameter for tests that need scaled-down durations.
