### PR TITLE
fix: remove redundant hold on transfer init that causes race conditions (WT-1399)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1858,8 +1858,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     var newState = state.copyWith(minimized: true);
 
-    await __onCallControlEventSetHeld(_CallControlEventSetHeld(event.callId, true), emit);
-
     newState = newState.copyWithMappedActiveCall(event.callId, (activeCall) {
       return activeCall.copyWith(
         transfer: const Transfer.blindTransferInitiated(),
@@ -1885,8 +1883,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     });
 
     emit(newState);
-
-    await __onCallControlEventSetHeld(_CallControlEventSetHeld(event.callId, true), emit);
   }
 
   Future<void> _onCallControlEventBlindTransferSubmitted(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1868,6 +1868,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     emit(newState);
 
     await callkeep.reportUpdateCall(state.activeCalls.current.callId, proximityEnabled: state.shouldListenToProximity);
+
+    // Hendgehog been there and removed putting on hold
+    // He knows it was nessacery for first implementation of attended! transfer when our code can't auto hold on new call creation
+    // but now we have it and hold inside _onCallControlEventAttendedTransferInitiated removed too
+    //
+    // The question is why it was added there (blind transter) also, because it cause race conditions
+    // Attentioin: if you wanna bring it back, consider to prevent race condition (WT-1399) beetween holding and submitting refer (e.g fast initiating above recents tab and click on user)
   }
 
   Future<void> _onCallControlEventAttendedTransferInitiated(


### PR DESCRIPTION
Removes hold before transfer initiation because for blind transfer it causes race conditions and for attendand transfer its not needed anymore to start transfering.