### PR TITLE
fix: update call_controller_test for connectivityService dependency

### DIFF
--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -7,16 +7,18 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
-import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
 import 'package:webtrit_phone/models/lines_state.dart';
+import 'package:webtrit_phone/services/connectivity_service.dart';
 
 class _MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {}
 
 class _MockCallRoutingCubit extends MockCubit<CallRoutingState?> implements CallRoutingCubit {}
 
 class _MockNotificationsBloc extends MockBloc<NotificationsEvent, NotificationsState> implements NotificationsBloc {}
+
+class _MockConnectivityService extends Mock implements ConnectivityService {}
 
 class _FakeCallRoutingState extends Fake implements CallRoutingState {
   _FakeCallRoutingState({required this.mainLinesState});
@@ -50,6 +52,7 @@ void main() {
   late _MockCallBloc callBloc;
   late _MockCallRoutingCubit callRoutingCubit;
   late _MockNotificationsBloc notificationsBloc;
+  late _MockConnectivityService connectivityService;
   late CallController controller;
 
   setUpAll(() {
@@ -61,13 +64,17 @@ void main() {
     callBloc = _MockCallBloc();
     callRoutingCubit = _MockCallRoutingCubit();
     notificationsBloc = _MockNotificationsBloc();
+    connectivityService = _MockConnectivityService();
+    when(() => callBloc.add(any())).thenReturn(null);
+    when(() => notificationsBloc.add(any())).thenReturn(null);
+    when(() => connectivityService.connectionStream).thenAnswer((_) => const Stream<bool>.empty());
+    when(() => connectivityService.checkConnection()).thenAnswer((_) async => true);
     controller = CallController(
       callBloc: callBloc,
       callRoutingCubit: callRoutingCubit,
       notificationsBloc: notificationsBloc,
+      connectivityService: connectivityService,
     );
-    when(() => callBloc.add(any())).thenReturn(null);
-    when(() => notificationsBloc.add(any())).thenReturn(null);
   });
 
   group('CallController.createCall', () {
@@ -152,7 +159,7 @@ void main() {
         verifyNever(() => callBloc.add(any()));
       });
 
-      test('submits NoInternetConnectionNotification when routing state does not arrive before timeout', () {
+      test('submits GeneralUnableToCallNotification when routing state does not arrive before timeout', () {
         when(() => callRoutingCubit.state).thenReturn(null);
         whenListen(callRoutingCubit, StreamController<CallRoutingState?>().stream);
 
@@ -162,7 +169,7 @@ void main() {
 
           final captured = verify(() => notificationsBloc.add(captureAny())).captured.single;
           expect(captured, isA<NotificationsSubmitted>());
-          expect((captured as NotificationsSubmitted).notification, isA<NoInternetConnectionNotification>());
+          expect((captured as NotificationsSubmitted).notification, isA<GeneralUnableToCallNotification>());
           verifyNever(() => callBloc.add(any()));
         });
       });


### PR DESCRIPTION
## Summary

- Added `_MockConnectivityService` mock and wired it into `CallController` constructor in tests
- Fixed timeout test: now expects `GeneralUnableToCallNotification` (code changed from `NoInternetConnectionNotification`)
- Removed unused import `app/notifications/models/notification.dart`