### PR TITLE
fix(call): prevent initiating a second call to the same number (WT-1382)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2177,6 +2177,17 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
     }
 
+    final duplicateCall = state.activeCalls.firstWhereOrNull(
+      (c) => c.handle.value == e.handle.value && c.hungUpTime == null,
+    );
+    if (duplicateCall != null) {
+      _logger.info(
+        '__onMutationControlStart: call to ${e.handle.value} already exists (${duplicateCall.callId}), surfacing existing call',
+      );
+      emit(state.copyWith(minimized: false));
+      return;
+    }
+
     /// If there is an active call, the call should be put on hold before making a new call.
     /// Or it will be ended automatically by platform (via callkeep:performEndAction).
     await Future.forEach(state.activeCalls, (ActiveCall activeCall) async {


### PR DESCRIPTION
## Summary

- Adds a guard in `CallBloc.__onMutationControlStart` that checks if a call to the same handle already exists before initiating a new outgoing call
- If a duplicate is detected, the new call is silently dropped and the existing call screen is surfaced (`minimized: false`)
- Covers all three STR scenarios from WT-1382: ringing without voicemail, ringing with voicemail, and active call

## Root cause

`__onMutationControlStart` was putting any existing call on hold and proceeding unconditionally — there was no guard on the destination number. The fix is a single `firstWhereOrNull` check on `activeCalls` before the hold loop.
