### PR TITLE
refactor: replace SessionStatus enum with class (signalingStatus + pushTokenError)

### DIFF
--- a/lib/extensions/session_status.dart
+++ b/lib/extensions/session_status.dart
@@ -35,8 +35,7 @@ extension SessionStatusColor on SessionStatus {
     final colorScheme = themeData.colorScheme;
     final callStatusStyles = themeData.extension<CallStatusStyles>()?.primary;
 
-    // TODO(Serdun): Move pushTokenError color to the color scheme
-    if (hasPushTokenError) return Colors.orange;
+    if (hasPushTokenError) return callStatusStyles?.connectIssue ?? colorScheme.error;
 
     return switch (signalingStatus) {
       CallStatus.connectivityNone => callStatusStyles?.connectivityNone ?? colorScheme.error,

--- a/lib/extensions/session_status.dart
+++ b/lib/extensions/session_status.dart
@@ -17,8 +17,9 @@ extension SessionStatusL10n on SessionStatus {
     };
   }
 
+  // Only called from MainAppBar when isEstablishing is true, so hasPushTokenError
+  // is always false at call site — no push token branch needed here.
   String appBarl10n(BuildContext context) {
-    if (hasPushTokenError) return context.l10n.sessionStatus_AppBar_disconnected;
     return switch (signalingStatus) {
       CallStatus.connectivityNone => context.l10n.sessionStatus_AppBar_waitingForNetwork,
       CallStatus.connectError || CallStatus.connectIssue => context.l10n.sessionStatus_AppBar_waitingForConnection,

--- a/lib/extensions/session_status.dart
+++ b/lib/extensions/session_status.dart
@@ -6,37 +6,26 @@ import 'package:webtrit_phone/theme/styles/styles.dart';
 
 extension SessionStatusL10n on SessionStatus {
   String l10n(BuildContext context) {
-    switch (this) {
-      case SessionStatus.connectivityNone:
-        return context.l10n.callStatus_connectivityNone;
-      case SessionStatus.connectError:
-        return context.l10n.callStatus_connectError;
-      case SessionStatus.appUnregistered:
-        return context.l10n.callStatus_appUnregistered;
-      case SessionStatus.connectIssue:
-        return context.l10n.callStatus_connectIssue;
-      case SessionStatus.inProgress:
-        return context.l10n.callStatus_inProgress;
-      case SessionStatus.ready:
-        return context.l10n.callStatus_ready;
-      case SessionStatus.pushTokenError:
-        return context.l10n.sessionStatus_pushNotificationServiceProblem;
-    }
+    if (hasPushTokenError) return context.l10n.sessionStatus_pushNotificationServiceProblem;
+    return switch (signalingStatus) {
+      CallStatus.connectivityNone => context.l10n.callStatus_connectivityNone,
+      CallStatus.connectError => context.l10n.callStatus_connectError,
+      CallStatus.appUnregistered => context.l10n.callStatus_appUnregistered,
+      CallStatus.connectIssue => context.l10n.callStatus_connectIssue,
+      CallStatus.inProgress => context.l10n.callStatus_inProgress,
+      CallStatus.ready => context.l10n.callStatus_ready,
+    };
   }
 
   String appBarl10n(BuildContext context) {
-    switch (this) {
-      case SessionStatus.connectivityNone:
-        return context.l10n.sessionStatus_AppBar_waitingForNetwork;
-      case SessionStatus.connectError || SessionStatus.connectIssue:
-        return context.l10n.sessionStatus_AppBar_waitingForConnection;
-      case SessionStatus.appUnregistered || SessionStatus.pushTokenError:
-        return context.l10n.sessionStatus_AppBar_disconnected;
-      case SessionStatus.inProgress:
-        return context.l10n.sessionStatus_AppBar_connecting;
-      case SessionStatus.ready:
-        return '_';
-    }
+    if (hasPushTokenError) return context.l10n.sessionStatus_AppBar_disconnected;
+    return switch (signalingStatus) {
+      CallStatus.connectivityNone => context.l10n.sessionStatus_AppBar_waitingForNetwork,
+      CallStatus.connectError || CallStatus.connectIssue => context.l10n.sessionStatus_AppBar_waitingForConnection,
+      CallStatus.appUnregistered => context.l10n.sessionStatus_AppBar_disconnected,
+      CallStatus.inProgress => context.l10n.sessionStatus_AppBar_connecting,
+      CallStatus.ready => '_',
+    };
   }
 }
 
@@ -46,43 +35,30 @@ extension SessionStatusColor on SessionStatus {
     final colorScheme = themeData.colorScheme;
     final callStatusStyles = themeData.extension<CallStatusStyles>()?.primary;
 
-    switch (this) {
-      case SessionStatus.connectivityNone:
-        return callStatusStyles?.connectivityNone ?? colorScheme.error;
-      case SessionStatus.connectError:
-        return callStatusStyles?.connectError ?? colorScheme.error;
-      case SessionStatus.appUnregistered:
-        return callStatusStyles?.appUnregistered ?? colorScheme.onSurfaceVariant;
-      case SessionStatus.connectIssue:
-        return callStatusStyles?.connectIssue ?? colorScheme.error;
-      case SessionStatus.inProgress:
-        return callStatusStyles?.inProgress ?? colorScheme.secondary;
-      case SessionStatus.ready:
-        return callStatusStyles?.ready ?? colorScheme.tertiary;
-      case SessionStatus.pushTokenError:
-        // TODO(Serdun): Move color to the color scheme
-        return Colors.orange;
-    }
+    // TODO(Serdun): Move pushTokenError color to the color scheme
+    if (hasPushTokenError) return Colors.orange;
+
+    return switch (signalingStatus) {
+      CallStatus.connectivityNone => callStatusStyles?.connectivityNone ?? colorScheme.error,
+      CallStatus.connectError => callStatusStyles?.connectError ?? colorScheme.error,
+      CallStatus.appUnregistered => callStatusStyles?.appUnregistered ?? colorScheme.onSurfaceVariant,
+      CallStatus.connectIssue => callStatusStyles?.connectIssue ?? colorScheme.error,
+      CallStatus.inProgress => callStatusStyles?.inProgress ?? colorScheme.secondary,
+      CallStatus.ready => callStatusStyles?.ready ?? colorScheme.tertiary,
+    };
   }
 }
 
 extension SessionStatusKey on SessionStatus {
   Key get key {
-    switch (this) {
-      case SessionStatus.connectivityNone:
-        return const Key('session_status_connectivityNone');
-      case SessionStatus.connectError:
-        return const Key('session_status_connectError');
-      case SessionStatus.appUnregistered:
-        return const Key('session_status_appUnregistered');
-      case SessionStatus.connectIssue:
-        return const Key('session_status_connectIssue');
-      case SessionStatus.inProgress:
-        return const Key('session_status_inProgress');
-      case SessionStatus.ready:
-        return const Key('session_status_ready');
-      case SessionStatus.pushTokenError:
-        return const Key('session_status_pushTokenError');
-    }
+    if (hasPushTokenError) return const Key('session_status_pushTokenError');
+    return switch (signalingStatus) {
+      CallStatus.connectivityNone => const Key('session_status_connectivityNone'),
+      CallStatus.connectError => const Key('session_status_connectError'),
+      CallStatus.appUnregistered => const Key('session_status_appUnregistered'),
+      CallStatus.connectIssue => const Key('session_status_connectIssue'),
+      CallStatus.inProgress => const Key('session_status_inProgress'),
+      CallStatus.ready => const Key('session_status_ready'),
+    };
   }
 }

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -52,20 +52,10 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   }
 
   SessionStatus _mapCallStatusToSessionStatus(CallStatus callStatus, PushTokensState pushTokens) {
-    // Use push token error as the main status if there is no push token or push token not delivered
-    if (pushTokens.pushToken == null && pushTokens.errorMessage != null) {
-      return SessionStatus.pushTokenError;
-    }
-
-    // Use call status as the main status
-    return switch (callStatus) {
-      CallStatus.connectivityNone => SessionStatus.connectivityNone,
-      CallStatus.connectError => SessionStatus.connectError,
-      CallStatus.appUnregistered => SessionStatus.appUnregistered,
-      CallStatus.connectIssue => SessionStatus.connectIssue,
-      CallStatus.inProgress => SessionStatus.inProgress,
-      CallStatus.ready => SessionStatus.ready,
-    };
+    final pushTokenError = (pushTokens.pushToken == null && pushTokens.errorMessage != null)
+        ? pushTokens.errorMessage
+        : null;
+    return SessionStatus(signalingStatus: callStatus, pushTokenError: pushTokenError);
   }
 
   @override

--- a/lib/features/session_status/bloc/session_status_state.dart
+++ b/lib/features/session_status/bloc/session_status_state.dart
@@ -2,7 +2,7 @@ part of 'session_status_cubit.dart';
 
 @freezed
 class SessionStatusState with _$SessionStatusState {
-  const SessionStatusState({this.status = SessionStatus.inProgress});
+  const SessionStatusState({this.status = const SessionStatus(signalingStatus: CallStatus.inProgress)});
 
   @override
   final SessionStatus status;

--- a/lib/models/session_status.dart
+++ b/lib/models/session_status.dart
@@ -10,6 +10,13 @@ class SessionStatus {
 
   bool get hasPushTokenError => pushTokenError != null;
 
+  /// Signaling is ready and push token is operational — app is fully connected.
+  bool get isReady => signalingStatus == CallStatus.ready && !hasPushTokenError;
+
+  /// App is actively trying to establish connection — show a progress indicator.
+  bool get isEstablishing =>
+      !hasPushTokenError && signalingStatus != CallStatus.ready && signalingStatus != CallStatus.appUnregistered;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/models/session_status.dart
+++ b/lib/models/session_status.dart
@@ -10,10 +10,15 @@ class SessionStatus {
 
   bool get hasPushTokenError => pushTokenError != null;
 
-  /// Signaling is ready and push token is operational — app is fully connected.
-  bool get isReady => signalingStatus == CallStatus.ready && !hasPushTokenError;
+  /// Signaling is connected — calls can be made and received.
+  /// Push token state is intentionally excluded: call functionality works
+  /// regardless of push notification delivery issues.
+  bool get isReady => signalingStatus == CallStatus.ready;
 
   /// App is actively trying to establish connection — show a progress indicator.
+  /// Push token error is excluded because it is surfaced separately via the
+  /// avatar ring color, matching previous behavior where pushTokenError overrode
+  /// all signaling states in the old enum.
   bool get isEstablishing =>
       !hasPushTokenError && signalingStatus != CallStatus.ready && signalingStatus != CallStatus.appUnregistered;
 
@@ -24,4 +29,7 @@ class SessionStatus {
 
   @override
   int get hashCode => Object.hash(signalingStatus, pushTokenError);
+
+  @override
+  String toString() => 'SessionStatus(signalingStatus: $signalingStatus, pushTokenError: $pushTokenError)';
 }

--- a/lib/models/session_status.dart
+++ b/lib/models/session_status.dart
@@ -1,1 +1,20 @@
-enum SessionStatus { connectivityNone, connectError, appUnregistered, connectIssue, inProgress, ready, pushTokenError }
+import 'call/call_status.dart';
+
+class SessionStatus {
+  const SessionStatus({required this.signalingStatus, this.pushTokenError});
+
+  final CallStatus signalingStatus;
+
+  /// Non-null when the push token registration failed. Independent of [signalingStatus].
+  final String? pushTokenError;
+
+  bool get hasPushTokenError => pushTokenError != null;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionStatus && signalingStatus == other.signalingStatus && pushTokenError == other.pushTokenError;
+
+  @override
+  int get hashCode => Object.hash(signalingStatus, pushTokenError);
+}

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -9,7 +9,7 @@ import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
-import 'package:webtrit_phone/models/session_status.dart';
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -44,16 +44,16 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
 
     return BlocBuilder<SessionStatusCubit, SessionStatusState>(
       builder: (context, sessionState) {
+        final status = sessionState.status;
         return AppBar(
           title: Builder(
             builder: (context) {
               Widget? widgetToShow;
-
-              if (sessionState.status != SessionStatus.ready &&
-                  sessionState.status != SessionStatus.appUnregistered &&
-                  sessionState.status != SessionStatus.pushTokenError) {
+              if (!status.hasPushTokenError &&
+                  status.signalingStatus != CallStatus.ready &&
+                  status.signalingStatus != CallStatus.appUnregistered) {
                 widgetToShow = Row(
-                  key: Key('${mainAppBarKey}_status_${sessionState.status.name}'),
+                  key: status.key,
                   mainAxisSize: MainAxisSize.max,
                   children: [
                     SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
@@ -101,7 +101,7 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
           elevation: elevation,
           centerTitle: false,
           actions: [
-            if (sessionState.status == SessionStatus.ready) ...[
+            if (status.signalingStatus == CallStatus.ready && !status.hasPushTokenError) ...[
               if (AppBarParams.of(context).pullableCallDialogs.isNotEmpty)
                 CallPullBadge(pullableCallDialogs: AppBarParams.of(context).pullableCallDialogs),
               if (AppBarParams.of(context).systemNotificationsEnabled) SystemNotificationsBadge(),

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -9,7 +9,6 @@ import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
-import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -49,9 +48,7 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
           title: Builder(
             builder: (context) {
               Widget? widgetToShow;
-              if (!status.hasPushTokenError &&
-                  status.signalingStatus != CallStatus.ready &&
-                  status.signalingStatus != CallStatus.appUnregistered) {
+              if (status.isEstablishing) {
                 widgetToShow = Row(
                   key: status.key,
                   mainAxisSize: MainAxisSize.max,
@@ -101,7 +98,7 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
           elevation: elevation,
           centerTitle: false,
           actions: [
-            if (status.signalingStatus == CallStatus.ready && !status.hasPushTokenError) ...[
+            if (status.isReady) ...[
               if (AppBarParams.of(context).pullableCallDialogs.isNotEmpty)
                 CallPullBadge(pullableCallDialogs: AppBarParams.of(context).pullableCallDialogs),
               if (AppBarParams.of(context).systemNotificationsEnabled) SystemNotificationsBadge(),

--- a/patrol_test/profile_and_registration_test.dart
+++ b/patrol_test/profile_and_registration_test.dart
@@ -7,7 +7,7 @@ import 'package:webtrit_phone/bootstrap.dart';
 import 'package:webtrit_phone/extensions/session_status.dart';
 import 'package:webtrit_phone/features/login/view/login_mode_select_screen.dart';
 import 'package:webtrit_phone/features/settings/widgets/widgets.dart';
-import 'package:webtrit_phone/models/session_status.dart';
+import 'package:webtrit_phone/models/models.dart';
 
 import 'components/integration_test_environment_config.dart';
 import 'subsequences/login_by_method.dart';
@@ -35,14 +35,26 @@ void main() {
     await pumpFor(const Duration(seconds: 2), $);
     expect($(UserInfoListTile).$(accountName), findsOneWidget, reason: 'Verify account name');
     expect($(UserInfoListTile).$(accountMainNumber), findsOneWidget, reason: 'Verify account main number');
-    expect($(SessionStatus.ready.key), findsOneWidget, reason: 'Should be registered');
+    expect(
+      $(const SessionStatus(signalingStatus: CallStatus.ready).key),
+      findsOneWidget,
+      reason: 'Should be registered',
+    );
 
     // Check manual sip registration.
     await $(SwitchListTile).tap();
     await pumpFor(const Duration(seconds: 2), $);
-    expect($(SessionStatus.appUnregistered.key), findsOneWidget, reason: 'Should unregister sip session');
+    expect(
+      $(const SessionStatus(signalingStatus: CallStatus.appUnregistered).key),
+      findsOneWidget,
+      reason: 'Should unregister sip session',
+    );
     await $(SwitchListTile).tap();
     await pumpFor(const Duration(seconds: 2), $);
-    expect($(SessionStatus.ready.key), findsOneWidget, reason: 'Should register sip session');
+    expect(
+      $(const SessionStatus(signalingStatus: CallStatus.ready).key),
+      findsOneWidget,
+      reason: 'Should register sip session',
+    );
   });
 }


### PR DESCRIPTION
## Summary

- `SessionStatus` is now a value class instead of an enum
- Holds two independent fields: `signalingStatus: CallStatus` (signaling layer) and `pushTokenError: String?` (push token layer)
- `pushTokenError` was semantically orthogonal to signaling status — merging them into one enum created an awkward special case in cubit mapping and blocked clean use of `isTransientReconnecting`
- Implements `==` and `hashCode` so Freezed equality works correctly
- All extensions (`l10n`, `appBarl10n`, `color`, `key`) updated: guard `if (hasPushTokenError)` first, then `switch (signalingStatus)`
- `MainAppBar` comparisons migrated to `.signalingStatus` and `.hasPushTokenError`
- `patrol_test` updated to use new constructor API

## Related

Part of the WT-1431 refactor plan — prepares ground for moving debounce logic to UI layer (toolbar).