### PR TITLE
fix(signaling): fix 8-hour reconnect loop silence on Android FGS (WT-1403)

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -166,11 +166,20 @@ class WebtritSignalingService implements SignalingModule {
   @override
   Future<void>? execute(Request request) {
     if (_isConnected) {
-      return _requestQueue.executeNow(
-        execute: SignalingServicePlatform.instance.execute,
-        request: request,
-        isActive: () => _isConnected,
-      );
+      return _requestQueue
+          .executeNow(
+            execute: SignalingServicePlatform.instance.execute,
+            request: request,
+            isActive: () => _isConnected,
+          )
+          ?.catchError((Object e, StackTrace s) {
+            if (e is NotConnectedException) {
+              _logger.warning('execute: ghost state detected — forcing reconnect', e, s);
+              _isConnected = false;
+              connect();
+            }
+            Error.throwWithStackTrace(e, s);
+          });
     }
     return _requestQueue.enqueue(request);
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -172,7 +172,7 @@ class WebtritSignalingService implements SignalingModule {
             request: request,
             isActive: () => _isConnected,
           )
-          ?.catchError((Object e, StackTrace s) {
+          .catchError((Object e, StackTrace s) {
             if (e is NotConnectedException) {
               _logger.warning('execute: ghost state detected — forcing reconnect', e, s);
               _isConnected = false;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/pubspec.yaml
@@ -34,5 +34,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  fake_async: ^1.3.1
   flutter_lints: ^6.0.0
   plugin_platform_interface: ^2.1.8

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
@@ -18,6 +19,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   final List<SignalingServiceMode> startedModes = [];
   int attachCount = 0;
   final List<Request> executedRequests = [];
+  Object? executeError;
   final List<SignalingServiceMode> updatedModes = [];
   final List<Function> incomingCallHandles = [];
   final List<SignalingModuleFactory> moduleFactories = [];
@@ -43,7 +45,10 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   Future<void> attach() async => attachCount++;
 
   @override
-  Future<void> execute(Request request) async => executedRequests.add(request);
+  Future<void> execute(Request request) async {
+    if (executeError != null) throw executeError!;
+    executedRequests.add(request);
+  }
 
   @override
   Future<void> updateMode(SignalingServiceMode mode) async => updatedModes.add(mode);
@@ -320,6 +325,126 @@ void main() {
     test('restoreService delegates to platform', () async {
       await WebtritSignalingService.restoreService();
       expect(platform.restoreServiceCount, 1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // execute() — ghost state detection (Bug #3 / WT-1403 3rd protection layer)
+  //
+  // "Ghost state": main-isolate _isConnected=true while the FGS SignalingModule
+  // has _client=null. The FGS hub throws NotConnectedException across the
+  // isolate boundary; WebtritSignalingService.execute() detects it, resets
+  // _isConnected, and calls connect() to recover.
+  // -------------------------------------------------------------------------
+
+  group('WebtritSignalingService -- execute() ghost state detection', () {
+    // _executeWithRetry retries NotConnectedException up to maxRetryCount (3)
+    // times with a 2-second backoff. We use fakeAsync to skip those delays.
+    // Total timer budget: 3 retries × 2 s = 6 s → elapse 7 s to be safe.
+
+    test('NotConnectedException resets isConnected to false', () {
+      fakeAsync((async) {
+        final service = WebtritSignalingService(config: _kConfig);
+        service.connect();
+        async.flushMicrotasks();
+        platform.inject(SignalingConnected());
+        async.flushMicrotasks();
+        expect(service.isConnected, isTrue);
+
+        platform.executeError = NotConnectedException('ghost state');
+        final request = HangupRequest(transaction: 'tx-ghost', line: 1, callId: 'call-ghost');
+        service.execute(request)!.ignore();
+
+        async.elapse(const Duration(seconds: 7));
+
+        expect(service.isConnected, isFalse);
+
+        service.dispose();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('NotConnectedException triggers connect() to recover', () {
+      fakeAsync((async) {
+        final service = WebtritSignalingService(config: _kConfig);
+        service.connect();
+        async.flushMicrotasks();
+        expect(platform.startedConfigs, hasLength(1));
+
+        platform.inject(SignalingConnected());
+        async.flushMicrotasks();
+
+        platform.executeError = NotConnectedException('ghost state');
+        final request = HangupRequest(transaction: 'tx-ghost', line: 1, callId: 'call-ghost');
+        service.execute(request)!.ignore();
+
+        async.elapse(const Duration(seconds: 7));
+
+        // connect() was called again after ghost state detected
+        expect(platform.startedConfigs, hasLength(2));
+
+        service.dispose();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('NotConnectedException is rethrown to the caller', () {
+      fakeAsync((async) {
+        final service = WebtritSignalingService(config: _kConfig);
+        platform.inject(SignalingConnected());
+        async.flushMicrotasks();
+
+        platform.executeError = NotConnectedException('ghost state');
+        final request = HangupRequest(transaction: 'tx-ghost', line: 1, callId: 'call-ghost');
+
+        Object? caught;
+        service
+            .execute(request)!
+            .then(
+              (_) {},
+              onError: (Object e, StackTrace _) {
+                caught = e;
+              },
+            );
+
+        async.elapse(const Duration(seconds: 7));
+
+        expect(caught, isA<NotConnectedException>());
+
+        service.dispose();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('successful execute does not trigger reconnect', () async {
+      final service = WebtritSignalingService(config: _kConfig);
+      service.connect();
+      await Future<void>.delayed(Duration.zero);
+      platform.inject(SignalingConnected());
+      await Future<void>.delayed(Duration.zero);
+
+      final request = HangupRequest(transaction: 'tx-1', line: 1, callId: 'call-1');
+      await service.execute(request)!;
+
+      expect(platform.startedConfigs, hasLength(1));
+      await service.dispose();
+    });
+
+    test('non-NotConnectedException is rethrown without triggering reconnect', () async {
+      final service = WebtritSignalingService(config: _kConfig);
+      service.connect();
+      await Future<void>.delayed(Duration.zero);
+      platform.inject(SignalingConnected());
+      await Future<void>.delayed(Duration.zero);
+
+      platform.executeError = Exception('transport error');
+      final request = HangupRequest(transaction: 'tx-1', line: 1, callId: 'call-1');
+
+      await expectLater(service.execute(request)!, throwsA(isA<Exception>()));
+
+      expect(service.isConnected, isTrue);
+      expect(platform.startedConfigs, hasLength(1));
+      await service.dispose();
     });
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub.dart
@@ -314,7 +314,7 @@ class SignalingHub {
   Future<void> _executeAndReply(SendPort replyPort, String correlationId, Map<String, dynamic> reqMap) async {
     try {
       final request = Request.fromJson(reqMap);
-      if (!_signalingModule.isConnected) throw StateError('Signaling not connected');
+      if (!_signalingModule.isConnected) throw NotConnectedException('ghost state: hub isConnected=false');
       await _signalingModule.execute(request)!;
       replyPort.send(encodeExecuteResult(correlationId, null));
     } catch (e) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/hub/signaling_hub_codec.dart
@@ -26,6 +26,7 @@ const _executeErrorTypeWebtritSignalingBadState = 'webtrit_signaling_bad_state';
 const _executeErrorTypeWebtritSignalingKeepaliveTransactionTimeout = 'webtrit_signaling_keepalive_transaction_timeout';
 const _executeErrorTypeWebtritSignalingTransactionTerminateByDisconnect =
     'webtrit_signaling_transaction_terminate_by_disconnect';
+const _executeErrorTypeNotConnected = 'not_connected';
 const _executeErrorIdKey = 'id';
 const _executeErrorCodeKey = 'code';
 const _executeErrorReasonKey = 'reason';
@@ -195,6 +196,9 @@ Object? _encodeExecuteError(Object? error) {
       _executeErrorCloseReasonKey: error.closeReason,
     };
   }
+  if (error is NotConnectedException) {
+    return {_executeErrorTypeKey: _executeErrorTypeNotConnected};
+  }
   return {_executeErrorTypeKey: _executeErrorTypeMessage, _executeErrorReasonKey: error.toString()};
 }
 
@@ -266,6 +270,8 @@ Object? _decodeExecuteError(Object? encodedError) {
         return Exception('Malformed webtrit_signaling_transaction_terminate_by_disconnect execute payload: $map');
       }
       return WebtritSignalingTransactionTerminateByDisconnectException(id, transactionId, closeCode, closeReason);
+    case _executeErrorTypeNotConnected:
+      return NotConnectedException('ghost state: hub not connected');
     case _executeErrorTypeMessage:
       final message = map[_executeErrorReasonKey] as String?;
       return Exception(message ?? 'Unknown execute error');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -134,6 +134,19 @@ class SignalingModuleImpl implements SignalingModule {
   /// consumers would otherwise receive two separate reconnect triggers.
   bool _errorHandled = false;
 
+  /// Identity token for the currently active [WebtritSignalingClient].
+  ///
+  /// A fresh [Object] is created in [_connectAsync] for each new client and
+  /// captured in the [onError]/[onDisconnect] closures. Callbacks whose token
+  /// does not match the current [_activeClientId] are discarded as stale.
+  ///
+  /// [_onError] and [_onDisconnect] both set [_activeClientId] to null after
+  /// handling the event, so any late-arriving callback from the same client
+  /// (e.g. a `_wsOnDone` that fires after `_onError`) is also filtered even
+  /// when [_client] is already null — closing the hole in the previous guard
+  /// `_client != null && !identical(_client, client)`.
+  Object? _activeClientId;
+
   /// Last connect error as string for deduplication.
   String? _lastConnectErrorString;
 
@@ -290,34 +303,24 @@ class SignalingModuleImpl implements SignalingModule {
           return;
         }
 
-        // Wrap onError and onDisconnect in closures that capture [client] and
-        // guard against stale callbacks from a superseded connection.
-        //
-        // Race: a zombie client[n-1] whose server-side close (code 4441) or
-        // late network error arrives after client[n] is already assigned would
-        // unconditionally clear _client and emit a spurious disconnect/failure,
-        // corrupting the active session with no auto-recovery.
-        //
-        // Guard condition: skip only when _client is a *different* non-null
-        // client (new connection replaced us). If _client is null — cleared by
-        // disconnect() or _onError — we are still the responsible client and
-        // must forward the callback.
-        //
-        // The same identity pattern is already used for _requestQueue.flush
-        // (isActive: () => identical(_client, client)) — this extends it to
-        // the error and disconnect paths.
+        // Assign a unique identity token before registering callbacks.
+        // Each client gets its own token; _onError and _onDisconnect clear it
+        // when they run, so any late-arriving callback (e.g. _wsOnDone after
+        // _onError) is discarded even when _client is already null.
+        final myId = _activeClientId = Object();
+
         client.listen(
           onStateHandshake: _onHandshake,
           onEvent: _onEvent,
           onError: (error, [stackTrace]) {
-            if (_client != null && !identical(_client, client)) {
+            if (!identical(_activeClientId, myId)) {
               _logger.fine('_onError: ignoring stale error from superseded client: $error');
               return;
             }
             _onError(error, stackTrace);
           },
           onDisconnect: (code, reason) {
-            if (_client != null && !identical(_client, client)) {
+            if (!identical(_activeClientId, myId)) {
               _logger.fine('_onDisconnect: ignoring stale close code=$code from superseded client');
               return;
             }
@@ -370,6 +373,7 @@ class SignalingModuleImpl implements SignalingModule {
     }
     _logger.severe('_onError', error, stackTrace);
     _client = null;
+    _activeClientId = null; // invalidate so any late _wsOnDone from this client is filtered
     _errorHandled = true;
 
     final errorString = error.toString();
@@ -381,6 +385,7 @@ class SignalingModuleImpl implements SignalingModule {
 
   void _onDisconnect(int? code, String? reason) {
     _client = null;
+    _activeClientId = null; // invalidate so further stale callbacks from this client are filtered
     final ack = _disconnectAck;
     _disconnectAck = null;
     final wasIntentional = _intentionalDisconnect;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -326,6 +326,7 @@ class SignalingModuleImpl implements SignalingModule {
         );
 
         _client = client;
+        _errorHandled = false;
         _lastConnectErrorString = null;
         _emit(SignalingConnected());
         unawaited(_requestQueue.flush(execute: client.execute, isActive: () => identical(_client, client)));

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -262,7 +262,7 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('SignalingModuleImpl — _errorHandled not reset on reconnect (WT-1403)', () {
-    SignalingModuleImpl _buildModuleWith(List<WebtritSignalingClient> clients) {
+    SignalingModuleImpl buildModuleWith(List<WebtritSignalingClient> clients) {
       var index = 0;
       return SignalingModuleImpl(
         coreUrl: 'https://example.com',
@@ -284,7 +284,7 @@ void main() {
     test('BUG: SignalingDisconnected suppressed when _errorHandled left true after prior clientA error', () async {
       final clientA = _ControllableClient();
       final clientB = _ControllableClient();
-      final module = _buildModuleWith([clientA, clientB]);
+      final module = buildModuleWith([clientA, clientB]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 
@@ -328,7 +328,7 @@ void main() {
       // just clientA error → clientB connects → clientB disconnects.
       final clientA = _ControllableClient();
       final clientB = _ControllableClient();
-      final module = _buildModuleWith([clientA, clientB]);
+      final module = buildModuleWith([clientA, clientB]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 
@@ -355,7 +355,7 @@ void main() {
     test('after fix: SignalingDisconnected emitted for clientB with correct code and reconnect delay', () async {
       final clientA = _ControllableClient();
       final clientB = _ControllableClient();
-      final module = _buildModuleWith([clientA, clientB]);
+      final module = buildModuleWith([clientA, clientB]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 
@@ -383,7 +383,7 @@ void main() {
       // only the stale disconnect fires (no clientB disconnect) → no event.
       final clientA = _ControllableClient();
       final clientB = _ControllableClient();
-      final module = _buildModuleWith([clientA, clientB]);
+      final module = buildModuleWith([clientA, clientB]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 
@@ -428,7 +428,7 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('SignalingModuleImpl — stale guard hole when _client == null', () {
-    SignalingModuleImpl _buildModuleWith2(List<WebtritSignalingClient> clients) {
+    SignalingModuleImpl buildModuleWith2(List<WebtritSignalingClient> clients) {
       var index = 0;
       return SignalingModuleImpl(
         coreUrl: 'https://example.com',
@@ -455,7 +455,7 @@ void main() {
         //   → clientA late 1002 fires → guard passes (null) → second SignalingDisconnected emitted
         final clientA = _ControllableClient();
         final clientB = _ControllableClient();
-        final module = _buildModuleWith2([clientA, clientB]);
+        final module = buildModuleWith2([clientA, clientB]);
         final events = <SignalingModuleEvent>[];
         module.events.listen(events.add);
 
@@ -495,7 +495,7 @@ void main() {
         //   clientA late stale callback fires → _client==null → guard passes
         //   → wasIntentional already reset → SignalingDisconnected(delay=3s) ← SPURIOUS
         final clientA = _ControllableClient();
-        final module = _buildModuleWith2([clientA]);
+        final module = buildModuleWith2([clientA]);
         final events = <SignalingModuleEvent>[];
         module.events.listen(events.add);
 
@@ -531,7 +531,7 @@ void main() {
       () async {
         final clientA = _ControllableClient();
         final clientB = _ControllableClient();
-        final module = _buildModuleWith2([clientA, clientB]);
+        final module = buildModuleWith2([clientA, clientB]);
         final events = <SignalingModuleEvent>[];
         module.events.listen(events.add);
 
@@ -553,7 +553,7 @@ void main() {
 
     test('after fix: stale callback after intentional disconnect is filtered — no spurious reconnect', () async {
       final clientA = _ControllableClient();
-      final module = _buildModuleWith2([clientA]);
+      final module = buildModuleWith2([clientA]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -1,15 +1,19 @@
 /// Unit tests for [SignalingModuleImpl].
 ///
-/// Reproduces the disconnect-during-connect race condition:
+/// Two independent bug scenarios are covered:
 ///
-/// When [SignalingModuleImpl.disconnect] is called while [_connectAsync] is
-/// still awaiting the client factory (_client == null, _connectToken != null),
-/// disconnect() must cancel the in-flight attempt by clearing _connectToken.
-/// The next connect() call must then be allowed to start a fresh attempt
-/// instead of being blocked by the stale in-flight operation.
+/// 1. disconnect-during-connect race condition:
+///    When [SignalingModuleImpl.disconnect] is called while [_connectAsync] is
+///    still awaiting the client factory (_client == null, _connectToken != null),
+///    disconnect() must cancel the in-flight attempt by clearing _connectToken.
 ///
-/// Tests labelled "BUG:" reproduce the broken behavior on the unfixed code.
-/// Tests labelled "after fix:" verify the correct behavior.
+/// 2. _errorHandled not reset on reconnect (WT-1403):
+///    When _onError fires for clientA (sets _errorHandled=true), then clientB
+///    connects, _errorHandled must be reset. If not, clientB's legitimate
+///    disconnect is silently suppressed and no reconnect is triggered.
+///
+/// Tests labelled "BUG:" assert correct behavior — they fail on the unfixed code.
+/// Tests labelled "after fix:" verify the same behavior stays correct.
 library;
 
 import 'dart:async';
@@ -43,6 +47,37 @@ class _FakeClient extends Fake implements WebtritSignalingClient {
 
   @override
   Future<void> execute(Request request, [Duration? timeout]) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Controllable client — captures onError + onDisconnect for manual triggering
+// ---------------------------------------------------------------------------
+
+class _ControllableClient extends Fake implements WebtritSignalingClient {
+  ErrorHandler? _capturedOnError;
+  DisconnectHandler? _capturedOnDisconnect;
+
+  @override
+  void listen({
+    required StateHandshakeHandler onStateHandshake,
+    required EventHandler onEvent,
+    required ErrorHandler onError,
+    required DisconnectHandler onDisconnect,
+  }) {
+    _capturedOnError = onError;
+    _capturedOnDisconnect = onDisconnect;
+  }
+
+  @override
+  Future<void> disconnect([int? code, String? reason]) async {
+    _capturedOnDisconnect?.call(code, reason);
+  }
+
+  @override
+  Future<void> execute(Request request, [Duration? timeout]) async {}
+
+  void triggerError(Object error) => _capturedOnError?.call(error, null);
+  void triggerDisconnect(int? code, [String? reason]) => _capturedOnDisconnect?.call(code, reason);
 }
 
 // ---------------------------------------------------------------------------
@@ -207,6 +242,162 @@ void main() {
       // Stale result must be discarded
       expect(module.isConnected, isFalse);
       expect(events.whereType<SignalingConnected>(), isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // WT-1403: _errorHandled not reset when a new client connects
+  //
+  // Sequence that triggers the bug:
+  //   1. clientA connects → _client=clientA, _errorHandled=false
+  //   2. clientA _onError fires → _errorHandled=true, _client=null
+  //   3. connect() again → clientB connects → _client=clientB
+  //      BUG: _errorHandled is NOT reset here
+  //   4. stale clientA _onDisconnect fires → guard returns early (clientB!=clientA)
+  //      _errorHandled stays true on buggy code
+  //   5. clientB legitimate disconnect → _onDisconnect called → sees _errorHandled=true
+  //      → silently suppresses SignalingDisconnected → no reconnect triggered
+  //
+  // Fix: add `_errorHandled = false;` in _connectAsync after `_client = client;`.
+  // ---------------------------------------------------------------------------
+
+  group('SignalingModuleImpl — _errorHandled not reset on reconnect (WT-1403)', () {
+    SignalingModuleImpl _buildModuleWith(List<WebtritSignalingClient> clients) {
+      var index = 0;
+      return SignalingModuleImpl(
+        coreUrl: 'https://example.com',
+        tenantId: 'tenant',
+        token: 'token',
+        trustedCertificates: TrustedCertificates.empty,
+        clientFactory:
+            ({
+              required Uri url,
+              required String tenantId,
+              required String token,
+              required Duration connectionTimeout,
+              required TrustedCertificates certs,
+              required bool force,
+            }) async => clients[index++],
+      );
+    }
+
+    test('BUG: SignalingDisconnected suppressed when _errorHandled left true after prior clientA error', () async {
+      final clientA = _ControllableClient();
+      final clientB = _ControllableClient();
+      final module = _buildModuleWith([clientA, clientB]);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      // Step 1: connect → clientA established
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+      expect(events.whereType<SignalingConnected>(), hasLength(1));
+
+      // Step 2: clientA error → _errorHandled=true, _client=null
+      clientA.triggerError(Exception('keepalive timeout'));
+      expect(events.whereType<SignalingConnectionFailed>(), hasLength(1));
+      expect(module.isConnected, isFalse);
+
+      // Step 3: reconnect → clientB established
+      // BUG: _errorHandled is NOT reset to false at _client=clientB
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+      expect(events.whereType<SignalingConnected>(), hasLength(2));
+      expect(module.isConnected, isTrue);
+
+      // Step 4: stale clientA _onDisconnect fires (e.g. force-attach-close 4441)
+      // Guard returns early — _errorHandled stays true on buggy code
+      clientA.triggerDisconnect(4441, 'force attach close');
+
+      // Step 5: clientB legitimate disconnect (server keepalive timeout 4502)
+      clientB.triggerDisconnect(4502, 'keepalive timeout');
+
+      // On buggy code: _errorHandled=true causes _onDisconnect to return early
+      // without emitting SignalingDisconnected → this assertion FAILS on current code
+      expect(
+        events.whereType<SignalingDisconnected>(),
+        hasLength(1),
+        reason:
+            'BUG: _errorHandled was not reset on reconnect — '
+            'clientB disconnect silently suppressed, no reconnect triggered',
+      );
+    });
+
+    test('BUG: SignalingDisconnected suppressed even without stale intermediate disconnect', () async {
+      // Same bug manifests without the stale clientA disconnect in step 4:
+      // just clientA error → clientB connects → clientB disconnects.
+      final clientA = _ControllableClient();
+      final clientB = _ControllableClient();
+      final module = _buildModuleWith([clientA, clientB]);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // clientA error → _errorHandled=true
+      clientA.triggerError(Exception('timeout'));
+
+      // clientB connects — _errorHandled NOT reset (buggy code)
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // clientB legitimate disconnect — suppressed on buggy code
+      clientB.triggerDisconnect(4502);
+
+      expect(
+        events.whereType<SignalingDisconnected>(),
+        hasLength(1),
+        reason: 'BUG: first disconnect after error always suppressed when _errorHandled not reset',
+      );
+    });
+
+    test('after fix: SignalingDisconnected emitted for clientB with correct code and reconnect delay', () async {
+      final clientA = _ControllableClient();
+      final clientB = _ControllableClient();
+      final module = _buildModuleWith([clientA, clientB]);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+      clientA.triggerError(Exception('keepalive timeout'));
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      clientA.triggerDisconnect(4441);
+      clientB.triggerDisconnect(4502);
+
+      final disconnects = events.whereType<SignalingDisconnected>().toList();
+      expect(disconnects, hasLength(1));
+      expect(disconnects.first.code, 4502);
+      expect(
+        disconnects.first.recommendedReconnectDelay,
+        isNotNull,
+        reason: 'code 4502 is not protocolError — reconnect delay must be provided',
+      );
+    });
+
+    test('after fix: stale clientA disconnect alone does not emit SignalingDisconnected', () async {
+      // Verifies the stale guard still works correctly after the fix:
+      // only the stale disconnect fires (no clientB disconnect) → no event.
+      final clientA = _ControllableClient();
+      final clientB = _ControllableClient();
+      final module = _buildModuleWith([clientA, clientB]);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+      clientA.triggerError(Exception('timeout'));
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Only stale clientA disconnect — clientB is still connected
+      clientA.triggerDisconnect(4441);
+
+      expect(module.isConnected, isTrue, reason: 'clientB should still be connected');
+      expect(events.whereType<SignalingDisconnected>(), isEmpty);
     });
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -12,8 +12,8 @@
 ///    connects, _errorHandled must be reset. If not, clientB's legitimate
 ///    disconnect is silently suppressed and no reconnect is triggered.
 ///
-/// Tests labelled "BUG:" assert correct behavior — they fail on the unfixed code.
-/// Tests labelled "after fix:" verify the same behavior stays correct.
+/// Tests labelled "regression:" reproduce the bug scenario and fail on unfixed code.
+/// Tests labelled "after fix:" verify correct behavior on fixed code.
 library;
 
 import 'dart:async';
@@ -122,6 +122,25 @@ SignalingModuleImpl _buildModule(SignalingClientFactory factory) => SignalingMod
   clientFactory: factory,
 );
 
+SignalingModuleImpl _buildModuleFromClients(List<WebtritSignalingClient> clients) {
+  var index = 0;
+  return SignalingModuleImpl(
+    coreUrl: 'https://example.com',
+    tenantId: 'tenant',
+    token: 'token',
+    trustedCertificates: TrustedCertificates.empty,
+    clientFactory:
+        ({
+          required Uri url,
+          required String tenantId,
+          required String token,
+          required Duration connectionTimeout,
+          required TrustedCertificates certs,
+          required bool force,
+        }) async => clients[index++],
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -132,36 +151,39 @@ void main() {
     // Core bug: disconnect while _client==null leaves _connecting=true
     // -----------------------------------------------------------------------
 
-    test('BUG: second connect() is silently dropped because _connecting stays true after disconnect()', () async {
-      // Arrange
-      final factory = _ControlledFactory();
-      final module = _buildModule(factory.factory);
+    test(
+      'regression: second connect() is silently dropped because _connecting stays true after disconnect()',
+      () async {
+        // Arrange
+        final factory = _ControlledFactory();
+        final module = _buildModule(factory.factory);
 
-      // Act: connect #1 → factory called, hangs
-      module.connect();
-      await Future<void>.delayed(Duration.zero);
-      expect(factory.callCount, 1, reason: 'first connect() must call the factory');
+        // Act: connect #1 → factory called, hangs
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+        expect(factory.callCount, 1, reason: 'first connect() must call the factory');
 
-      // disconnect() while _client==null — the bug: does not reset _connecting
-      await module.disconnect();
+        // disconnect() while _client==null — the bug: does not reset _connecting
+        await module.disconnect();
 
-      // connect #2 — must call the factory again; currently it is silently dropped
-      module.connect();
-      await Future<void>.delayed(Duration.zero);
+        // connect #2 — must call the factory again; currently it is silently dropped
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
 
-      // BUG: factory was not called a second time — second connect() was dropped
-      expect(
-        factory.callCount,
-        2,
-        reason: 'second connect() was silently dropped: factory call count did not increase',
-      );
-    });
+        // BUG: factory was not called a second time — second connect() was dropped
+        expect(
+          factory.callCount,
+          2,
+          reason: 'second connect() was silently dropped: factory call count did not increase',
+        );
+      },
+    );
 
     // -----------------------------------------------------------------------
     // Consequence: stale connect completes and leaves module in wrong state
     // -----------------------------------------------------------------------
 
-    test('BUG: stale in-flight connect completes after disconnect() and leaves module connected', () async {
+    test('regression: stale in-flight connect completes after disconnect() and leaves module connected', () async {
       // Arrange
       final factory = _ControlledFactory();
       final module = _buildModule(factory.factory);
@@ -262,73 +284,57 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('SignalingModuleImpl — _errorHandled not reset on reconnect (WT-1403)', () {
-    SignalingModuleImpl buildModuleWith(List<WebtritSignalingClient> clients) {
-      var index = 0;
-      return SignalingModuleImpl(
-        coreUrl: 'https://example.com',
-        tenantId: 'tenant',
-        token: 'token',
-        trustedCertificates: TrustedCertificates.empty,
-        clientFactory:
-            ({
-              required Uri url,
-              required String tenantId,
-              required String token,
-              required Duration connectionTimeout,
-              required TrustedCertificates certs,
-              required bool force,
-            }) async => clients[index++],
-      );
-    }
+    test(
+      'regression: SignalingDisconnected suppressed when _errorHandled left true after prior clientA error',
+      () async {
+        final clientA = _ControllableClient();
+        final clientB = _ControllableClient();
+        final module = _buildModuleFromClients([clientA, clientB]);
+        final events = <SignalingModuleEvent>[];
+        module.events.listen(events.add);
 
-    test('BUG: SignalingDisconnected suppressed when _errorHandled left true after prior clientA error', () async {
-      final clientA = _ControllableClient();
-      final clientB = _ControllableClient();
-      final module = buildModuleWith([clientA, clientB]);
-      final events = <SignalingModuleEvent>[];
-      module.events.listen(events.add);
+        // Step 1: connect → clientA established
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+        expect(events.whereType<SignalingConnected>(), hasLength(1));
 
-      // Step 1: connect → clientA established
-      module.connect();
-      await Future<void>.delayed(Duration.zero);
-      expect(events.whereType<SignalingConnected>(), hasLength(1));
+        // Step 2: clientA error → _errorHandled=true, _client=null
+        clientA.triggerError(Exception('keepalive timeout'));
+        expect(events.whereType<SignalingConnectionFailed>(), hasLength(1));
+        expect(module.isConnected, isFalse);
 
-      // Step 2: clientA error → _errorHandled=true, _client=null
-      clientA.triggerError(Exception('keepalive timeout'));
-      expect(events.whereType<SignalingConnectionFailed>(), hasLength(1));
-      expect(module.isConnected, isFalse);
+        // Step 3: reconnect → clientB established
+        // BUG: _errorHandled is NOT reset to false at _client=clientB
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+        expect(events.whereType<SignalingConnected>(), hasLength(2));
+        expect(module.isConnected, isTrue);
 
-      // Step 3: reconnect → clientB established
-      // BUG: _errorHandled is NOT reset to false at _client=clientB
-      module.connect();
-      await Future<void>.delayed(Duration.zero);
-      expect(events.whereType<SignalingConnected>(), hasLength(2));
-      expect(module.isConnected, isTrue);
+        // Step 4: stale clientA _onDisconnect fires (e.g. force-attach-close 4441)
+        // Guard returns early — _errorHandled stays true on buggy code
+        clientA.triggerDisconnect(4441, 'force attach close');
 
-      // Step 4: stale clientA _onDisconnect fires (e.g. force-attach-close 4441)
-      // Guard returns early — _errorHandled stays true on buggy code
-      clientA.triggerDisconnect(4441, 'force attach close');
+        // Step 5: clientB legitimate disconnect (server keepalive timeout 4502)
+        clientB.triggerDisconnect(4502, 'keepalive timeout');
 
-      // Step 5: clientB legitimate disconnect (server keepalive timeout 4502)
-      clientB.triggerDisconnect(4502, 'keepalive timeout');
+        // On buggy code: _errorHandled=true causes _onDisconnect to return early
+        // without emitting SignalingDisconnected → this assertion FAILS on current code
+        expect(
+          events.whereType<SignalingDisconnected>(),
+          hasLength(1),
+          reason:
+              'BUG: _errorHandled was not reset on reconnect — '
+              'clientB disconnect silently suppressed, no reconnect triggered',
+        );
+      },
+    );
 
-      // On buggy code: _errorHandled=true causes _onDisconnect to return early
-      // without emitting SignalingDisconnected → this assertion FAILS on current code
-      expect(
-        events.whereType<SignalingDisconnected>(),
-        hasLength(1),
-        reason:
-            'BUG: _errorHandled was not reset on reconnect — '
-            'clientB disconnect silently suppressed, no reconnect triggered',
-      );
-    });
-
-    test('BUG: SignalingDisconnected suppressed even without stale intermediate disconnect', () async {
+    test('regression: SignalingDisconnected suppressed even without stale intermediate disconnect', () async {
       // Same bug manifests without the stale clientA disconnect in step 4:
       // just clientA error → clientB connects → clientB disconnects.
       final clientA = _ControllableClient();
       final clientB = _ControllableClient();
-      final module = buildModuleWith([clientA, clientB]);
+      final module = _buildModuleFromClients([clientA, clientB]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 
@@ -355,7 +361,7 @@ void main() {
     test('after fix: SignalingDisconnected emitted for clientB with correct code and reconnect delay', () async {
       final clientA = _ControllableClient();
       final clientB = _ControllableClient();
-      final module = buildModuleWith([clientA, clientB]);
+      final module = _buildModuleFromClients([clientA, clientB]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 
@@ -383,7 +389,7 @@ void main() {
       // only the stale disconnect fires (no clientB disconnect) → no event.
       final clientA = _ControllableClient();
       final clientB = _ControllableClient();
-      final module = buildModuleWith([clientA, clientB]);
+      final module = _buildModuleFromClients([clientA, clientB]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 
@@ -428,34 +434,15 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('SignalingModuleImpl — stale guard hole when _client == null', () {
-    SignalingModuleImpl buildModuleWith2(List<WebtritSignalingClient> clients) {
-      var index = 0;
-      return SignalingModuleImpl(
-        coreUrl: 'https://example.com',
-        tenantId: 'tenant',
-        token: 'token',
-        trustedCertificates: TrustedCertificates.empty,
-        clientFactory:
-            ({
-              required Uri url,
-              required String tenantId,
-              required String token,
-              required Duration connectionTimeout,
-              required TrustedCertificates certs,
-              required bool force,
-            }) async => clients[index++],
-      );
-    }
-
     test(
-      'BUG: stale clientA _wsOnDone(1002) fires after clientB disconnect clears _client — emits duplicate SignalingDisconnected',
+      'regression: stale clientA _wsOnDone(1002) fires after clientB disconnect clears _client — emits duplicate SignalingDisconnected',
       () async {
         // Scenario A:
         //   clientA error → clientB connects → clientB disconnect(4502) clears _client=null
         //   → clientA late 1002 fires → guard passes (null) → second SignalingDisconnected emitted
         final clientA = _ControllableClient();
         final clientB = _ControllableClient();
-        final module = buildModuleWith2([clientA, clientB]);
+        final module = _buildModuleFromClients([clientA, clientB]);
         final events = <SignalingModuleEvent>[];
         module.events.listen(events.add);
 
@@ -488,14 +475,14 @@ void main() {
     );
 
     test(
-      'BUG: stale callback after intentional disconnect emits spurious SignalingDisconnected with delay — triggers unexpected reconnect',
+      'regression: stale callback after intentional disconnect emits spurious SignalingDisconnected with delay — triggers unexpected reconnect',
       () async {
         // Scenario B:
         //   module.disconnect() → intentional → SignalingDisconnected(delay=null) ← correct
         //   clientA late stale callback fires → _client==null → guard passes
         //   → wasIntentional already reset → SignalingDisconnected(delay=3s) ← SPURIOUS
         final clientA = _ControllableClient();
-        final module = buildModuleWith2([clientA]);
+        final module = _buildModuleFromClients([clientA]);
         final events = <SignalingModuleEvent>[];
         module.events.listen(events.add);
 
@@ -531,7 +518,7 @@ void main() {
       () async {
         final clientA = _ControllableClient();
         final clientB = _ControllableClient();
-        final module = buildModuleWith2([clientA, clientB]);
+        final module = _buildModuleFromClients([clientA, clientB]);
         final events = <SignalingModuleEvent>[];
         module.events.listen(events.add);
 
@@ -553,7 +540,7 @@ void main() {
 
     test('after fix: stale callback after intentional disconnect is filtered — no spurious reconnect', () async {
       final clientA = _ControllableClient();
-      final module = buildModuleWith2([clientA]);
+      final module = _buildModuleFromClients([clientA]);
       final events = <SignalingModuleEvent>[];
       module.events.listen(events.add);
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -400,4 +400,172 @@ void main() {
       expect(events.whereType<SignalingDisconnected>(), isEmpty);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Stale guard hole: _client == null
+  //
+  // The existing guard `_client != null && !identical(_client, client)` is
+  // bypassed whenever _client is null — the AND short-circuits to false.
+  //
+  // Scenario A (WT-1403 secondary):
+  //   clientA error → _client=null
+  //   clientB connects → _client=clientB
+  //   clientB disconnect(4502) → _client=null   ← clears _client
+  //   clientA late _wsOnDone(1002) fires:
+  //     guard: _client==null → passes! → _onDisconnect(1002)
+  //     → SignalingDisconnected(delay=null) emitted ← duplicate event
+  //
+  // Scenario B (intentional disconnect + stale callback):
+  //   clientA connected
+  //   module.disconnect() → intentional → SignalingDisconnected(delay=null)
+  //   clientA late stale callback fires:
+  //     guard: _client==null → passes! → _onDisconnect
+  //     → wasIntentional already reset → SignalingDisconnected(delay=3s) ← spurious reconnect
+  //
+  // Fix: replace the guard with an explicit `_activeClientId` token that is
+  // set when a client connects and cleared in _onError / _onDisconnect.
+  // Guard becomes `!identical(_activeClientId, myId)` — works even when null.
+  // ---------------------------------------------------------------------------
+
+  group('SignalingModuleImpl — stale guard hole when _client == null', () {
+    SignalingModuleImpl _buildModuleWith2(List<WebtritSignalingClient> clients) {
+      var index = 0;
+      return SignalingModuleImpl(
+        coreUrl: 'https://example.com',
+        tenantId: 'tenant',
+        token: 'token',
+        trustedCertificates: TrustedCertificates.empty,
+        clientFactory:
+            ({
+              required Uri url,
+              required String tenantId,
+              required String token,
+              required Duration connectionTimeout,
+              required TrustedCertificates certs,
+              required bool force,
+            }) async => clients[index++],
+      );
+    }
+
+    test(
+      'BUG: stale clientA _wsOnDone(1002) fires after clientB disconnect clears _client — emits duplicate SignalingDisconnected',
+      () async {
+        // Scenario A:
+        //   clientA error → clientB connects → clientB disconnect(4502) clears _client=null
+        //   → clientA late 1002 fires → guard passes (null) → second SignalingDisconnected emitted
+        final clientA = _ControllableClient();
+        final clientB = _ControllableClient();
+        final module = _buildModuleWith2([clientA, clientB]);
+        final events = <SignalingModuleEvent>[];
+        module.events.listen(events.add);
+
+        // Step 1–3: clientA error → clientB connected
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+        clientA.triggerError(Exception('keepalive timeout'));
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+
+        // Step 4: clientB legitimate disconnect → _client=null, SignalingDisconnected(4502) emitted
+        clientB.triggerDisconnect(4502);
+
+        // Step 5: clientA's late _wsOnDone(1002) fires AFTER _client was cleared
+        // BUG: _client==null → guard does not filter → _onDisconnect(1002) called
+        // → SignalingDisconnected(code:1002, delay:null) emitted as second event
+        clientA.triggerDisconnect(1002);
+
+        // Expect only the single legitimate disconnect from clientB
+        final disconnects = events.whereType<SignalingDisconnected>().toList();
+        expect(
+          disconnects,
+          hasLength(1),
+          reason:
+              'BUG: stale clientA _wsOnDone(1002) passed through guard when _client==null — '
+              'emitted duplicate SignalingDisconnected that could cancel scheduled reconnect',
+        );
+        expect(disconnects.first.code, 4502, reason: 'only the clientB disconnect should be visible');
+      },
+    );
+
+    test(
+      'BUG: stale callback after intentional disconnect emits spurious SignalingDisconnected with delay — triggers unexpected reconnect',
+      () async {
+        // Scenario B:
+        //   module.disconnect() → intentional → SignalingDisconnected(delay=null) ← correct
+        //   clientA late stale callback fires → _client==null → guard passes
+        //   → wasIntentional already reset → SignalingDisconnected(delay=3s) ← SPURIOUS
+        final clientA = _ControllableClient();
+        final module = _buildModuleWith2([clientA]);
+        final events = <SignalingModuleEvent>[];
+        module.events.listen(events.add);
+
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+        expect(module.isConnected, isTrue);
+
+        // Intentional disconnect — fires onDisconnect once through client.disconnect()
+        await module.disconnect();
+
+        // Late stale callback from the same client (e.g. server close frame arriving late)
+        // BUG: _client==null → guard passes → wasIntentional already false → delay=3s
+        clientA.triggerDisconnect(1000);
+
+        final disconnects = events.whereType<SignalingDisconnected>().toList();
+        expect(
+          disconnects,
+          hasLength(1),
+          reason:
+              'BUG: second stale callback after intentional disconnect emitted spurious '
+              'SignalingDisconnected that could trigger an unexpected reconnect',
+        );
+        expect(
+          disconnects.first.recommendedReconnectDelay,
+          isNull,
+          reason: 'the only disconnect event must be the intentional one with delay=null',
+        );
+      },
+    );
+
+    test(
+      'after fix: stale clientA _wsOnDone(1002) filtered when _client==null — only clientB event survives',
+      () async {
+        final clientA = _ControllableClient();
+        final clientB = _ControllableClient();
+        final module = _buildModuleWith2([clientA, clientB]);
+        final events = <SignalingModuleEvent>[];
+        module.events.listen(events.add);
+
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+        clientA.triggerError(Exception('keepalive timeout'));
+        module.connect();
+        await Future<void>.delayed(Duration.zero);
+
+        clientB.triggerDisconnect(4502);
+        clientA.triggerDisconnect(1002); // late stale — must be filtered
+
+        final disconnects = events.whereType<SignalingDisconnected>().toList();
+        expect(disconnects, hasLength(1));
+        expect(disconnects.first.code, 4502);
+        expect(disconnects.first.recommendedReconnectDelay, isNotNull);
+      },
+    );
+
+    test('after fix: stale callback after intentional disconnect is filtered — no spurious reconnect', () async {
+      final clientA = _ControllableClient();
+      final module = _buildModuleWith2([clientA]);
+      final events = <SignalingModuleEvent>[];
+      module.events.listen(events.add);
+
+      module.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      await module.disconnect();
+      clientA.triggerDisconnect(1000); // stale — must be filtered
+
+      final disconnects = events.whereType<SignalingDisconnected>().toList();
+      expect(disconnects, hasLength(1));
+      expect(disconnects.first.recommendedReconnectDelay, isNull, reason: 'only intentional disconnect, no reconnect');
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Root cause analysis of WT-1403 (Xiaomi/pixel devices stuck without signaling for hours after background) revealed a **two-bug chain** in `SignalingModuleImpl` plus a **missing error type** in the cross-isolate codec. Three independent fixes:

**Bug #1 — `_errorHandled` not reset on reconnect** (`85110c822`)
When `_onError` fires for clientA it sets `_errorHandled = true`. If clientB then connects without resetting this flag, clientB's legitimate disconnect is silently swallowed in `_onDisconnect` — no `SignalingDisconnected` event is emitted, `SignalingReconnectController` never fires, loop goes silent.
Fix: `_errorHandled = false` in `_connectAsync` after `_client = client`.

**Bug #2 — stale callback guard hole when `_client == null`** (`c6ffcf848`)
Old guard: `_client != null && !identical(_client, client)`. When `_client` is already null (cleared by `_onError`), any stale `_wsOnDone` from a superseded client passes through, emitting a spurious `SignalingDisconnected(delay=null)`. `SignalingReconnectController` interprets `delay=null` as "do not reconnect" and breaks its loop.
Fix: `_activeClientId` — unique `Object` token per client, captured in closures before `client.listen()`, cleared in both `_onError` and `_onDisconnect`. Guard: `!identical(_activeClientId, myId)`.

**Bug #3 — ghost-state detection via `NotConnectedException`** (`c6ffcf848`)
When the FGS hub is disconnected but main-isolate `_isConnected = true`, `SignalingHub._executeAndReply` threw `StateError` which the codec serialized as a generic `Exception`. `WebtritSignalingService.execute()` couldn't identify it and skipped recovery. Now the hub throws `NotConnectedException`, the codec encodes/decodes it by type, and `execute()` detects it via `catchError` → resets `_isConnected = false` → calls `connect()`.

## Test plan

- [ ] 8 new tests in `signaling_module_impl_test.dart` (4 BUG-reproducing + 4 after-fix) for Bug #1 and #2
- [ ] 5 new tests in `signaling_service_test.dart` for Bug #3 (ghost-state reset, reconnect trigger, rethrow, normal path, non-NCE path)
- [ ] All 85 tests pass (`flutter test` in platform_interface + service packages)
- [ ] Reproduce on Xiaomi device: connect → background 8+ hours → foreground → verify reconnect within seconds