### PR TITLE
fix(call): show missed call notification on Android for signaling path

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -513,6 +513,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
 
                       return CallBloc(
                         callLogsRepository: context.read<CallLogsRepository>(),
+                        localPushRepository: context.read<LocalPushRepository>(),
                         linesStateRepository: context.read<LinesStateRepository>(),
                         presenceInfoRepository: context.read<PresenceInfoRepository>(),
                         dialogInfoRepository: context.read<DialogInfoRepository>(),

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1274,7 +1274,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         if (call.direction == CallDirection.incoming && !call.wasAccepted) {
           if (code == SignalingResponseCode.declineCall) endReason = CallkeepEndCallReason.declinedElsewhere;
           if (code == SignalingResponseCode.requestTerminated) endReason = CallkeepEndCallReason.unanswered;
-          if (Platform.isAndroid) {
+          if (Platform.isAndroid && code != SignalingResponseCode.declineCall) {
             _showMissedCallNotification(event.callId, call.displayName ?? call.handle.value);
           }
         }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -23,6 +23,7 @@ import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/push_notification/push_notifications.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
@@ -58,6 +59,7 @@ const _getUserMediaPushKitTimeout = Duration(seconds: 8);
 
 class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver implements CallkeepDelegate {
   final CallLogsRepository callLogsRepository;
+  final LocalPushRepository localPushRepository;
   final UserRepository userRepository;
   final LinesStateRepository linesStateRepository;
   final PresenceInfoRepository presenceInfoRepository;
@@ -102,6 +104,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   CallBloc({
     required this.callLogsRepository,
+    required this.localPushRepository,
     required this.linesStateRepository,
     required this.presenceInfoRepository,
     required this.dialogInfoRepository,
@@ -1271,6 +1274,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         if (call.direction == CallDirection.incoming && !call.wasAccepted) {
           if (code == SignalingResponseCode.declineCall) endReason = CallkeepEndCallReason.declinedElsewhere;
           if (code == SignalingResponseCode.requestTerminated) endReason = CallkeepEndCallReason.unanswered;
+          if (Platform.isAndroid) {
+            _showMissedCallNotification(event.callId, call.displayName ?? call.handle.value);
+          }
         }
 
         try {
@@ -1288,6 +1294,20 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     } catch (e) {
       _logger.warning('__onCallSignalingEventHangup: $e');
     }
+  }
+
+  void _showMissedCallNotification(String callId, String callerName) {
+    localPushRepository
+        .displayPush(
+          AppLocalPush(
+            callId.hashCode,
+            // TODO: Add localization
+            'Missed Call',
+            callerName,
+            payload: {'callId': callId, 'type': 'missed_call'},
+          ),
+        )
+        .catchError((e) => _logger.warning('_showMissedCallNotification: $e'));
   }
 
   Future<void> __onCallSignalingEventCallUpdating(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1298,15 +1298,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   void _showMissedCallNotification(String callId, String callerName) {
     localPushRepository
-        .displayPush(
-          AppLocalPush(
-            callId.hashCode,
-            // TODO: Add localization
-            'Missed Call',
-            callerName,
-            payload: {'callId': callId, 'type': 'missed_call'},
-          ),
-        )
+        .displayPush(AppLocalPush.missedCall(callId, callerName))
         .catchError((e) => _logger.warning('_showMissedCallNotification: $e'));
   }
 

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -481,13 +481,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   Future<void> _showMissedCallNotification(HangupEvent event, NewCall call) async {
     try {
       await localPushRepository.displayPush(
-        AppLocalPush(
-          event.callId.hashCode,
-          // TODO: Add localization
-          'Missed Call',
-          _getDisplayNameForMissedCall(event, call) ?? 'Unknown',
-          payload: {'callId': event.callId, 'type': 'missed_call'},
-        ),
+        AppLocalPush.missedCall(event.callId, _getDisplayNameForMissedCall(event, call) ?? 'Unknown'),
       );
     } catch (e) {
       logger.severe('Failed to show missed call notification', e);

--- a/lib/push_notification/app_local_push.dart
+++ b/lib/push_notification/app_local_push.dart
@@ -6,6 +6,16 @@ class AppLocalPush {
 
   AppLocalPush(this.id, this.title, this.body, {this.payload});
 
+  factory AppLocalPush.missedCall(String callId, String callerName) {
+    return AppLocalPush(
+      callId.hashCode,
+      // TODO: Add localization
+      'Missed Call',
+      callerName,
+      payload: {'callId': callId, 'type': 'missed_call'},
+    );
+  }
+
   @override
   String toString() {
     return 'AppLocalPush{id: $id, title: $title, body: $body, payload: $payload}';


### PR DESCRIPTION
## Summary

- Missed call notifications were only shown when a call arrived via FCM push (handled by `PushNotificationIsolateManager`). When the app was alive and the call arrived via the signaling WebSocket, the `HangupEvent` hit `CallBloc.__onCallSignalingEventHangup` — which logged the call and notified Callkeep, but never posted an OS notification.
- Added `LocalPushRepository` dependency to `CallBloc` and a `_showMissedCallNotification` helper. The notification is guarded to `Platform.isAndroid` since iOS handles missed calls natively via CallKit/PushKit.
- Extracted `AppLocalPush.missedCall(callId, callerName)` factory constructor to centralise notification construction — removes duplication between `CallBloc` and `PushNotificationIsolateManager`.
