### PR TITLE
fix(call): fast-path offer and line delivery to unblock push-answer mutation queue deadlock

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -940,6 +940,28 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _logger.infoPretty(event.jsep?.sdp, tag: '__onCallSignalingEventIncoming');
 
     final handle = CallkeepHandle.number(event.caller);
+
+    if (event.jsep != null) {
+      final waitingCall = state.retrieveActiveCall(event.callId);
+      if (waitingCall != null && waitingCall.incomingOffer == null) {
+        final s = waitingCall.processingStatus;
+        if (s == CallProcessingStatus.incomingFromPush ||
+            s == CallProcessingStatus.incomingSubmittedAnswer ||
+            s == CallProcessingStatus.incomingPerformingStarted) {
+          _logger.info(
+            '__onCallSignalingEventIncoming: fast-pathing offer to awaiting push call — '
+            'callId=${event.callId} status=$s',
+          );
+          emit(
+            state.copyWithMappedActiveCall(
+              event.callId,
+              (call) => call.copyWith(incomingOffer: event.jsep, line: event.line),
+            ),
+          );
+        }
+      }
+    }
+
     final contactName = await contactNameResolver.resolveWithNumber(handle.value);
     final displayName = contactName ?? (event.callerDisplayName?.isEmpty == true ? null : event.callerDisplayName);
 


### PR DESCRIPTION
## Problem

When answering an incoming push call (kill-on-background enabled), the call gets stuck in `preparing` state and drops after ~10 seconds.

**Root cause:** `__onMutationPerformAnswer` holds the sequential mutation queue slot while awaiting `stream.firstWhere(incomingOffer != null)`. `__onMutationSignalingIncoming` (which stores the offer in state) is queued behind it — deadlock that ends in a 10 s timeout.

## Fix

`__onCallSignalingEventIncoming` runs in the independent `_CallSignalingEvent` queue. When an offer arrives for a call that is already in `incomingFromPush`, `incomingSubmittedAnswer`, or `incomingPerformingStarted` with no offer yet, emit both `incomingOffer` and `line` directly to BLoC state. This unblocks `stream.firstWhere` immediately without waiting for the mutation queue.

`__onMutationSignalingIncoming` still runs afterwards and re-sets the same values (harmless). The `canPerformAnswer` guard drops any duplicate `CallControlEvent.answered` safely.


## Related

- webtrit_callkeep https://github.com/WebTrit/webtrit_callkeep/pull/281 — companion fix: `markAnswered()` not called when `flutterApi == null`, causing `HandshakeProcessor` to send `DeclineRequest` for a deliberately answered call.