### PR TITLE
fix(wt-1416): show caller number instead of Unknown in missed call notification

### DIFF
--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -498,17 +498,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   ///
   /// Priority: signaling caller name → push metadata display name → phone number.
   String? _getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
-    final signalingName = call.username;
-    if (signalingName?.isNotEmpty == true) return signalingName;
-
-    if (_metadata?.callId == event.callId && (_metadata!.displayName?.isNotEmpty ?? false)) {
-      return _metadata!.displayName;
-    }
-
-    final number = call.number;
-    if (number.isNotEmpty) return number;
-
-    return null;
+    final metadataName = _metadata?.callId == event.callId ? _metadata?.displayName : null;
+    return [call.username, metadataName, call.number].firstWhere((s) => s != null && s.isNotEmpty, orElse: () => null);
   }
 }
 

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -280,7 +280,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
         final incomingEventLog = _incomingCallEvents.remove(event.callId);
         _onHangupCall(event, (
           direction: CallDirection.incoming,
-          number: incomingEventLog?.caller ?? _metadata?.handle?.value ?? 'unknown',
+          number: incomingEventLog?.caller ?? _metadata?.handle?.value ?? '',
           video: JsepValue.fromOptional(incomingEventLog?.jsep)?.hasVideo ?? false,
           username: incomingEventLog?.callerDisplayName,
           createdTime: _initialConnectionTime,
@@ -506,7 +506,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     }
 
     final number = call.number;
-    if (number.isNotEmpty && number != 'unknown') return number;
+    if (number.isNotEmpty) return number;
 
     return null;
   }

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -280,7 +280,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
         final incomingEventLog = _incomingCallEvents.remove(event.callId);
         _onHangupCall(event, (
           direction: CallDirection.incoming,
-          number: incomingEventLog?.caller ?? 'unknown',
+          number: incomingEventLog?.caller ?? _metadata?.handle?.value ?? 'unknown',
           video: JsepValue.fromOptional(incomingEventLog?.jsep)?.hasVideo ?? false,
           username: incomingEventLog?.callerDisplayName,
           createdTime: _initialConnectionTime,
@@ -496,8 +496,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
   /// Returns the best available display name for the missed-call notification.
   ///
-  /// Prefers the signaling caller name; falls back to push metadata display
-  /// name if signaling did not provide one.
+  /// Priority: signaling caller name → push metadata display name → phone number.
   String? _getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
     final signalingName = call.username;
     if (signalingName?.isNotEmpty == true) return signalingName;
@@ -506,7 +505,10 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       return _metadata!.displayName;
     }
 
-    return signalingName;
+    final number = call.number;
+    if (number.isNotEmpty && number != 'unknown') return number;
+
+    return null;
   }
 }
 


### PR DESCRIPTION
## Problem

Missed call notification on Android shows **"Unknown"** instead of the caller's phone number (WT-1416, affected: mob/1.15.0).

## Root Cause

In the push isolate, when `HangupEvent` arrives before `IncomingCallEvent` is stored (race condition — push connects after the event passed through the signaling hub), `incomingEventLog` is `null`:

```dart
// before
number: incomingEventLog?.caller ?? 'unknown',
```

`_metadata.handle.value` (populated from FCM push payload before the isolate starts) is always available but was not used as a fallback.

Additionally, `_getDisplayNameForMissedCall()` returned `null` when both signaling and push metadata had no display name, resulting in `null ?? 'Unknown'` in the notification body — even though `call.number` held the real phone number.