### PR TITLE
fix(signaling): prevent zombie race in WebtritSignalingServiceDirect (WT-1497)

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -35,11 +35,15 @@ final _logger = Logger('WebtritSignalingServiceAndroid');
 /// - **persistent** -- service survives app closure; restarted after device reboot.
 class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   WebtritSignalingServiceAndroid._({BinaryMessenger? binaryMessenger})
-    : _hostApi = PSignalingServiceHostApi(binaryMessenger: binaryMessenger);
+    : _hostApi = PSignalingServiceHostApi(binaryMessenger: binaryMessenger),
+      _directService = WebtritSignalingServiceAndroidDirect();
 
   @visibleForTesting
-  WebtritSignalingServiceAndroid.forTesting({BinaryMessenger? binaryMessenger})
-    : _hostApi = PSignalingServiceHostApi(binaryMessenger: binaryMessenger);
+  WebtritSignalingServiceAndroid.forTesting({
+    BinaryMessenger? binaryMessenger,
+    WebtritSignalingServiceDirect? directService,
+  }) : _hostApi = PSignalingServiceHostApi(binaryMessenger: binaryMessenger),
+       _directService = directService ?? WebtritSignalingServiceAndroidDirect();
 
   @visibleForTesting
   void initStateForTesting({required SignalingServiceConfig config, required SignalingServiceMode mode}) {
@@ -77,7 +81,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   );
 
   /// Delegate for pushBound direct WebSocket mode.
-  final _directService = WebtritSignalingServiceAndroidDirect();
+  final WebtritSignalingServiceDirect _directService;
 
   /// Active subscription forwarding events from [_directService] into
   /// [_eventsController]. Non-null only while in pushBound mode.
@@ -299,7 +303,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       // previous session and guarantees the replay on subscribe is fresh.
       await _directService.start(config, mode: mode);
 
