### PR TITLE
fix(signaling-hub): populate call history from StateHandshake lines on FGS reconnect

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
@@ -82,11 +82,12 @@ class SignalingHub {
   /// treat an already-answered call as still ringing.
   ///
   /// Lifecycle:
-  /// - [IncomingCallEvent] → new entry created for callId.
-  /// - Subsequent [CallEvent]s (e.g. [AcceptedEvent], [RingingEvent]) → appended.
-  /// - Terminal events ([HangupEvent], [MissedCallEvent]) → entry removed;
+  /// - [IncomingCallEvent] - new entry created for callId.
+  /// - Non-null [StateHandshake] lines on connect - entry created for each active line in [_onModuleEvent].
+  /// - Subsequent [CallEvent]s (e.g. [AcceptedEvent], [RingingEvent]) - appended.
+  /// - Terminal events ([HangupEvent], [MissedCallEvent]) - entry removed;
   ///   the dead call's line is also evicted from the buffered handshake.
-  /// - [SignalingConnecting] → entire map cleared (new session).
+  /// - [SignalingConnecting] - entire map cleared (new session).
   final Map<String, List<List<dynamic>>> _callEventHistory = {};
 
   StreamSubscription<SignalingModuleEvent>? _moduleSubscription;
@@ -144,6 +145,13 @@ class SignalingHub {
     final encoded = encodeHubEvent(event);
     if (event is! SignalingProtocolEvent) {
       _sessionBuffer.add(encoded);
+      if (event is SignalingHandshakeReceived) {
+        for (final line in event.handshake.lines) {
+          if (line != null) {
+            _callEventHistory.putIfAbsent(line.callId, () => []);
+          }
+        }
+      }
     } else {
       _updateCallHistory(event.event, encoded);
       if (_isRegistrationEvent(event.event)) {
@@ -177,11 +185,9 @@ class SignalingHub {
     if (event is! CallEvent) return;
 
     if (event is HangupEvent || event is MissedCallEvent) {
-      // Always evict the dead call's line from the handshake — regardless of
-      // whether this call was tracked in [_callEventHistory]. Calls that arrived
-      // in the initial [StateHandshake] (before the hub started) are never added
-      // to [_callEventHistory], but their stale handshake line must still be
-      // removed so late subscribers don't see an ended call in handshake.lines.
+      // Always evict the dead call's line from the handshake - regardless of
+      // how the call was tracked in [_callEventHistory] (via IncomingCallEvent
+      // or via StateHandshake lines populated in [_onModuleEvent]).
       _evictHandshakeLine(event.callId);
       _callEventHistory.remove(event.callId);
       _logger.fine('Hub: call history removed (terminal) callId=${event.callId}');


### PR DESCRIPTION
## Problem

When a persistent-session device reconnects after an OEM freeze, the FGS WebSocket reconnects and receives a \`StateHandshake\` with active call lines. However, \`_callEventHistory\` was only populated from \`IncomingCallEvent\` protocol events - calls already present in handshake lines were invisible to it.

As a result, when the Activity opened and triggered a config-change sync, \`hasActiveCalls\` returned \`false\`, the sync handler recreated the signaling manager, and the WebSocket was torn down mid-call.

## Fix

\`_callEventHistory\` is now also populated from non-null \`StateHandshake\` lines when a handshake is received. This makes \`hasActiveCalls\` return \`true\` when a call arrived via handshake, so the sync handler skips manager recreation and the active call is preserved.

## Affected file

\`packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart\`

## Part of

WT-1499 fix chain - complements https://github.com/WebTrit/webtrit_phone/pull/1257 and https://github.com/WebTrit/webtrit_phone/pull/1258