### PR TITLE
fix(session-status): debounce transient reconnect status transitions to prevent banner flicker

### DIFF
--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -15,6 +15,11 @@ const kCallRoutingStateTimeout = Duration(seconds: 10);
 const kSignalingClientReconnectDelay = Duration(seconds: 3);
 const kSignalingClientFastReconnectDelay = Duration(seconds: 1);
 
+/// Debounce window for transient signaling status transitions (connectIssue,
+/// inProgress, connectError). Slightly longer than [kSignalingClientReconnectDelay]
+/// so one full reconnect cycle is absorbed before the UI updates.
+const kSignalingStatusDebounce = Duration(seconds: 3, milliseconds: 500);
+
 /// How long [WebtritSignalingService.connect] waits for a terminal event
 /// (Connected / Disconnected / ConnectionFailed) before resetting
 /// [_startPending] and retrying. Covers the case where the background isolate

--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -12,14 +12,14 @@ const kSignalingClientConnectionTimeout = Duration(seconds: 10);
 /// network interruption (e.g. switching from Wi-Fi to LTE).
 const kOutgoingCallSignalingWaitTimeout = Duration(seconds: 30);
 const kCallRoutingStateTimeout = Duration(seconds: 10);
-const kSignalingClientReconnectDelaySeconds = 3;
-const kSignalingClientReconnectDelay = Duration(seconds: kSignalingClientReconnectDelaySeconds);
+const _kSignalingClientReconnectDelaySeconds = 3;
+const kSignalingClientReconnectDelay = Duration(seconds: _kSignalingClientReconnectDelaySeconds);
 const kSignalingClientFastReconnectDelay = Duration(seconds: 1);
 
 /// Debounce window for transient signaling status transitions (connectIssue,
 /// inProgress, connectError). Slightly longer than [kSignalingClientReconnectDelay]
 /// so one full reconnect cycle is absorbed before the UI updates.
-const kSignalingStatusDebounce = Duration(seconds: kSignalingClientReconnectDelaySeconds, milliseconds: 500);
+const kSignalingStatusDebounce = Duration(seconds: _kSignalingClientReconnectDelaySeconds, milliseconds: 500);
 
 /// How long [WebtritSignalingService.connect] waits for a terminal event
 /// (Connected / Disconnected / ConnectionFailed) before resetting

--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -12,13 +12,14 @@ const kSignalingClientConnectionTimeout = Duration(seconds: 10);
 /// network interruption (e.g. switching from Wi-Fi to LTE).
 const kOutgoingCallSignalingWaitTimeout = Duration(seconds: 30);
 const kCallRoutingStateTimeout = Duration(seconds: 10);
-const kSignalingClientReconnectDelay = Duration(seconds: 3);
+const kSignalingClientReconnectDelaySeconds = 3;
+const kSignalingClientReconnectDelay = Duration(seconds: kSignalingClientReconnectDelaySeconds);
 const kSignalingClientFastReconnectDelay = Duration(seconds: 1);
 
 /// Debounce window for transient signaling status transitions (connectIssue,
 /// inProgress, connectError). Slightly longer than [kSignalingClientReconnectDelay]
 /// so one full reconnect cycle is absorbed before the UI updates.
-const kSignalingStatusDebounce = Duration(seconds: 3, milliseconds: 500);
+const kSignalingStatusDebounce = Duration(seconds: kSignalingClientReconnectDelaySeconds, milliseconds: 500);
 
 /// How long [WebtritSignalingService.connect] waits for a terminal event
 /// (Connected / Disconnected / ConnectionFailed) before resetting

--- a/lib/extensions/call_status.dart
+++ b/lib/extensions/call_status.dart
@@ -5,6 +5,10 @@ import 'package:webtrit_phone/theme/styles/styles.dart';
 import 'package:webtrit_phone/models/models.dart';
 
 extension CallStatusReconnect on CallStatus {
+  /// Returns true for statuses that represent a transient signaling reconnect
+  /// cycle: [CallStatus.connectIssue], [CallStatus.inProgress],
+  /// [CallStatus.connectError]. Used to debounce UI updates during reconnect
+  /// backoff so the display does not flicker on every attempt.
   bool get isTransientReconnecting =>
       this == CallStatus.connectIssue || this == CallStatus.inProgress || this == CallStatus.connectError;
 }

--- a/lib/extensions/call_status.dart
+++ b/lib/extensions/call_status.dart
@@ -4,6 +4,11 @@ import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/theme/styles/styles.dart';
 import 'package:webtrit_phone/models/models.dart';
 
