### PR TITLE
fix: messaging day separator using local datetime (WT-1394)

### DIFF
--- a/lib/extensions/datetime.dart
+++ b/lib/extensions/datetime.dart
@@ -28,6 +28,11 @@ extension DateTimeFormatting on DateTime {
 
 extension DateTimeComprassion on DateTime {
   bool isSameDay(DateTime anotherDate) {
-    return year == anotherDate.year && month == anotherDate.month && day == anotherDate.day;
+    final anotherLocal = anotherDate.toLocal();
+    final thisLocal = toLocal();
+
+    return thisLocal.year == anotherLocal.year &&
+        thisLocal.month == anotherLocal.month &&
+        thisLocal.day == anotherLocal.day;
   }
 }


### PR DESCRIPTION
Use local datetime for splitting messages (yesterday, today, etc) in messaging.