### PR TITLE
fix(wt-1417): debounce ICE restart on connectivity change

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -90,7 +90,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
   StreamSubscription<void>? _foregroundCallPushSubscription;
-  final Map<String, Timer> _iceRestartTimers = {};
+  final _iceRestartDebounce = DebounceMap<String>(const Duration(seconds: 2));
 
   late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
@@ -222,10 +222,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     _presenceInfoSyncTimer?.cancel();
 
-    for (final timer in _iceRestartTimers.values) {
-      timer.cancel();
-    }
-    _iceRestartTimers.clear();
+    _iceRestartDebounce.dispose();
 
     await _signalingSubscription.cancel();
 
@@ -3735,12 +3732,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// network interface (e.g. VPN tunnel) to finish initializing before ICE probing starts.
   /// Any pending restart for the same call is cancelled and rescheduled on each call, so
   /// rapid consecutive connectivity events result in a single restart.
-  static const _iceRestartDebounce = Duration(seconds: 2);
-
   void _scheduleIceRestart(String callId) {
-    _iceRestartTimers[callId]?.cancel();
-    _iceRestartTimers[callId] = Timer(_iceRestartDebounce, () async {
-      _iceRestartTimers.remove(callId);
+    _iceRestartDebounce.schedule(callId, () async {
       final pc = await _peerConnectionManager.retrieve(callId);
       if (pc == null) return;
       _logger.info('_scheduleIceRestart: restarting ICE for call $callId');

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -90,6 +90,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
   StreamSubscription<void>? _foregroundCallPushSubscription;
+  final Map<String, Timer> _iceRestartTimers = {};
 
   late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
@@ -220,6 +221,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _reconnectController.dispose();
 
     _presenceInfoSyncTimer?.cancel();
+
+    for (final timer in _iceRestartTimers.values) {
+      timer.cancel();
+    }
+    _iceRestartTimers.clear();
 
     await _signalingSubscription.cancel();
 
@@ -554,6 +560,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       //  - in network loss scenario restarts RTP from almost imediately compating to built-in WebRTC connectivity checks which can take around 10-20 seconds
       //  - in double network scenario (e.g already has mobile network, but also connected to wifi)
       //    it helps to switch to better network instead of staying on old until rtp breaks.
+      //
+      // ICE restart is debounced to allow the new network interface (e.g. VPN tunnel) to fully
+      // initialize before probing starts. Calling restartIce() immediately after onConnectivityChanged
+      // can cause ICE failure because the interface is registered but not yet ready to carry traffic.
       for (var activeCall in state.activeCalls) {
         if (!activeCall.processingStatus.hasPeerConnectionReady) {
           _logger.info(
@@ -562,10 +572,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
           continue;
         }
         _logger.info(
-          '_onConnectivityResultChanged: restarting ICE for call ${activeCall.callId} (status: ${activeCall.processingStatus})',
+          '_onConnectivityResultChanged: scheduling ICE restart for call ${activeCall.callId} (status: ${activeCall.processingStatus})',
         );
-        final pc = await _peerConnectionManager.retrieve(activeCall.callId);
-        pc?.restartIce();
+        _scheduleIceRestart(activeCall.callId);
       }
     }
 
@@ -3720,6 +3729,23 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       callId,
       () => RenegotiationHandler(callErrorReporter: callErrorReporter, sdpMunger: sdpMunger),
     );
+  }
+
+  /// Schedules an ICE restart for [callId] after a short delay to allow a newly created
+  /// network interface (e.g. VPN tunnel) to finish initializing before ICE probing starts.
+  /// Any pending restart for the same call is cancelled and rescheduled on each call, so
+  /// rapid consecutive connectivity events result in a single restart.
+  static const _iceRestartDebounce = Duration(seconds: 2);
+
+  void _scheduleIceRestart(String callId) {
+    _iceRestartTimers[callId]?.cancel();
+    _iceRestartTimers[callId] = Timer(_iceRestartDebounce, () async {
+      _iceRestartTimers.remove(callId);
+      final pc = await _peerConnectionManager.retrieve(callId);
+      if (pc == null) return;
+      _logger.info('_scheduleIceRestart: restarting ICE for call $callId');
+      pc.restartIce();
+    });
   }
 
   /// Performs a safe renegotiation by first checking if the active call and peer connection still exist before proceeding and no "updating" state is detected on the call.

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -175,6 +175,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     on<_AppLifecycleStateChanged>(_onAppLifecycleStateChanged, transformer: sequential());
     on<_ConnectivityResultChanged>(_onConnectivityResultChanged, transformer: sequential());
     on<_NavigatorMediaDevicesChange>(_onNavigatorMediaDevicesChange, transformer: debounce());
+    on<_IceRestartTriggered>(_onIceRestartTriggered, transformer: sequential());
     on<_RegistrationChange>(_onRegistrationChange, transformer: droppable());
     on<_ResetStateEvent>(_onResetStateEvent, transformer: droppable());
     on<_SignalingClientEvent>(_onSignalingClientEvent, transformer: restartable());
@@ -645,6 +646,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> __onResetStateEventCompleteCall(_ResetStateEventCompleteCall event, Emitter<CallState> emit) async {
     _logger.warning('__onResetStateEventCompleteCall: ${event.callId}');
 
+    _iceRestartDebounce.cancel(event.callId);
     await _stopRingbackSound();
 
     try {
@@ -3733,12 +3735,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// Any pending restart for the same call is cancelled and rescheduled on each call, so
   /// rapid consecutive connectivity events result in a single restart.
   void _scheduleIceRestart(String callId) {
-    _iceRestartDebounce.schedule(callId, () async {
-      final pc = await _peerConnectionManager.retrieve(callId);
-      if (pc == null) return;
-      _logger.info('_scheduleIceRestart: restarting ICE for call $callId');
-      pc.restartIce();
-    });
+    _iceRestartDebounce.schedule(callId, () => add(_IceRestartTriggered(callId)));
+  }
+
+  Future<void> _onIceRestartTriggered(_IceRestartTriggered event, Emitter<CallState> emit) async {
+    final pc = await _peerConnectionManager.retrieve(event.callId);
+    if (pc == null) return;
+    _logger.info('_onIceRestartTriggered: restarting ICE for call ${event.callId}');
+    pc.restartIce();
   }
 
   /// Performs a safe renegotiation by first checking if the active call and peer connection still exist before proceeding and no "updating" state is detected on the call.

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -33,6 +33,15 @@ class _NavigatorMediaDevicesChange extends CallEvent {
   const _NavigatorMediaDevicesChange();
 }
 
+class _IceRestartTriggered extends CallEvent {
+  const _IceRestartTriggered(this.callId);
+
+  final String callId;
+
+  @override
+  List<Object?> get props => [callId];
+}
+
 // registration event change
 
 class _RegistrationChange extends CallEvent {

--- a/lib/utils/debounce_map.dart
+++ b/lib/utils/debounce_map.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+/// Debounces repeated actions keyed by an identifier.
+///
+/// Calling [schedule] with the same key cancels any pending callback for that
+/// key and starts a new [duration] countdown. Useful when the same logical
+/// action may be triggered many times in quick succession and only the last
+/// occurrence should execute.
+class DebounceMap<K> {
+  DebounceMap(this.duration);
+
+  final Duration duration;
+  final Map<K, Timer> _timers = {};
+
+  void schedule(K key, void Function() callback) {
+    _timers[key]?.cancel();
+    _timers[key] = Timer(duration, () {
+      _timers.remove(key);
+      callback();
+    });
+  }
+
+  void cancel(K key) {
+    _timers.remove(key)?.cancel();
+  }
+
+  void dispose() {
+    for (final t in _timers.values) {
+      t.cancel();
+    }
+    _timers.clear();
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,11 +1,11 @@
 export 'backoff_retries.dart';
-export 'debounce_map.dart';
 export 'badge_layout.dart';
 export 'bloc_concurrency.dart';
 export 'buffer_transformer.dart';
 export 'connectivity_checker.dart';
 export 'core_support.dart';
 export 'crashlytics_utils.dart';
+export 'debounce_map.dart';
 export 'equatable_prop_to_string.dart';
 export 'expiring_cache.dart';
 export 'fixed_delay_scheduler.dart';

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,4 +1,5 @@
 export 'backoff_retries.dart';
+export 'debounce_map.dart';
 export 'badge_layout.dart';
 export 'bloc_concurrency.dart';
 export 'buffer_transformer.dart';

--- a/test/utils/debounce_map_test.dart
+++ b/test/utils/debounce_map_test.dart
@@ -1,0 +1,144 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/utils/debounce_map.dart';
+
+void main() {
+  const duration = Duration(seconds: 2);
+
+  group('DebounceMap', () {
+    test('fires callback after duration elapses', () {
+      fakeAsync((async) {
+        final map = DebounceMap<String>(duration);
+        var called = false;
+
+        map.schedule('a', () => called = true);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(called, isFalse);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(called, isTrue);
+
+        map.dispose();
+      });
+    });
+
+    test('reschedules on repeated calls — only fires once', () {
+      fakeAsync((async) {
+        final map = DebounceMap<String>(duration);
+        var count = 0;
+
+        map.schedule('a', () => count++);
+        async.elapse(const Duration(seconds: 1));
+
+        map.schedule('a', () => count++);
+        async.elapse(const Duration(seconds: 1));
+
+        // first timer was cancelled, second not yet done
+        expect(count, 0);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(count, 1);
+
+        map.dispose();
+      });
+    });
+
+    test('independent keys fire independently', () {
+      fakeAsync((async) {
+        final map = DebounceMap<String>(duration);
+        var aFired = false;
+        var bFired = false;
+
+        map.schedule('a', () => aFired = true);
+        async.elapse(const Duration(seconds: 1));
+
+        map.schedule('b', () => bFired = true);
+        async.elapse(const Duration(seconds: 1));
+
+        expect(aFired, isTrue);
+        expect(bFired, isFalse);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(bFired, isTrue);
+
+        map.dispose();
+      });
+    });
+
+    test('cancel prevents callback from firing', () {
+      fakeAsync((async) {
+        final map = DebounceMap<String>(duration);
+        var called = false;
+
+        map.schedule('a', () => called = true);
+        async.elapse(const Duration(seconds: 1));
+
+        map.cancel('a');
+        async.elapse(const Duration(seconds: 2));
+
+        expect(called, isFalse);
+
+        map.dispose();
+      });
+    });
+
+    test('cancel on unknown key is a no-op', () {
+      fakeAsync((async) {
+        final map = DebounceMap<String>(duration);
+        expect(() => map.cancel('nonexistent'), returnsNormally);
+        map.dispose();
+      });
+    });
+
+    test('dispose cancels all pending callbacks', () {
+      fakeAsync((async) {
+        final map = DebounceMap<String>(duration);
+        var aFired = false;
+        var bFired = false;
+
+        map.schedule('a', () => aFired = true);
+        map.schedule('b', () => bFired = true);
+
+        map.dispose();
+
+        async.elapse(const Duration(seconds: 3));
+
+        expect(aFired, isFalse);
+        expect(bFired, isFalse);
+      });
+    });
+
+    test('can schedule again after dispose', () {
+      fakeAsync((async) {
+        final map = DebounceMap<String>(duration);
+        var called = false;
+
+        map.schedule('a', () {});
+        map.dispose();
+
+        map.schedule('a', () => called = true);
+        async.elapse(const Duration(seconds: 2));
+
+        expect(called, isTrue);
+
+        map.dispose();
+      });
+    });
+
+    test('works with integer keys', () {
+      fakeAsync((async) {
+        final map = DebounceMap<int>(duration);
+        var called = false;
+
+        map.schedule(42, () => called = true);
+        async.elapse(const Duration(seconds: 2));
+
+        expect(called, isTrue);
+
+        map.dispose();
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Problem

When switching VPN on/off during an active call, ICE restart was triggered immediately on `onConnectivityChanged`. At that moment, the VPN tunnel (`tun0`) is registered in the routing table but not yet ready to carry traffic — STUN packets are dropped, candidate gathering takes 6–10s instead of 1s, and ICE fails → call drops.

When a call starts with VPN already active, ICE establishes normally because the tunnel is fully initialized from the start.

## Root cause

`pc?.restartIce()` was called synchronously inside `_onConnectivityResultChanged`, before the new network interface (VPN or any other) finishes initializing.

Observed in logs:
- **develop**: `restarting ICE` → `RTCIceGatheringStateGathering` (0–2s) → 6–10s gathering → `RTCIceConnectionStateDisconnected` → `RTCIceConnectionStateFailed`
- **fix**: `scheduling ICE restart` → 2s delay → `restarting ICE` → gathering completes in **1s** → `RTCIceConnectionStateConnected` ✓

## Fix

**Debounce ICE restart by 2 seconds.** Rapid consecutive connectivity events (VPN connecting + WS drop) cancel and reschedule the timer, resulting in a single ICE restart once the interface is stable.

Implementation:
- `DebounceMap<K>` (`lib/utils/debounce_map.dart`) — reusable cancel-and-reschedule timer per key, with `schedule / cancel / dispose`
- `_scheduleIceRestart(callId)` schedules `add(_IceRestartTriggered(callId))` via `DebounceMap`; the timer callback is sync (no fire-and-forget Future)
- `_onIceRestartTriggered` handles `retrieve + restartIce` inside the BLoC event loop — exceptions are caught by `onError`, state is consistent, closed BLoC silently drops the event
- Pending timer cancelled in `__onResetStateEventCompleteCall` to avoid spurious work after call teardown

## Test result

Tested with 9+ VPN on/off cycles during an active call:
- **develop**: call drops after 2–3 cycles (ICE Failed → server HangingupEvent)
- **fix**: call survives all cycles with audio intact; HangingupEvent only on manual hang-up

## Tests

`test/utils/debounce_map_test.dart` — 8 unit tests via `fake_async`:
- fires after duration, debounces repeated calls, independent keys, cancel, cancel unknown key, dispose cancels all, schedule after dispose, non-string key type