+extension CallStatusReconnect on CallStatus {
+  bool get isTransientReconnecting =>
+      this == CallStatus.connectIssue || this == CallStatus.inProgress || this == CallStatus.connectError;
+}
+
 extension CallStatusL10n on CallStatus {
   String l10n(BuildContext context) {
     switch (this) {

--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -91,7 +91,7 @@ class _CallInfoState extends State<CallInfo> {
   }
 
   void _updateDisplayedStatus(CallStatus newStatus) {
-    if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(_displayedCallStatus)) {
+    if (newStatus.isTransientReconnecting && _displayedCallStatus.isTransientReconnecting) {
       if (newStatus == _displayedCallStatus || newStatus == _pendingCallStatus) return;
       _pendingCallStatus = newStatus;
       _debounce.schedule(() {
@@ -104,9 +104,6 @@ class _CallInfoState extends State<CallInfo> {
       setState(() => _displayedCallStatus = newStatus);
     }
   }
-
-  bool _isTransientReconnecting(CallStatus status) =>
-      status == CallStatus.connectIssue || status == CallStatus.inProgress || status == CallStatus.connectError;
 
   void _durationTimerInit(DateTime acceptedTime) {
     durationTimer = Timer.periodic(const Duration(seconds: 1), (_) {

--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -49,14 +49,12 @@ class CallInfo extends StatefulWidget {
 }
 
 class _CallInfoState extends State<CallInfo> {
-  static const _kStatusDebounce = kSignalingStatusDebounce;
-
   Timer? durationTimer;
   Duration? duration;
 
   late CallStatus _displayedCallStatus;
   CallStatus? _pendingCallStatus;
-  final _debounce = Debounce(_kStatusDebounce);
+  final _debounce = Debounce(kSignalingStatusDebounce);
 
   @override
   void initState() {

--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -4,9 +4,11 @@ import 'package:flutter/material.dart';
 
 import 'package:clock/clock.dart';
 
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 
 import '../extensions/extensions.dart';
 import '../models/models.dart';
@@ -47,12 +49,19 @@ class CallInfo extends StatefulWidget {
 }
 
 class _CallInfoState extends State<CallInfo> {
+  static final _kStatusDebounce = kSignalingClientReconnectDelay + const Duration(milliseconds: 500);
+
   Timer? durationTimer;
   Duration? duration;
+
+  late CallStatus _displayedCallStatus;
+  CallStatus? _pendingCallStatus;
+  final _debounce = Debounce(_kStatusDebounce);
 
   @override
   void initState() {
     super.initState();
+    _displayedCallStatus = widget.callStatus;
     final acceptedTime = widget.acceptedTime;
     if (acceptedTime != null) {
       _durationTimerInit(acceptedTime);
@@ -62,6 +71,9 @@ class _CallInfoState extends State<CallInfo> {
   @override
   void didUpdateWidget(CallInfo oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.callStatus != oldWidget.callStatus) {
+      _updateDisplayedStatus(widget.callStatus);
+    }
     if (widget.acceptedTime != oldWidget.acceptedTime) {
       _durationTimerCancel();
       final acceptedTime = widget.acceptedTime;
@@ -73,9 +85,28 @@ class _CallInfoState extends State<CallInfo> {
 
   @override
   void dispose() {
+    _debounce.dispose();
     _durationTimerCancel();
     super.dispose();
   }
+
+  void _updateDisplayedStatus(CallStatus newStatus) {
+    if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(_displayedCallStatus)) {
+      if (newStatus == _displayedCallStatus || newStatus == _pendingCallStatus) return;
+      _pendingCallStatus = newStatus;
+      _debounce.schedule(() {
+        _pendingCallStatus = null;
+        setState(() => _displayedCallStatus = widget.callStatus);
+      });
+    } else {
+      _pendingCallStatus = null;
+      _debounce.cancel();
+      setState(() => _displayedCallStatus = newStatus);
+    }
+  }
+
+  bool _isTransientReconnecting(CallStatus status) =>
+      status == CallStatus.connectIssue || status == CallStatus.inProgress || status == CallStatus.connectError;
 
   void _durationTimerInit(DateTime acceptedTime) {
     durationTimer = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -157,8 +188,8 @@ class _CallInfoState extends State<CallInfo> {
   String _buildStatusMessage(BuildContext context) {
     final duration = this.duration;
 
-    if (widget.callStatus != CallStatus.ready) {
-      return widget.callStatus.l10n(context);
+    if (_displayedCallStatus != CallStatus.ready) {
+      return _displayedCallStatus.l10n(context);
     } else if (duration == null) {
       if (widget.inviteToAttendedTransfer) {
         return context.l10n.call_description_inviteToAttendedTransfer;

--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -52,14 +52,17 @@ class _CallInfoState extends State<CallInfo> {
   Timer? durationTimer;
   Duration? duration;
 
-  late CallStatus _displayedCallStatus;
-  CallStatus? _pendingCallStatus;
-  final _debounce = Debounce(kSignalingStatusDebounce);
+  late final TransientDebouncer<CallStatus> _debouncer;
 
   @override
   void initState() {
     super.initState();
-    _displayedCallStatus = widget.callStatus;
+    _debouncer = TransientDebouncer<CallStatus>(
+      initial: widget.callStatus,
+      duration: kSignalingStatusDebounce,
+      isTransient: (s) => s.isTransientReconnecting,
+      getLatest: () => widget.callStatus,
+    );
     final acceptedTime = widget.acceptedTime;
     if (acceptedTime != null) {
       _durationTimerInit(acceptedTime);
@@ -70,7 +73,7 @@ class _CallInfoState extends State<CallInfo> {
   void didUpdateWidget(CallInfo oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.callStatus != oldWidget.callStatus) {
-      _updateDisplayedStatus(widget.callStatus);
+      _debouncer.update(widget.callStatus, () => setState(() {}));
     }
     if (widget.acceptedTime != oldWidget.acceptedTime) {
       _durationTimerCancel();
@@ -83,24 +86,9 @@ class _CallInfoState extends State<CallInfo> {
 
   @override
   void dispose() {
-    _debounce.dispose();
+    _debouncer.dispose();
     _durationTimerCancel();
     super.dispose();
-  }
-
-  void _updateDisplayedStatus(CallStatus newStatus) {
-    if (newStatus.isTransientReconnecting && _displayedCallStatus.isTransientReconnecting) {
-      if (newStatus == _displayedCallStatus || newStatus == _pendingCallStatus) return;
-      _pendingCallStatus = newStatus;
-      _debounce.schedule(() {
-        _pendingCallStatus = null;
-        setState(() => _displayedCallStatus = widget.callStatus);
-      });
-    } else {
-      _pendingCallStatus = null;
-      _debounce.cancel();
-      setState(() => _displayedCallStatus = newStatus);
-    }
   }
 
   void _durationTimerInit(DateTime acceptedTime) {
@@ -183,8 +171,8 @@ class _CallInfoState extends State<CallInfo> {
   String _buildStatusMessage(BuildContext context) {
     final duration = this.duration;
 
-    if (_displayedCallStatus != CallStatus.ready) {
-      return _displayedCallStatus.l10n(context);
+    if (_debouncer.displayed != CallStatus.ready) {
+      return _debouncer.displayed.l10n(context);
     } else if (duration == null) {
       if (widget.inviteToAttendedTransfer) {
         return context.l10n.call_description_inviteToAttendedTransfer;

--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -49,7 +49,7 @@ class CallInfo extends StatefulWidget {
 }
 
 class _CallInfoState extends State<CallInfo> {
-  static final _kStatusDebounce = kSignalingClientReconnectDelay + const Duration(milliseconds: 500);
+  static const _kStatusDebounce = kSignalingStatusDebounce;
 
   Timer? durationTimer;
   Duration? duration;

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -5,6 +5,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
@@ -26,19 +27,21 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     _emitCombinedStatus();
   }
 
-  static const _kReconnectDebounce = kSignalingStatusDebounce;
-
   late final StreamSubscription<PushTokensState> _pushTokensSubscription;
   late final StreamSubscription<CallState> _callSubscription;
 
   PushTokensState? _lastPushTokensState;
   CallState? _lastCallState;
 
+  /// The [CallStatus] of the last successfully emitted state.
+  /// Used to check whether the previous emitted state was in the transient zone.
+  CallStatus? _lastEmittedCallStatus;
+
   /// Debounces transitions within the transient reconnecting zone to prevent
   /// AnimatedSwitcher from animating on every reconnect attempt.
-  final _debounce = Debounce(_kReconnectDebounce);
+  final _debounce = Debounce(kSignalingStatusDebounce);
 
-  /// The status queued by [_debounce] but not yet emitted.
+  /// The [CallStatus] queued by [_debounce] but not yet emitted.
   /// Prevents the debounce timer from resetting when the same target status
   /// arrives repeatedly during the reconnect backoff cycle.
   ///
@@ -47,7 +50,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   /// fires only once the cycle stabilises. The UI intentionally stays on the
   /// last emitted pre-transient status (e.g. connectIssue) until the connection
   /// resolves or the cycle stops alternating.
-  SessionStatus? _pendingStatus;
+  CallStatus? _pendingCallStatus;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
     _lastPushTokensState = pushTokens;
@@ -62,49 +65,44 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   void _emitCombinedStatus() {
     _logger.finest('emitCombinedStatus: $_lastPushTokensState, $_lastCallState');
 
-    final newStatus = _resolveCurrentStatus();
-    if (newStatus == null) return;
-
-    if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(state.status)) {
-      // Suppress AnimatedSwitcher flicker during reconnect backoff (WT-1431).
-      // Debounce fires only when the target status changes — not on every event —
-      // so rapid transitions between connectIssue, inProgress, connectError do not animate.
-      if (newStatus == state.status || newStatus == _pendingStatus) return;
-      _pendingStatus = newStatus;
-      _debounce.schedule(_emitDebouncedStatus);
-    } else {
-      // Critical boundary: ready, error, connectivityNone, appUnregistered — immediate.
-      _pendingStatus = null;
-      _debounce.cancel();
-      emit(state.copyWith(status: newStatus));
-    }
-  }
-
-  void _emitDebouncedStatus() {
-    _pendingStatus = null;
-    final freshStatus = _resolveCurrentStatus();
-    if (freshStatus == null) return;
-    _logger.info('debounce fired, status: $freshStatus');
-    emit(state.copyWith(status: freshStatus));
-  }
-
-  /// Computes the current [SessionStatus] from the latest [PushTokensState]
-  /// and [CallState]. Returns null and logs a warning if either is not yet
-  /// available.
-  SessionStatus? _resolveCurrentStatus() {
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;
     if (pushTokens == null || call == null) {
       _logger.warning('resolveCurrentStatus: skipped — pushTokens=$pushTokens, call=$call');
-      return null;
+      return;
     }
-    return _mapCallStatusToSessionStatus(call.status, pushTokens);
+
+    final newCallStatus = call.status;
+    final lastEmitted = _lastEmittedCallStatus;
+
+    if (lastEmitted != null && newCallStatus.isTransientReconnecting && lastEmitted.isTransientReconnecting) {
+      // Suppress AnimatedSwitcher flicker during reconnect backoff (WT-1431).
+      // Debounce fires only when the target status changes — not on every event —
+      // so rapid transitions between connectIssue, inProgress, connectError do not animate.
+      if (newCallStatus == _pendingCallStatus) return;
+      _pendingCallStatus = newCallStatus;
+      _debounce.schedule(_emitDebouncedStatus);
+    } else {
+      // Critical boundary: ready, connectivityNone, appUnregistered — immediate.
+      _pendingCallStatus = null;
+      _debounce.cancel();
+      _emitMapped(newCallStatus, pushTokens);
+    }
   }
 
-  bool _isTransientReconnecting(SessionStatus status) =>
-      status == SessionStatus.connectIssue ||
-      status == SessionStatus.inProgress ||
-      status == SessionStatus.connectError;
+  void _emitDebouncedStatus() {
+    _pendingCallStatus = null;
+    final pushTokens = _lastPushTokensState;
+    final call = _lastCallState;
+    if (pushTokens == null || call == null) return;
+    _logger.info('debounce fired, callStatus: ${call.status}');
+    _emitMapped(call.status, pushTokens);
+  }
+
+  void _emitMapped(CallStatus callStatus, PushTokensState pushTokens) {
+    _lastEmittedCallStatus = callStatus;
+    emit(state.copyWith(status: _mapCallStatusToSessionStatus(callStatus, pushTokens)));
+  }
 
   SessionStatus _mapCallStatusToSessionStatus(CallStatus callStatus, PushTokensState pushTokens) {
     final pushTokenError = (pushTokens.pushToken == null && pushTokens.errorMessage != null)

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -37,7 +37,13 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   PushTokensState? _lastPushTokensState;
   CallState? _lastCallState;
 
+  /// Debounces transitions within the transient reconnecting zone to prevent
+  /// AnimatedSwitcher from animating on every reconnect attempt.
   final _debounce = Debounce(_kReconnectDebounce);
+
+  /// The status queued by [_debounce] but not yet emitted.
+  /// Prevents the debounce timer from resetting when the same target status
+  /// arrives repeatedly during the reconnect backoff cycle.
   SessionStatus? _pendingStatus;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -4,11 +4,8 @@ import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 
-import 'package:webtrit_phone/app/constants.dart';
-import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/utils/utils.dart';
 
 part 'session_status_state.dart';
 
@@ -33,25 +30,6 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   PushTokensState? _lastPushTokensState;
   CallState? _lastCallState;
 
-  /// The [CallStatus] of the last successfully emitted state.
-  /// Used to check whether the previous emitted state was in the transient zone.
-  CallStatus? _lastEmittedCallStatus;
-
-  /// Debounces transitions within the transient reconnecting zone to prevent
-  /// AnimatedSwitcher from animating on every reconnect attempt.
-  final _debounce = Debounce(kSignalingStatusDebounce);
-
-  /// The [CallStatus] queued by [_debounce] but not yet emitted.
-  /// Prevents the debounce timer from resetting when the same target status
-  /// arrives repeatedly during the reconnect backoff cycle.
-  ///
-  /// Note: when statuses alternate (e.g. inProgress, connectError, inProgress)
-  /// each arrival carries a different target, so the timer keeps resetting and
-  /// fires only once the cycle stabilises. The UI intentionally stays on the
-  /// last emitted pre-transient status (e.g. connectIssue) until the connection
-  /// resolves or the cycle stops alternating.
-  CallStatus? _pendingCallStatus;
-
   void _onPushTokensChanged(PushTokensState pushTokens) {
     _lastPushTokensState = pushTokens;
     _emitCombinedStatus();
@@ -68,54 +46,24 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;
     if (pushTokens == null || call == null) {
-      _logger.warning('resolveCurrentStatus: skipped — pushTokens=$pushTokens, call=$call');
+      _logger.warning('emitCombinedStatus: skipped — pushTokens=$pushTokens, call=$call');
       return;
     }
 
-    final newCallStatus = call.status;
-    final lastEmitted = _lastEmittedCallStatus;
-
-    if (lastEmitted != null && newCallStatus.isTransientReconnecting && lastEmitted.isTransientReconnecting) {
-      // Suppress AnimatedSwitcher flicker during reconnect backoff (WT-1431).
-      // Debounce fires only when the target status changes — not on every event —
-      // so rapid transitions between connectIssue, inProgress, connectError do not animate.
-      if (newCallStatus == _pendingCallStatus) return;
-      _pendingCallStatus = newCallStatus;
-      _debounce.schedule(_emitDebouncedStatus);
-    } else {
-      // Critical boundary: ready, connectivityNone, appUnregistered — immediate.
-      _pendingCallStatus = null;
-      _debounce.cancel();
-      _emitMapped(newCallStatus, pushTokens);
-    }
-  }
-
-  void _emitDebouncedStatus() {
-    _pendingCallStatus = null;
-    final pushTokens = _lastPushTokensState;
-    final call = _lastCallState;
-    if (pushTokens == null || call == null) return;
-    _logger.info('debounce fired, callStatus: ${call.status}');
-    _emitMapped(call.status, pushTokens);
-  }
-
-  void _emitMapped(CallStatus callStatus, PushTokensState pushTokens) {
-    _lastEmittedCallStatus = callStatus;
-    emit(state.copyWith(status: _mapCallStatusToSessionStatus(callStatus, pushTokens)));
-  }
-
-  SessionStatus _mapCallStatusToSessionStatus(CallStatus callStatus, PushTokensState pushTokens) {
     final pushTokenError = (pushTokens.pushToken == null && pushTokens.errorMessage != null)
         ? pushTokens.errorMessage
         : null;
-    return SessionStatus(signalingStatus: callStatus, pushTokenError: pushTokenError);
+    emit(
+      state.copyWith(
+        status: SessionStatus(signalingStatus: call.status, pushTokenError: pushTokenError),
+      ),
+    );
   }
 
   @override
   Future<void> close() {
     _callSubscription.cancel();
     _pushTokensSubscription.cancel();
-    _debounce.dispose();
     return super.close();
   }
 }

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -26,7 +26,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   }
 
   // Reconnect cycle fires every 3 sec; 3.5 sec absorbs status changes within
-  // a cycle without delaying genuine transitions (ready↔error).
+  // a cycle without delaying genuine transitions between ready and error states.
   static const _kReconnectDebounce = Duration(milliseconds: 3500);
 
   late final StreamSubscription<PushTokensState> _pushTokensSubscription;
@@ -64,12 +64,12 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(state.status)) {
       // Suppress AnimatedSwitcher flicker during reconnect backoff (WT-1431).
       // Debounce fires only when the target status changes — not on every event —
-      // so rapid connectIssue ↔ inProgress ↔ connectError cycles do not animate.
+      // so rapid transitions between connectIssue, inProgress, connectError do not animate.
       if (newStatus == state.status || newStatus == _pendingStatus) return;
       _pendingStatus = newStatus;
       _debounce.schedule('status', _emitDebouncedStatus);
     } else {
-      // Critical boundary: ready ↔ error, connectivityNone, appUnregistered — immediate.
+      // Critical boundary: ready, error, connectivityNone, appUnregistered — immediate.
       _pendingStatus = null;
       _debounce.cancel('status');
       emit(state.copyWith(status: newStatus));
@@ -85,7 +85,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
       return;
     }
     final freshStatus = _mapCallStatusToSessionStatus(call.status, pushTokens);
-    _logger.info('debounce fired → $freshStatus');
+    _logger.info('debounce fired, status: $freshStatus');
     emit(state.copyWith(status: freshStatus));
   }
 

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -6,7 +6,7 @@ import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/utils/debounce_map.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 
 part 'session_status_state.dart';
 

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -44,6 +44,12 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   /// The status queued by [_debounce] but not yet emitted.
   /// Prevents the debounce timer from resetting when the same target status
   /// arrives repeatedly during the reconnect backoff cycle.
+  ///
+  /// Note: when statuses alternate (e.g. inProgress, connectError, inProgress)
+  /// each arrival carries a different target, so the timer keeps resetting and
+  /// fires only once the cycle stabilises. The UI intentionally stays on the
+  /// last emitted pre-transient status (e.g. connectIssue) until the connection
+  /// resolves or the cycle stops alternating.
   SessionStatus? _pendingStatus;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
@@ -112,9 +118,9 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
 
   @override
   Future<void> close() {
-    _debounce.dispose();
-    _pushTokensSubscription.cancel();
     _callSubscription.cancel();
+    _pushTokensSubscription.cancel();
+    _debounce.dispose();
     return super.close();
   }
 }

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -85,6 +85,9 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     emit(state.copyWith(status: freshStatus));
   }
 
+  /// Computes the current [SessionStatus] from the latest [PushTokensState]
+  /// and [CallState]. Returns null and logs a warning if either is not yet
+  /// available.
   SessionStatus? _resolveCurrentStatus() {
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -37,7 +37,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   PushTokensState? _lastPushTokensState;
   CallState? _lastCallState;
 
-  final _debounce = DebounceMap<String>(_kReconnectDebounce);
+  final _debounce = Debounce(_kReconnectDebounce);
   SessionStatus? _pendingStatus;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
@@ -69,11 +69,11 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
       // so rapid transitions between connectIssue, inProgress, connectError do not animate.
       if (newStatus == state.status || newStatus == _pendingStatus) return;
       _pendingStatus = newStatus;
-      _debounce.schedule('status', _emitDebouncedStatus);
+      _debounce.schedule(_emitDebouncedStatus);
     } else {
       // Critical boundary: ready, error, connectivityNone, appUnregistered — immediate.
       _pendingStatus = null;
-      _debounce.cancel('status');
+      _debounce.cancel();
       emit(state.copyWith(status: newStatus));
     }
   }

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -53,15 +53,8 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   void _emitCombinedStatus() {
     _logger.finest('emitCombinedStatus: $_lastPushTokensState, $_lastCallState');
 
-    final pushTokens = _lastPushTokensState;
-    final call = _lastCallState;
-
-    if (pushTokens == null || call == null) {
-      _logger.warning('emitCombinedStatus: skipped — pushTokens=$pushTokens, call=$call');
-      return;
-    }
-
-    final newStatus = _mapCallStatusToSessionStatus(call.status, pushTokens);
+    final newStatus = _resolveCurrentStatus('emitCombinedStatus');
+    if (newStatus == null) return;
 
     if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(state.status)) {
       // Suppress AnimatedSwitcher flicker during reconnect backoff (WT-1431).
@@ -80,15 +73,20 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
 
   void _emitDebouncedStatus() {
     _pendingStatus = null;
+    final freshStatus = _resolveCurrentStatus('emitDebouncedStatus');
+    if (freshStatus == null) return;
+    _logger.info('debounce fired, status: $freshStatus');
+    emit(state.copyWith(status: freshStatus));
+  }
+
+  SessionStatus? _resolveCurrentStatus(String caller) {
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;
     if (pushTokens == null || call == null) {
-      _logger.warning('emitDebouncedStatus: skipped — pushTokens=$pushTokens, call=$call');
-      return;
+      _logger.warning('$caller: skipped — pushTokens=$pushTokens, call=$call');
+      return null;
     }
-    final freshStatus = _mapCallStatusToSessionStatus(call.status, pushTokens);
-    _logger.info('debounce fired, status: $freshStatus');
-    emit(state.copyWith(status: freshStatus));
+    return _mapCallStatusToSessionStatus(call.status, pushTokens);
   }
 
   bool _isTransientReconnecting(SessionStatus status) =>

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -4,6 +4,7 @@ import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
@@ -25,9 +26,10 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     _emitCombinedStatus();
   }
 
-  // Reconnect cycle fires every 3 sec; 3.5 sec absorbs status changes within
-  // a cycle without delaying genuine transitions between ready and error states.
-  static const _kReconnectDebounce = Duration(milliseconds: 3500);
+  // Slightly longer than kSignalingClientReconnectDelay so the debounce absorbs
+  // all status changes within one reconnect cycle without delaying genuine
+  // transitions between ready and error states.
+  static final _kReconnectDebounce = kSignalingClientReconnectDelay + const Duration(milliseconds: 500);
 
   late final StreamSubscription<PushTokensState> _pushTokensSubscription;
   late final StreamSubscription<CallState> _callSubscription;

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -26,10 +26,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     _emitCombinedStatus();
   }
 
-  // Slightly longer than kSignalingClientReconnectDelay so the debounce absorbs
-  // all status changes within one reconnect cycle without delaying genuine
-  // transitions between ready and error states.
-  static final _kReconnectDebounce = kSignalingClientReconnectDelay + const Duration(milliseconds: 500);
+  static const _kReconnectDebounce = kSignalingStatusDebounce;
 
   late final StreamSubscription<PushTokensState> _pushTokensSubscription;
   late final StreamSubscription<CallState> _callSubscription;

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -54,33 +54,38 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;
 
-    if (pushTokens == null || call == null) return;
+    if (pushTokens == null || call == null) {
+      _logger.warning('emitCombinedStatus: skipped — pushTokens=$pushTokens, call=$call');
+      return;
+    }
 
     final newStatus = _mapCallStatusToSessionStatus(call.status, pushTokens);
 
     if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(state.status)) {
-      // Both sides are within the reconnecting zone (connectIssue / inProgress /
-      // connectError). Debounce transitions between them so the AnimatedSwitcher
-      // in MainAppBar does not flicker on every reconnect attempt (WT-1431).
-      // Timer resets only when the *target* status changes, not on every event.
+      // Suppress AnimatedSwitcher flicker during reconnect backoff (WT-1431).
+      // Debounce fires only when the target status changes — not on every event —
+      // so rapid connectIssue ↔ inProgress ↔ connectError cycles do not animate.
       if (newStatus == state.status || newStatus == _pendingStatus) return;
       _pendingStatus = newStatus;
-      _debounce.schedule('status', _fireDebounce);
+      _debounce.schedule('status', _emitDebouncedStatus);
     } else {
-      // Critical boundary (ready↔error, network loss, unregistered) — immediate.
+      // Critical boundary: ready ↔ error, connectivityNone, appUnregistered — immediate.
       _pendingStatus = null;
       _debounce.cancel('status');
       emit(state.copyWith(status: newStatus));
     }
   }
 
-  void _fireDebounce() {
+  void _emitDebouncedStatus() {
     _pendingStatus = null;
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;
-    if (pushTokens == null || call == null) return;
+    if (pushTokens == null || call == null) {
+      _logger.warning('emitDebouncedStatus: skipped — pushTokens=$pushTokens, call=$call');
+      return;
+    }
     final freshStatus = _mapCallStatusToSessionStatus(call.status, pushTokens);
-    _logger.info('_emitCombinedStatus debounce fired -> $freshStatus');
+    _logger.info('debounce fired → $freshStatus');
     emit(state.copyWith(status: freshStatus));
   }
 

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -6,6 +6,7 @@ import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/utils/debounce_map.dart';
 
 part 'session_status_state.dart';
 
@@ -24,11 +25,18 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     _emitCombinedStatus();
   }
 
+  // Reconnect cycle fires every 3 sec; 3.5 sec absorbs status changes within
+  // a cycle without delaying genuine transitions (ready↔error).
+  static const _kReconnectDebounce = Duration(milliseconds: 3500);
+
   late final StreamSubscription<PushTokensState> _pushTokensSubscription;
   late final StreamSubscription<CallState> _callSubscription;
 
   PushTokensState? _lastPushTokensState;
   CallState? _lastCallState;
+
+  final _debounce = DebounceMap<String>(_kReconnectDebounce);
+  SessionStatus? _pendingStatus;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
     _lastPushTokensState = pushTokens;
@@ -46,10 +54,40 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;
 
-    if (pushTokens != null && call != null) {
-      emit(state.copyWith(status: _mapCallStatusToSessionStatus(call.status, pushTokens)));
+    if (pushTokens == null || call == null) return;
+
+    final newStatus = _mapCallStatusToSessionStatus(call.status, pushTokens);
+
+    if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(state.status)) {
+      // Both sides are within the reconnecting zone (connectIssue / inProgress /
+      // connectError). Debounce transitions between them so the AnimatedSwitcher
+      // in MainAppBar does not flicker on every reconnect attempt (WT-1431).
+      // Timer resets only when the *target* status changes, not on every event.
+      if (newStatus == state.status || newStatus == _pendingStatus) return;
+      _pendingStatus = newStatus;
+      _debounce.schedule('status', _fireDebounce);
+    } else {
+      // Critical boundary (ready↔error, network loss, unregistered) — immediate.
+      _pendingStatus = null;
+      _debounce.cancel('status');
+      emit(state.copyWith(status: newStatus));
     }
   }
+
+  void _fireDebounce() {
+    _pendingStatus = null;
+    final pushTokens = _lastPushTokensState;
+    final call = _lastCallState;
+    if (pushTokens == null || call == null) return;
+    final freshStatus = _mapCallStatusToSessionStatus(call.status, pushTokens);
+    _logger.info('_emitCombinedStatus debounce fired -> $freshStatus');
+    emit(state.copyWith(status: freshStatus));
+  }
+
+  bool _isTransientReconnecting(SessionStatus status) =>
+      status == SessionStatus.connectIssue ||
+      status == SessionStatus.inProgress ||
+      status == SessionStatus.connectError;
 
   SessionStatus _mapCallStatusToSessionStatus(CallStatus callStatus, PushTokensState pushTokens) {
     final pushTokenError = (pushTokens.pushToken == null && pushTokens.errorMessage != null)
@@ -60,6 +98,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
 
   @override
   Future<void> close() {
+    _debounce.dispose();
     _pushTokensSubscription.cancel();
     _callSubscription.cancel();
     return super.close();

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -53,7 +53,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   void _emitCombinedStatus() {
     _logger.finest('emitCombinedStatus: $_lastPushTokensState, $_lastCallState');
 
-    final newStatus = _resolveCurrentStatus('emitCombinedStatus');
+    final newStatus = _resolveCurrentStatus();
     if (newStatus == null) return;
 
     if (_isTransientReconnecting(newStatus) && _isTransientReconnecting(state.status)) {
@@ -73,17 +73,17 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
 
   void _emitDebouncedStatus() {
     _pendingStatus = null;
-    final freshStatus = _resolveCurrentStatus('emitDebouncedStatus');
+    final freshStatus = _resolveCurrentStatus();
     if (freshStatus == null) return;
     _logger.info('debounce fired, status: $freshStatus');
     emit(state.copyWith(status: freshStatus));
   }
 
-  SessionStatus? _resolveCurrentStatus(String caller) {
+  SessionStatus? _resolveCurrentStatus() {
     final pushTokens = _lastPushTokensState;
     final call = _lastCallState;
     if (pushTokens == null || call == null) {
-      _logger.warning('$caller: skipped — pushTokens=$pushTokens, call=$call');
+      _logger.warning('resolveCurrentStatus: skipped — pushTokens=$pushTokens, call=$call');
       return null;
     }
     return _mapCallStatusToSessionStatus(call.status, pushTokens);

--- a/lib/utils/debounce.dart
+++ b/lib/utils/debounce.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+/// Single-key debounce utility.
+///
+/// Calling [schedule] cancels any pending callback and starts a new [duration]
+/// countdown. Only the last scheduled callback within the quiet window executes.
+class Debounce {
+  Debounce(this.duration);
+
+  final Duration duration;
+  Timer? _timer;
+
+  void schedule(void Function() callback) {
+    _timer?.cancel();
+    _timer = Timer(duration, () {
+      _timer = null;
+      callback();
+    });
+  }
+
+  void cancel() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}

--- a/lib/utils/debounce_map.dart
+++ b/lib/utils/debounce_map.dart
@@ -19,8 +19,8 @@ class DebounceMap<K> {
   void cancel(K key) => _debouncers[key]?.cancel();
 
   void dispose() {
-    for (final d in _debouncers.values) {
-      d.dispose();
+    for (final debouncer in _debouncers.values) {
+      debouncer.dispose();
     }
     _debouncers.clear();
   }

--- a/lib/utils/debounce_map.dart
+++ b/lib/utils/debounce_map.dart
@@ -16,7 +16,7 @@ class DebounceMap<K> {
     (_debouncers[key] ??= Debounce(duration)).schedule(callback);
   }
 
-  void cancel(K key) => _debouncers[key]?.cancel();
+  void cancel(K key) => _debouncers.remove(key)?.cancel();
 
   void dispose() {
     for (final debouncer in _debouncers.values) {

--- a/lib/utils/debounce_map.dart
+++ b/lib/utils/debounce_map.dart
@@ -13,7 +13,10 @@ class DebounceMap<K> {
   final Map<K, Debounce> _debouncers = {};
 
   void schedule(K key, void Function() callback) {
-    (_debouncers[key] ??= Debounce(duration)).schedule(callback);
+    (_debouncers[key] ??= Debounce(duration)).schedule(() {
+      _debouncers.remove(key);
+      callback();
+    });
   }
 
   void cancel(K key) => _debouncers.remove(key)?.cancel();

--- a/lib/utils/debounce_map.dart
+++ b/lib/utils/debounce_map.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+import 'debounce.dart';
 
 /// Debounces repeated actions keyed by an identifier.
 ///
@@ -10,24 +10,18 @@ class DebounceMap<K> {
   DebounceMap(this.duration);
 
   final Duration duration;
-  final Map<K, Timer> _timers = {};
+  final Map<K, Debounce> _debouncers = {};
 
   void schedule(K key, void Function() callback) {
-    _timers[key]?.cancel();
-    _timers[key] = Timer(duration, () {
-      _timers.remove(key);
-      callback();
-    });
+    (_debouncers[key] ??= Debounce(duration)).schedule(callback);
   }
 
-  void cancel(K key) {
-    _timers.remove(key)?.cancel();
-  }
+  void cancel(K key) => _debouncers[key]?.cancel();
 
   void dispose() {
-    for (final t in _timers.values) {
-      t.cancel();
+    for (final d in _debouncers.values) {
+      d.dispose();
     }
-    _timers.clear();
+    _debouncers.clear();
   }
 }

--- a/lib/utils/transient_debouncer.dart
+++ b/lib/utils/transient_debouncer.dart
@@ -1,0 +1,65 @@
+import 'debounce.dart';
+
+/// Debounces rapid transitions between transient states.
+///
+/// Immediate update when either the old or new value is non-transient.
+/// Debounced update when both old and new are transient, so quick
+/// oscillations within a transient zone don't flicker the UI.
+///
+/// Usage in a StatefulWidget:
+/// ```dart
+/// late final _debouncer = TransientDebouncer<MyStatus>(
+///   initial: widget.status,
+///   duration: kDebounce,
+///   isTransient: (s) => s.isTransient,
+///   getLatest: () => widget.status,
+/// );
+///
+/// // In didUpdateWidget:
+/// _debouncer.update(widget.status, (s) => setState(() {}));
+///
+/// // In dispose:
+/// _debouncer.dispose();
+/// ```
+class TransientDebouncer<T> {
+  TransientDebouncer({
+    required T initial,
+    required Duration duration,
+    required bool Function(T) isTransient,
+    required T Function() getLatest,
+  }) : _displayed = initial,
+       _isTransient = isTransient,
+       _getLatest = getLatest,
+       _debounce = Debounce(duration);
+
+  T _displayed;
+  T? _pending;
+
+  final bool Function(T) _isTransient;
+  final T Function() _getLatest;
+  final Debounce _debounce;
+
+  T get displayed => _displayed;
+
+  /// Call whenever the value may have changed.
+  /// [onUpdate] is called synchronously on immediate updates; the debounced
+  /// callback also fires it after the quiet window expires.
+  void update(T newValue, void Function() onUpdate) {
+    if (_isTransient(newValue) && _isTransient(_displayed)) {
+      if (newValue == _displayed || newValue == _pending) return;
+      _pending = newValue;
+      _debounce.schedule(() {
+        _pending = null;
+        _displayed = _getLatest();
+        onUpdate();
+      });
+    } else {
+      _pending = null;
+      _debounce.cancel();
+      _displayed = newValue;
+      onUpdate();
+    }
+  }
+
+  void dispose() => _debounce.dispose();
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -5,6 +5,7 @@ export 'buffer_transformer.dart';
 export 'connectivity_checker.dart';
 export 'core_support.dart';
 export 'crashlytics_utils.dart';
+export 'debounce.dart';
 export 'debounce_map.dart';
 export 'equatable_prop_to_string.dart';
 export 'expiring_cache.dart';

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -7,6 +7,7 @@ export 'core_support.dart';
 export 'crashlytics_utils.dart';
 export 'debounce.dart';
 export 'debounce_map.dart';
+export 'transient_debouncer.dart';
 export 'equatable_prop_to_string.dart';
 export 'expiring_cache.dart';
 export 'fixed_delay_scheduler.dart';

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -43,36 +43,29 @@ class MainAppBar extends StatefulWidget implements PreferredSizeWidget {
 }
 
 class _MainAppBarState extends State<MainAppBar> {
-  late SessionStatus _displayedStatus;
-  SessionStatus? _pendingStatus;
-  final _debounce = Debounce(kSignalingStatusDebounce);
+  late final TransientDebouncer<SessionStatus> _debouncer;
 
   @override
   void initState() {
     super.initState();
-    _displayedStatus = context.read<SessionStatusCubit>().state.status;
+    final initial = context.read<SessionStatusCubit>().state.status;
+    _debouncer = TransientDebouncer<SessionStatus>(
+      initial: initial,
+      duration: kSignalingStatusDebounce,
+      isTransient: (s) => s.signalingStatus.isTransientReconnecting,
+      getLatest: () => context.read<SessionStatusCubit>().state.status,
+    );
   }
 
   @override
   void dispose() {
-    _debounce.dispose();
+    _debouncer.dispose();
     super.dispose();
   }
 
   void _updateDisplayedStatus(SessionStatus newStatus) {
-    if (newStatus.signalingStatus.isTransientReconnecting && _displayedStatus.signalingStatus.isTransientReconnecting) {
-      if (newStatus == _displayedStatus || newStatus == _pendingStatus) return;
-      _pendingStatus = newStatus;
-      _debounce.schedule(() {
-        if (!mounted) return;
-        _pendingStatus = null;
-        setState(() => _displayedStatus = context.read<SessionStatusCubit>().state.status);
-      });
-    } else {
-      _pendingStatus = null;
-      _debounce.cancel();
-      setState(() => _displayedStatus = newStatus);
-    }
+    if (!mounted) return;
+    _debouncer.update(newStatus, () => setState(() {}));
   }
 
   @override
@@ -85,16 +78,16 @@ class _MainAppBarState extends State<MainAppBar> {
         title: Builder(
           builder: (context) {
             Widget? widgetToShow;
-            if (_displayedStatus.isEstablishing) {
+            if (_debouncer.displayed.isEstablishing) {
               widgetToShow = Row(
-                key: _displayedStatus.key,
+                key: _debouncer.displayed.key,
                 mainAxisSize: MainAxisSize.max,
                 children: [
                   SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
                   SizedBox(width: 8),
                   Flexible(
                     child: Text(
-                      _displayedStatus.appBarl10n(context),
+                      _debouncer.displayed.appBarl10n(context),
                       style: theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
                       overflow: TextOverflow.ellipsis,
                       maxLines: 1,
@@ -134,14 +127,14 @@ class _MainAppBarState extends State<MainAppBar> {
         elevation: widget.elevation,
         centerTitle: false,
         actions: [
-          if (_displayedStatus.isReady) ...[
+          if (_debouncer.displayed.isReady) ...[
             if (AppBarParams.of(context).pullableCallDialogs.isNotEmpty)
               CallPullBadge(pullableCallDialogs: AppBarParams.of(context).pullableCallDialogs),
             if (AppBarParams.of(context).systemNotificationsEnabled) SystemNotificationsBadge(),
           ],
           Ink(
             decoration: ShapeDecoration(
-              shape: CircleBorder(side: BorderSide(color: _displayedStatus.color(context))),
+              shape: CircleBorder(side: BorderSide(color: _debouncer.displayed.color(context))),
             ),
             child: BlocBuilder<UserInfoCubit, UserInfoState>(
               builder: (context, userinfoState) {

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -52,7 +52,7 @@ class _MainAppBarState extends State<MainAppBar> {
     _debouncer = TransientDebouncer<SessionStatus>(
       initial: initial,
       duration: kSignalingStatusDebounce,
-      isTransient: (s) => s.signalingStatus.isTransientReconnecting,
+      isTransient: (s) => s.signalingStatus.isTransientReconnecting && !s.hasPushTokenError,
       getLatest: () => context.read<SessionStatusCubit>().state.status,
     );
   }

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -5,14 +5,16 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
-class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
+class MainAppBar extends StatefulWidget implements PreferredSizeWidget {
   const MainAppBar({
     super.key,
     this.title,
@@ -37,130 +39,163 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   @override
+  State<MainAppBar> createState() => _MainAppBarState();
+}
+
+class _MainAppBarState extends State<MainAppBar> {
+  late SessionStatus _displayedStatus;
+  SessionStatus? _pendingStatus;
+  final _debounce = Debounce(kSignalingStatusDebounce);
+
+  @override
+  void initState() {
+    super.initState();
+    _displayedStatus = context.read<SessionStatusCubit>().state.status;
+  }
+
+  @override
+  void dispose() {
+    _debounce.dispose();
+    super.dispose();
+  }
+
+  void _updateDisplayedStatus(SessionStatus newStatus) {
+    if (newStatus.signalingStatus.isTransientReconnecting && _displayedStatus.signalingStatus.isTransientReconnecting) {
+      if (newStatus == _displayedStatus || newStatus == _pendingStatus) return;
+      _pendingStatus = newStatus;
+      _debounce.schedule(() {
+        if (!mounted) return;
+        _pendingStatus = null;
+        setState(() => _displayedStatus = context.read<SessionStatusCubit>().state.status);
+      });
+    } else {
+      _pendingStatus = null;
+      _debounce.cancel();
+      setState(() => _displayedStatus = newStatus);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    // final colorScheme = theme.colorScheme;
 
-    return BlocBuilder<SessionStatusCubit, SessionStatusState>(
-      builder: (context, sessionState) {
-        final status = sessionState.status;
-        return AppBar(
-          title: Builder(
-            builder: (context) {
-              Widget? widgetToShow;
-              if (status.isEstablishing) {
-                widgetToShow = Row(
-                  key: status.key,
-                  mainAxisSize: MainAxisSize.max,
-                  children: [
-                    SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
-                    SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        sessionState.status.appBarl10n(context),
-                        style: theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                      ),
+    return BlocListener<SessionStatusCubit, SessionStatusState>(
+      listener: (context, state) => _updateDisplayedStatus(state.status),
+      child: AppBar(
+        title: Builder(
+          builder: (context) {
+            Widget? widgetToShow;
+            if (_displayedStatus.isEstablishing) {
+              widgetToShow = Row(
+                key: _displayedStatus.key,
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
+                  SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      _displayedStatus.appBarl10n(context),
+                      style: theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
                     ),
-                  ],
-                );
-              }
-              widgetToShow ??= Row(mainAxisSize: MainAxisSize.max, children: [title ?? SizedBox.shrink()]);
-
-              return AnimatedSwitcher(
-                duration: const Duration(milliseconds: 500),
-                transitionBuilder: (child, animation) {
-                  final r = animation.status == AnimationStatus.reverse;
-                  return FadeTransition(
-                    opacity: animation.drive(CurveTween(curve: Curves.easeInOut)),
-                    child: SlideTransition(
-                      position: animation.drive(
-                        Tween<Offset>(
-                          begin: Offset(0, r ? -1 : 1),
-                          end: Offset.zero,
-                        ).chain(CurveTween(curve: Curves.easeOut)),
-                      ),
-                      child: child,
-                    ),
-                  );
-                },
-                switchInCurve: Curves.easeInExpo,
-                switchOutCurve: Curves.easeOutExpo,
-
-                child: widgetToShow,
+                  ),
+                ],
               );
-            },
-          ),
-          bottom: bottom,
-          backgroundColor: backgroundColor,
-          flexibleSpace: flexibleSpace,
-          elevation: elevation,
-          centerTitle: false,
-          actions: [
-            if (status.isReady) ...[
-              if (AppBarParams.of(context).pullableCallDialogs.isNotEmpty)
-                CallPullBadge(pullableCallDialogs: AppBarParams.of(context).pullableCallDialogs),
-              if (AppBarParams.of(context).systemNotificationsEnabled) SystemNotificationsBadge(),
-            ],
-            Ink(
-              decoration: ShapeDecoration(
-                shape: CircleBorder(side: BorderSide(color: sessionState.status.color(context))),
-              ),
-              child: BlocBuilder<UserInfoCubit, UserInfoState>(
-                builder: (context, userinfoState) {
-                  final info = userinfoState.userInfo;
-                  return IconButton(
-                    key: mainAppBarKey,
-                    constraints: const BoxConstraints.tightFor(
-                      width: kMinInteractiveDimension,
-                      height: kMinInteractiveDimension,
+            }
+            widgetToShow ??= Row(mainAxisSize: MainAxisSize.max, children: [widget.title ?? SizedBox.shrink()]);
+
+            return AnimatedSwitcher(
+              duration: const Duration(milliseconds: 500),
+              transitionBuilder: (child, animation) {
+                final r = animation.status == AnimationStatus.reverse;
+                return FadeTransition(
+                  opacity: animation.drive(CurveTween(curve: Curves.easeInOut)),
+                  child: SlideTransition(
+                    position: animation.drive(
+                      Tween<Offset>(
+                        begin: Offset(0, r ? -1 : 1),
+                        end: Offset.zero,
+                      ).chain(CurveTween(curve: Curves.easeOut)),
                     ),
-                    padding: const EdgeInsets.all(2),
-                    icon: Stack(
-                      clipBehavior: Clip.none,
-                      children: <Widget>[
-                        LeadingAvatar(
-                          username: info?.name ?? info?.numbers.main,
-                          thumbnailUrl: gravatarThumbnailUrl(info?.email),
-                          radius: kMinInteractiveDimension / 2,
-                          showLoading: true,
-                        ),
-                        BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
-                          builder: (context, microphoneStatusState) {
-                            return Visibility(
-                              visible:
-                                  microphoneStatusState.microphonePermissionGranted != null &&
-                                  !microphoneStatusState.microphonePermissionGranted!,
-                              child: Positioned(
-                                right: -8,
-                                top: -2,
-                                child: Container(
-                                  padding: EdgeInsets.all(3),
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(context).colorScheme.error,
-                                    shape: BoxShape.circle,
-                                  ),
-                                  child: Icon(Icons.mic_off, color: Colors.white, size: 14),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ],
-                    ),
-                    onPressed: () {
-                      FocusScope.of(context).unfocus();
-                      context.router.navigate(const SettingsRouterPageRoute());
-                    },
-                  );
-                },
-              ),
-            ),
-            const SizedBox(width: NavigationToolbar.kMiddleSpacing),
+                    child: child,
+                  ),
+                );
+              },
+              switchInCurve: Curves.easeInExpo,
+              switchOutCurve: Curves.easeOutExpo,
+              child: widgetToShow,
+            );
+          },
+        ),
+        bottom: widget.bottom,
+        backgroundColor: widget.backgroundColor,
+        flexibleSpace: widget.flexibleSpace,
+        elevation: widget.elevation,
+        centerTitle: false,
+        actions: [
+          if (_displayedStatus.isReady) ...[
+            if (AppBarParams.of(context).pullableCallDialogs.isNotEmpty)
+              CallPullBadge(pullableCallDialogs: AppBarParams.of(context).pullableCallDialogs),
+            if (AppBarParams.of(context).systemNotificationsEnabled) SystemNotificationsBadge(),
           ],
-        );
-      },
+          Ink(
+            decoration: ShapeDecoration(
+              shape: CircleBorder(side: BorderSide(color: _displayedStatus.color(context))),
+            ),
+            child: BlocBuilder<UserInfoCubit, UserInfoState>(
+              builder: (context, userinfoState) {
+                final info = userinfoState.userInfo;
+                return IconButton(
+                  key: mainAppBarKey,
+                  constraints: const BoxConstraints.tightFor(
+                    width: kMinInteractiveDimension,
+                    height: kMinInteractiveDimension,
+                  ),
+                  padding: const EdgeInsets.all(2),
+                  icon: Stack(
+                    clipBehavior: Clip.none,
+                    children: <Widget>[
+                      LeadingAvatar(
+                        username: info?.name ?? info?.numbers.main,
+                        thumbnailUrl: gravatarThumbnailUrl(info?.email),
+                        radius: kMinInteractiveDimension / 2,
+                        showLoading: true,
+                      ),
+                      BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
+                        builder: (context, microphoneStatusState) {
+                          return Visibility(
+                            visible:
+                                microphoneStatusState.microphonePermissionGranted != null &&
+                                !microphoneStatusState.microphonePermissionGranted!,
+                            child: Positioned(
+                              right: -8,
+                              top: -2,
+                              child: Container(
+                                padding: EdgeInsets.all(3),
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).colorScheme.error,
+                                  shape: BoxShape.circle,
+                                ),
+                                child: Icon(Icons.mic_off, color: Colors.white, size: 14),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                  onPressed: () {
+                    FocusScope.of(context).unfocus();
+                    context.router.navigate(const SettingsRouterPageRoute());
+                  },
+                );
+              },
+            ),
+          ),
+          const SizedBox(width: NavigationToolbar.kMiddleSpacing),
+        ],
+      ),
     );
   }
 }

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -15,7 +15,8 @@ class _MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
 
 class _MockPushTokensBloc extends MockBloc<PushTokensEvent, PushTokensState> implements PushTokensBloc {}
 
-SessionStatus _statusFor(CallStatus s) => SessionStatus(signalingStatus: s);
+SessionStatus _statusFor(CallStatus s, {String? pushTokenError}) =>
+    SessionStatus(signalingStatus: s, pushTokenError: pushTokenError);
 
 CallState _cs(CallStatus target) => switch (target) {
   CallStatus.ready => CallState(
@@ -58,138 +59,82 @@ void main() {
       return SessionStatusCubit(pushTokensBloc: pushTokensBloc, callBloc: callBloc);
     }
 
-    test('ready → connectIssue emits immediately without debounce', () {
+    test('emits initial status from constructor state', () {
       fakeAsync((async) {
-        final callController = StreamController<CallState>(sync: true);
-
-        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: const Stream.empty());
 
         expect(cubit.state.status, _statusFor(CallStatus.ready));
-
-        // connectIssue is transient, ready is not — crosses non-transient boundary, immediate
-        callController.add(_cs(CallStatus.connectIssue));
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        callController.close();
         unawaited(cubit.close());
       });
     });
 
-    test('connectIssue → inProgress → connectError suppressed until debounce fires', () {
+    test('emits immediately on every callStatus change — no debounce', () {
       fakeAsync((async) {
         final callController = StreamController<CallState>(sync: true);
 
         final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
 
-        // Cross into transient zone immediately (ready is non-transient)
         callController.add(_cs(CallStatus.connectIssue));
         expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
-        // Both subsequent statuses are transient — debounce suppresses them
         callController.add(_cs(CallStatus.inProgress));
+        expect(cubit.state.status, _statusFor(CallStatus.inProgress));
+
         callController.add(_cs(CallStatus.connectError));
-
-        async.elapse(const Duration(seconds: 1));
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        // Advance past the 3.5-second debounce window
-        async.elapse(const Duration(seconds: 3));
         expect(cubit.state.status, _statusFor(CallStatus.connectError));
 
-        callController.close();
-        unawaited(cubit.close());
-      });
-    });
-
-    test('inProgress → ready cancels debounce and emits ready immediately', () {
-      fakeAsync((async) {
-        final callController = StreamController<CallState>(sync: true);
-
-        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
-
-        callController.add(_cs(CallStatus.connectIssue)); // immediate
-        callController.add(_cs(CallStatus.inProgress)); // debounced
-
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        // ready is non-transient — cancels debounce and emits immediately
         callController.add(_cs(CallStatus.ready));
         expect(cubit.state.status, _statusFor(CallStatus.ready));
 
-        // No deferred emission after the debounce window
-        async.elapse(const Duration(seconds: 4));
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('emits pushTokenError when push token is missing', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+        final pushController = StreamController<PushTokensState>(sync: true);
+
+        final cubit = buildCubit(
+          initialCallState: _cs(CallStatus.ready),
+          callStream: callController.stream,
+          pushStream: pushController.stream,
+        );
+
         expect(cubit.state.status, _statusFor(CallStatus.ready));
 
+        pushController.add(const PushTokensState(errorMessage: 'token failed'));
+        expect(cubit.state.status.hasPushTokenError, isTrue);
+        expect(cubit.state.status.signalingStatus, CallStatus.ready);
+
         callController.close();
+        pushController.close();
         unawaited(cubit.close());
       });
     });
 
-    test('connectivityNone bypasses debounce from within transient zone', () {
+    test('clears pushTokenError when push token is restored', () {
       fakeAsync((async) {
         final callController = StreamController<CallState>(sync: true);
+        final pushController = StreamController<PushTokensState>(sync: true);
 
-        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+        final cubit = buildCubit(
+          initialCallState: _cs(CallStatus.ready),
+          callStream: callController.stream,
+          initialPushState: const PushTokensState(errorMessage: 'token failed'),
+          pushStream: pushController.stream,
+        );
 
-        callController.add(_cs(CallStatus.connectIssue)); // immediate
-        callController.add(_cs(CallStatus.inProgress)); // debounced
+        expect(cubit.state.status.hasPushTokenError, isTrue);
 
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        // connectivityNone is non-transient — immediate even from within transient zone
-        callController.add(_cs(CallStatus.connectivityNone));
-        expect(cubit.state.status, _statusFor(CallStatus.connectivityNone));
-
-        async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, _statusFor(CallStatus.connectivityNone));
-
-        callController.close();
-        unawaited(cubit.close());
-      });
-    });
-
-    test('appUnregistered bypasses debounce from within transient zone', () {
-      fakeAsync((async) {
-        final callController = StreamController<CallState>(sync: true);
-
-        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
-
-        callController.add(_cs(CallStatus.connectIssue)); // immediate
-        callController.add(_cs(CallStatus.inProgress)); // debounced
-
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        // appUnregistered is non-transient — immediate even from within transient zone
-        callController.add(_cs(CallStatus.appUnregistered));
-        expect(cubit.state.status, _statusFor(CallStatus.appUnregistered));
-
-        async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, _statusFor(CallStatus.appUnregistered));
+        pushController.add(const PushTokensState(pushToken: 'abc'));
+        expect(cubit.state.status.hasPushTokenError, isFalse);
+        expect(cubit.state.status.signalingStatus, CallStatus.ready);
 
         callController.close();
+        pushController.close();
         unawaited(cubit.close());
-      });
-    });
-
-    test('close() while debounce pending does not emit', () {
-      fakeAsync((async) {
-        final callController = StreamController<CallState>(sync: true);
-
-        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
-
-        callController.add(_cs(CallStatus.connectIssue)); // immediate
-        callController.add(_cs(CallStatus.inProgress)); // debounced
-
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        // close() disposes the debounce timer, so the pending emission is dropped
-        unawaited(cubit.close());
-        async.flushMicrotasks();
-
-        async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        callController.close();
       });
     });
   });

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart' as ws;
+
+import 'package:webtrit_phone/features/call/call.dart';
+import 'package:webtrit_phone/features/push_tokens/bloc/push_tokens_bloc.dart';
+import 'package:webtrit_phone/features/session_status/bloc/session_status_cubit.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+class _MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {}
+
+class _MockPushTokensBloc extends MockBloc<PushTokensEvent, PushTokensState> implements PushTokensBloc {}
+
+CallState _cs(CallStatus target) => switch (target) {
+  CallStatus.ready => CallState(
+    callServiceState: CallServiceState(
+      signalingClientStatus: SignalingClientStatus.connect,
+      registration: const ws.Registration(status: ws.RegistrationStatus.registered),
+    ),
+  ),
+  CallStatus.inProgress => CallState(),
+  CallStatus.connectIssue => CallState(callServiceState: const CallServiceState(lastSignalingDisconnectCode: 1006)),
+  CallStatus.connectError => CallState(
+    callServiceState: const CallServiceState(lastSignalingClientConnectError: 'err'),
+  ),
+  CallStatus.connectivityNone => CallState(callServiceState: const CallServiceState(networkStatus: NetworkStatus.none)),
+  CallStatus.appUnregistered => CallState(
+    callServiceState: CallServiceState(registration: const ws.Registration(status: ws.RegistrationStatus.unregistered)),
+  ),
+};
+
+void main() {
+  group('SessionStatusCubit', () {
+    late _MockCallBloc callBloc;
+    late _MockPushTokensBloc pushTokensBloc;
+
+    setUp(() {
+      callBloc = _MockCallBloc();
+      pushTokensBloc = _MockPushTokensBloc();
+    });
+
+    SessionStatusCubit buildCubit({
+      required CallState initialCallState,
+      required Stream<CallState> callStream,
+      PushTokensState initialPushState = const PushTokensState(),
+      Stream<PushTokensState>? pushStream,
+    }) {
+      when(() => callBloc.state).thenReturn(initialCallState);
+      when(() => callBloc.stream).thenAnswer((_) => callStream);
+      when(() => pushTokensBloc.state).thenReturn(initialPushState);
+      when(() => pushTokensBloc.stream).thenAnswer((_) => pushStream ?? const Stream.empty());
+      return SessionStatusCubit(pushTokensBloc: pushTokensBloc, callBloc: callBloc);
+    }
+
+    test('ready → connectIssue emits immediately without debounce', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        expect(cubit.state.status, SessionStatus.ready);
+
+        // connectIssue is transient, ready is not — crosses non-transient boundary, immediate
+        callController.add(_cs(CallStatus.connectIssue));
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('connectIssue → inProgress → connectError suppressed until debounce fires', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        // Cross into transient zone immediately (ready is non-transient)
+        callController.add(_cs(CallStatus.connectIssue));
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        // Both subsequent statuses are transient — debounce suppresses them
+        callController.add(_cs(CallStatus.inProgress));
+        callController.add(_cs(CallStatus.connectError));
+
+        async.elapse(const Duration(seconds: 1));
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        // Advance past the 3.5-second debounce window
+        async.elapse(const Duration(seconds: 3));
+        expect(cubit.state.status, SessionStatus.connectError);
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('inProgress → ready cancels debounce and emits ready immediately', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.connectIssue)); // immediate
+        callController.add(_cs(CallStatus.inProgress)); // debounced
+
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        // ready is non-transient — cancels debounce and emits immediately
+        callController.add(_cs(CallStatus.ready));
+        expect(cubit.state.status, SessionStatus.ready);
+
+        // No deferred emission after the debounce window
+        async.elapse(const Duration(seconds: 4));
+        expect(cubit.state.status, SessionStatus.ready);
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('connectivityNone bypasses debounce from within transient zone', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.connectIssue)); // immediate
+        callController.add(_cs(CallStatus.inProgress)); // debounced
+
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        // connectivityNone is non-transient — immediate even from within transient zone
+        callController.add(_cs(CallStatus.connectivityNone));
+        expect(cubit.state.status, SessionStatus.connectivityNone);
+
+        async.elapse(const Duration(seconds: 4));
+        expect(cubit.state.status, SessionStatus.connectivityNone);
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('appUnregistered bypasses debounce from within transient zone', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.connectIssue)); // immediate
+        callController.add(_cs(CallStatus.inProgress)); // debounced
+
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        // appUnregistered is non-transient — immediate even from within transient zone
+        callController.add(_cs(CallStatus.appUnregistered));
+        expect(cubit.state.status, SessionStatus.appUnregistered);
+
+        async.elapse(const Duration(seconds: 4));
+        expect(cubit.state.status, SessionStatus.appUnregistered);
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('close() while debounce pending does not emit', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.connectIssue)); // immediate
+        callController.add(_cs(CallStatus.inProgress)); // debounced
+
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        // close() disposes the debounce timer, so the pending emission is dropped
+        unawaited(cubit.close());
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 4));
+        expect(cubit.state.status, SessionStatus.connectIssue);
+
+        callController.close();
+      });
+    });
+  });
+}

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -15,7 +15,7 @@ class _MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
 
 class _MockPushTokensBloc extends MockBloc<PushTokensEvent, PushTokensState> implements PushTokensBloc {}
 
-SessionStatus _ss(CallStatus s) => SessionStatus(signalingStatus: s);
+SessionStatus _statusFor(CallStatus s) => SessionStatus(signalingStatus: s);
 
 CallState _cs(CallStatus target) => switch (target) {
   CallStatus.ready => CallState(
@@ -64,11 +64,11 @@ void main() {
 
         final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
 
-        expect(cubit.state.status, _ss(CallStatus.ready));
+        expect(cubit.state.status, _statusFor(CallStatus.ready));
 
         // connectIssue is transient, ready is not — crosses non-transient boundary, immediate
         callController.add(_cs(CallStatus.connectIssue));
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         callController.close();
         unawaited(cubit.close());
@@ -83,18 +83,18 @@ void main() {
 
         // Cross into transient zone immediately (ready is non-transient)
         callController.add(_cs(CallStatus.connectIssue));
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         // Both subsequent statuses are transient — debounce suppresses them
         callController.add(_cs(CallStatus.inProgress));
         callController.add(_cs(CallStatus.connectError));
 
         async.elapse(const Duration(seconds: 1));
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         // Advance past the 3.5-second debounce window
         async.elapse(const Duration(seconds: 3));
-        expect(cubit.state.status, _ss(CallStatus.connectError));
+        expect(cubit.state.status, _statusFor(CallStatus.connectError));
 
         callController.close();
         unawaited(cubit.close());
@@ -110,15 +110,15 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         // ready is non-transient — cancels debounce and emits immediately
         callController.add(_cs(CallStatus.ready));
-        expect(cubit.state.status, _ss(CallStatus.ready));
+        expect(cubit.state.status, _statusFor(CallStatus.ready));
 
         // No deferred emission after the debounce window
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, _ss(CallStatus.ready));
+        expect(cubit.state.status, _statusFor(CallStatus.ready));
 
         callController.close();
         unawaited(cubit.close());
@@ -134,14 +134,14 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         // connectivityNone is non-transient — immediate even from within transient zone
         callController.add(_cs(CallStatus.connectivityNone));
-        expect(cubit.state.status, _ss(CallStatus.connectivityNone));
+        expect(cubit.state.status, _statusFor(CallStatus.connectivityNone));
 
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, _ss(CallStatus.connectivityNone));
+        expect(cubit.state.status, _statusFor(CallStatus.connectivityNone));
 
         callController.close();
         unawaited(cubit.close());
@@ -157,14 +157,14 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         // appUnregistered is non-transient — immediate even from within transient zone
         callController.add(_cs(CallStatus.appUnregistered));
-        expect(cubit.state.status, _ss(CallStatus.appUnregistered));
+        expect(cubit.state.status, _statusFor(CallStatus.appUnregistered));
 
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, _ss(CallStatus.appUnregistered));
+        expect(cubit.state.status, _statusFor(CallStatus.appUnregistered));
 
         callController.close();
         unawaited(cubit.close());
@@ -180,14 +180,14 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         // close() disposes the debounce timer, so the pending emission is dropped
         unawaited(cubit.close());
         async.flushMicrotasks();
 
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, _ss(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         callController.close();
       });

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -15,6 +15,8 @@ class _MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
 
 class _MockPushTokensBloc extends MockBloc<PushTokensEvent, PushTokensState> implements PushTokensBloc {}
 
+SessionStatus _ss(CallStatus s) => SessionStatus(signalingStatus: s);
+
 CallState _cs(CallStatus target) => switch (target) {
   CallStatus.ready => CallState(
     callServiceState: CallServiceState(
@@ -62,11 +64,11 @@ void main() {
 
         final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
 
-        expect(cubit.state.status, SessionStatus.ready);
+        expect(cubit.state.status, _ss(CallStatus.ready));
 
         // connectIssue is transient, ready is not — crosses non-transient boundary, immediate
         callController.add(_cs(CallStatus.connectIssue));
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         callController.close();
         unawaited(cubit.close());
@@ -81,18 +83,18 @@ void main() {
 
         // Cross into transient zone immediately (ready is non-transient)
         callController.add(_cs(CallStatus.connectIssue));
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         // Both subsequent statuses are transient — debounce suppresses them
         callController.add(_cs(CallStatus.inProgress));
         callController.add(_cs(CallStatus.connectError));
 
         async.elapse(const Duration(seconds: 1));
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         // Advance past the 3.5-second debounce window
         async.elapse(const Duration(seconds: 3));
-        expect(cubit.state.status, SessionStatus.connectError);
+        expect(cubit.state.status, _ss(CallStatus.connectError));
 
         callController.close();
         unawaited(cubit.close());
@@ -108,15 +110,15 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         // ready is non-transient — cancels debounce and emits immediately
         callController.add(_cs(CallStatus.ready));
-        expect(cubit.state.status, SessionStatus.ready);
+        expect(cubit.state.status, _ss(CallStatus.ready));
 
         // No deferred emission after the debounce window
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, SessionStatus.ready);
+        expect(cubit.state.status, _ss(CallStatus.ready));
 
         callController.close();
         unawaited(cubit.close());
@@ -132,14 +134,14 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         // connectivityNone is non-transient — immediate even from within transient zone
         callController.add(_cs(CallStatus.connectivityNone));
-        expect(cubit.state.status, SessionStatus.connectivityNone);
+        expect(cubit.state.status, _ss(CallStatus.connectivityNone));
 
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, SessionStatus.connectivityNone);
+        expect(cubit.state.status, _ss(CallStatus.connectivityNone));
 
         callController.close();
         unawaited(cubit.close());
@@ -155,14 +157,14 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         // appUnregistered is non-transient — immediate even from within transient zone
         callController.add(_cs(CallStatus.appUnregistered));
-        expect(cubit.state.status, SessionStatus.appUnregistered);
+        expect(cubit.state.status, _ss(CallStatus.appUnregistered));
 
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, SessionStatus.appUnregistered);
+        expect(cubit.state.status, _ss(CallStatus.appUnregistered));
 
         callController.close();
         unawaited(cubit.close());
@@ -178,14 +180,14 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue)); // immediate
         callController.add(_cs(CallStatus.inProgress)); // debounced
 
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         // close() disposes the debounce timer, so the pending emission is dropped
         unawaited(cubit.close());
         async.flushMicrotasks();
 
         async.elapse(const Duration(seconds: 4));
-        expect(cubit.state.status, SessionStatus.connectIssue);
+        expect(cubit.state.status, _ss(CallStatus.connectIssue));
 
         callController.close();
       });

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -68,7 +68,7 @@ void main() {
       });
     });
 
-    test('emits immediately on every callStatus change — no debounce', () {
+    test('emits status on every callStatus change', () {
       fakeAsync((async) {
         final callController = StreamController<CallState>(sync: true);
 

--- a/test/utils/debounce_test.dart
+++ b/test/utils/debounce_test.dart
@@ -1,0 +1,102 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/utils/debounce.dart';
+
+void main() {
+  const duration = Duration(seconds: 2);
+
+  group('Debounce', () {
+    test('fires callback after duration elapses', () {
+      fakeAsync((async) {
+        final debounce = Debounce(duration);
+        var called = false;
+
+        debounce.schedule(() => called = true);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(called, isFalse);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(called, isTrue);
+
+        debounce.dispose();
+      });
+    });
+
+    test('reschedules on repeated calls — only fires once', () {
+      fakeAsync((async) {
+        final debounce = Debounce(duration);
+        var count = 0;
+
+        debounce.schedule(() => count++);
+        async.elapse(const Duration(seconds: 1));
+
+        debounce.schedule(() => count++);
+        async.elapse(const Duration(seconds: 1));
+
+        expect(count, 0);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(count, 1);
+
+        debounce.dispose();
+      });
+    });
+
+    test('cancel prevents callback from firing', () {
+      fakeAsync((async) {
+        final debounce = Debounce(duration);
+        var called = false;
+
+        debounce.schedule(() => called = true);
+        async.elapse(const Duration(seconds: 1));
+
+        debounce.cancel();
+        async.elapse(const Duration(seconds: 2));
+
+        expect(called, isFalse);
+
+        debounce.dispose();
+      });
+    });
+
+    test('cancel is no-op when nothing is scheduled', () {
+      fakeAsync((async) {
+        final debounce = Debounce(duration);
+        expect(() => debounce.cancel(), returnsNormally);
+        debounce.dispose();
+      });
+    });
+
+    test('dispose cancels pending callback', () {
+      fakeAsync((async) {
+        final debounce = Debounce(duration);
+        var called = false;
+
+        debounce.schedule(() => called = true);
+        debounce.dispose();
+
+        async.elapse(const Duration(seconds: 3));
+        expect(called, isFalse);
+      });
+    });
+
+    test('can schedule again after cancel', () {
+      fakeAsync((async) {
+        final debounce = Debounce(duration);
+        var count = 0;
+
+        debounce.schedule(() => count++);
+        debounce.cancel();
+
+        debounce.schedule(() => count++);
+        async.elapse(const Duration(seconds: 2));
+
+        expect(count, 1);
+
+        debounce.dispose();
+      });
+    });
+  });
+}

--- a/test/utils/transient_debouncer_test.dart
+++ b/test/utils/transient_debouncer_test.dart
@@ -1,0 +1,189 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/utils/transient_debouncer.dart';
+
+void main() {
+  const duration = Duration(seconds: 2);
+
+  // Simple enum-like values for testing
+  const transientA = 'transientA';
+  const transientB = 'transientB';
+  const stable = 'stable';
+
+  bool isTransient(String s) => s.startsWith('transient');
+
+  TransientDebouncer<String> make(String initial, {String? latest}) => TransientDebouncer<String>(
+    initial: initial,
+    duration: duration,
+    isTransient: isTransient,
+    getLatest: () => latest ?? initial,
+  );
+
+  group('TransientDebouncer', () {
+    test('non-transient → non-transient emits immediately', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        final d = make(stable);
+
+        d.update('stable2', () => updateCount++);
+
+        expect(d.displayed, 'stable2');
+        expect(updateCount, 1);
+
+        d.dispose();
+      });
+    });
+
+    test('non-transient → transient emits immediately', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        final d = make(stable);
+
+        d.update(transientA, () => updateCount++);
+
+        expect(d.displayed, transientA);
+        expect(updateCount, 1);
+
+        d.dispose();
+      });
+    });
+
+    test('transient → non-transient emits immediately and cancels any pending timer', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        String? latestValue = transientA;
+        final d = TransientDebouncer<String>(
+          initial: transientA,
+          duration: duration,
+          isTransient: isTransient,
+          getLatest: () => latestValue!,
+        );
+
+        // Schedule a debounced update within transient zone
+        latestValue = transientB;
+        d.update(transientB, () => updateCount++);
+        expect(d.displayed, transientA); // still debounced
+
+        // Now transition to non-transient — should cancel pending timer and emit immediately
+        latestValue = stable;
+        d.update(stable, () => updateCount++);
+        expect(d.displayed, stable);
+        expect(updateCount, 1);
+
+        // Timer that was scheduled should NOT fire
+        async.elapse(const Duration(seconds: 3));
+        expect(d.displayed, stable);
+        expect(updateCount, 1);
+
+        d.dispose();
+      });
+    });
+
+    test('transient → transient debounces and shows getLatest() on fire', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        String latestValue = transientA;
+        final d = TransientDebouncer<String>(
+          initial: transientA,
+          duration: duration,
+          isTransient: isTransient,
+          getLatest: () => latestValue,
+        );
+
+        latestValue = transientB;
+        d.update(transientB, () => updateCount++);
+
+        expect(d.displayed, transientA); // not yet emitted
+        expect(updateCount, 0);
+
+        async.elapse(const Duration(seconds: 2));
+
+        expect(d.displayed, transientB); // getLatest() result
+        expect(updateCount, 1);
+
+        d.dispose();
+      });
+    });
+
+    test('same pending value does not re-schedule the timer', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        final d = TransientDebouncer<String>(
+          initial: transientA,
+          duration: duration,
+          isTransient: isTransient,
+          getLatest: () => transientB,
+        );
+
+        d.update(transientB, () => updateCount++);
+        async.elapse(const Duration(seconds: 1));
+
+        // Same value again — should be a no-op
+        d.update(transientB, () => updateCount++);
+        async.elapse(const Duration(seconds: 1));
+
+        // Timer from first call fires now (2 s total from first schedule)
+        expect(d.displayed, transientB);
+        expect(updateCount, 1);
+
+        d.dispose();
+      });
+    });
+
+    test('same displayed value does not schedule a timer', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        final d = make(transientA);
+
+        d.update(transientA, () => updateCount++);
+
+        expect(updateCount, 0);
+        async.elapse(const Duration(seconds: 3));
+        expect(updateCount, 0);
+
+        d.dispose();
+      });
+    });
+
+    test('dispose cancels pending debounced update', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        final d = make(transientA, latest: transientB);
+
+        d.update(transientB, () => updateCount++);
+        d.dispose();
+
+        async.elapse(const Duration(seconds: 3));
+        expect(updateCount, 0);
+      });
+    });
+
+    test('rapid transient oscillation — only fires once after quiet window', () {
+      fakeAsync((async) {
+        var updateCount = 0;
+        String latestValue = transientA;
+        final d = TransientDebouncer<String>(
+          initial: transientA,
+          duration: duration,
+          isTransient: isTransient,
+          getLatest: () => latestValue,
+        );
+
+        for (var i = 0; i < 5; i++) {
+          latestValue = 'transient$i';
+          d.update('transient$i', () => updateCount++);
+          async.elapse(const Duration(milliseconds: 500));
+        }
+
+        expect(updateCount, 0);
+
+        async.elapse(const Duration(seconds: 2));
+        expect(updateCount, 1);
+        expect(d.displayed, 'transient4');
+
+        d.dispose();
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Problem

During the 3-second signaling reconnect backoff cycle, `CallStatus` rapidly transitions
through `connectIssue → inProgress → connectError → inProgress`. Each transition carries
a different key into `AnimatedSwitcher` in `MainAppBar`, triggering a 500 ms fade+slide
animation on every attempt — visible as a flickering banner. The same flicker affected
the call status text in `CallInfo` during reconnect.

Additionally, `SessionStatus` was an enum that mixed signaling state with push token
error state — two independent axes treated as a flat list of variants.

## Solution

### 1 — `SessionStatus` enum → class

Replaced the flat enum with a value class:

```dart
class SessionStatus {
  final CallStatus signalingStatus;
  final String? pushTokenError; // null = no error
  bool get hasPushTokenError => pushTokenError != null;
  bool get isReady => signalingStatus == CallStatus.ready;
  bool get isEstablishing => !hasPushTokenError && signalingStatus != ready && signalingStatus != appUnregistered;
}
```

Push token error is now an independent axis — surfaced via avatar ring color, not by
overriding the signaling state.

### 2 — `SessionStatusCubit` is a pure stream merger

`SessionStatusCubit` combines `CallBloc` + `PushTokensBloc` into a single `SessionStatus`
and emits immediately on every change — no debounce, no timer logic.

The `MainAppBar` `StatefulWidget` owns the debounce, keeping UI concerns out of the
business logic layer. Push token errors bypass debounce and surface immediately
regardless of signaling state.

### 3 — `TransientDebouncer<T>` extracted as a reusable utility

Both `MainAppBar` and `CallInfo` share the same debounce pattern. Extracted into
`lib/utils/transient_debouncer.dart`:

```dart
class TransientDebouncer<T> {
  // Immediate update when either old or new value is non-transient.
  // Debounced update when both are transient — stops flicker during reconnect oscillation.
  void update(T newValue, void Function() onUpdate);
}
```

Key design decisions:
- Debounce fires with `getLatest()` result — avoids showing a stale intermediate state
- Debounce window: `kSignalingClientReconnectDelay` + 500 ms — covers one full reconnect cycle plus connection attempt buffer
- `isTransient` for `SessionStatus`: `signalingStatus.isTransientReconnecting && !hasPushTokenError`
- Critical transitions — `ready`, `connectivityNone`, `appUnregistered`, `pushTokenError` — bypass debounce

Fixes: WT-1431