### PR TITLE
fix(push): skip direct WS on persistent-session devices when push fallback fires

### DIFF
--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -73,6 +73,7 @@ class PushIsolateContext extends IsolateContext {
     required super.packageInfo,
     required super.secureStorage,
     required super.appLabelsProvider,
+    required this.incomingCallTypeRepository,
     required this.appPath,
     required this.appCertificates,
     required this.appDatabase,
@@ -80,6 +81,7 @@ class PushIsolateContext extends IsolateContext {
     required this.callLogsRepository,
   });
 
+  final IncomingCallTypeRepository incomingCallTypeRepository;
   final AppPath appPath;
   final AppCertificates appCertificates;
   final AppDatabase appDatabase;
@@ -88,6 +90,7 @@ class PushIsolateContext extends IsolateContext {
 
   static Future<PushIsolateContext> init() async {
     final base = await IsolateContext.init();
+    final appPreferences = await AppPreferencesImpl.init();
     final appPath = await AppPath.init();
     final appCertificates = await AppCertificates.init();
 
@@ -103,6 +106,7 @@ class PushIsolateContext extends IsolateContext {
       packageInfo: base.packageInfo,
       secureStorage: base.secureStorage,
       appLabelsProvider: base.appLabelsProvider,
+      incomingCallTypeRepository: IncomingCallTypeRepositoryPrefsImpl(appPreferences),
       appPath: appPath,
       appCertificates: appCertificates,
       appDatabase: appDatabase,

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -73,6 +73,7 @@ class PushIsolateContext extends IsolateContext {
     required super.packageInfo,
     required super.secureStorage,
     required super.appLabelsProvider,
+    required this.appPreferences,
     required this.appPath,
     required this.appCertificates,
     required this.appDatabase,
@@ -80,6 +81,7 @@ class PushIsolateContext extends IsolateContext {
     required this.callLogsRepository,
   });
 
+  final AppPreferences appPreferences;
   final AppPath appPath;
   final AppCertificates appCertificates;
   final AppDatabase appDatabase;
@@ -88,6 +90,7 @@ class PushIsolateContext extends IsolateContext {
 
   static Future<PushIsolateContext> init() async {
     final base = await IsolateContext.init();
+    final appPreferences = await AppPreferencesImpl.init();
     final appPath = await AppPath.init();
     final appCertificates = await AppCertificates.init();
 
@@ -103,6 +106,7 @@ class PushIsolateContext extends IsolateContext {
       packageInfo: base.packageInfo,
       secureStorage: base.secureStorage,
       appLabelsProvider: base.appLabelsProvider,
+      appPreferences: appPreferences,
       appPath: appPath,
       appCertificates: appCertificates,
       appDatabase: appDatabase,

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -73,7 +73,6 @@ class PushIsolateContext extends IsolateContext {
     required super.packageInfo,
     required super.secureStorage,
     required super.appLabelsProvider,
-    required this.appPreferences,
     required this.appPath,
     required this.appCertificates,
     required this.appDatabase,
@@ -81,7 +80,6 @@ class PushIsolateContext extends IsolateContext {
     required this.callLogsRepository,
   });
 
-  final AppPreferences appPreferences;
   final AppPath appPath;
   final AppCertificates appCertificates;
   final AppDatabase appDatabase;
@@ -90,7 +88,6 @@ class PushIsolateContext extends IsolateContext {
 
   static Future<PushIsolateContext> init() async {
     final base = await IsolateContext.init();
-    final appPreferences = await AppPreferencesImpl.init();
     final appPath = await AppPath.init();
     final appCertificates = await AppCertificates.init();
 
@@ -106,7 +103,6 @@ class PushIsolateContext extends IsolateContext {
       packageInfo: base.packageInfo,
       secureStorage: base.secureStorage,
       appLabelsProvider: base.appLabelsProvider,
-      appPreferences: appPreferences,
       appPath: appPath,
       appCertificates: appCertificates,
       appDatabase: appDatabase,

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -5,6 +5,9 @@ import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
 import 'package:webtrit_phone/common/common.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 
 import 'isolate_manager.dart';
 
@@ -22,6 +25,10 @@ export 'package:webtrit_signaling_service/webtrit_signaling_service.dart'
         SignalingProtocolEvent;
 
 const _kPushNotificationSyncTimeout = Duration(seconds: 20);
+
+// When false, push fallback on persistent-session devices is suppressed entirely
+// and only logged. Flip to false to isolate FGS recovery behavior during testing.
+const _kPersistentPushFallbackEnabled = true;
 
 final _logger = Logger('BackgroundCallIsolate');
 
@@ -83,7 +90,16 @@ Future<void> _disposeContext() async {
 /// then disposes all resources.
 /// Registered via [AndroidCallkeepServices.backgroundPushNotificationBootstrapService.initializeCallback].
 ///
-/// ## Lifecycle and handoff
+/// ## Persistent-session devices
+///
+/// When [IncomingCallType.socket] is selected the FGS owns the persistent WebSocket.
+/// A push arriving on such a device means the FGS was frozen or killed by the OEM —
+/// the push is a fallback wake-up, not a signal to open a competing WebSocket.
+/// Opening a direct WS here would race with the FGS reconnect and trigger a 4441
+/// eviction loop. Instead, [restoreService] is called to restart the FGS if it was
+/// killed (no-op when it is merely frozen), and the push isolate exits immediately.
+///
+/// ## pushBound devices — lifecycle and handoff
 ///
 /// The push isolate opens its own WebSocket directly (no FGS). It runs until
 /// one of three outcomes:
@@ -98,10 +114,33 @@ Future<void> _disposeContext() async {
 ///   arrives first completes the push lifecycle early via `notifyActivityTookOver()`.
 @pragma('vm:entry-point')
 Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
+  final prefs = await AppPreferencesImpl.init();
+  final incomingCallType = IncomingCallTypeRepositoryPrefsImpl(prefs).getIncomingCallType();
+
+  if (incomingCallType == IncomingCallType.socket) {
+    if (!_kPersistentPushFallbackEnabled) {
+      _logger.warning(
+        'onPushNotificationSyncCallback: push fallback received on persistent-session device '
+        '(callId=${metadata?.callId}) — fallback disabled by flag, skipping FGS recovery',
+      );
+      return;
+    }
+    _logger.info(
+      'onPushNotificationSyncCallback: push fallback received on persistent-session device '
+      '(callId=${metadata?.callId}) — FGS was likely frozen or killed by OEM; '
+      'skipping direct WS, attempting FGS recovery via restoreService()',
+    );
+    try {
+      await WebtritSignalingService.restoreService();
+    } catch (e, st) {
+      _logger.warning('onPushNotificationSyncCallback: restoreService() failed', e, st);
+    }
+    return;
+  }
+
+  // pushBound: open a direct WebSocket in this isolate and run the full call lifecycle.
   try {
-    // Initialise context and manager lazily on first push notification.
     final manager = await _getOrInit();
-    // Run the full incoming-call lifecycle; guard with a timeout in case it stalls.
     final incomingCallProcessing = manager.run(metadata);
     await incomingCallProcessing.timeout(
       _kPushNotificationSyncTimeout,
@@ -111,11 +150,6 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     _logger.severe('onPushNotificationSyncCallback: error=$e');
   } finally {
     await _disposeContext();
-    try {
-      await WebtritSignalingService.restoreService();
-    } catch (e, st) {
-      _logger.warning('restoreService() after push failed', e, st);
-    }
   }
 }
 

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -5,7 +5,6 @@ import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
 import 'package:webtrit_phone/common/common.dart';
-import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
@@ -36,16 +35,17 @@ final _logger = Logger('BackgroundCallIsolate');
 PushIsolateContext? _context;
 PushNotificationIsolateManager? _manager;
 
-/// Returns the isolate-level manager, initialising context and manager on the
-/// first call and reusing the same instances on every subsequent call.
+/// Returns the isolate-level manager, reusing an existing instance if already
+/// initialised. Accepts an already-constructed [PushIsolateContext] so the
+/// caller controls when heavy resources (DB, certificates) are opened.
 ///
 /// [PushIsolateContext] is kept separate from [PushNotificationIsolateManager]
 /// because the manager depends on feature-layer imports that must not be pulled
 /// into [lib/common]. Both are torn down together by [_disposeContext].
-Future<PushNotificationIsolateManager> _getOrInit() async {
+Future<PushNotificationIsolateManager> _getOrInit(PushIsolateContext context) async {
   if (_manager != null) return _manager!;
 
-  _context = await PushIsolateContext.init();
+  _context = context;
 
   // The push isolate is a separate Dart VM — it never receives the setModuleFactory()
   // call made in bootstrap.dart (Activity isolate). Register the factory here so
@@ -114,10 +114,11 @@ Future<void> _disposeContext() async {
 ///   arrives first completes the push lifecycle early via `notifyActivityTookOver()`.
 @pragma('vm:entry-point')
 Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
-  final prefs = await AppPreferencesImpl.init();
-  final incomingCallType = IncomingCallTypeRepositoryPrefsImpl(prefs).getIncomingCallType();
+  final context = await PushIsolateContext.init();
+  final incomingCallType = IncomingCallTypeRepositoryPrefsImpl(context.appPreferences).getIncomingCallType();
 
   if (incomingCallType == IncomingCallType.socket) {
+    await context.dispose();
     if (!_kPersistentPushFallbackEnabled) {
       _logger.warning(
         'onPushNotificationSyncCallback: push fallback received on persistent-session device '
@@ -140,7 +141,7 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
 
   // pushBound: open a direct WebSocket in this isolate and run the full call lifecycle.
   try {
-    final manager = await _getOrInit();
+    final manager = await _getOrInit(context);
     final incomingCallProcessing = manager.run(metadata);
     await incomingCallProcessing.timeout(
       _kPushNotificationSyncTimeout,

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -31,8 +31,7 @@ const _kPersistentPushFallbackEnabled = true;
 
 final _logger = Logger('BackgroundCallIsolate');
 
-// Lazily-initialised isolate-level context.
-PushIsolateContext? _context;
+// Lazily-initialised isolate-level manager.
 PushNotificationIsolateManager? _manager;
 
 /// Returns the isolate-level manager, reusing an existing instance if already
@@ -45,8 +44,6 @@ PushNotificationIsolateManager? _manager;
 Future<PushNotificationIsolateManager> _getOrInit(PushIsolateContext context) async {
   if (_manager != null) return _manager!;
 
-  _context = context;
-
   // The push isolate is a separate Dart VM — it never receives the setModuleFactory()
   // call made in bootstrap.dart (Activity isolate). Register the factory here so
   // _startDirect() can create a SignalingModule when connect() is called from run().
@@ -55,11 +52,11 @@ Future<PushNotificationIsolateManager> _getOrInit(PushIsolateContext context) as
   _logger.info('_getOrInit: module factory and handoff callback registered');
 
   _manager = PushNotificationIsolateManager(
-    callLogsRepository: _context!.callLogsRepository,
-    localPushRepository: _context!.localPushRepository,
+    callLogsRepository: context.callLogsRepository,
+    localPushRepository: context.localPushRepository,
     callkeep: BackgroundPushNotificationService(),
-    storage: _context!.secureStorage,
-    certificates: _context!.appCertificates.trustedCertificates,
+    storage: context.secureStorage,
+    certificates: context.appCertificates.trustedCertificates,
     logger: Logger('PushNotificationIsolateManager'),
   );
   // init() constructs WebtritSignalingService and wires up the event subscription.
@@ -76,10 +73,9 @@ Future<PushNotificationIsolateManager> _getOrInit(PushIsolateContext context) as
 /// Must be called when [CallkeepPushNotificationSyncStatus.releaseResources]
 /// is received so the isolate does not hold open database connections or
 /// active signaling sessions after the OS reclaims the background process.
-Future<void> _disposeContext() async {
+Future<void> _disposeContext(PushIsolateContext context) async {
   await _manager?.close();
-  await _context?.dispose();
-  _context = null;
+  await context.dispose();
   _manager = null;
 }
 
@@ -150,7 +146,7 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
   } catch (e) {
     _logger.severe('onPushNotificationSyncCallback: error=$e');
   } finally {
-    await _disposeContext();
+    await _disposeContext(context);
   }
 }
 

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -5,9 +5,7 @@ import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
 import 'package:webtrit_phone/common/common.dart';
-import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/repositories/repositories.dart';
 
 import 'isolate_manager.dart';
 
@@ -111,11 +109,18 @@ Future<void> _disposeContext(PushIsolateContext context) async {
 ///   arrives first completes the push lifecycle early via `notifyActivityTookOver()`.
 @pragma('vm:entry-point')
 Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
-  // Lightweight prefs read — SharedPreferences only, no DB / certificates / remote config.
-  final prefs = await AppPreferencesImpl.init();
-  final incomingCallType = IncomingCallTypeRepositoryPrefsImpl(prefs).getIncomingCallType();
+  PushIsolateContext? context;
+  try {
+    context = await PushIsolateContext.init();
+  } catch (e) {
+    _logger.severe('onPushNotificationSyncCallback: context init failed, aborting: $e');
+    return;
+  }
+
+  final incomingCallType = context.incomingCallTypeRepository.getIncomingCallType();
 
   if (incomingCallType == IncomingCallType.socket) {
+    await context.dispose();
     if (!_kPersistentPushFallbackEnabled) {
       _logger.warning(
         'onPushNotificationSyncCallback: push fallback received on persistent-session device '
@@ -136,12 +141,8 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     return;
   }
 
-  // pushBound: build the full context (DB, certs, remote config) and run the
-  // direct-WS call lifecycle. Context is created inside try so any init failure
-  // is caught and dispose() is guaranteed in finally.
-  PushIsolateContext? context;
+  // pushBound: run the direct-WS call lifecycle with the already-initialised context.
   try {
-    context = await PushIsolateContext.init();
     final manager = await _getOrInit(context);
     final incomingCallProcessing = manager.run(metadata);
     await incomingCallProcessing.timeout(
@@ -151,7 +152,7 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
   } catch (e) {
     _logger.severe('onPushNotificationSyncCallback: error=$e');
   } finally {
-    if (context != null) await _disposeContext(context);
+    await _disposeContext(context);
   }
 }
 

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -5,6 +5,7 @@ import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
 import 'package:webtrit_phone/common/common.dart';
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
@@ -110,11 +111,11 @@ Future<void> _disposeContext(PushIsolateContext context) async {
 ///   arrives first completes the push lifecycle early via `notifyActivityTookOver()`.
 @pragma('vm:entry-point')
 Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
-  final context = await PushIsolateContext.init();
-  final incomingCallType = IncomingCallTypeRepositoryPrefsImpl(context.appPreferences).getIncomingCallType();
+  // Lightweight prefs read — SharedPreferences only, no DB / certificates / remote config.
+  final prefs = await AppPreferencesImpl.init();
+  final incomingCallType = IncomingCallTypeRepositoryPrefsImpl(prefs).getIncomingCallType();
 
   if (incomingCallType == IncomingCallType.socket) {
-    await context.dispose();
     if (!_kPersistentPushFallbackEnabled) {
       _logger.warning(
         'onPushNotificationSyncCallback: push fallback received on persistent-session device '
@@ -135,8 +136,12 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     return;
   }
 
-  // pushBound: open a direct WebSocket in this isolate and run the full call lifecycle.
+  // pushBound: build the full context (DB, certs, remote config) and run the
+  // direct-WS call lifecycle. Context is created inside try so any init failure
+  // is caught and dispose() is guaranteed in finally.
+  PushIsolateContext? context;
   try {
+    context = await PushIsolateContext.init();
     final manager = await _getOrInit(context);
     final incomingCallProcessing = manager.run(metadata);
     await incomingCallProcessing.timeout(
@@ -146,7 +151,7 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
   } catch (e) {
     _logger.severe('onPushNotificationSyncCallback: error=$e');
   } finally {
-    await _disposeContext(context);
+    if (context != null) await _disposeContext(context);
   }
 }
 


### PR DESCRIPTION
## Problem

On persistent-session devices (`IncomingCallType.socket`) the FGS owns the persistent WebSocket. When the OEM (ColorOS/MIUI) freezes the FGS process overnight, the Core cannot reach the device via WS and falls back to an FCM push.

The push wake-up (SIGCONT) resumes both the FGS isolate (which starts reconnecting its WS) and the push isolate (which previously opened its own direct WS). Both WS connections use `force=true` against the same account token → server evicts one → `4441` → immediate reconnect → eviction loop.

The mutual exclusion guard from WT-1497 (`updateMode` + `_startServiceToken`) does not cover this path because the push isolate and FGS isolate are separate Dart VMs — `_hubManager.tearDown()` in one has no effect on the other.

## Fix

In `onPushNotificationSyncCallback`, read the saved `IncomingCallType` before starting any signaling:

- **`IncomingCallType.socket` (persistent):** call `restoreService()` to restart the FGS if it was killed (no-op if merely frozen after SIGCONT), then return immediately — no competing WS opened.
- **`IncomingCallType.pushNotification` (pushBound):** existing direct-WS flow, unchanged.

Also removes `restoreService()` from the pushBound `finally` block — it was a no-op (connection config cleared by `stopService()`) and a remnant of the old architecture where FGS was always involved in the push flow.

## Testing

Set `_kPersistentPushFallbackEnabled = false` to suppress FGS recovery and observe only the log entry — useful for isolating behavior without triggering `restoreService()`.

## Affected file

`lib/features/call/services/background_isolate_callbacks.dart`

## Known limitation — follow-up required

`PushIsolateContext.init()` currently fails as a unit if any single dependency (DB, certificates, remote config) throws. A failure in a non-critical resource (e.g. DB unavailable) causes the entire push isolate to abort, skipping FGS recovery on persistent devices.

This will be fixed in a follow-up PR: each resource will be initialised independently with best-effort fallback — non-critical fields become nullable, critical fields (`secureStorage`, `incomingCallTypeRepository`, `appCertificates`) remain required. The main flow will continue even with partial context.