### PR TITLE
fix(fgs): suppress FGS notification in pushBound mode

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/build.gradle
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/build.gradle
@@ -61,6 +61,7 @@ kotlin {
 dependencies {
     implementation "androidx.core:core-ktx:1.16.0"
     implementation "androidx.work:work-runtime-ktx:2.9.0"
+    implementation "androidx.lifecycle:lifecycle-process:2.8.7"
 
     if (flutterSdkPath) {
         compileOnly files("$flutterSdkPath/bin/cache/artifacts/engine/android-x86/flutter.jar")

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/build.gradle
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/build.gradle
@@ -61,7 +61,6 @@ kotlin {
 dependencies {
     implementation "androidx.core:core-ktx:1.16.0"
     implementation "androidx.work:work-runtime-ktx:2.9.0"
-    implementation "androidx.lifecycle:lifecycle-process:2.8.7"
 
     if (flutterSdkPath) {
         compileOnly files("$flutterSdkPath/bin/cache/artifacts/engine/android-x86/flutter.jar")

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -119,6 +119,16 @@ class SignalingForegroundService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "SignalingForegroundService onStartCommand")
 
+        // Re-satisfy Android's startForeground() requirement for this startForegroundService() call.
+        // In pushBound mode the service runs without a visible notification (stopForeground is called
+        // in onCreate). When startForegroundService() is called on an already-running-but-not-foreground
+        // service, Android starts a fresh 5-second timer — onCreate() is NOT called again, so without
+        // this call the timer expires and the app crashes with ForegroundServiceDidNotStartInTimeException.
+        startForeground()
+        if (StorageDelegate.isPushBound(applicationContext)) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        }
+
         // Path 4 guard: stopService() arrived in the Pigeon FIFO queue before this
         // service's H.CREATE_SERVICE ran (main thread was overloaded). The plugin
         // deferred the stop because calling context.stopService() at that point would

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -15,6 +15,10 @@ import android.util.Log
 import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import io.flutter.plugin.common.BinaryMessenger
 
 /// Foreground service that manages the background Flutter engine for signaling.
@@ -58,6 +62,13 @@ class SignalingForegroundService : Service() {
     /// again before the already-posted block runs.
     /// Accessed only on the main thread.
     private var _engineInitPending = false
+
+    private var _isForeground = false
+
+    private val _appLifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) = suppressNotification()
+        override fun onStop(owner: LifecycleOwner) = restoreNotification()
+    }
 
     /// Set to true by the startup watchdog Runnable (after [stopSelf] is called).
     /// Prevents [startStartupWatchdog] from re-arming in the brief window between
@@ -106,7 +117,10 @@ class SignalingForegroundService : Service() {
     override fun onCreate() {
         super.onCreate()
         startForeground()
-
+        ProcessLifecycleOwner.get().lifecycle.addObserver(_appLifecycleObserver)
+        if (ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            suppressNotification()
+        }
         Log.d(TAG, "SignalingForegroundService onCreate")
         instance = this
         val callbackHandle = StorageDelegate.getCallbackDispatcher(applicationContext)
@@ -226,6 +240,7 @@ class SignalingForegroundService : Service() {
     }
 
     override fun onDestroy() {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(_appLifecycleObserver)
         // Enqueue restart before any teardown so the job is queued while the process is still valid.
         // Credentials guard: stopService() calls clearConnectionConfig() before stopping the service,
         // so after explicit logout coreUrl is already empty here and no job is scheduled.
@@ -276,6 +291,21 @@ class SignalingForegroundService : Service() {
         notificationDescription = description
     }
 
+    internal fun suppressNotification() {
+        if (!_isForeground) return
+        if (!StorageDelegate.isPushBound(applicationContext)) return
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        _isForeground = false
+        Log.d(TAG, "notification suppressed (app in foreground)")
+    }
+
+    internal fun restoreNotification() {
+        if (_isForeground) return
+        if (!StorageDelegate.isPushBound(applicationContext)) return
+        startForeground()
+        Log.d(TAG, "notification restored (app going to background)")
+    }
+
     /// Stops the service immediately without signalling the background isolate,
     /// simulating an abrupt OS kill.
     ///
@@ -315,6 +345,7 @@ class SignalingForegroundService : Service() {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
             else 0,
         )
+        _isForeground = true
     }
 
     private fun createNotificationChannel(): String {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -108,6 +108,7 @@ class SignalingForegroundService : Service() {
         startForeground()
         if (StorageDelegate.isPushBound(applicationContext)) {
             stopForeground(STOP_FOREGROUND_REMOVE)
+            Log.d(TAG, "onCreate: pushBound mode -- notification suppressed")
         }
         Log.d(TAG, "SignalingForegroundService onCreate")
         instance = this
@@ -127,6 +128,7 @@ class SignalingForegroundService : Service() {
         startForeground()
         if (StorageDelegate.isPushBound(applicationContext)) {
             stopForeground(STOP_FOREGROUND_REMOVE)
+            Log.d(TAG, "onStartCommand: pushBound mode -- notification suppressed")
         }
 
         // Path 4 guard: stopService() arrived in the Pigeon FIFO queue before this

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -15,10 +15,6 @@ import android.util.Log
 import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.ProcessLifecycleOwner
 import io.flutter.plugin.common.BinaryMessenger
 
 /// Foreground service that manages the background Flutter engine for signaling.
@@ -62,13 +58,6 @@ class SignalingForegroundService : Service() {
     /// again before the already-posted block runs.
     /// Accessed only on the main thread.
     private var _engineInitPending = false
-
-    private var _isForeground = false
-
-    private val _appLifecycleObserver = object : DefaultLifecycleObserver {
-        override fun onStart(owner: LifecycleOwner) = suppressNotification()
-        override fun onStop(owner: LifecycleOwner) = restoreNotification()
-    }
 
     /// Set to true by the startup watchdog Runnable (after [stopSelf] is called).
     /// Prevents [startStartupWatchdog] from re-arming in the brief window between
@@ -117,9 +106,8 @@ class SignalingForegroundService : Service() {
     override fun onCreate() {
         super.onCreate()
         startForeground()
-        ProcessLifecycleOwner.get().lifecycle.addObserver(_appLifecycleObserver)
-        if (ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-            suppressNotification()
+        if (StorageDelegate.isPushBound(applicationContext)) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
         }
         Log.d(TAG, "SignalingForegroundService onCreate")
         instance = this
@@ -240,7 +228,6 @@ class SignalingForegroundService : Service() {
     }
 
     override fun onDestroy() {
-        ProcessLifecycleOwner.get().lifecycle.removeObserver(_appLifecycleObserver)
         // Enqueue restart before any teardown so the job is queued while the process is still valid.
         // Credentials guard: stopService() calls clearConnectionConfig() before stopping the service,
         // so after explicit logout coreUrl is already empty here and no job is scheduled.
@@ -291,21 +278,6 @@ class SignalingForegroundService : Service() {
         notificationDescription = description
     }
 
-    internal fun suppressNotification() {
-        if (!_isForeground) return
-        if (!StorageDelegate.isPushBound(applicationContext)) return
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        _isForeground = false
-        Log.d(TAG, "notification suppressed (app in foreground)")
-    }
-
-    internal fun restoreNotification() {
-        if (_isForeground) return
-        if (!StorageDelegate.isPushBound(applicationContext)) return
-        startForeground()
-        Log.d(TAG, "notification restored (app going to background)")
-    }
-
     /// Stops the service immediately without signalling the background isolate,
     /// simulating an abrupt OS kill.
     ///
@@ -345,7 +317,6 @@ class SignalingForegroundService : Service() {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
             else 0,
         )
-        _isForeground = true
     }
 
     private fun createNotificationChannel(): String {


### PR DESCRIPTION
## Summary

- In pushBound mode, the FGS persistent notification is now immediately hidden after `startForeground()` via `stopForeground(STOP_FOREGROUND_REMOVE)` — called in both `onCreate()` and `onStartCommand()`
- In persistent mode, the notification remains always visible (user-facing indicator of the always-on service)
- Recovery when OS kills the service while backgrounded: incoming-call push notification restarts the FGS session

## Why onStartCommand too

When the service is already running but not in foreground state (after `stopForeground` in `onCreate`), a new `startForegroundService()` call triggers `onStartCommand()` only — `onCreate()` is not called again. Android restarts the 5-second `startForeground` timer for each `startForegroundService()` call. Without the call in `onStartCommand`, the timer expires and the app crashes with `ForegroundServiceDidNotStartInTimeException`.

## Test plan

- [ ] pushBound mode: open app — no FGS notification visible
- [ ] pushBound mode: minimize app — no notification (OS may kill; push recovers on incoming call)
- [ ] pushBound mode: receive call while backgrounded — push restores session, call rings
- [ ] persistent mode: notification always visible regardless of app state
- [ ] no `ForegroundServiceDidNotStartInTimeException` crash on repeated `startForegroundService()` calls