### PR TITLE
fix(call): audio routing fixes for video calls (Android + iOS)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -411,7 +411,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> _onVideoStreamReady(String callId) async {
     final call = state.retrieveActiveCall(callId);
     if (call?.video == true) {
-      await _mediaManager.onVideoEnabled(callId);
+      await _mediaManager.onVideoEnabled(callId, speakerDevice: state.availableAudioDevices.getSpeaker);
     }
   }
 
@@ -2259,10 +2259,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       currentVideoTrack.enabled = e.enabled;
       emit(state.copyWithMappedActiveCall(e.callId, (call) => call.copyWith(video: e.enabled)));
       if (e.enabled) {
-        await _mediaManager.onVideoEnabled(e.callId);
+        await _mediaManager.onVideoEnabled(e.callId, speakerDevice: state.availableAudioDevices.getSpeaker);
       } else {
         final speakerActive = state.audioDevice?.type == CallAudioDeviceType.speaker;
-        await _mediaManager.onVideoDisabled(e.callId, speakerActive: speakerActive);
+        await _mediaManager.onVideoDisabled(
+          e.callId,
+          speakerActive: speakerActive,
+          earpieceDevice: state.availableAudioDevices.getEarpiece,
+        );
         await callkeep.reportUpdateCall(e.callId, hasVideo: false);
       }
       return;
@@ -2291,7 +2295,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
 
       emit(state.copyWithMappedActiveCall(e.callId, (call) => call.copyWith(video: true)));
