### PR TITLE
fix(call): prevent transient camera preview flash on signaling update

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1131,7 +1131,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         return activeCall.copyWith(
           handle: handle,
           displayName: displayName ?? activeCall.displayName,
-          video: event.jsep?.hasVideo ?? activeCall.video,
+          // Do NOT update `video` here from remote SDP. `video` tracks local camera
+          // intent (user-controlled). Setting it from the remote offer causes a
+          // transient isCameraActive=true flash when a disabled policy-applier track
+          // already exists in localStream. The mutation handler resets video if needed.
           updating: true,
         );
       }),

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -213,6 +213,11 @@ class ActiveCall with _$ActiveCall implements CallEntry {
   @override
   final DateTime createdTime;
 
+  /// Whether the user has explicitly enabled the local camera for this call.
+  ///
+  /// This is local camera intent, not remote SDP capability. It is set only by
+  /// user actions ([CallControlEvent.cameraEnabled]) and initial media setup.
+  /// Never derive it from a remote SDP offer — that is what [remoteVideo] is for.
   @override
   final bool video;
 

--- a/lib/features/call/view/call_shell.dart
+++ b/lib/features/call/view/call_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
@@ -13,6 +14,8 @@ import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/app/constants.dart';
 
 import '../call.dart';
+
+final _logger = Logger('CallShell');
 
 class CallShell extends StatefulWidget {
   const CallShell({required this.child, this.stickyPadding = kStickyOverlayPadding, super.key});
@@ -116,18 +119,23 @@ class _CallShellState extends State<CallShell> {
   void _updateOverlayContent(BuildContext context, CallState state, StackRouter router) {
     final hasActiveCalls = state.activeCalls.isNotEmpty;
 
+    _logger.fine('_updateOverlayContent: display=${state.display}, hasActiveCalls=$hasActiveCalls');
+
     if (!hasActiveCalls || state.display == CallDisplay.none || state.display == CallDisplay.noneScreen) {
+      _logger.fine('_updateOverlayContent: hiding overlay (no active calls or display=none)');
       _hideOverlay();
       return;
     }
 
     switch (state.display) {
       case CallDisplay.overlay:
+        _logger.fine('_updateOverlayContent: showing active call thumbnail');
         _showActiveCallThumbnail(context, state, router);
         break;
 
       case CallDisplay.screen:
         final activeCall = state.activeCalls.current;
+        _logger.fine('_updateOverlayContent: screen display, isCameraActive=${activeCall.isCameraActive}');
         if (activeCall.isCameraActive) {
           _showLocalCameraPreview(context, state);
         } else {

--- a/lib/features/call/view/call_shell.dart
+++ b/lib/features/call/view/call_shell.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:logging/logging.dart';
 
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
@@ -14,8 +13,6 @@ import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/app/constants.dart';
 
 import '../call.dart';
-
-final _logger = Logger('CallShell');
 
 class CallShell extends StatefulWidget {
   const CallShell({required this.child, this.stickyPadding = kStickyOverlayPadding, super.key});
@@ -119,23 +116,18 @@ class _CallShellState extends State<CallShell> {
   void _updateOverlayContent(BuildContext context, CallState state, StackRouter router) {
     final hasActiveCalls = state.activeCalls.isNotEmpty;
 
-    _logger.fine('_updateOverlayContent: display=${state.display}, hasActiveCalls=$hasActiveCalls');
-
     if (!hasActiveCalls || state.display == CallDisplay.none || state.display == CallDisplay.noneScreen) {
-      _logger.fine('_updateOverlayContent: hiding overlay (no active calls or display=none)');
       _hideOverlay();
       return;
     }
 
     switch (state.display) {
       case CallDisplay.overlay:
-        _logger.fine('_updateOverlayContent: showing active call thumbnail');
         _showActiveCallThumbnail(context, state, router);
         break;
 
       case CallDisplay.screen:
         final activeCall = state.activeCalls.current;
-        _logger.fine('_updateOverlayContent: screen display, isCameraActive=${activeCall.isCameraActive}');
         if (activeCall.isCameraActive) {
           _showLocalCameraPreview(context, state);
         } else {


### PR DESCRIPTION
## Summary

- `video` flag in `ActiveCall` represents **local camera intent** (user-controlled), not remote SDP capability
- Setting it from the remote SDP offer in the first emit of `__onCallSignalingEventCallUpdating` caused a transient `isCameraActive=true` flash
- When a disabled track from a previous policy-applier run already existed in `localStream`, the combination of `video=true + hasLocalVideoTrack=true` made `isCameraActive=true` momentarily, flashing the local camera preview overlay for several seconds
- Also adds `fine`-level logging to `_updateOverlayContent` in `CallShell` for future traceability

## Root cause

On each signaling update with `m=video` in the remote SDP:
1. First emit sets `video=true` (from remote SDP)
2. If `localStream` already contains a disabled track (added by policy applier in a previous update), `isCameraActive = video && hasLocalVideoTrack = true && true = true` — overlay flashes on
3. Async SDP operations take 1–3 s before the correction emit fires `video=false`

## Fix

Remove the premature `video` update from the initial snapshot emit in `__onCallSignalingEventCallUpdating`. The mutation handler already passes `event.jsep?.hasVideo` directly to `reportUpdateCall`, and its correction emit at the end of the handler resets `video=false` when needed.

## Test plan

- [x] Voice call: enable camera → preview overlay appears; disable camera → overlay disappears (no black frame regression)
- [x] Voice call where remote sends SDP update with `m=video` (e.g. remote adds video): camera preview must NOT flash on the local side if the user never enabled their camera
- [x] Video call (both sides have camera on): camera stays visible through signaling updates