### PR TITLE
fix(call): unblock push-answer when signaling reconnects after kill-on-background

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -940,6 +940,38 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _logger.infoPretty(event.jsep?.sdp, tag: '__onCallSignalingEventIncoming');
 
     final handle = CallkeepHandle.number(event.caller);
+
+    // Fast-path offer delivery for push-registered calls waiting for an SDP offer.
+    //
+    // __onMutationPerformAnswer (in the sequential mutation queue) awaits
+    // stream.firstWhere(incomingOffer != null). The offer normally arrives via
+    // __onMutationSignalingIncoming, which is also a _CallMutationEvent. Because
+    // the mutation queue is sequential, __onMutationSignalingIncoming cannot run
+    // until __onMutationPerformAnswer completes — a deadlock that ends in a 10 s
+    // timeout.
+    //
+    // This handler runs in the _CallSignalingEvent queue, which is independent of
+    // the mutation queue. Emitting the offer here unblocks stream.firstWhere
+    // immediately, without waiting for the mutation to be scheduled.
+    // __onMutationSignalingIncoming still runs afterwards and re-sets the same
+    // offer (harmless), then dispatches CallControlEvent.answered which the
+    // canPerformAnswer guard drops safely.
+    if (event.jsep != null) {
+      final waitingCall = state.retrieveActiveCall(event.callId);
+      if (waitingCall != null && waitingCall.incomingOffer == null) {
+        final s = waitingCall.processingStatus;
+        if (s == CallProcessingStatus.incomingFromPush ||
+            s == CallProcessingStatus.incomingSubmittedAnswer ||
+            s == CallProcessingStatus.incomingPerformingStarted) {
+          _logger.info(
+            '__onCallSignalingEventIncoming: fast-pathing offer to awaiting push call — '
+            'callId=${event.callId} status=$s',
+          );
+          emit(state.copyWithMappedActiveCall(event.callId, (call) => call.copyWith(incomingOffer: event.jsep)));
+        }
+      }
+    }
+
     final contactName = await contactNameResolver.resolveWithNumber(handle.value);
     final displayName = contactName ?? (event.callerDisplayName?.isEmpty == true ? null : event.callerDisplayName);
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -3205,13 +3205,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
                 ),
               )
               ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived hangupRequest error'));
-          // Early return is intentional: HangupSignalingAction means the
-          // entire session is being torn down. Offer-replay for other calls
-          // is deferred to the next handshake cycle after the hang-up settles.
-          _logger.info(
-            '_handleHandshakeReceived: HangupSignalingAction — skipping offer-replay, callId=${action.callId}',
-          );
-          return;
+          _logger.info('_handleHandshakeReceived: HangupSignalingAction callId=${action.callId}');
 
         case DeclineSignalingAction():
           await _signalingModule
@@ -3223,12 +3217,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
                 ),
               )
               ?.catchError((e, s) => callErrorReporter.handle(e, s, '_handleHandshakeReceived declineRequest error'));