-      if (_isStopped || !identical(_startServiceToken, myToken)) {
+      if (_isStopped) {
+        _logger.fine('_startService: aborted — stopped during direct start');
+        return;
+      }
+      if (!identical(_startServiceToken, myToken)) {
         _logger.fine('_startService: aborted — superseded during direct start');
         return;
       }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -83,6 +83,16 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   /// [_eventsController]. Non-null only while in pushBound mode.
   StreamSubscription<SignalingModuleEvent>? _directServiceSub;
 
+  /// Identity token for the active pushBound [_startService] invocation.
+  ///
+  /// Mirrors the [_startToken] pattern in [WebtritSignalingServiceDirect]:
+  /// concurrent [_startService] calls (from [start], [updateMode], or
+  /// [_onHubServiceDead]) all await [_directService.start] before subscribing
+  /// to [_directService.events]. Without this guard the faster-returning
+  /// (superseded) call would attach an orphaned subscription that forwards
+  /// duplicate events into [_eventsController].
+  Object? _startServiceToken;
+
   SignalingServiceConfig? _currentConfig;
 
   /// Active mode, set by [start] and [updateMode], cleared by [dispose].
@@ -277,6 +287,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
     if (mode == SignalingServiceMode.pushBound) {
       _logger.fine('_startService mode=pushBound -- delegating to direct service');
+      final myToken = _startServiceToken = Object();
 
       // Cancel any existing forwarding subscription before starting the new
       // session to avoid stale event forwarding and duplicate subscriptions.
@@ -287,6 +298,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       // buffered before we subscribe -- this clears any stale events from a
       // previous session and guarantees the replay on subscribe is fresh.
       await _directService.start(config, mode: mode);
+
+      if (_isStopped || !identical(_startServiceToken, myToken)) {
+        _logger.fine('_startService: aborted — superseded during direct start');
+        return;
+      }
 
       // Subscribe after start() so the replay contains only [SignalingConnecting]
       // (and any events already emitted synchronously during connect()).

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -1,9 +1,52 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ssl_certificates/ssl_certificates.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
 
 import 'package:webtrit_signaling_service_android/src/plugin.dart';
+
+/// Fake direct service that delays its first [start] call until [releaseStart]
+/// is called, letting tests create a controlled overlap with a second call.
+class _FakeDirectService extends WebtritSignalingServiceDirect {
+  final _eventsStreamController = StreamController<SignalingModuleEvent>.broadcast();
+
+  // Gate is kept here so [releaseStart] can complete it even after [start]
+  // has already captured the reference and set [_gateConsumed].
+  Completer<void>? _gate;
+  bool _gateConsumed = false;
+
+  void holdNextStart() {
+    _gate = Completer<void>();
+    _gateConsumed = false;
+  }
+
+  void releaseStart() => _gate?.complete();
+
+  void emit(SignalingModuleEvent event) => _eventsStreamController.add(event);
+
+  @override
+  Future<void> start(
+    SignalingServiceConfig config, {
+    SignalingServiceMode mode = SignalingServiceMode.pushBound,
+  }) async {
+    // Only the first call is gated; subsequent calls pass through immediately.
+    if (!_gateConsumed && _gate != null) {
+      _gateConsumed = true;
+      await _gate!.future;
+    }
+  }
+
+  @override
+  Stream<SignalingModuleEvent> get events => _eventsStreamController.stream;
+
+  @override
+  Future<void> stopService() async {}
+
+  @override
+  Future<void> dispose() async => _eventsStreamController.close();
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -136,6 +179,46 @@ void main() {
       await plugin.triggerOnServiceDeadForTesting();
 
       expect(startCalled, isFalse);
+    });
+  });
+
+  group('WebtritSignalingServiceAndroid -- _startServiceToken (pushBound overlap)', () {
+    const testConfig = SignalingServiceConfig(
+      coreUrl: 'https://example.com',
+      tenantId: 'tenant',
+      token: 'token',
+      trustedCertificates: TrustedCertificates.empty,
+    );
+
+    test('only the latest start attaches a forwarding subscription', () async {
+      final fakeDirect = _FakeDirectService();
+      final plugin = WebtritSignalingServiceAndroid.forTesting(directService: fakeDirect);
+
+      // Hold the first start so the second overtakes it.
+      fakeDirect.holdNextStart();
+
+      final f1 = plugin.start(testConfig, mode: SignalingServiceMode.pushBound);
+      // Yield so f1 reaches the suspension point inside _directService.start().
+      await Future<void>.microtask(() {});
+
+      // Second start — no gate, completes immediately and takes the token.
+      final f2 = plugin.start(testConfig, mode: SignalingServiceMode.pushBound);
+      await Future<void>.microtask(() {});
+
+      // Release the gate so f1 can resume and detect that it was superseded.
+      fakeDirect.releaseStart();
+      await Future.wait([f1, f2]);
+
+      // Only the second start should have attached a subscription.
+      // An event emitted by the fake service must appear exactly once.
+      final received = <SignalingModuleEvent>[];
+      final sub = plugin.events.listen(received.add);
+      fakeDirect.emit(SignalingConnecting());
+      // Two async broadcast hops: fake stream → _eventsController → plugin.events.
+      await Future<void>.delayed(Duration.zero);
+      sub.cancel();
+
+      expect(received.length, 1);
     });
   });
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -73,6 +73,17 @@ SignalingModule createSignalingModule(SignalingServiceConfig config) {
 /// lifecycle. Safe to use in the main isolate, a background isolate, or an
 /// integration test without any Flutter dependency.
 ///
+/// ## Lifecycle contract
+///
+/// [coreUrl], [tenantId], and [token] are bound at construction and cannot
+/// change. A token refresh or server change requires creating a new instance.
+///
+/// [dispose] closes the internal broadcast [StreamController] permanently.
+/// After [dispose] the instance must not be reused — create a new one instead.
+/// This single-session contract keeps the internal state machine simple and
+/// avoids partial-reset bugs that arise from recycling a stream that may have
+/// buffered stale events.
+///
 /// Parameters:
 /// - [connectionTimeout] -- how long to wait for the initial WebSocket handshake.
 /// - [reconnectDelay] -- delay hint emitted in [SignalingConnectionFailed] and

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -22,6 +22,26 @@ final _logger = Logger('WebtritSignalingServiceDirect');
 /// no Foreground Service, no background isolate. Used as-is on iOS and as
 /// the pushBound delegate on Android.
 ///
+/// ## Module rotation
+///
+/// Each [start] call unconditionally disposes the previous [SignalingModule]
+/// and creates a fresh one via the registered factory — even when the config
+/// has not changed. The design trades a small per-reconnect overhead for a
+/// simpler invariant: no stale session state can carry over between starts,
+/// and no config-equality check is needed at the call site.
+///
+/// Reuse is not possible regardless: [SignalingModuleImpl] binds connection
+/// credentials (`token`, `tenantId`, `coreUrl`) as `final` fields, and
+/// [SignalingModule.dispose] closes the internal [StreamController]
+/// permanently, so a disposed instance can neither accept new credentials
+/// nor emit further events.
+///
+/// The rotation introduces two async suspension points inside [start] —
+/// [_tearDownModule] and [onBeforeStart] — where a second concurrent [start]
+/// call can slip through the [_isStopped] guard and create a duplicate
+/// WebSocket connection (zombie race). See [_isStopped] for what it covers
+/// and where it falls short.
+///
 /// Subclasses may override [onBeforeStart] and [onConnected] to inject
 /// platform-specific behaviour (e.g. Android push-isolate handoff via
 /// [IsolateNameServer]) without duplicating the core connection logic.
@@ -36,9 +56,22 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   final _eventBuffer = SignalingEventBuffer();
 
   /// Set to true by [stopService] and [dispose]; reset to false at the start
-  /// of [start]. Guards against concurrent teardown racing with a new start
-  /// during the async gaps of [_tearDownModule] and [onBeforeStart].
+  /// of [start]. Guards against a [dispose]/[stopService] call racing with an
+  /// in-progress [start] at the [_tearDownModule] and [onBeforeStart]
+  /// suspension points.
+  ///
+  /// Does NOT protect against two concurrent [start] calls: both reset this
+  /// flag to `false`, so neither can detect the other's presence.
   bool _isStopped = false;
+
+  /// Identity token for the active [start] invocation.
+  ///
+  /// A fresh [Object] is assigned at the beginning of each [start] call.
+  /// After every suspension point the in-progress call compares its captured
+  /// token against the current value: a mismatch means a newer [start] has
+  /// been issued and this invocation must abort without creating a module,
+  /// preventing two concurrent [module.connect] calls from reaching the server.
+  Object? _startToken;
 
   @override
   Stream<SignalingModuleEvent> get events {
@@ -63,6 +96,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     SignalingServiceMode mode = SignalingServiceMode.pushBound,
   }) async {
     _isStopped = false;
+    final myToken = _startToken = Object();
 
     final factory = _factory;
     if (factory == null) {
@@ -74,14 +108,14 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     }
 
     await _tearDownModule();
-    if (_isStopped) {
-      _logger.fine('start: aborted — stopped during _tearDownModule');
+    if (_isStopped || !identical(_startToken, myToken)) {
+      _logger.fine('start: aborted — superseded during _tearDownModule');
       return;
     }
 
     await onBeforeStart(config);
-    if (_isStopped) {
-      _logger.fine('start: aborted — stopped during onBeforeStart');
+    if (_isStopped || !identical(_startToken, myToken)) {
+      _logger.fine('start: aborted — superseded during onBeforeStart');
       return;
     }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -108,13 +108,21 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     }
 
     await _tearDownModule();
-    if (_isStopped || !identical(_startToken, myToken)) {
+    if (_isStopped) {
+      _logger.fine('start: aborted — stopped during _tearDownModule');
+      return;
+    }
+    if (!identical(_startToken, myToken)) {
       _logger.fine('start: aborted — superseded during _tearDownModule');
       return;
     }
 
     await onBeforeStart(config);
-    if (_isStopped || !identical(_startToken, myToken)) {
+    if (_isStopped) {
+      _logger.fine('start: aborted — stopped during onBeforeStart');
+      return;
+    }
+    if (!identical(_startToken, myToken)) {
       _logger.fine('start: aborted — superseded during onBeforeStart');
       return;
     }


### PR DESCRIPTION
## Problem

`WebtritSignalingServiceDirect.start()` has no guard against concurrent calls in the same isolate. Both calls pass through async suspension points and each creates a separate `SignalingModule`, resulting in two simultaneous WebSocket connections for the same account.

`WebtritSignalingServiceAndroid._startService(pushBound)` has the same gap: a superseded call can attach an orphaned subscription, forwarding duplicate events.

## Fix

Added an identity-token guard to both methods. Only the latest call proceeds to create a module and connect; superseded calls abort at each suspension point.

This fix covers concurrent calls **within a single isolate**.

Fixes: WT-1497