### PR TITLE
fix(call): keep local controls active during SDP renegotiation (WT-1435)

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -209,6 +209,8 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                             if (incomingRingingCalls.isEmpty)
                                               ActiveCallActions(
                                                 style: style?.actions,
+                                                // Blocks signaling-dependent actions (hold, transfer, camera).
+                                                // False during: interaction debounce, signaling not ready, SDP renegotiation.
                                                 enableInteractions:
                                                     interactionsDebounceActive == false &&
                                                     widget.callStatus == CallStatus.ready &&

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -157,7 +157,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     final themeData = Theme.of(context);
 
     final onCameraChanged = widget.enableInteractions ? widget.onCameraChanged : null;
-    final onMutedChanged = widget.enableInteractions ? widget.onMutedChanged : null;
+    final onMutedChanged = widget.onMutedChanged;
     final audioDevice = widget.audioDevice;
     final onAudioDeviceChanged = widget.onAudioDeviceChanged;
     final speakerOn = audioDevice?.type == CallAudioDeviceType.speaker;

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -157,6 +157,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     final themeData = Theme.of(context);
 
     final onCameraChanged = widget.enableInteractions ? widget.onCameraChanged : null;
+    // Mute and speaker are local-only (no SDP change), so they stay active during renegotiation.
     final onMutedChanged = widget.onMutedChanged;
     final audioDevice = widget.audioDevice;
     final onAudioDeviceChanged = widget.onAudioDeviceChanged;

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -263,30 +263,30 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
         if (widget.availableAudioDevices.onlyBuiltIn)
           Tooltip(
             key: callActionsSpeakerKey,
-            message: speakerOn ?? false
+            message: speakerOn
                 ? context.l10n.call_CallActionsTooltip_disableSpeaker
                 : context.l10n.call_CallActionsTooltip_enableSpeaker,
             child: TextButton(
               onPressed: () {
                 final speakerDevice = widget.availableAudioDevices.getSpeaker;
                 final earpieceDevice = widget.availableAudioDevices.getEarpiece;
-                if (speakerOn == true) {
+                if (speakerOn) {
                   if (earpieceDevice != null) {
-                    onAudioDeviceChanged?.call(earpieceDevice);
+                    onAudioDeviceChanged.call(earpieceDevice);
                   } else {
                     _logger.warning('Earpiece device not found while trying to disable speakerphone');
                   }
                 } else {
                   if (speakerDevice != null) {
-                    onAudioDeviceChanged?.call(speakerDevice);
+                    onAudioDeviceChanged.call(speakerDevice);
                   } else {
                     _logger.warning('Speaker device not found while trying to enable speakerphone');
                   }
                 }
               },
-              statesController: _speakerStatesController..update(WidgetState.selected, speakerOn ?? false),
+              statesController: _speakerStatesController..update(WidgetState.selected, speakerOn),
               style: widget.style?.speaker,
-              child: Icon((speakerOn ?? false) ? Icons.volume_up : Icons.phone_in_talk, size: actionPadIconSize),
+              child: Icon(speakerOn ? Icons.volume_up : Icons.phone_in_talk, size: actionPadIconSize),
             ),
           ),
         if (!widget.availableAudioDevices.onlyBuiltIn)

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -158,9 +158,9 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
 
     final onCameraChanged = widget.enableInteractions ? widget.onCameraChanged : null;
     final onMutedChanged = widget.enableInteractions ? widget.onMutedChanged : null;
-    final audioDevice = widget.enableInteractions ? widget.audioDevice : null;
-    final onAudioDeviceChanged = widget.enableInteractions ? widget.onAudioDeviceChanged : null;
-    final speakerOn = widget.enableInteractions ? audioDevice?.type == CallAudioDeviceType.speaker : null;
+    final audioDevice = widget.audioDevice;
+    final onAudioDeviceChanged = widget.onAudioDeviceChanged;
+    final speakerOn = audioDevice?.type == CallAudioDeviceType.speaker;
     final onBlindTransferInitiated = widget.enableInteractions ? widget.onBlindTransferInitiated : null;
     final onAttendedTransferInitiated = widget.enableInteractions ? widget.onAttendedTransferInitiated : null;
     final onAttendedTransferSubmitted = widget.enableInteractions ? widget.onAttendedTransferSubmitted : null;

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -156,6 +156,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
 
+    // Camera can trigger SDP renegotiation when adding a new track, so it is gated.
     final onCameraChanged = widget.enableInteractions ? widget.onCameraChanged : null;
     // Mute is local-only (no SDP change), so it stays active during renegotiation.
     final onMutedChanged = widget.onMutedChanged;
@@ -167,6 +168,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     final onBlindTransferInitiated = widget.onBlindTransferInitiated;
     final onAttendedTransferInitiated = widget.onAttendedTransferInitiated;
     final onAttendedTransferSubmitted = widget.onAttendedTransferSubmitted;
+    // Hold and swap send signaling requests and trigger renegotiation.
     final onHeldChanged = widget.enableInteractions ? widget.onHeldChanged : null;
     final onSwapPressed = widget.enableInteractions ? widget.onSwapPressed : null;
     final onKeyPressed = widget.enableInteractions ? widget.onKeyPressed : null;

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -163,9 +163,10 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     final audioDevice = widget.audioDevice;
     final onAudioDeviceChanged = widget.onAudioDeviceChanged;
     final speakerOn = audioDevice?.type == CallAudioDeviceType.speaker;
-    final onBlindTransferInitiated = widget.enableInteractions ? widget.onBlindTransferInitiated : null;
-    final onAttendedTransferInitiated = widget.enableInteractions ? widget.onAttendedTransferInitiated : null;
-    final onAttendedTransferSubmitted = widget.enableInteractions ? widget.onAttendedTransferSubmitted : null;
+    // Transfer button itself is local (opens a popup), only the actions inside are signaling-dependent.
+    final onBlindTransferInitiated = widget.onBlindTransferInitiated;
+    final onAttendedTransferInitiated = widget.onAttendedTransferInitiated;
+    final onAttendedTransferSubmitted = widget.onAttendedTransferSubmitted;
     final onHeldChanged = widget.enableInteractions ? widget.onHeldChanged : null;
     final onSwapPressed = widget.enableInteractions ? widget.onSwapPressed : null;
     final onKeyPressed = widget.enableInteractions ? widget.onKeyPressed : null;
@@ -355,6 +356,8 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
                   if (onAttendedTransferSubmitted != null)
                     CallPopupMenuItem(
                       key: callActionsTransferMenuNumberKey,
+                      // Transfer is signaling-dependent, disable during renegotiation.
+                      enabled: widget.enableInteractions,
                       onTap: () => onAttendedTransferSubmitted.call(call),
                       text: call.displayName ?? call.handle.value,
                       icon: Icon(
@@ -366,6 +369,8 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
                     ),
                 if (onBlindTransferInitiated != null)
                   CallPopupMenuItem(
+                    // Transfer is signaling-dependent, disable during renegotiation.
+                    enabled: widget.enableInteractions,
                     onTap: onBlindTransferInitiated,
                     text: context.l10n.call_CallActionsTooltip_transfer_choose,
                     icon: Icon(
@@ -395,6 +400,8 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
                 if (onBlindTransferInitiated != null)
                   CallPopupMenuItem(
                     key: callActionsTransferMenuBlindInitKey,
+                    // Transfer is signaling-dependent, disable during renegotiation.
+                    enabled: widget.enableInteractions,
                     onTap: onBlindTransferInitiated,
                     text: context.l10n.call_CallActionsTooltip_unattended_transfer,
                     icon: Icon(
@@ -406,6 +413,8 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
                   ),
                 if (onAttendedTransferInitiated != null)
                   CallPopupMenuItem(
+                    // Transfer is signaling-dependent, disable during renegotiation.
+                    enabled: widget.enableInteractions,
                     onTap: onAttendedTransferInitiated,
                     text: context.l10n.call_CallActionsTooltip_attended_transfer,
                     icon: Icon(

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -157,8 +157,9 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     final themeData = Theme.of(context);
 
     final onCameraChanged = widget.enableInteractions ? widget.onCameraChanged : null;
-    // Mute and speaker are local-only (no SDP change), so they stay active during renegotiation.
+    // Mute is local-only (no SDP change), so it stays active during renegotiation.
     final onMutedChanged = widget.onMutedChanged;
+    // Speaker switching is local-only (no SDP change), so it stays active during renegotiation.
     final audioDevice = widget.audioDevice;
     final onAudioDeviceChanged = widget.onAudioDeviceChanged;
     final speakerOn = audioDevice?.type == CallAudioDeviceType.speaker;


### PR DESCRIPTION
## Summary

Fixes visual flickering of call control buttons during SDP renegotiation triggered by video toggle.

**Root cause:** all action callbacks in `ActiveCallActions` were gated behind a single `enableInteractions` flag. When `activeCall.updating = true` (renegotiation in progress), the flag became `false`, which caused:
- Speaker: `speakerOn = null → false` — lost selected state, icon flipped from `volume_up` to `phone_in_talk`, tap logic inverted
- Mute: `onPressed = null` — entered Flutter `disabled` state, appeared dimmed despite being active
- Transfer button: fully dimmed even though it only opens a local popup

**Fix:** separated local-only actions from signaling-dependent ones:

| Action | Mechanism | Before | After |
|--------|-----------|--------|-------|
| Mute | `setMicrophoneMute` on local track — no SDP change | blocked | always active |
| Speaker | local audio device switch — no SDP change | blocked | always active |
| Transfer button | opens popup (local UI) | dimmed | always active |
| Transfer menu items | signaling request | hidden | visible, disabled via `enabled:` |
| Camera | can add new track → `onRenegotiationNeeded` | blocked | unchanged |
| Hold / Swap | `HoldRequest` → signaling → renegotiation | blocked | unchanged |
