### PR TITLE
fix(login): show error notification on password login failure

### DIFF
--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -525,7 +525,13 @@ class LoginCubit extends Cubit<LoginState> {
         'otp_verification_attempts_exceeded' => const LoginOtpVerificationAttemptsExceededNotification(),
         'otp_already_verified' => const LoginOtpAlreadyVerifiedNotification(),
         'phone_not_found' => const LoginPhoneNotFoundNotification(),
-        _ => null, // Maybe better show general error, like 'Something went wrong. Please try again.'
+        'incorrect_credentials' => const LoginIncorrectCredentialsNotification(),
+        'user_not_found' => const LoginUserNotFoundNotification(),
+        'unconfigured_bundle_id' => const LoginUnconfiguredBundleIdNotification(),
+        'validation_error' => const LoginValidationErrorNotification(),
+        'parameters_apply_issue' => const LoginParametersApplyIssueNotification(),
+        'empty_email' => const LoginEmptyEmailNotification(),
+        _ => null,
       };
       if (readableNotification != null) {
         _logger.warning('Known login error occurred: ${error.error}', error);

--- a/lib/features/login/models/notifications.dart
+++ b/lib/features/login/models/notifications.dart
@@ -96,6 +96,60 @@ final class LoginPhoneNotFoundNotification extends MessageNotification {
   }
 }
 
