### PR TITLE
fix: replace unnecessary double-underscore with wildcard _ in pool mutation error handler

### DIFF
--- a/lib/features/call/utils/user_media_builder.dart
+++ b/lib/features/call/utils/user_media_builder.dart
@@ -54,7 +54,7 @@ class DefaultUserMediaBuilder implements UserMediaBuilder {
 
   Future<T> _runPoolMutation<T>(Future<T> Function() action) {
     final result = _poolMutationQueue.then((_) => action());
-    _poolMutationQueue = result.then((_) {}, onError: (_, __) {});
+    _poolMutationQueue = result.then((_) {}, onError: (_, _) {});
     return result;
   }
 


### PR DESCRIPTION
## Summary

- Fixes `unnecessary_underscores` lint warning in `user_media_builder.dart:57`
- Replaced `__` (unused named parameter) with `_` wildcard in the `onError` callback of `_runPoolMutation`

## Changes

`lib/features/call/utils/user_media_builder.dart` — line 57:
```dart
// before
_poolMutationQueue = result.then((_) {}, onError: (_, __) {});
// after
_poolMutationQueue = result.then((_) {}, onError: (_, _) {});
```