### PR TITLE
fix(android): disable AudioSwitch audio focus to fix stuck volume controls after call (WT-1429)

### DIFF
--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -47,7 +47,11 @@ class CallMediaManager {
   void _configure() {
     if (Platform.isAndroid) {
       AndroidNativeAudioManagement.setAndroidAudioConfiguration(
-        AndroidAudioConfiguration(preferredOutputOrder: _voiceCallOutputOrder),
+        AndroidAudioConfiguration(
+          preferredOutputOrder: _voiceCallOutputOrder,
+          // Telecom owns audio focus; dual ownership leaves volume stuck in call mode on older MIUI (WT-1429).
+          manageAudioFocus: false,
+        ),
       );
     }
     if (Platform.isIOS) AppleNativeAudioManagement.setUseManualAudio(true);

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -46,12 +46,10 @@ class CallMediaManager {
   // management so CallKit controls activation instead of WebRTC doing it automatically.
   void _configure() {
     if (Platform.isAndroid) {
+      // manageAudioFocus: false — Telecom owns audio focus for VoIP calls.
+      // Dual ownership with AudioSwitch leaves volume stuck in call mode on older MIUI (WT-1429).
       AndroidNativeAudioManagement.setAndroidAudioConfiguration(
-        AndroidAudioConfiguration(
-          preferredOutputOrder: _voiceCallOutputOrder,
-          // Telecom owns audio focus; dual ownership leaves volume stuck in call mode on older MIUI (WT-1429).
-          manageAudioFocus: false,
-        ),
+        AndroidAudioConfiguration(preferredOutputOrder: _voiceCallOutputOrder, manageAudioFocus: false),
       );
     }
     if (Platform.isIOS) AppleNativeAudioManagement.setUseManualAudio(true);


### PR DESCRIPTION
## Summary

- Disables AudioSwitch (`manageAudioFocus: false`) so Telecom is the sole owner of Android audio focus during VoIP calls
- Fixes volume buttons staying stuck in call mode after a call ends on older MIUI devices (Xiaomi Mi 9 Lite Android 10, Redmi Note 5 Android 9)
- One-line change in `CallMediaManager._configure()` — no flutter-webrtc changes needed

## Root cause

Two independent audio focus clients competed for `AUDIOFOCUS_GAIN`:
1. **Telecom** (`AudioFocus_For_Phone_Ring_And_Calls`) — always correctly abandoned focus on call end
2. **AudioSwitch** (`com.cloudwebrtc.webrtc.audio.c`) — requested permanent `AUDIOFOCUS_GAIN` on call start but did not always release it

When Telecom abandoned focus, Android dispatched `AUDIOFOCUS_GAIN` back to AudioSwitch, which held it permanently. Android kept `MODE_IN_COMMUNICATION` active, so volume buttons controlled call volume instead of media/ring volume. Only Force Stop (which triggers `removeFocusStackEntryOnDeath`) restored normal behaviour.

Setting `manageAudioFocus: false` prevents AudioSwitch from requesting focus at all. Telecom becomes the sole manager and reliably releases focus on every call end. Device routing (earpiece / speakerphone / bluetooth) and `MODE_IN_COMMUNICATION` are unaffected — AudioSwitch still handles them regardless of the focus flag.

## Test plan

- [ ] Make and end a call on Xiaomi Android 9–10 — volume buttons should control media/ring volume immediately after the call
- [ ] Verify earpiece → speakerphone toggle works during a call
- [ ] Verify Bluetooth headset routes correctly during a call
- [ ] Verify no regression on Samsung / newer Android devices
- [ ] Verify incoming call answer/reject audio routing is correct