### PR TITLE
fix: re-verify connectivity when cached state is false before blocking call

### DIFF
--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -36,12 +36,12 @@ class CallController {
   /// don't get confused with signaling connectivity (SIP registration)
   /// this is needed to determine what notification to show
   Future<bool> get isNetworkConnected async {
-    // If we already have a connectivity status from the stream, return it immediately.
-    // For cases if app was initialized and we know our connectivity status, we can avoid the overhead of an additional checkConnection call.
-    if (_netConnected != null) return _netConnected!;
+    // Only trust the cached value when it says connected. A cached false may be
+    // stale — OEMs (e.g. Xiaomi) can signal ConnectivityResult.none while the
+    // app is backgrounded even when the network interface stays up, and the
+    // stream may not re-emit after the app returns to the foreground.
+    if (_netConnected == true) return true;
 
-    // But if its null its means app was just launched and we haven't received any connectivity updates yet,
-    // so we should perform an active check to determine our connectivity status before proceeding with the call.
     _netConnected = await connectivityService.checkConnection().timeout(
       const Duration(seconds: 5),
       onTimeout: () {


### PR DESCRIPTION
## Problem

On Xiaomi (Android 15 / HyperOS), after restoring the app from background:
- Signaling shows **connected** in the UI
- Attempting to make a call shows: **"It seems you are not connected to the internet"**
- Actual network IS connected

Logcat shows the socket opens at ~11:16:36, yet six seconds later the call is blocked with `"Cannot create call: no network connectivity"` — while the network hardware reports `inetCondition = 1`.

## Root Cause

`CallController` caches connectivity state in `_netConnected: bool?`, updated only via `connectivityService.connectionStream` events.

While the app is in background, Xiaomi (OEM aggressive battery/network management) signals `ConnectivityResult.none` even when the network interface stays up — setting `_netConnected = false`. When the app returns to foreground the stream does not immediately re-emit, leaving the cache stale. The call attempt reads the stale `false` and blocks without re-checking actual network state.

The signaling layer is unaffected because `SignalingReconnectController` already handles `AppLifecycleState.resumed` proactively.

## Fix

Only trust the cached value when it says `true`. When the cached value is `false` or `null`, always perform a fresh `checkConnection()` before blocking the call.

```dart
// Before
if (_netConnected != null) return _netConnected!;

// After
if (_netConnected == true) return true;
```

When genuinely offline, `checkConnectivity()` (native OS call) returns `ConnectivityResult.none` and short-circuits before the HTTP health check — no meaningful latency added for the truly-offline case.