### PR TITLE
fix(test): stub getSenders/getReceivers in renegotiation handler tests

### DIFF
--- a/test/features/call/utils/renegotiation_handler_test.dart
+++ b/test/features/call/utils/renegotiation_handler_test.dart
@@ -73,6 +73,8 @@ void main() {
       // native "stable", so null must be treated as stable to allow the
       // first offer after restoration.
       when(() => mockPC.signalingState).thenReturn(null);
+      when(() => mockPC.getSenders()).thenAnswer((_) async => []);
+      when(() => mockPC.getReceivers()).thenAnswer((_) async => []);
       when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
       when(() => mockPC.setLocalDescription(any())).thenAnswer((_) async {});
 
@@ -110,6 +112,8 @@ void main() {
       when(
         () => mockPC.signalingState,
       ).thenAnswer((_) => callCount++ == 0 ? RTCSignalingState.RTCSignalingStateStable : null);
+      when(() => mockPC.getSenders()).thenAnswer((_) async => []);
+      when(() => mockPC.getReceivers()).thenAnswer((_) async => []);
       when(() => mockPC.createOffer(any())).thenAnswer((_) async => kOffer);
       when(() => mockPC.setLocalDescription(any())).thenAnswer((_) async {});
     });
@@ -155,6 +159,8 @@ void main() {
   group('RenegotiationHandler — execute error handling', () {
     setUp(() {
       when(() => mockErrorReporter.handle(any(), any(), any())).thenReturn(null);
+      when(() => mockPC.getSenders()).thenAnswer((_) async => []);
+      when(() => mockPC.getReceivers()).thenAnswer((_) async => []);
     });
 
     test('reports error via callErrorReporter when execute throws', () async {


### PR DESCRIPTION
## Summary

- `RenegotiationHandler.handle` was updated to call `getSenders()` and `getReceivers()` before `createOffer` (to determine `anyoneHasVideo`), but 5 tests in `renegotiation_handler_test.dart` did not stub these methods
- The unstubbed calls returned `null` instead of `Future<List<RTCRtpSender>>`, causing a `TypeError` that short-circuited execution before verify assertions could pass
- Added `getSenders`/`getReceivers` stubs (returning empty lists) to the 3 affected `setUp` / test locations
