### PR TITLE
fix(wt-1417): treat ConnectivityResult.vpn as NetworkStatus.available

### DIFF
--- a/lib/features/call/extensions/connectivity.dart
+++ b/lib/features/call/extensions/connectivity.dart
@@ -11,6 +11,8 @@ extension ConnectivityResultX on ConnectivityResult {
         return NetworkStatus.available;
       case ConnectivityResult.ethernet:
         return NetworkStatus.available;
+      case ConnectivityResult.vpn:
+        return NetworkStatus.available;
       case ConnectivityResult.none:
         return NetworkStatus.none;
       default:


### PR DESCRIPTION
## Summary

- `ConnectivityResult.vpn` was falling through to the `default` case in `toNetworkStatus()` and returning `NetworkStatus.none`
- When VPN was active, the app showed "waiting network" indefinitely and skipped signaling reconnect
- Fix: add explicit `case ConnectivityResult.vpn: return NetworkStatus.available`
