### PR TITLE
fix: media tracks lease race condition (WT-1432)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1344,6 +1344,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       if (jsep != null) {
         final remoteDescription = jsep.toDescription();
         sdpSanitizer?.apply(remoteDescription);
+        _logger.infoPretty(remoteDescription.sdp, tag: '__onCallSignalingEventCallUpdating received new offer SDP');
         await state.performOnActiveCall(event.callId, (activeCall) async {
           final peerConnection = await _peerConnectionManager.retrieve(event.callId);
           if (peerConnection == null) {
@@ -1396,6 +1397,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
             }
             final localDescription = await peerConnection.createAnswer({});
             sdpMunger?.apply(localDescription);
+            _logger.infoPretty(localDescription.sdp, tag: '__onCallSignalingEventCallUpdating created answer SDP');
 
             // According to RFC 8829 5.6 (https://datatracker.ietf.org/doc/html/rfc8829#section-5.6),
             // localDescription should be set before sending the answer to transition into stable state.

--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
@@ -48,6 +50,13 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   final Map<String, _BorrowedStreamLease> _borrowedStreams = {};
   _PooledTrack? _audioTrack;
   _PooledTrack? _videoTrack;
+  Future<void> _poolMutationQueue = Future<void>.value();
+
+  Future<T> _runPoolMutation<T>(Future<T> Function() action) {
+    final result = _poolMutationQueue.then((_) => action());
+    _poolMutationQueue = result.then((_) {}, onError: (_, __) {});
+    return result;
+  }
 
   /// Requests access to the user's media input devices (camera and/or microphone).
   ///
@@ -67,58 +76,57 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
   /// https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
   @override
   Future<MediaStream> build({required bool video, bool? frontCamera, bool allowAudioFallback = false}) async {
-    final resolvedVideo = video && (!allowAudioFallback || await _isCameraAvailable());
+    return _runPoolMutation(() async {
+      final resolvedVideo = video && (!allowAudioFallback || await _isCameraAvailable());
 
-    try {
-      return await _acquirePooledStream(resolvedVideo: resolvedVideo, frontCamera: frontCamera);
-    } catch (_) {
-      if (!allowAudioFallback || !resolvedVideo) rethrow;
-      return _acquirePooledStream(resolvedVideo: false, frontCamera: frontCamera);
-    }
+      try {
+        return await _acquirePooledStream(resolvedVideo: resolvedVideo, frontCamera: frontCamera);
+      } catch (_) {
+        if (!allowAudioFallback || !resolvedVideo) rethrow;
+        return _acquirePooledStream(resolvedVideo: false, frontCamera: frontCamera);
+      }
+    });
   }
 
   @override
   Future<MediaStreamTrack?> ensureVideoTrack(MediaStream stream, {bool? frontCamera}) async {
-    final existingTrack = stream.getVideoTracks().firstOrNull;
-    if (existingTrack != null) return existingTrack;
+    return _runPoolMutation(() async {
+      final existingTrack = stream.getVideoTracks().firstOrNull;
+      if (existingTrack != null) return existingTrack;
 
-    final videoTrack = await _acquireVideoTrack(frontCamera: frontCamera);
+      final videoTrack = await _acquireVideoTrack(frontCamera: frontCamera);
 
-    try {
-      await stream.addTrack(videoTrack);
-      _borrowedStreams.update(
-        stream.id,
-        (lease) => lease.copyWith(videoTrackId: videoTrack.id),
-        ifAbsent: () => _BorrowedStreamLease(videoTrackId: videoTrack.id),
-      );
+      try {
+        await stream.addTrack(videoTrack);
+        _borrowedStreams.update(
+          stream.id,
+          (lease) => lease.copyWith(videoTrackId: videoTrack.id),
+          ifAbsent: () => _BorrowedStreamLease(videoTrackId: videoTrack.id),
+        );
 
-      await _configureAppleAudio(hasVideo: true);
-      return videoTrack;
-    } catch (e) {
-      await _releaseVideoTrack(videoTrack.id);
-      throw UserMediaError(e.toString());
-    }
+        await _configureAppleAudio(hasVideo: true);
+        return videoTrack;
+      } catch (e) {
+        await _releaseVideoTrack(videoTrack.id);
+        throw UserMediaError(e.toString());
+      }
+    });
   }
 
   @override
   Future<void> release(MediaStream stream) async {
-    final lease = _borrowedStreams.remove(stream.id);
+    await _runPoolMutation(() async {
+      final lease = _borrowedStreams.remove(stream.id);
 
-    if (lease != null) {
-      // Detach pooled tracks from the stream before disposing it.
-      // On iOS and Android, streamDispose iterates stream.audioTracks /
-      // stream.videoTracks and removes each from the native localTracks
-      // registry. If a track is still referenced by another active call
-      // (references > 1), removing it from the stream first prevents
-      // streamDispose from evicting it — mediaStreamRemoveTrack does not
-      // touch localTracks, only the stream's own track list.
-      await _detachIfStillPooled(stream, lease.audioTrackId, _audioTrack);
-      await _detachIfStillPooled(stream, lease.videoTrackId, _videoTrack);
-      await _releaseAudioTrack(lease.audioTrackId);
-      await _releaseVideoTrack(lease.videoTrackId);
-    }
+      if (lease != null) {
+        await _detachIfStillPooled(stream, lease.audioTrackId, _audioTrack);
+        await _detachIfStillPooled(stream, lease.videoTrackId, _videoTrack);
+        await _releaseAudioTrack(lease.audioTrackId);
+        await _releaseVideoTrack(lease.videoTrackId);
+      }
 
-    await stream.dispose();
+      await stream.dispose();
+    });
   }
 
   Future<void> _detachIfStillPooled(MediaStream stream, String? trackId, _PooledTrack? pooled) async {

--- a/test/features/call/utils/user_media_builder_test.dart
+++ b/test/features/call/utils/user_media_builder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:mocktail/mocktail.dart';
@@ -157,6 +159,83 @@ void main() {
 
       final localStream2 = localStreamFactory.streams[1];
       verifyNever(() => localStream2.removeTrack(any()));
+    });
+
+    test('serializes release and subsequent build pool mutations', () async {
+      final disposeGate = Completer<void>();
+      final events = <String>[];
+      var streamIndex = 0;
+      var getUserMediaCalls = 0;
+
+      Future<MediaStream> createBlockingLocalStream(String _) async {
+        streamIndex++;
+        final currentIndex = streamIndex;
+        final stream = MockMediaStream();
+        final audioTracks = <MediaStreamTrack>[];
+        final videoTracks = <MediaStreamTrack>[];
+
+        when(() => stream.id).thenReturn('local-stream-$currentIndex');
+        when(() => stream.getAudioTracks()).thenAnswer((_) => audioTracks);
+        when(() => stream.getVideoTracks()).thenAnswer((_) => videoTracks);
+        when(() => stream.addTrack(any())).thenAnswer((invocation) async {
+          final track = invocation.positionalArguments.first as MediaStreamTrack;
+          if (track.kind == 'audio') {
+            audioTracks.add(track);
+          } else if (track.kind == 'video') {
+            videoTracks.add(track);
+          }
+        });
+        when(() => stream.removeTrack(any())).thenAnswer((_) async {});
+        when(() => stream.dispose()).thenAnswer((_) async {
+          if (currentIndex != 1) return;
+          events.add('release_dispose_start');
+          await disposeGate.future;
+          events.add('release_dispose_end');
+        });
+
+        return stream;
+      }
+
+      final subject = DefaultUserMediaBuilder(
+        getUserMedia: (constraints) async {
+          getUserMediaCalls++;
+          events.add('gum_$getUserMediaCalls');
+
+          final hasAudio = constraints['audio'] != false;
+          final hasVideo = constraints['video'] != false;
+
+          if (hasAudio && !hasVideo) return audioSourceStream;
+          if (!hasAudio && hasVideo) return videoSourceStream;
+
+          throw Exception('Unsupported constraints in test: $constraints');
+        },
+        createLocalStream: createBlockingLocalStream,
+      );
+
+      final firstStream = await subject.build(video: false);
+      expect(getUserMediaCalls, 1);
+
+      final releaseFuture = subject.release(firstStream);
+      await Future<void>.delayed(Duration.zero);
+      expect(events, contains('release_dispose_start'));
+
+      final secondBuildFuture = subject.build(video: false);
+      await Future<void>.delayed(Duration.zero);
+      expect(getUserMediaCalls, 1);
+
+      disposeGate.complete();
+
+      final secondStream = await secondBuildFuture;
+      await releaseFuture;
+
+      expect(secondStream, isA<MediaStream>());
+      expect(getUserMediaCalls, 2);
+
+      final releaseDisposeEndIndex = events.indexOf('release_dispose_end');
+      final secondGetUserMediaIndex = events.indexOf('gum_2');
+
+      expect(releaseDisposeEndIndex, greaterThan(-1));
+      expect(secondGetUserMediaIndex, greaterThan(releaseDisposeEndIndex));
     });
   });
 


### PR DESCRIPTION
**Summary**
- Fixes a race condition in media track pooling that could fail outgoing call setup with PlatformException mediaStreamAddTrack track is null.
- Serializes pooled track mutations so acquire and release flows cannot overlap in a way that invalidates native track references.
- Adds regression coverage for concurrent release and build behavior.

**Root Cause**
- Pooled track lifecycle operations were allowed to run concurrently.
- A release path could dispose or invalidate native track state while another flow was still attaching the same pooled track to a new stream.

**What Changed**
1. Added a pool mutation queue and executor in user_media_builder.dart.
2. Wrapped build, ensureVideoTrack, and release in serialized execution in user_media_builder.dart.
3. Added a deterministic concurrency regression test in user_media_builder_test.dart.