+final class LoginIncorrectCredentialsNotification extends MessageNotification {
+  const LoginIncorrectCredentialsNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.login_RequestFailureIncorrectCredentialsError;
+  }
+}
+
+final class LoginUserNotFoundNotification extends MessageNotification {
+  const LoginUserNotFoundNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.login_RequestFailureUserNotFoundError;
+  }
+}
+
+final class LoginUnconfiguredBundleIdNotification extends MessageNotification {
+  const LoginUnconfiguredBundleIdNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.login_RequestFailureUnconfiguredBundleIdError;
+  }
+}
+
+final class LoginValidationErrorNotification extends MessageNotification {
+  const LoginValidationErrorNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.login_RequestFailureIdentifierIsNotValid;
+  }
+}
+
+final class LoginParametersApplyIssueNotification extends MessageNotification {
+  const LoginParametersApplyIssueNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.login_RequestFailureParametersApplyIssueError;
+  }
+}
+
+final class LoginEmptyEmailNotification extends MessageNotification {
+  const LoginEmptyEmailNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.login_RequestFailureEmptyEmailError;
+  }
+}
+
 final class SupportedLoginTypeMissedErrorNotification extends MessageNotification {
   const SupportedLoginTypeMissedErrorNotification();
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1407,6 +1407,18 @@ abstract class AppLocalizations {
   /// **'Phone number not found'**
   String get login_RequestFailurePhoneNotFoundError;
 
+  /// Shown during password login when the provided username or password is incorrect. Condition: the backend returns incorrect_credentials in response to POST /session.
+  ///
+  /// In en, this message translates to:
+  /// **'Incorrect username or password'**
+  String get login_RequestFailureIncorrectCredentialsError;
+
+  /// Shown during password login when the provided user reference does not exist. Condition: the backend returns user_not_found in response to POST /session.
+  ///
+  /// In en, this message translates to:
+  /// **'User not found'**
+  String get login_RequestFailureUserNotFoundError;
+
   /// Shown during login or signup when the app's bundle identifier is not configured or supported by the WebTrit Cloud Backend. Condition: the backend does not recognize the app, typically due to missing or incorrect bundle ID setup.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -753,6 +753,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get login_RequestFailurePhoneNotFoundError => 'Phone number not found';
 
   @override
+  String get login_RequestFailureIncorrectCredentialsError => 'Incorrect username or password';
+
+  @override
+  String get login_RequestFailureUserNotFoundError => 'User not found';
+
+  @override
   String get login_RequestFailureUnconfiguredBundleIdError => 'The app is not supported by your WebTrit Cloud Backend';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -757,6 +757,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get login_RequestFailurePhoneNotFoundError => 'Numero di telefono non trovato';
 
   @override
+  String get login_RequestFailureIncorrectCredentialsError => 'Nome utente o password non corretti';
+
+  @override
+  String get login_RequestFailureUserNotFoundError => 'Utente non trovato';
+
+  @override
   String get login_RequestFailureUnconfiguredBundleIdError =>
       'Errore di configurazione del backend dell\'app - avvisare il proprio fornitore di servizi';
 

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -761,6 +761,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get login_RequestFailurePhoneNotFoundError => 'Номер телефону не знайдено';
 
   @override
+  String get login_RequestFailureIncorrectCredentialsError => 'Невірне ім\'я користувача або пароль';
+
+  @override
+  String get login_RequestFailureUserNotFoundError => 'Користувача не знайдено';
+
+  @override
   String get login_RequestFailureUnconfiguredBundleIdError =>
       'Помилка конфігурації сервера застосунку - сповістіть свого постачальника послуг';
 

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -638,6 +638,14 @@
   "@login_RequestFailurePhoneNotFoundError": {
     "description": "Shown during login or signup when the user provides a phone number that cannot be found in the system. Condition: the entered phone number does not exist or is not recognized by the backend."
   },
+  "login_RequestFailureIncorrectCredentialsError": "Incorrect username or password",
+  "@login_RequestFailureIncorrectCredentialsError": {
+    "description": "Shown during password login when the provided username or password is incorrect. Condition: the backend returns incorrect_credentials in response to POST /session."
+  },
+  "login_RequestFailureUserNotFoundError": "User not found",
+  "@login_RequestFailureUserNotFoundError": {
+    "description": "Shown during password login when the provided user reference does not exist. Condition: the backend returns user_not_found in response to POST /session."
+  },
   "login_RequestFailureUnconfiguredBundleIdError": "The app is not supported by your WebTrit Cloud Backend",
   "@login_RequestFailureUnconfiguredBundleIdError": {
     "description": "Shown during login or signup when the app's bundle identifier is not configured or supported by the WebTrit Cloud Backend. Condition: the backend does not recognize the app, typically due to missing or incorrect bundle ID setup."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -638,6 +638,14 @@
   "@login_RequestFailurePhoneNotFoundError": {
     "description": "Shown during login or signup when the user provides a phone number that cannot be found in the system. Condition: the entered phone number does not exist or is not recognized by the backend."
   },
+  "login_RequestFailureIncorrectCredentialsError": "Nome utente o password non corretti",
+  "@login_RequestFailureIncorrectCredentialsError": {
+    "description": "Shown during password login when the provided username or password is incorrect. Condition: the backend returns incorrect_credentials in response to POST /session."
+  },
+  "login_RequestFailureUserNotFoundError": "Utente non trovato",
+  "@login_RequestFailureUserNotFoundError": {
+    "description": "Shown during password login when the provided user reference does not exist. Condition: the backend returns user_not_found in response to POST /session."
+  },
   "login_RequestFailureUnconfiguredBundleIdError": "Errore di configurazione del backend dell'app - avvisare il proprio fornitore di servizi",
   "@login_RequestFailureUnconfiguredBundleIdError": {
     "description": "Shown during login or signup when the app's bundle identifier is not configured or supported by the WebTrit Cloud Backend. Condition: the backend does not recognize the app, typically due to missing or incorrect bundle ID setup."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -638,6 +638,14 @@
   "@login_RequestFailurePhoneNotFoundError": {
     "description": "Shown during login or signup when the user provides a phone number that cannot be found in the system. Condition: the entered phone number does not exist or is not recognized by the backend."
   },
+  "login_RequestFailureIncorrectCredentialsError": "Невірне ім'я користувача або пароль",
+  "@login_RequestFailureIncorrectCredentialsError": {
+    "description": "Shown during password login when the provided username or password is incorrect. Condition: the backend returns incorrect_credentials in response to POST /session."
+  },
+  "login_RequestFailureUserNotFoundError": "Користувача не знайдено",
+  "@login_RequestFailureUserNotFoundError": {
+    "description": "Shown during password login when the provided user reference does not exist. Condition: the backend returns user_not_found in response to POST /session."
+  },
   "login_RequestFailureUnconfiguredBundleIdError": "Помилка конфігурації сервера застосунку - сповістіть свого постачальника послуг",
   "@login_RequestFailureUnconfiguredBundleIdError": {
     "description": "Shown during login or signup when the app's bundle identifier is not configured or supported by the WebTrit Cloud Backend. Condition: the backend does not recognize the app, typically due to missing or incorrect bundle ID setup."


### PR DESCRIPTION
## Summary

- Adds missing error codes to `handleError` switch in `LoginCubit` so users receive actionable error messages during password login
- `incorrect_credentials` → "Incorrect username or password" (**core fix for WT-1417**)
- `user_not_found` → "User not found"
- Restores `unconfigured_bundle_id`, `validation_error`, `parameters_apply_issue`, `empty_email` — these had l10n strings but were only handled in the now-deprecated `LoginErrorNotification`

## Root cause

`handleError()` switch only covered OTP-flow error codes. When `POST /session` returned `incorrect_credentials`, the `_ => null` fallback silently sent the error to Crashlytics with no user-visible notification.

## Changes

- `lib/features/login/cubit/login_cubit.dart` — +6 cases in `handleError` switch
- `lib/features/login/models/notifications.dart` — +7 new `MessageNotification` classes
- `lib/l10n/arb/app_en.arb` / `app_uk.arb` / `app_it.arb` — +2 new l10n keys
- Regenerated `app_localizations*.g.dart`