-      await _mediaManager.onVideoEnabled(e.callId);
+      await _mediaManager.onVideoEnabled(e.callId, speakerDevice: state.availableAudioDevices.getSpeaker);
       await callkeep.reportUpdateCall(e.callId, hasVideo: true);
     } on UserMediaError catch (e) {
       _logger.warning('__onMutationControlSetCameraEnabled cant enable: $e');

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -410,7 +410,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// in Telecom, so setAudioDevice can route to speaker safely.
   Future<void> _onVideoStreamReady(String callId) async {
     final call = state.retrieveActiveCall(callId);
-    if (call?.video == true) {
+    if (call?.video == true && call?.direction == CallDirection.outgoing) {
       await _mediaManager.onVideoEnabled(callId, speakerDevice: state.availableAudioDevices.getSpeaker);
     }
   }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -410,7 +410,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// in Telecom, so setAudioDevice can route to speaker safely.
   Future<void> _onVideoStreamReady(String callId) async {
     final call = state.retrieveActiveCall(callId);
-    if (call?.video == true && call?.direction == CallDirection.outgoing) {
+    if (call?.video == true) {
       await _mediaManager.onVideoEnabled(callId, speakerDevice: state.availableAudioDevices.getSpeaker);
     }
   }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -391,11 +391,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final isEmpty = currentCalls.isEmpty;
 
     // First call started (0 → 1).
-    if (wasEmpty && !isEmpty) unawaited(_mediaManager.setSpeaker(null, enabled: false));
+    if (wasEmpty && !isEmpty) unawaited(_mediaManager.setSpeaker(enabled: false));
 
     // Last call ended (N → 0).
     if (!wasEmpty && isEmpty) {
-      unawaited(_mediaManager.setSpeaker(null, enabled: false));
+      unawaited(_mediaManager.setSpeaker(enabled: false));
       _mediaManager.clearCommunicationDevice();
     }
   }
@@ -410,7 +410,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// in Telecom, so setAudioDevice can route to speaker safely.
   Future<void> _onVideoStreamReady(String callId) async {
     final call = state.retrieveActiveCall(callId);
-    if (call?.video == true) await _mediaManager.onVideoEnabled(callId);
+    if (call?.video == true) {
+      await _mediaManager.onVideoEnabled(callId, speakerDevice: state.availableAudioDevices.getSpeaker);
+    }
   }
 
   void _handleConnectionFailed(SignalingFailureInfo failure) {
@@ -2257,10 +2259,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       currentVideoTrack.enabled = e.enabled;
       emit(state.copyWithMappedActiveCall(e.callId, (call) => call.copyWith(video: e.enabled)));
       if (e.enabled) {
-        await _mediaManager.onVideoEnabled(e.callId);
+        await _mediaManager.onVideoEnabled(e.callId, speakerDevice: state.availableAudioDevices.getSpeaker);
       } else {
         final speakerActive = state.audioDevice?.type == CallAudioDeviceType.speaker;
-        await _mediaManager.onVideoDisabled(e.callId, speakerActive: speakerActive);
+        await _mediaManager.onVideoDisabled(
+          e.callId,
+          speakerActive: speakerActive,
+          earpieceDevice: state.availableAudioDevices.getEarpiece,
+        );
         await callkeep.reportUpdateCall(e.callId, hasVideo: false);
       }
       return;
@@ -2289,7 +2295,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
 
       emit(state.copyWithMappedActiveCall(e.callId, (call) => call.copyWith(video: true)));
-      await _mediaManager.onVideoEnabled(e.callId);
+      await _mediaManager.onVideoEnabled(e.callId, speakerDevice: state.availableAudioDevices.getSpeaker);
       await callkeep.reportUpdateCall(e.callId, hasVideo: true);
     } on UserMediaError catch (e) {
       _logger.warning('__onMutationControlSetCameraEnabled cant enable: $e');

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -411,7 +411,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> _onVideoStreamReady(String callId) async {
     final call = state.retrieveActiveCall(callId);
     if (call?.video == true) {
-      await _mediaManager.onVideoEnabled(callId, speakerDevice: state.availableAudioDevices.getSpeaker);
+      await _mediaManager.onVideoEnabled(callId);
     }
   }
 
@@ -2259,14 +2259,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       currentVideoTrack.enabled = e.enabled;
       emit(state.copyWithMappedActiveCall(e.callId, (call) => call.copyWith(video: e.enabled)));
       if (e.enabled) {
-        await _mediaManager.onVideoEnabled(e.callId, speakerDevice: state.availableAudioDevices.getSpeaker);
+        await _mediaManager.onVideoEnabled(e.callId);
       } else {
         final speakerActive = state.audioDevice?.type == CallAudioDeviceType.speaker;
-        await _mediaManager.onVideoDisabled(
-          e.callId,
-          speakerActive: speakerActive,
-          earpieceDevice: state.availableAudioDevices.getEarpiece,
-        );
+        await _mediaManager.onVideoDisabled(e.callId, speakerActive: speakerActive);
         await callkeep.reportUpdateCall(e.callId, hasVideo: false);
       }
       return;
@@ -2295,7 +2291,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
 
       emit(state.copyWithMappedActiveCall(e.callId, (call) => call.copyWith(video: true)));
-      await _mediaManager.onVideoEnabled(e.callId, speakerDevice: state.availableAudioDevices.getSpeaker);
+      await _mediaManager.onVideoEnabled(e.callId);
       await callkeep.reportUpdateCall(e.callId, hasVideo: true);
     } on UserMediaError catch (e) {
       _logger.warning('__onMutationControlSetCameraEnabled cant enable: $e');

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -136,10 +136,13 @@ class CallMediaManager {
 
   /// Resets speaker state on the WebRTC layer (AudioSwitch / AVAudioSession).
   ///
-  /// Used for global resets at call start/end when no Telecom connection exists.
+  /// Android: used for global resets at call start/end when no Telecom connection exists.
   /// For routing during a live call use [setDevice] (user-triggered) or the
   /// video helpers [onVideoEnabled] / [onVideoDisabled] — they supply the actual
   /// device ID required by Telecom on Android.
+  ///
+  /// iOS: also called by [setDevice] during a live call — iOS has no Telecom layer,
+  /// so [Helper.setSpeakerphoneOn] is the only routing API needed.
   Future<void> setSpeaker({required bool enabled}) async {
     await Helper.setSpeakerphoneOn(enabled);
   }
@@ -195,6 +198,12 @@ class CallMediaManager {
       return;
     }
     await Helper.setSpeakerphoneOn(false);
-    if (earpieceDevice != null) await _callkeep.setAudioDevice(callId, earpieceDevice.toCallkeep());
+    if (earpieceDevice != null) {
+      await _callkeep.setAudioDevice(callId, earpieceDevice.toCallkeep());
+    } else {
+      _logger.warning(
+        'onVideoDisabled: earpiece device not available — Telecom route not updated, audio may stay on speaker',
+      );
+    }
   }
 }

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -110,24 +110,20 @@ class CallMediaManager {
 
   /// Routes audio to [device] for the given [callId].
   ///
-  /// Android: delegates to Telecom via [WebtritCallkeep.setAudioDevice].
+  /// Android: calls both [Helper.setSpeakerphoneOn] (AudioSwitch/AOSP) and
+  /// [WebtritCallkeep.setAudioDevice] (Telecom/MIUI) with the actual device ID
+  /// for cross-OEM compatibility.
   /// iOS: uses [Helper.setSpeakerphoneOn] and [Helper.selectAudioInput].
   Future<void> setDevice(String callId, CallAudioDevice device) async {
     _logger.info('setDevice: ${device.type} (id=${device.id}) for call $callId');
     if (Platform.isAndroid) {
-      if (device.type == CallAudioDeviceType.speaker) {
-        await setSpeaker(callId, enabled: true);
-      } else {
-        // Only clear AudioSwitch speaker state — Telecom routing goes directly
-        // to the target device below to avoid a double setAudioDevice call.
-        await Helper.setSpeakerphoneOn(false);
-        await _callkeep.setAudioDevice(callId, device.toCallkeep());
-      }
+      await Helper.setSpeakerphoneOn(device.type == CallAudioDeviceType.speaker);
+      await _callkeep.setAudioDevice(callId, device.toCallkeep());
     } else if (Platform.isIOS) {
       if (device.type == CallAudioDeviceType.speaker) {
-        await setSpeaker(callId, enabled: true);
+        await setSpeaker(enabled: true);
       } else {
-        await setSpeaker(callId, enabled: false);
+        await setSpeaker(enabled: false);
         final deviceId = device.id;
         if (deviceId != null) await Helper.selectAudioInput(deviceId);
       }
@@ -138,25 +134,14 @@ class CallMediaManager {
   // Speaker helpers
   // ---------------------------------------------------------------------------
 
-  /// Toggles speakerphone for [callId].
+  /// Resets speaker state on the WebRTC layer (AudioSwitch / AVAudioSession).
   ///
-  /// On Android both plugins must be called for cross-OEM compatibility:
-  /// - [Helper.setSpeakerphoneOn] (AudioSwitch/flutter-webrtc): AOSP and devices
-  ///   where AudioSwitch owns hardware routing and overrides direct AudioManager calls.
-  /// - [Callkeep.setAudioDevice] (Telecom): MIUI and OEMs that ignore direct
-  ///   AudioManager calls and only respond to Telecom routing.
-  ///
-  /// [callId] is optional — when null only the WebRTC side is updated (used for
-  /// global resets at call start/end when no Telecom connection is available).
-  /// On iOS [Helper.setSpeakerphoneOn] is sufficient — no Telecom layer involved.
-  Future<void> setSpeaker(String? callId, {required bool enabled}) async {
+  /// Used for global resets at call start/end when no Telecom connection exists.
+  /// For routing during a live call use [setDevice] (user-triggered) or the
+  /// video helpers [onVideoEnabled] / [onVideoDisabled] — they supply the actual
+  /// device ID required by Telecom on Android.
+  Future<void> setSpeaker({required bool enabled}) async {
     await Helper.setSpeakerphoneOn(enabled);
-    if (Platform.isAndroid && callId != null) {
-      await _callkeep.setAudioDevice(
-        callId,
-        CallAudioDevice(type: enabled ? CallAudioDeviceType.speaker : CallAudioDeviceType.earpiece).toCallkeep(),
-      );
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -168,30 +153,33 @@ class CallMediaManager {
   /// Must be called after [getUserMedia] completes — AudioSwitch (AudioSwitchManager)
   /// calls activate() inside getUserAudio(), so any routing request before that is a no-op.
   ///
-  /// Android: explicitly routes audio to speakerphone, mirroring iOS behavior
-  /// where WebRTC automatically switches to speaker via AVAudioSession
-  /// VideoChat mode when a video track is added.
-  /// iOS: no-op — the mode switch is handled by WebRTC internally.
-  Future<void> onVideoEnabled(String callId) async {
+  /// Android: routes audio to speakerphone via both AudioSwitch and Telecom.
+  /// [speakerDevice] must be the speaker entry from [CallState.availableAudioDevices];
+  /// when null the Telecom routing step is skipped.
+  /// iOS: no-op — WebRTC sets AVAudioSessionModeVideoChat automatically when a
+  /// video track is added, which routes audio to the speaker.
+  Future<void> onVideoEnabled(String callId, {CallAudioDevice? speakerDevice}) async {
     _logger.info('onVideoEnabled: $callId');
-    if (Platform.isAndroid) setSpeaker(callId, enabled: true);
-    // iOS: WebRTC sets AVAudioSessionModeVideoChat automatically when a video
-    // track is added, which routes audio to the speaker.
+    if (Platform.isAndroid) {
+      await Helper.setSpeakerphoneOn(true);
+      if (speakerDevice != null) await _callkeep.setAudioDevice(callId, speakerDevice.toCallkeep());
+    }
   }
 
   /// Called when video is disabled (camera turned off during a call).
   ///
-  /// Reverts audio routing back to voice mode on both platforms.
-  /// Skipped when the user has explicitly chosen speaker ([speakerActive])
-  /// so their preference is preserved after turning the camera off.
+  /// Reverts audio routing back to voice mode. Skipped when the user has
+  /// explicitly chosen speaker ([speakerActive]).
+  ///
+  /// Android: routes audio back to earpiece via both AudioSwitch and Telecom.
+  /// [earpieceDevice] must be the earpiece entry from [CallState.availableAudioDevices];
+  /// when null the Telecom routing step is skipped.
   ///
   /// iOS: resets the shared [RTCAudioSessionConfiguration] singleton from
   /// VideoChat → VoiceChat before calling [Helper.setSpeakerphoneOn(false)].
   /// Without this reset, [setSpeakerphoneOn(false)] re-applies VideoChat mode
   /// and keeps audio on speaker regardless of port override.
-  ///
-  /// Android: routes audio back to earpiece via Telecom.
-  Future<void> onVideoDisabled(String callId, {required bool speakerActive}) async {
+  Future<void> onVideoDisabled(String callId, {required bool speakerActive, CallAudioDevice? earpieceDevice}) async {
     _logger.info('onVideoDisabled: $callId speakerActive=$speakerActive');
     if (speakerActive) return;
     if (Platform.isIOS) {
@@ -199,6 +187,7 @@ class CallMediaManager {
       await Helper.setSpeakerphoneOn(false);
       return;
     }
-    setSpeaker(callId, enabled: false);
+    await Helper.setSpeakerphoneOn(false);
+    if (earpieceDevice != null) await _callkeep.setAudioDevice(callId, earpieceDevice.toCallkeep());
   }
 }

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -153,14 +153,20 @@ class CallMediaManager {
   /// Must be called after [getUserMedia] completes — AudioSwitch (AudioSwitchManager)
   /// calls activate() inside getUserAudio(), so any routing request before that is a no-op.
   ///
-  /// Android: routes to speaker via AudioSwitch only ([Helper.setSpeakerphoneOn]).
-  /// Telecom routing is intentionally skipped — AudioSwitch owns the device selection
-  /// here and a competing Telecom call can override AudioSwitch and silence the speaker.
+  /// Android: Telecom (uid 1000) holds the active audio route and overrides AudioSwitch
+  /// when both compete. Both APIs must be called:
+  /// - [Helper.setSpeakerphoneOn] updates AudioSwitch state.
+  /// - [WebtritCallkeep.setAudioDevice] updates the Telecom route so it stops overriding.
+  /// [speakerDevice] is the speaker entry from [CallState.availableAudioDevices];
+  /// when null the Telecom call is skipped (AudioSwitch only).
   /// iOS: no-op — WebRTC sets AVAudioSessionModeVideoChat automatically when a
   /// video track is added, which routes audio to the speaker.
-  Future<void> onVideoEnabled(String callId) async {
+  Future<void> onVideoEnabled(String callId, {CallAudioDevice? speakerDevice}) async {
     _logger.info('onVideoEnabled: $callId');
-    if (Platform.isAndroid) await Helper.setSpeakerphoneOn(true);
+    if (Platform.isAndroid) {
+      await Helper.setSpeakerphoneOn(true);
+      if (speakerDevice != null) await _callkeep.setAudioDevice(callId, speakerDevice.toCallkeep());
+    }
   }
 
   /// Called when video is disabled (camera turned off during a call).
@@ -168,14 +174,15 @@ class CallMediaManager {
   /// Reverts audio routing back to voice mode. Skipped when the user has
   /// explicitly chosen speaker ([speakerActive]).
   ///
-  /// Android: reverts via AudioSwitch only — mirrors [onVideoEnabled] so the
-  /// two paths stay symmetric and don't compete with Telecom routing.
+  /// Android: mirrors [onVideoEnabled] — both AudioSwitch and Telecom are updated.
+  /// [earpieceDevice] is the earpiece entry from [CallState.availableAudioDevices];
+  /// when null the Telecom call is skipped.
   ///
   /// iOS: resets the shared [RTCAudioSessionConfiguration] singleton from
   /// VideoChat → VoiceChat before calling [Helper.setSpeakerphoneOn(false)].
   /// Without this reset, [setSpeakerphoneOn(false)] re-applies VideoChat mode
   /// and keeps audio on speaker regardless of port override.
-  Future<void> onVideoDisabled(String callId, {required bool speakerActive}) async {
+  Future<void> onVideoDisabled(String callId, {required bool speakerActive, CallAudioDevice? earpieceDevice}) async {
     _logger.info('onVideoDisabled: $callId speakerActive=$speakerActive');
     if (speakerActive) return;
     if (Platform.isIOS) {
@@ -184,5 +191,6 @@ class CallMediaManager {
       return;
     }
     await Helper.setSpeakerphoneOn(false);
+    if (earpieceDevice != null) await _callkeep.setAudioDevice(callId, earpieceDevice.toCallkeep());
   }
 }

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -153,17 +153,14 @@ class CallMediaManager {
   /// Must be called after [getUserMedia] completes — AudioSwitch (AudioSwitchManager)
   /// calls activate() inside getUserAudio(), so any routing request before that is a no-op.
   ///
-  /// Android: routes audio to speakerphone via both AudioSwitch and Telecom.
-  /// [speakerDevice] must be the speaker entry from [CallState.availableAudioDevices];
-  /// when null the Telecom routing step is skipped.
+  /// Android: routes to speaker via AudioSwitch only ([Helper.setSpeakerphoneOn]).
+  /// Telecom routing is intentionally skipped — AudioSwitch owns the device selection
+  /// here and a competing Telecom call can override AudioSwitch and silence the speaker.
   /// iOS: no-op — WebRTC sets AVAudioSessionModeVideoChat automatically when a
   /// video track is added, which routes audio to the speaker.
-  Future<void> onVideoEnabled(String callId, {CallAudioDevice? speakerDevice}) async {
+  Future<void> onVideoEnabled(String callId) async {
     _logger.info('onVideoEnabled: $callId');
-    if (Platform.isAndroid) {
-      await Helper.setSpeakerphoneOn(true);
-      if (speakerDevice != null) await _callkeep.setAudioDevice(callId, speakerDevice.toCallkeep());
-    }
+    if (Platform.isAndroid) await Helper.setSpeakerphoneOn(true);
   }
 
   /// Called when video is disabled (camera turned off during a call).
@@ -171,15 +168,14 @@ class CallMediaManager {
   /// Reverts audio routing back to voice mode. Skipped when the user has
   /// explicitly chosen speaker ([speakerActive]).
   ///
-  /// Android: routes audio back to earpiece via both AudioSwitch and Telecom.
-  /// [earpieceDevice] must be the earpiece entry from [CallState.availableAudioDevices];
-  /// when null the Telecom routing step is skipped.
+  /// Android: reverts via AudioSwitch only — mirrors [onVideoEnabled] so the
+  /// two paths stay symmetric and don't compete with Telecom routing.
   ///
   /// iOS: resets the shared [RTCAudioSessionConfiguration] singleton from
   /// VideoChat → VoiceChat before calling [Helper.setSpeakerphoneOn(false)].
   /// Without this reset, [setSpeakerphoneOn(false)] re-applies VideoChat mode
   /// and keeps audio on speaker regardless of port override.
-  Future<void> onVideoDisabled(String callId, {required bool speakerActive, CallAudioDevice? earpieceDevice}) async {
+  Future<void> onVideoDisabled(String callId, {required bool speakerActive}) async {
     _logger.info('onVideoDisabled: $callId speakerActive=$speakerActive');
     if (speakerActive) return;
     if (Platform.isIOS) {
@@ -188,6 +184,5 @@ class CallMediaManager {
       return;
     }
     await Helper.setSpeakerphoneOn(false);
-    if (earpieceDevice != null) await _callkeep.setAudioDevice(callId, earpieceDevice.toCallkeep());
   }
 }

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -159,13 +159,17 @@ class CallMediaManager {
   /// - [WebtritCallkeep.setAudioDevice] updates the Telecom route so it stops overriding.
   /// [speakerDevice] is the speaker entry from [CallState.availableAudioDevices];
   /// when null the Telecom call is skipped (AudioSwitch only).
-  /// iOS: no-op — WebRTC sets AVAudioSessionModeVideoChat automatically when a
-  /// video track is added, which routes audio to the speaker.
+  ///
+  /// iOS: [setUseManualAudio] is enabled so WebRTC does not auto-switch the session mode.
+  /// The mode must be set explicitly to VideoChat before enabling speaker.
   Future<void> onVideoEnabled(String callId, {CallAudioDevice? speakerDevice}) async {
     _logger.info('onVideoEnabled: $callId');
     if (Platform.isAndroid) {
       await Helper.setSpeakerphoneOn(true);
       if (speakerDevice != null) await _callkeep.setAudioDevice(callId, speakerDevice.toCallkeep());
+    } else if (Platform.isIOS) {
+      await Helper.setAppleAudioConfiguration(AppleAudioConfiguration(appleAudioMode: AppleAudioMode.videoChat));
+      await Helper.setSpeakerphoneOn(true);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Android**: passing `id=null` to Telecom when switching audio device caused `Cannot set audio device: null device id`. Fixed by passing the real device UUID from `availableAudioDevices` in both `setDevice` and `onVideoEnabled`/`onVideoDisabled`.
- **Android**: `setSpeakerphoneOn(true)` alone is insufficient — Telecom (uid=1000) overrides AudioSwitch. Both `Helper.setSpeakerphoneOn` and `_callkeep.setAudioDevice` are now called in `onVideoEnabled`/`onVideoDisabled` for cross-OEM compatibility.
- **iOS**: with `setUseManualAudio(true)` active, WebRTC does not auto-switch `AVAudioSessionMode`. `onVideoEnabled` now explicitly sets `AppleAudioMode.videoChat` + `setSpeakerphoneOn(true)`, mirroring the reverse of `onVideoDisabled`.
- Speaker auto-enables for all video calls (incoming and outgoing).