-          // Early return mirrors HangupSignalingAction: the incoming call is
-          // being declined server-side, so offer-replay is not applicable.
-          _logger.info(
-            '_handleHandshakeReceived: DeclineSignalingAction — skipping offer-replay, callId=${action.callId}',
-          );
-          return;
+          _logger.info('_handleHandshakeReceived: DeclineSignalingAction callId=${action.callId}');
 
         case RestoreCallAction():
           add(
@@ -3294,9 +3283,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // (break after match) to avoid dispatching the same offer more than once
     // in the unlikely case a call log contains duplicate entries.
     //
-    // Note: this block is unreachable when [HangupSignalingAction] or
-    // [DeclineSignalingAction] triggers an early return above. Those cases
-    // tear down the session entirely, making offer-replay irrelevant.
+    // [HangupSignalingAction] and [DeclineSignalingAction] no longer trigger an
+    // early return: those actions target calls that are absent from BLoC state
+    // (not in [activeCallIds]), so [retrieveActiveCall] below returns null for
+    // them and this block correctly skips them while still replaying offers for
+    // any other active call that is waiting for one (e.g. a call in
+    // [incomingPerformingStarted] status when a stale guestLine call is declined).
     // ---------------------------------------------------------------------------
     final linesToScan = [...stateHandshake.lines, stateHandshake.guestLine].whereType<Line>();
 

--- a/lib/features/call/utils/handshake_processor.dart
+++ b/lib/features/call/utils/handshake_processor.dart
@@ -29,8 +29,11 @@ final class HangupSignalingAction extends HandshakeAction {
 
 /// Send a [DeclineRequest] to the signaling server and stop processing.
 ///
-/// Emitted when the Callkeep connection for the line is [CallkeepConnectionState.stateDisconnected]
-/// and the latest call event is [IncomingCallEvent].
+/// Emitted when the Callkeep connection for the line is [CallkeepConnectionState.stateDisconnected],
+/// the latest call event is [IncomingCallEvent], and the call is **not** already
+/// tracked in BLoC state ([activeCallIds]). The [activeCallIds] guard prevents
+/// declining a call the user answered mid-service-restart, where the Callkeep
+/// connection can appear disconnected even though the answer is in progress.
 final class DeclineSignalingAction extends HandshakeAction {
   const DeclineSignalingAction({required this.line, required this.callId});
 
@@ -164,7 +167,14 @@ class HandshakeProcessor {
 
         if (connection?.state == CallkeepConnectionState.stateDisconnected) {
           if (callEvent is IncomingCallEvent) {
-            return [...actions, DeclineSignalingAction(line: callEvent.line, callId: callEvent.callId)];
+            // Guard: if CallBloc is already tracking this call (e.g. user answered
+            // mid-service-restart and the Callkeep connection ended up disconnected
+            // because the push-isolate flutterApi was null), do not decline it.
+            // The offer-replay block in _handleHandshakeReceived will deliver the
+            // SDP offer to unblock the answer path.
+            if (!activeCallIds.contains(callEvent.callId)) {
+              return [...actions, DeclineSignalingAction(line: callEvent.line, callId: callEvent.callId)];
+            }
           } else if (callEvent is! HangupEvent && callEvent is! MissedCallEvent) {
             return [...actions, HangupSignalingAction(line: callEvent.line, callId: callEvent.callId)];
           }

--- a/test/features/call/bloc/handshake_processor_test.dart
+++ b/test/features/call/bloc/handshake_processor_test.dart
@@ -397,6 +397,24 @@ void main() {
       final a = actions.first as DeclineSignalingAction;
       expect(a.callId, _kCallId);
     });
+
+    test('skips DeclineSignalingAction when call is already in BLoC state (mid-answer race)', () async {
+      // Reproduces the kill-on-background race: user answers from push notification
+      // while the service is restarting. The push-isolate flutterApi is null so the
+      // Callkeep connection ends up stateDisconnected, but CallBloc is already
+      // tracking the call in incomingPerformingStarted. Declining here would abort
+      // a call the user deliberately answered; offer-replay in _handleHandshakeReceived
+      // unblocks the answer path instead.
+      when(
+        () => mockConnections.getConnection(_kCallId),
+      ).thenAnswer((_) async => _makeConnection(state: CallkeepConnectionState.stateDisconnected));
+
+      final line = _makeLine(callLogs: [CallEventLog(timestamp: 1000, callEvent: _makeIncomingEvent())]);
+
+      final actions = await processor.process(lines: [line], guestLine: null, activeCallIds: {_kCallId});
+
+      expect(actions, isEmpty);
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three-layer fix for the bug where answering an incoming push call while signaling is reconnecting causes the call screen to get stuck in \"preparing\" status, then drops after 10 seconds.

This happens when the app is backgrounded long enough for the OS to kill the signaling service — the next incoming call arrives via FCM push before signaling has a chance to reconnect.

- **Bug 1 — HandshakeProcessor guard**: `DeclineSignalingAction` was incorrectly generated for the active push-answered call when its Callkeep connection appeared `disconnected` (push isolate connection). Added `!activeCallIds.contains(callEvent.callId)` guard to skip decline for calls already tracked in BLoC state.

- **Bug 2 — Offer-replay early return**: `_handleHandshakeReceived` returned early after processing `DeclineSignalingAction`/`HangupSignalingAction`, skipping the offer-replay block. Removed the early returns so offer-replay always runs.

- **Bug 3 — Mutation queue deadlock**: `__onMutationPerformAnswer` held the sequential mutation queue slot while awaiting `stream.firstWhere(offer != null)`. `__onMutationSignalingIncoming` (which stores the offer in state) was queued behind it and could never run → 10s timeout. Fixed by emitting the offer directly to BLoC state from `__onCallSignalingEventIncoming` (independent `_CallSignalingEvent` queue) before the mutation queue processes it.

## Test plan

- [ ] App is backgrounded for an extended period (signaling service killed by OS)
- [ ] Incoming call arrives via FCM push notification
- [ ] User answers from the notification — call screen proceeds past "preparing" to connected
- [ ] Verify no 10s timeout disconnect
- [ ] User answers while a previous unanswered call is still present in signaling state (stale `guestLine`) — call proceeds normally, no spurious decline
- [ ] Normal incoming call flow (signaling already connected) is unaffected