### PR TITLE
fix(android): change SignalingForegroundService FGS type from remoteMessaging to phoneCall

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/AndroidManifest.xml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/AndroidManifest.xml
@@ -2,27 +2,29 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
         <!--
-            SignalingForegroundService uses foregroundServiceType="remoteMessaging".
+            SignalingForegroundService uses foregroundServiceType="phoneCall".
 
-            This service maintains a persistent WebSocket connection to the WebTrit signaling
-            server to exchange call-signaling messages (SDP, ICE candidates, call state events).
-            The remoteMessaging type is defined by Android as the appropriate type for services
-            that keep a long-running connection alive so a remote server can deliver messages to
-            the device at any time — which is exactly what this service does.
+            This service maintains a persistent WebSocket connection to the WebTrit VoIP
+            signaling server so that incoming call invitations (SDP offers, ICE candidates)
+            are delivered to the device immediately — within the SIP ring timeout (~30 s).
+            Without this service, incoming VoIP calls cannot be received reliably in the
+            background on devices where FCM high-priority push is restricted (Xiaomi MIUI,
+            Huawei EMUI). The phoneCall type is appropriate because the sole purpose of this
+            service is to enable VoIP call delivery.
 
-            Required permission: FOREGROUND_SERVICE_REMOTE_MESSAGING (declared above).
+            Required permission: FOREGROUND_SERVICE_PHONE_CALL (declared above).
             Applies on Android 14+ (API 34+); older versions pass type=0.
         -->
         <service
             android:name=".SignalingForegroundService"
-            android:foregroundServiceType="remoteMessaging"
+            android:foregroundServiceType="phoneCall"
             android:exported="false" />
 
         <receiver

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -49,8 +49,8 @@ import io.flutter.plugin.common.BinaryMessenger
 class SignalingForegroundService : Service() {
 
     private lateinit var flutterEngineHelper: FlutterEngineHelper
-    private var notificationTitle: String = "Signaling Service"
-    private var notificationDescription: String = "Maintaining connection"
+    private var notificationTitle: String = "VoIP call service"
+    private var notificationDescription: String = "Waiting for incoming calls"
 
     private var _isolateFlutterApi: PSignalingServiceFlutterApi? = null
 
@@ -301,18 +301,17 @@ class SignalingForegroundService : Service() {
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
 
-        // FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING: this service maintains a persistent
-        // WebSocket to the WebTrit signaling server so it can receive call-signaling
-        // messages (SDP, ICE candidates, call events) at any time. The remoteMessaging
-        // type is the Android-defined category for exactly this use case.
-        // Passed to startForeground() on API 34+ only; older versions pass 0 and do
-        // not enforce a foreground service type here.
+        // FOREGROUND_SERVICE_TYPE_PHONE_CALL: this service maintains a persistent
+        // WebSocket to the WebTrit VoIP signaling server so that incoming call invitations
+        // are delivered immediately. The phoneCall type applies because the sole purpose
+        // of this service is to enable VoIP call receipt.
+        // Passed to startForeground() on API 34+ only; older versions pass 0.
         ServiceCompat.startForeground(
             this,
             NOTIFICATION_ID,
             notification,
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
             else 0,
         )
     }
@@ -322,7 +321,7 @@ class SignalingForegroundService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 channelId,
-                "Signaling Service",
+                "VoIP Call Service",
                 NotificationManager.IMPORTANCE_LOW,
             )
             val manager = getSystemService(NotificationManager::class.java)


### PR DESCRIPTION
## Summary

Cherry-pick of #1241 onto `develop`.

Google Play rejected `FOREGROUND_SERVICE_REMOTE_MESSAGING` as incorrectly declared for VoIP signaling. Changed `SignalingForegroundService` to use `phoneCall` type — the sole purpose of this service is incoming VoIP call delivery.

## Changes

**`webtrit_signaling_service_android/AndroidManifest.xml`**
- `FOREGROUND_SERVICE_REMOTE_MESSAGING` → `FOREGROUND_SERVICE_PHONE_CALL`
- `foregroundServiceType="remoteMessaging"` → `foregroundServiceType="phoneCall"`

**`SignalingForegroundService.kt`**
- `FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING` → `FOREGROUND_SERVICE_TYPE_PHONE_CALL`
- Notification title: `"Signaling Service"` → `"VoIP call service"`
- Notification text: `"Maintaining connection"` → `"Waiting for incoming calls"`
- Channel name: `"Signaling Service"` → `"VoIP Call Service"`

## Context

Google Play issued three rejection reasons for `FOREGROUND_SERVICE_REMOTE_MESSAGING`:
1. Use case can be deferred without negative UX
2. Incorrectly declared under wrong FGS type
3. FGS not perceptible to the user

The `phoneCall` type correctly represents the service purpose and addresses all three points.