### PR TITLE
fix(isolate): resilient IsolateContext and PushIsolateContext init

### DIFF
--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -56,18 +56,22 @@ class IsolateContext {
           )
         : null;
 
-    if (remoteConfigService != null && appLabelsProvider != null) {
-      try {
-        final overrides = FeatureOverridesFactory.create(remoteConfigService.snapshot);
-        final loggingConfig = LoggingMapper.mapFromOverridesOnly(overrides);
-        await AppLogger.init(
-          loggingConfig,
-          LogzioLoggingService.fromEnvironment(loggingConfig.remoteLoggingEnabled),
-          () => appLabelsProvider.logLabels,
-        );
-      } catch (e) {
-        Logger.root.warning('IsolateContext: AppLogger init failed, continuing without remote logging: $e');
-      }
+    try {
+      final loggingConfig = remoteConfigService != null
+          ? LoggingMapper.mapFromOverridesOnly(FeatureOverridesFactory.create(remoteConfigService.snapshot))
+          : const LoggingConfig(
+              logLevel: Level.INFO,
+              monitorCheckInterval: Duration(seconds: 15),
+              remoteLoggingEnabled: false,
+              anonymizationEnabled: true,
+            );
+      await AppLogger.init(
+        loggingConfig,
+        LogzioLoggingService.fromEnvironment(loggingConfig.remoteLoggingEnabled),
+        () => appLabelsProvider?.logLabels ?? {},
+      );
+    } catch (e, st) {
+      Logger.root.warning('IsolateContext: AppLogger init failed, continuing without remote logging', e, st);
     }
 
     return IsolateContext(

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -103,9 +103,9 @@ class PushIsolateContext extends IsolateContext {
     super.deviceInfo,
     super.packageInfo,
     super.appLabelsProvider,
+    required this.localPushRepository,
     this.appPath,
     this.appDatabase,
-    this.localPushRepository,
     this.callLogsRepository,
   });
 
@@ -113,7 +113,7 @@ class PushIsolateContext extends IsolateContext {
   final AppCertificates appCertificates;
   final AppPath? appPath;
   final AppDatabase? appDatabase;
-  final LocalPushRepository? localPushRepository;
+  final LocalPushRepository localPushRepository;
   final CallLogsRepository? callLogsRepository;
 
   static Future<PushIsolateContext> init() async {
@@ -136,7 +136,7 @@ class PushIsolateContext extends IsolateContext {
       Logger.root.warning('PushIsolateContext: AppPath unavailable — skipping DB init');
     }
 
-    final localPushRepository = appDatabase != null ? LocalPushRepositoryFLNImpl() : null;
+    final localPushRepository = LocalPushRepositoryFLNImpl();
     final callLogsRepository = appDatabase != null ? CallLogsRepository(appDatabase: appDatabase) : null;
 
     return PushIsolateContext(

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -23,9 +23,9 @@ Future<T?> _tryInit<T>(Future<T> Function() factory, String name) async {
 ///
 /// Used by both the Firebase background message handler and the CallKeep
 /// push-notification isolate. Each isolate maintains its own instance via a
-/// top-level nullable variable -- isolates do not share memory.
+/// top-level nullable variable - isolates do not share memory.
 ///
-/// Non-critical fields are nullable -- init failures are caught individually so
+/// Non-critical fields are nullable - init failures are caught individually so
 /// the main flow continues with partial data rather than aborting entirely.
 class IsolateContext {
   IsolateContext({
@@ -37,10 +37,10 @@ class IsolateContext {
     this.appLabelsProvider,
   });
 
-  /// Required -- credentials for signaling auth. Throws on failure.
+  /// Required - credentials for signaling auth. Throws on failure.
   final SecureStorage secureStorage;
 
-  /// Nullable -- best-effort. Null when remote config is unavailable.
+  /// Nullable - best-effort. Null when remote config is unavailable.
   final RemoteConfigService? remoteConfigService;
   final AppInfo? appInfo;
   final DeviceInfo? deviceInfo;
@@ -100,7 +100,7 @@ class IsolateContext {
 /// free of feature-layer imports.
 ///
 /// Critical fields ([incomingCallTypeRepository], [appCertificates]) are
-/// required -- failures there abort the push flow. All other push-specific
+/// required - failures there abort the push flow. All other push-specific
 /// fields are nullable with best-effort init.
 class PushIsolateContext extends IsolateContext {
   PushIsolateContext({
@@ -118,31 +118,31 @@ class PushIsolateContext extends IsolateContext {
     this.callLogsRepository,
   });
 
-  /// Required -- mode check (persistent vs pushBound). Throws on failure.
+  /// Required - mode check (persistent vs pushBound). Throws on failure.
   final IncomingCallTypeRepository incomingCallTypeRepository;
 
-  /// Required -- TLS certificates for WebSocket. Throws on failure.
+  /// Required - TLS certificates for WebSocket. Throws on failure.
   final AppCertificates appCertificates;
 
-  /// Nullable -- best-effort. Null when filesystem path is unavailable.
+  /// Nullable - best-effort. Null when filesystem path is unavailable.
   final AppPath? appPath;
 
-  /// Nullable -- best-effort. Null when [appPath] or DB open fails.
+  /// Nullable - best-effort. Null when [appPath] or DB open fails.
   final AppDatabase? appDatabase;
 
-  /// Always initialised -- uses FlutterLocalNotificationsPlugin, no DB dependency.
+  /// Always initialised - uses FlutterLocalNotificationsPlugin, no DB dependency.
   final LocalPushRepository localPushRepository;
 
-  /// Nullable -- best-effort. Null when [appDatabase] is unavailable.
+  /// Nullable - best-effort. Null when [appDatabase] is unavailable.
   final CallLogsRepository? callLogsRepository;
 
   static Future<PushIsolateContext> init() async {
-    // Phase 1 -- critical: abort if these fail.
+    // Phase 1 - critical: abort if these fail.
     final base = await IsolateContext.init();
     final appPreferences = await AppPreferencesImpl.init();
     final appCertificates = await AppCertificates.init();
 
-    // Phase 2 -- best-effort: failures are isolated, flow continues with nulls.
+    // Phase 2 - best-effort: failures are isolated, flow continues with nulls.
     final appPath = await _tryInit(AppPath.init, 'AppPath');
 
     AppDatabase? appDatabase;
@@ -153,7 +153,7 @@ class PushIsolateContext extends IsolateContext {
         'AppDatabase',
       );
     } else {
-      Logger.root.warning('PushIsolateContext: AppPath unavailable -- skipping DB init');
+      Logger.root.warning('PushIsolateContext: AppPath unavailable - skipping DB init');
     }
 
     final localPushRepository = LocalPushRepositoryFLNImpl();

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -11,8 +11,8 @@ import 'logging/logging.dart';
 Future<T?> _tryInit<T>(Future<T> Function() factory, String name) async {
   try {
     return await factory();
-  } catch (e) {
-    Logger.root.warning('IsolateContext: $name init failed, continuing without it: $e');
+  } catch (e, st) {
+    Logger.root.warning('$name init failed, continuing without it', e, st);
     return null;
   }
 }

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -8,50 +8,74 @@ import 'app_id_provider.dart';
 import 'db/db.dart';
 import 'logging/logging.dart';
 
+Future<T?> _tryInit<T>(Future<T> Function() factory, String name) async {
+  try {
+    return await factory();
+  } catch (e) {
+    Logger.root.warning('IsolateContext: $name init failed, continuing without it: $e');
+    return null;
+  }
+}
+
 /// Shared lazily-initialised dependencies for background isolates.
 ///
 /// Used by both the Firebase background message handler and the CallKeep
 /// push-notification isolate. Each isolate maintains its own instance via a
 /// top-level nullable variable -- isolates do not share memory.
+///
+/// Non-critical fields are nullable — init failures are caught individually so
+/// the main flow continues with partial data rather than aborting entirely.
 class IsolateContext {
   IsolateContext({
-    required this.remoteConfigService,
-    required this.appInfo,
-    required this.deviceInfo,
-    required this.packageInfo,
     required this.secureStorage,
-    required this.appLabelsProvider,
+    this.remoteConfigService,
+    this.appInfo,
+    this.deviceInfo,
+    this.packageInfo,
+    this.appLabelsProvider,
   });
 
-  final RemoteConfigService remoteConfigService;
-  final AppInfo appInfo;
-  final DeviceInfo deviceInfo;
-  final PackageInfo packageInfo;
   final SecureStorage secureStorage;
-  final AppMetadataProvider appLabelsProvider;
+  final RemoteConfigService? remoteConfigService;
+  final AppInfo? appInfo;
+  final DeviceInfo? deviceInfo;
+  final PackageInfo? packageInfo;
+  final AppMetadataProvider? appLabelsProvider;
 
   static Future<IsolateContext> init() async {
-    final remoteConfigService = await DefaultRemoteCacheConfigService.init();
-    final appInfo = await AppInfo.init(const SharedPreferencesAppIdProvider());
-    final deviceInfo = await DeviceInfoFactory.init();
-    final packageInfo = await PackageInfoFactory.init();
     final secureStorage = await SecureStorageImpl.init();
-    final appLabelsProvider = await DefaultAppMetadataProvider.init(packageInfo, deviceInfo, appInfo, secureStorage);
 
-    final overrides = FeatureOverridesFactory.create(remoteConfigService.snapshot);
-    final loggingConfig = LoggingMapper.mapFromOverridesOnly(overrides);
-    await AppLogger.init(
-      loggingConfig,
-      LogzioLoggingService.fromEnvironment(loggingConfig.remoteLoggingEnabled),
-      () => appLabelsProvider.logLabels,
-    );
+    final remoteConfigService = await _tryInit(DefaultRemoteCacheConfigService.init, 'RemoteConfigService');
+    final appInfo = await _tryInit(() => AppInfo.init(const SharedPreferencesAppIdProvider()), 'AppInfo');
+    final deviceInfo = await _tryInit(DeviceInfoFactory.init, 'DeviceInfo');
+    final packageInfo = await _tryInit(PackageInfoFactory.init, 'PackageInfo');
+    final appLabelsProvider = packageInfo != null && deviceInfo != null && appInfo != null
+        ? await _tryInit(
+            () => DefaultAppMetadataProvider.init(packageInfo, deviceInfo, appInfo, secureStorage),
+            'AppMetadataProvider',
+          )
+        : null;
+
+    if (remoteConfigService != null && appLabelsProvider != null) {
+      try {
+        final overrides = FeatureOverridesFactory.create(remoteConfigService.snapshot);
+        final loggingConfig = LoggingMapper.mapFromOverridesOnly(overrides);
+        await AppLogger.init(
+          loggingConfig,
+          LogzioLoggingService.fromEnvironment(loggingConfig.remoteLoggingEnabled),
+          () => appLabelsProvider.logLabels,
+        );
+      } catch (e) {
+        Logger.root.warning('IsolateContext: AppLogger init failed, continuing without remote logging: $e');
+      }
+    }
 
     return IsolateContext(
+      secureStorage: secureStorage,
       remoteConfigService: remoteConfigService,
       appInfo: appInfo,
       deviceInfo: deviceInfo,
       packageInfo: packageInfo,
-      secureStorage: secureStorage,
       appLabelsProvider: appLabelsProvider,
     );
   }
@@ -65,55 +89,71 @@ class IsolateContext {
 ///
 /// Does NOT hold [PushNotificationIsolateManager] itself to keep this class
 /// free of feature-layer imports.
+///
+/// Critical fields ([incomingCallTypeRepository], [appCertificates]) are
+/// required — failures there abort the push flow. All other push-specific
+/// fields are nullable with best-effort init.
 class PushIsolateContext extends IsolateContext {
   PushIsolateContext({
-    required super.remoteConfigService,
-    required super.appInfo,
-    required super.deviceInfo,
-    required super.packageInfo,
     required super.secureStorage,
-    required super.appLabelsProvider,
     required this.incomingCallTypeRepository,
-    required this.appPath,
     required this.appCertificates,
-    required this.appDatabase,
-    required this.localPushRepository,
-    required this.callLogsRepository,
+    super.remoteConfigService,
+    super.appInfo,
+    super.deviceInfo,
+    super.packageInfo,
+    super.appLabelsProvider,
+    this.appPath,
+    this.appDatabase,
+    this.localPushRepository,
+    this.callLogsRepository,
   });
 
   final IncomingCallTypeRepository incomingCallTypeRepository;
-  final AppPath appPath;
   final AppCertificates appCertificates;
-  final AppDatabase appDatabase;
-  final LocalPushRepository localPushRepository;
-  final CallLogsRepository callLogsRepository;
+  final AppPath? appPath;
+  final AppDatabase? appDatabase;
+  final LocalPushRepository? localPushRepository;
+  final CallLogsRepository? callLogsRepository;
 
   static Future<PushIsolateContext> init() async {
+    // Phase 1 — critical: abort if these fail.
     final base = await IsolateContext.init();
     final appPreferences = await AppPreferencesImpl.init();
-    final appPath = await AppPath.init();
     final appCertificates = await AppCertificates.init();
 
-    Logger.root.info('IsolateDatabase.connectOrCreate call from PushIsolateContext.init');
-    final appDatabase = await IsolateDatabase.connectOrCreate(directoryPath: appPath.applicationDocumentsPath);
-    final localPushRepository = LocalPushRepositoryFLNImpl();
-    final callLogsRepository = CallLogsRepository(appDatabase: appDatabase);
+    // Phase 2 — best-effort: failures are isolated, flow continues with nulls.
+    final appPath = await _tryInit(AppPath.init, 'AppPath');
+
+    AppDatabase? appDatabase;
+    if (appPath != null) {
+      Logger.root.info('IsolateDatabase.connectOrCreate call from PushIsolateContext.init');
+      appDatabase = await _tryInit(
+        () => IsolateDatabase.connectOrCreate(directoryPath: appPath.applicationDocumentsPath),
+        'AppDatabase',
+      );
+    } else {
+      Logger.root.warning('PushIsolateContext: AppPath unavailable — skipping DB init');
+    }
+
+    final localPushRepository = appDatabase != null ? LocalPushRepositoryFLNImpl() : null;
+    final callLogsRepository = appDatabase != null ? CallLogsRepository(appDatabase: appDatabase) : null;
 
     return PushIsolateContext(
+      secureStorage: base.secureStorage,
       remoteConfigService: base.remoteConfigService,
       appInfo: base.appInfo,
       deviceInfo: base.deviceInfo,
       packageInfo: base.packageInfo,
-      secureStorage: base.secureStorage,
       appLabelsProvider: base.appLabelsProvider,
       incomingCallTypeRepository: IncomingCallTypeRepositoryPrefsImpl(appPreferences),
-      appPath: appPath,
       appCertificates: appCertificates,
+      appPath: appPath,
       appDatabase: appDatabase,
       localPushRepository: localPushRepository,
       callLogsRepository: callLogsRepository,
     );
   }
 
-  Future<void> dispose() => appDatabase.close();
+  Future<void> dispose() => appDatabase?.close() ?? Future.value();
 }

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -8,6 +8,8 @@ import 'app_id_provider.dart';
 import 'db/db.dart';
 import 'logging/logging.dart';
 
+/// Runs [factory] and returns its result, or `null` if it throws.
+/// Logs a warning with the full stack trace so failures are visible in the isolate log.
 Future<T?> _tryInit<T>(Future<T> Function() factory, String name) async {
   try {
     return await factory();
@@ -35,7 +37,10 @@ class IsolateContext {
     this.appLabelsProvider,
   });
 
+  /// Required — credentials for signaling auth. Throws on failure.
   final SecureStorage secureStorage;
+
+  /// Nullable — best-effort. Null when remote config is unavailable.
   final RemoteConfigService? remoteConfigService;
   final AppInfo? appInfo;
   final DeviceInfo? deviceInfo;
@@ -113,11 +118,22 @@ class PushIsolateContext extends IsolateContext {
     this.callLogsRepository,
   });
 
+  /// Required — mode check (persistent vs pushBound). Throws on failure.
   final IncomingCallTypeRepository incomingCallTypeRepository;
+
+  /// Required — TLS certificates for WebSocket. Throws on failure.
   final AppCertificates appCertificates;
+
+  /// Nullable — best-effort. Null when filesystem path is unavailable.
   final AppPath? appPath;
+
+  /// Nullable — best-effort. Null when [appPath] or DB open fails.
   final AppDatabase? appDatabase;
+
+  /// Always initialised — uses FlutterLocalNotificationsPlugin, no DB dependency.
   final LocalPushRepository localPushRepository;
+
+  /// Nullable — best-effort. Null when [appDatabase] is unavailable.
   final CallLogsRepository? callLogsRepository;
 
   static Future<PushIsolateContext> init() async {

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -25,7 +25,7 @@ Future<T?> _tryInit<T>(Future<T> Function() factory, String name) async {
 /// push-notification isolate. Each isolate maintains its own instance via a
 /// top-level nullable variable -- isolates do not share memory.
 ///
-/// Non-critical fields are nullable — init failures are caught individually so
+/// Non-critical fields are nullable -- init failures are caught individually so
 /// the main flow continues with partial data rather than aborting entirely.
 class IsolateContext {
   IsolateContext({
@@ -37,10 +37,10 @@ class IsolateContext {
     this.appLabelsProvider,
   });
 
-  /// Required — credentials for signaling auth. Throws on failure.
+  /// Required -- credentials for signaling auth. Throws on failure.
   final SecureStorage secureStorage;
 
-  /// Nullable — best-effort. Null when remote config is unavailable.
+  /// Nullable -- best-effort. Null when remote config is unavailable.
   final RemoteConfigService? remoteConfigService;
   final AppInfo? appInfo;
   final DeviceInfo? deviceInfo;
@@ -100,7 +100,7 @@ class IsolateContext {
 /// free of feature-layer imports.
 ///
 /// Critical fields ([incomingCallTypeRepository], [appCertificates]) are
-/// required — failures there abort the push flow. All other push-specific
+/// required -- failures there abort the push flow. All other push-specific
 /// fields are nullable with best-effort init.
 class PushIsolateContext extends IsolateContext {
   PushIsolateContext({
@@ -118,31 +118,31 @@ class PushIsolateContext extends IsolateContext {
     this.callLogsRepository,
   });
 
-  /// Required — mode check (persistent vs pushBound). Throws on failure.
+  /// Required -- mode check (persistent vs pushBound). Throws on failure.
   final IncomingCallTypeRepository incomingCallTypeRepository;
 
-  /// Required — TLS certificates for WebSocket. Throws on failure.
+  /// Required -- TLS certificates for WebSocket. Throws on failure.
   final AppCertificates appCertificates;
 
-  /// Nullable — best-effort. Null when filesystem path is unavailable.
+  /// Nullable -- best-effort. Null when filesystem path is unavailable.
   final AppPath? appPath;
 
-  /// Nullable — best-effort. Null when [appPath] or DB open fails.
+  /// Nullable -- best-effort. Null when [appPath] or DB open fails.
   final AppDatabase? appDatabase;
 
-  /// Always initialised — uses FlutterLocalNotificationsPlugin, no DB dependency.
+  /// Always initialised -- uses FlutterLocalNotificationsPlugin, no DB dependency.
   final LocalPushRepository localPushRepository;
 
-  /// Nullable — best-effort. Null when [appDatabase] is unavailable.
+  /// Nullable -- best-effort. Null when [appDatabase] is unavailable.
   final CallLogsRepository? callLogsRepository;
 
   static Future<PushIsolateContext> init() async {
-    // Phase 1 — critical: abort if these fail.
+    // Phase 1 -- critical: abort if these fail.
     final base = await IsolateContext.init();
     final appPreferences = await AppPreferencesImpl.init();
     final appCertificates = await AppCertificates.init();
 
-    // Phase 2 — best-effort: failures are isolated, flow continues with nulls.
+    // Phase 2 -- best-effort: failures are isolated, flow continues with nulls.
     final appPath = await _tryInit(AppPath.init, 'AppPath');
 
     AppDatabase? appDatabase;
@@ -153,7 +153,7 @@ class PushIsolateContext extends IsolateContext {
         'AppDatabase',
       );
     } else {
-      Logger.root.warning('PushIsolateContext: AppPath unavailable — skipping DB init');
+      Logger.root.warning('PushIsolateContext: AppPath unavailable -- skipping DB init');
     }
 
     final localPushRepository = LocalPushRepositoryFLNImpl();

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -43,7 +43,7 @@ PushNotificationIsolateManager? _manager;
 Future<PushNotificationIsolateManager> _getOrInit(PushIsolateContext context) async {
   if (_manager != null) return _manager!;
 
-  // The push isolate is a separate Dart VM — it never receives the setModuleFactory()
+  // The push isolate is a separate Dart VM -- it never receives the setModuleFactory()
   // call made in bootstrap.dart (Activity isolate). Register the factory here so
   // _startDirect() can create a SignalingModule when connect() is called from run().
   await WebtritSignalingService.setModuleFactory(createSignalingModule);
@@ -88,24 +88,24 @@ Future<void> _disposeContext(PushIsolateContext context) async {
 /// ## Persistent-session devices
 ///
 /// When [IncomingCallType.socket] is selected the FGS owns the persistent WebSocket.
-/// A push arriving on such a device means the FGS was frozen or killed by the OEM —
+/// A push arriving on such a device means the FGS was frozen or killed by the OEM --
 /// the push is a fallback wake-up, not a signal to open a competing WebSocket.
 /// Opening a direct WS here would race with the FGS reconnect and trigger a 4441
 /// eviction loop. Instead, [restoreService] is called to restart the FGS if it was
 /// killed (no-op when it is merely frozen), and the push isolate exits immediately.
 ///
-/// ## pushBound devices — lifecycle and handoff
+/// ## pushBound devices -- lifecycle and handoff
 ///
 /// The push isolate opens its own WebSocket directly (no FGS). It runs until
 /// one of three outcomes:
-/// - **Missed call**: [HangupEvent] received before the user answers →
+/// - **Missed call**: [HangupEvent] received before the user answers ->
 ///   `releaseCall()` terminates the [PhoneConnection] and stops [IncomingCallService].
-/// - **Answered via push UI**: `performAnswerCall` fires before the timeout →
+/// - **Answered via push UI**: `performAnswerCall` fires before the timeout ->
 ///   `handoffCall()` stops [IncomingCallService] without terminating the connection,
 ///   leaving the Activity to adopt the live call.
 /// - **Activity took over**: the Activity opens its own WebSocket, the server sends
 ///   4441 (`controllerForceAttachClose`) to the push isolate, or the plugin detects
-///   the Activity via [IsolateNameServer] and calls the handoff callback — whichever
+///   the Activity via [IsolateNameServer] and calls the handoff callback -- whichever
 ///   arrives first completes the push lifecycle early via `notifyActivityTookOver()`.
 @pragma('vm:entry-point')
 Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
@@ -124,13 +124,13 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     if (!_kPersistentPushFallbackEnabled) {
       _logger.warning(
         'onPushNotificationSyncCallback: push fallback received on persistent-session device '
-        '(callId=${metadata?.callId}) — fallback disabled by flag, skipping FGS recovery',
+        '(callId=${metadata?.callId}) -- fallback disabled by flag, skipping FGS recovery',
       );
       return;
     }
     _logger.info(
       'onPushNotificationSyncCallback: push fallback received on persistent-session device '
-      '(callId=${metadata?.callId}) — FGS was likely frozen or killed by OEM; '
+      '(callId=${metadata?.callId}) -- FGS was likely frozen or killed by OEM; '
       'skipping direct WS, attempting FGS recovery via restoreService()',
     );
     try {

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -43,7 +43,7 @@ PushNotificationIsolateManager? _manager;
 Future<PushNotificationIsolateManager> _getOrInit(PushIsolateContext context) async {
   if (_manager != null) return _manager!;
 
-  // The push isolate is a separate Dart VM -- it never receives the setModuleFactory()
+  // The push isolate is a separate Dart VM - it never receives the setModuleFactory()
   // call made in bootstrap.dart (Activity isolate). Register the factory here so
   // _startDirect() can create a SignalingModule when connect() is called from run().
   await WebtritSignalingService.setModuleFactory(createSignalingModule);
@@ -94,7 +94,7 @@ Future<void> _disposeContext(PushIsolateContext context) async {
 /// eviction loop. Instead, [restoreService] is called to restart the FGS if it was
 /// killed (no-op when it is merely frozen), and the push isolate exits immediately.
 ///
-/// ## pushBound devices -- lifecycle and handoff
+/// ## pushBound devices - lifecycle and handoff
 ///
 /// The push isolate opens its own WebSocket directly (no FGS). It runs until
 /// one of three outcomes:
@@ -105,7 +105,7 @@ Future<void> _disposeContext(PushIsolateContext context) async {
 ///   leaving the Activity to adopt the live call.
 /// - **Activity took over**: the Activity opens its own WebSocket, the server sends
 ///   4441 (`controllerForceAttachClose`) to the push isolate, or the plugin detects
-///   the Activity via [IsolateNameServer] and calls the handoff callback -- whichever
+///   the Activity via [IsolateNameServer] and calls the handoff callback - whichever
 ///   arrives first completes the push lifecycle early via `notifyActivityTookOver()`.
 @pragma('vm:entry-point')
 Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metadata) async {
@@ -124,13 +124,13 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
     if (!_kPersistentPushFallbackEnabled) {
       _logger.warning(
         'onPushNotificationSyncCallback: push fallback received on persistent-session device '
-        '(callId=${metadata?.callId}) -- fallback disabled by flag, skipping FGS recovery',
+        '(callId=${metadata?.callId}) - fallback disabled by flag, skipping FGS recovery',
       );
       return;
     }
     _logger.info(
       'onPushNotificationSyncCallback: push fallback received on persistent-session device '
-      '(callId=${metadata?.callId}) -- FGS was likely frozen or killed by OEM; '
+      '(callId=${metadata?.callId}) - FGS was likely frozen or killed by OEM; '
       'skipping direct WS, attempting FGS recovery via restoreService()',
     );
     try {

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -20,7 +20,7 @@ import '../models/jsep_value.dart';
 /// Opened once per incoming push notification, connects to the signaling server
 /// to retrieve call state, handles missed-call logging and notifications, and
 /// releases the incoming call service when all work is done.
-/// Never reconnects — the isolate is short-lived by design.
+/// Never reconnects -- the isolate is short-lived by design.
 ///
 /// On both Android and iOS the connection runs directly in the current isolate.
 /// Call [init] after construction and before [run].
@@ -107,7 +107,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     logger.info('run: callId=${metadata?.callId} isConnected=${_signalingModule.isConnected}');
     // WebtritSignalingService.connect() is idempotent: the internal
     // _startPending / _isConnected guard makes repeated calls safe.
-    // Always call it — idempotent on any subsequent call.
+    // Always call it -- idempotent on any subsequent call.
     _signalingModule.connect();
     return _completer!.future;
   }
@@ -117,7 +117,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   /// [onPushNotificationSyncCallback] finally block, disposing the module and
   /// cancelling any pending reconnect timers before they fire.
   void notifyActivityTookOver() {
-    logger.info('notifyActivityTookOver: Activity WebSocket connected — completing push session early');
+    logger.info('notifyActivityTookOver: Activity WebSocket connected -- completing push session early');
     _complete();
   }
 
@@ -140,7 +140,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     if (_answeredCallId != null) {
       await _handoffCall(_answeredCallId);
     } else if (_incomingCallEvents.containsKey(_metadata?.callId)) {
-      // The call is still active server-side (no HangupEvent received) — the
+      // The call is still active server-side (no HangupEvent received) -- the
       // Activity has likely taken over via a full-screen intent. Hand off
       // instead of releasing so the ringing call is not terminated prematurely.
       await _handoffCall(_metadata?.callId);
@@ -148,7 +148,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       // In direct mode the push isolate's WebSocket is independent from the
       // Activity's. If the Activity took over before IncomingCallEvent arrived
       // (empty _incomingCallEvents), releaseCall only stops IncomingCallService
-      // here — the Activity keeps its own connection and handles the call normally.
+      // here -- the Activity keeps its own connection and handles the call normally.
       await _releaseCall(_metadata?.callId);
     }
     _completeWithError(StateError('PushNotificationIsolateManager closed'));
@@ -189,7 +189,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
   /// Sets up [WebtritSignalingService] for this isolate in
   /// [SignalingServiceMode.pushBound] mode. Each isolate (push and Activity)
-  /// opens its own direct WebSocket — no shared FGS hub. [connect] is called
+  /// opens its own direct WebSocket -- no shared FGS hub. [connect] is called
   /// from [run], not here, so the connection starts only when processing begins.
   void _initSignaling() {
     logger.info('_initSignaling: creating WebtritSignalingService (pushBound)');
@@ -429,7 +429,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
     final lineIndex = _lines[callId];
     if (lineIndex == null) {
-      logger.warning('_sendRequest: callId=$callId not in active lines — dropping request');
+      logger.warning('_sendRequest: callId=$callId not in active lines -- dropping request');
       return;
     }
 
@@ -505,7 +505,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
   /// Returns the best available display name for the missed-call notification.
   ///
-  /// Priority: signaling caller name → push metadata display name → phone number.
+  /// Priority: signaling caller name -> push metadata display name -> phone number.
   String? _getDisplayNameForMissedCall(HangupEvent event, NewCall call) {
     final metadataName = _metadata?.callId == event.callId ? _metadata?.displayName : null;
     return [call.username, metadataName, call.number].firstWhere((s) => s != null && s.isNotEmpty, orElse: () => null);

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -20,7 +20,7 @@ import '../models/jsep_value.dart';
 /// Opened once per incoming push notification, connects to the signaling server
 /// to retrieve call state, handles missed-call logging and notifications, and
 /// releases the incoming call service when all work is done.
-/// Never reconnects -- the isolate is short-lived by design.
+/// Never reconnects - the isolate is short-lived by design.
 ///
 /// On both Android and iOS the connection runs directly in the current isolate.
 /// Call [init] after construction and before [run].
@@ -107,7 +107,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     logger.info('run: callId=${metadata?.callId} isConnected=${_signalingModule.isConnected}');
     // WebtritSignalingService.connect() is idempotent: the internal
     // _startPending / _isConnected guard makes repeated calls safe.
-    // Always call it -- idempotent on any subsequent call.
+    // Always call it - idempotent on any subsequent call.
     _signalingModule.connect();
     return _completer!.future;
   }
@@ -117,7 +117,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   /// [onPushNotificationSyncCallback] finally block, disposing the module and
   /// cancelling any pending reconnect timers before they fire.
   void notifyActivityTookOver() {
-    logger.info('notifyActivityTookOver: Activity WebSocket connected -- completing push session early');
+    logger.info('notifyActivityTookOver: Activity WebSocket connected - completing push session early');
     _complete();
   }
 
@@ -140,7 +140,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     if (_answeredCallId != null) {
       await _handoffCall(_answeredCallId);
     } else if (_incomingCallEvents.containsKey(_metadata?.callId)) {
-      // The call is still active server-side (no HangupEvent received) -- the
+      // The call is still active server-side (no HangupEvent received) - the
       // Activity has likely taken over via a full-screen intent. Hand off
       // instead of releasing so the ringing call is not terminated prematurely.
       await _handoffCall(_metadata?.callId);
@@ -148,7 +148,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
       // In direct mode the push isolate's WebSocket is independent from the
       // Activity's. If the Activity took over before IncomingCallEvent arrived
       // (empty _incomingCallEvents), releaseCall only stops IncomingCallService
-      // here -- the Activity keeps its own connection and handles the call normally.
+      // here - the Activity keeps its own connection and handles the call normally.
       await _releaseCall(_metadata?.callId);
     }
     _completeWithError(StateError('PushNotificationIsolateManager closed'));
@@ -189,7 +189,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
   /// Sets up [WebtritSignalingService] for this isolate in
   /// [SignalingServiceMode.pushBound] mode. Each isolate (push and Activity)
-  /// opens its own direct WebSocket -- no shared FGS hub. [connect] is called
+  /// opens its own direct WebSocket - no shared FGS hub. [connect] is called
   /// from [run], not here, so the connection starts only when processing begins.
   void _initSignaling() {
     logger.info('_initSignaling: creating WebtritSignalingService (pushBound)');
@@ -429,7 +429,7 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
 
     final lineIndex = _lines[callId];
     if (lineIndex == null) {
-      logger.warning('_sendRequest: callId=$callId not in active lines -- dropping request');
+      logger.warning('_sendRequest: callId=$callId not in active lines - dropping request');
       return;
     }
 

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -30,8 +30,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     required this.storage,
     required this.certificates,
     required this.logger,
+    required this.localPushRepository,
     this.callLogsRepository,
-    this.localPushRepository,
   }) : _pushService = callkeep {
     // setBackgroundServiceDelegate is called in the constructor so callkeep can
     // route performAnswerCall / performEndCall as soon as the object exists,
@@ -40,8 +40,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   }
 
   final Logger logger;
+  final LocalPushRepository localPushRepository;
   final CallLogsRepository? callLogsRepository;
-  final LocalPushRepository? localPushRepository;
   final SecureStorage storage;
   final TrustedCertificates certificates;
 
@@ -494,12 +494,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   }
 
   Future<void> _showMissedCallNotification(HangupEvent event, NewCall call) async {
-    if (localPushRepository == null) {
-      logger.warning('_showMissedCallNotification: repository unavailable, skipping');
-      return;
-    }
     try {
-      await localPushRepository!.displayPush(
+      await localPushRepository.displayPush(
         AppLocalPush.missedCall(event.callId, _getDisplayNameForMissedCall(event, call) ?? 'Unknown'),
       );
     } catch (e) {

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -488,8 +488,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
     }
     try {
       await callLogsRepository!.add(call);
-    } catch (e) {
-      logger.severe('Failed to add call log', e);
+    } catch (e, st) {
+      logger.severe('Failed to add call log', e, st);
     }
   }
 

--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -26,12 +26,12 @@ import '../models/jsep_value.dart';
 /// Call [init] after construction and before [run].
 class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegate {
   PushNotificationIsolateManager({
-    required this.callLogsRepository,
-    required this.localPushRepository,
     required BackgroundPushNotificationService callkeep,
     required this.storage,
     required this.certificates,
     required this.logger,
+    this.callLogsRepository,
+    this.localPushRepository,
   }) : _pushService = callkeep {
     // setBackgroundServiceDelegate is called in the constructor so callkeep can
     // route performAnswerCall / performEndCall as soon as the object exists,
@@ -40,8 +40,8 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   }
 
   final Logger logger;
-  final CallLogsRepository callLogsRepository;
-  final LocalPushRepository localPushRepository;
+  final CallLogsRepository? callLogsRepository;
+  final LocalPushRepository? localPushRepository;
   final SecureStorage storage;
   final TrustedCertificates certificates;
 
@@ -482,16 +482,24 @@ class PushNotificationIsolateManager implements CallkeepBackgroundServiceDelegat
   // ---------------------------------------------------------------------------
 
   Future<void> _logCall(NewCall call) async {
+    if (callLogsRepository == null) {
+      logger.warning('_logCall: repository unavailable, skipping');
+      return;
+    }
     try {
-      await callLogsRepository.add(call);
+      await callLogsRepository!.add(call);
     } catch (e) {
       logger.severe('Failed to add call log', e);
     }
   }
 
   Future<void> _showMissedCallNotification(HangupEvent event, NewCall call) async {
+    if (localPushRepository == null) {
+      logger.warning('_showMissedCallNotification: repository unavailable, skipping');
+      return;
+    }
     try {
-      await localPushRepository.displayPush(
+      await localPushRepository!.displayPush(
         AppLocalPush.missedCall(event.callId, _getDisplayNameForMissedCall(event, call) ?? 'Unknown'),
       );
     } catch (e) {


### PR DESCRIPTION
## Problem

A failure in any single background resource (DB, filesystem path, remote config) caused the entire push isolate to abort, regardless of whether that resource was actually needed for the current flow.

On persistent-session devices this meant FGS recovery was skipped on a DB failure even though recovering the FGS only requires reading a single SharedPreferences value. On pushBound devices the call lifecycle never started - no missed call notification, no call log, no native release.

## Fix

Background isolate initialisation is now resilient. Critical resources that are genuinely required still propagate failures. Everything else is initialised with best-effort fallback - a failure in one resource does not affect the others, and the main flow continues with whatever is available.

Missed call notifications are now shown even when the database is unavailable, since the notification layer has no dependency on the DB.

## Follow-up to

https://github.com/WebTrit/webtrit_phone/pull/1257