### PR TITLE
fix(wt-1428): show user not found notification on OTP sign-in 404

### DIFF
--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -517,6 +517,12 @@ class LoginCubit extends Cubit<LoginState> {
 
   void handleError(Object error, StackTrace stackTrace, String context) {
     if (error is RequestFailure) {
+      if (error is UserNotFoundException) {
+        _logger.warning('Known login error occurred: user not found', error);
+        notificationsBloc.add(NotificationsSubmitted(const LoginUserNotFoundNotification()));
+        return;
+      }
+
       final code = error.error?.code;
       final readableNotification = switch (code) {
         'otp_not_found' => const LoginOtpNotFoundNotification(),

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -518,7 +518,7 @@ class LoginCubit extends Cubit<LoginState> {
   void handleError(Object error, StackTrace stackTrace, String context) {
     if (error is RequestFailure) {
       if (error is UserNotFoundException) {
-        _logger.warning('Known login error occurred: user not found', error);
+        _logger.warning('Known login error occurred: $error', error);
         notificationsBloc.add(NotificationsSubmitted(const LoginUserNotFoundNotification()));
         return;
       }

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -345,15 +345,22 @@ class WebtritApiClient {
   }) async {
     final requestJson = sessionOtpCredential.toJson();
 
-    final responseJson = await _httpClientExecutePost(
-      [..._apiBasePathSegmentsV1, 'session', 'otp-create'],
-      null,
-      null,
-      requestJson,
-      requestOptions: options,
-    );
+    try {
+      final responseJson = await _httpClientExecutePost(
+        [..._apiBasePathSegmentsV1, 'session', 'otp-create'],
+        null,
+        null,
+        requestJson,
+        requestOptions: options,
+      );
 
-    return SessionOtpProvisional.fromJson(responseJson);
+      return SessionOtpProvisional.fromJson(responseJson);
+    } on RequestFailure catch (e) {
+      if (e.statusCode == 404) {
+        throw UserNotFoundException(url: e.url, requestId: e.requestId, statusCode: e.statusCode!);
+      }
+      rethrow;
+    }
   }
 
   Future<SessionToken> verifySessionOtp(

--- a/packages/webtrit_api/test/webtrit_api_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_test.dart
@@ -336,6 +336,22 @@ void main() {
       );
     });
 
+    test('otp request throws UserNotFoundException on 404', () {
+      Future<Response> handler(Request request) async {
+        return Response('', 404, request: request);
+      }
+
+      final httpClient = MockClient(expectAsync1(handler));
+      final apiClient = WebtritApiClient.inner(Uri.https(authority), '', httpClient: httpClient);
+
+      expect(
+        apiClient.createSessionOtp(
+          SessionOtpCredential(type: AppType.web, identifier: 'identifier_1', userRef: 'user@example.com'),
+        ),
+        throwsA(isA<UserNotFoundException>()),
+      );
+    });
+
     test('otp verify', () {
       Future<Response> handler(Request request) async {
         expect(request.method, equalsIgnoringCase('post'));


### PR DESCRIPTION
## Summary

- `createSessionOtp` in `WebtritApiClient` now catches 404 and rethrows as `UserNotFoundException` (same pattern as `getUserInfo`)
- `LoginCubit.handleError` handles `UserNotFoundException` explicitly and shows `LoginUserNotFoundNotification`

Previously the 404 was converted to `EndpointNotSupportedException` (no `error` field), fell through the error code switch as `null`, and was logged as an unexpected error with no UI feedback.

## Related

Fixes: WT-1428