### PR TITLE
fix(fgs): stop ringtone and dismiss notification on hangup in persistent mode

### DIFF
--- a/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import com.webtrit.callkeep.BackgroundPushNotificationIsolateBootstrapApi
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateBootstrapApi
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateApi
-import com.webtrit.callkeep.services.services.incoming_call.IncomingCallRelease
-import com.webtrit.callkeep.services.services.incoming_call.IncomingCallService
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.signaling_service.SignalingForegroundService
 
 /// App-level initialization that wires together two independent Flutter plugins:
@@ -50,24 +50,24 @@ class WebtritApplication : Application() {
             )
             // Register the full isolate API on the FGS engine so that releaseCall() /
             // endCall() triggered from onSignalingBackgroundCallEvent reach a handler
-            // instead of timing out. The implementation delegates to IncomingCallService
-            // via its existing broadcast mechanism — the same path used by all other callers.
-            // If IncomingCallService is not running the broadcast is silently dropped.
+            // instead of timing out. Mirrors the CallLifecycleHandler path used in
+            // push-bound mode: Dart calls releaseCall() → Kotlin terminates the Telecom
+            // connection via CallkeepCore, which stops the ringtone and cleans up state.
             PHostBackgroundPushNotificationIsolateApi.setUp(
                 messenger,
                 object : PHostBackgroundPushNotificationIsolateApi {
                     override fun releaseCall(callId: String, callback: (Result<Unit>) -> Unit) {
-                        IncomingCallService.release(context, IncomingCallRelease.IC_RELEASE_WITH_DECLINE)
+                        CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
                         callback(Result.success(Unit))
                     }
 
                     override fun endCall(callId: String, callback: (Result<Unit>) -> Unit) {
-                        IncomingCallService.release(context, IncomingCallRelease.IC_RELEASE_WITH_DECLINE)
+                        CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
                         callback(Result.success(Unit))
                     }
 
                     override fun endAllCalls(callback: (Result<Unit>) -> Unit) {
-                        IncomingCallService.release(context, IncomingCallRelease.IC_RELEASE_WITH_DECLINE)
+                        CallkeepCore.instance.sendTearDownConnections()
                         callback(Result.success(Unit))
                     }
 

--- a/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
@@ -49,13 +49,13 @@ class WebtritApplication : Application() {
                 messenger,
                 BackgroundPushNotificationIsolateBootstrapApi(context),
             )
-            // TODO: move this block into webtrit_callkeep_android — expose a single
+            // TODO: move this block into webtrit_callkeep_android - expose a single
             //  WebtritCallkeepPlugin.setUpFgsEngine(context, messenger) entry point so
             //  the app does not need to know about internal Pigeon channels or CallkeepCore.
             // Register the full isolate API on the FGS engine so that releaseCall() /
             // endCall() triggered from onSignalingBackgroundCallEvent reach a handler
             // instead of timing out. Mirrors the CallLifecycleHandler path used in
-            // push-bound mode: Dart calls releaseCall() → Kotlin terminates the Telecom
+            // push-bound mode: Dart calls releaseCall() -> Kotlin terminates the Telecom
             // connection via CallkeepCore, which stops the ringtone and cleans up state.
             PHostBackgroundPushNotificationIsolateApi.setUp(
                 messenger,

--- a/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
@@ -48,6 +48,9 @@ class WebtritApplication : Application() {
                 messenger,
                 BackgroundPushNotificationIsolateBootstrapApi(context),
             )
+            // TODO: move this block into webtrit_callkeep_android — expose a single
+            //  WebtritCallkeepPlugin.setUpFgsEngine(context, messenger) entry point so
+            //  the app does not need to know about internal Pigeon channels or CallkeepCore.
             // Register the full isolate API on the FGS engine so that releaseCall() /
             // endCall() triggered from onSignalingBackgroundCallEvent reach a handler
             // instead of timing out. Mirrors the CallLifecycleHandler path used in

--- a/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
@@ -3,6 +3,9 @@ package com.webtrit.app
 import android.app.Application
 import com.webtrit.callkeep.BackgroundPushNotificationIsolateBootstrapApi
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateBootstrapApi
+import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateApi
+import com.webtrit.callkeep.services.services.incoming_call.IncomingCallRelease
+import com.webtrit.callkeep.services.services.incoming_call.IncomingCallService
 import com.webtrit.signaling_service.SignalingForegroundService
 
 /// App-level initialization that wires together two independent Flutter plugins:
@@ -44,6 +47,35 @@ class WebtritApplication : Application() {
             PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(
                 messenger,
                 BackgroundPushNotificationIsolateBootstrapApi(context),
+            )
+            // Register the full isolate API on the FGS engine so that releaseCall() /
+            // endCall() triggered from onSignalingBackgroundCallEvent reach a handler
+            // instead of timing out. The implementation delegates to IncomingCallService
+            // via its existing broadcast mechanism — the same path used by all other callers.
+            // If IncomingCallService is not running the broadcast is silently dropped.
+            PHostBackgroundPushNotificationIsolateApi.setUp(
+                messenger,
+                object : PHostBackgroundPushNotificationIsolateApi {
+                    override fun releaseCall(callId: String, callback: (Result<Unit>) -> Unit) {
+                        IncomingCallService.release(context, IncomingCallRelease.IC_RELEASE_WITH_DECLINE)
+                        callback(Result.success(Unit))
+                    }
+
+                    override fun endCall(callId: String, callback: (Result<Unit>) -> Unit) {
+                        IncomingCallService.release(context, IncomingCallRelease.IC_RELEASE_WITH_DECLINE)
+                        callback(Result.success(Unit))
+                    }
+
+                    override fun endAllCalls(callback: (Result<Unit>) -> Unit) {
+                        IncomingCallService.release(context, IncomingCallRelease.IC_RELEASE_WITH_DECLINE)
+                        callback(Result.success(Unit))
+                    }
+
+                    override fun handoffCall(callId: String, callback: (Result<Unit>) -> Unit) {
+                        // FGS owns the WebSocket in persistent mode; handoff is not applicable.
+                        callback(Result.success(Unit))
+                    }
+                },
             )
         }
     }

--- a/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
+++ b/android/app/src/main/kotlin/com/webtrit/app/WebtritApplication.kt
@@ -3,6 +3,7 @@ package com.webtrit.app
 import android.app.Application
 import com.webtrit.callkeep.BackgroundPushNotificationIsolateBootstrapApi
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateBootstrapApi
+import android.util.Log
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateApi
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.core.CallkeepCore
@@ -60,18 +61,33 @@ class WebtritApplication : Application() {
                 messenger,
                 object : PHostBackgroundPushNotificationIsolateApi {
                     override fun releaseCall(callId: String, callback: (Result<Unit>) -> Unit) {
-                        CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
-                        callback(Result.success(Unit))
+                        try {
+                            CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
+                            callback(Result.success(Unit))
+                        } catch (e: Exception) {
+                            Log.e("WebtritApplication", "releaseCall failed for callId=$callId", e)
+                            callback(Result.failure(e))
+                        }
                     }
 
                     override fun endCall(callId: String, callback: (Result<Unit>) -> Unit) {
-                        CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
-                        callback(Result.success(Unit))
+                        try {
+                            CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
+                            callback(Result.success(Unit))
+                        } catch (e: Exception) {
+                            Log.e("WebtritApplication", "endCall failed for callId=$callId", e)
+                            callback(Result.failure(e))
+                        }
                     }
 
                     override fun endAllCalls(callback: (Result<Unit>) -> Unit) {
-                        CallkeepCore.instance.sendTearDownConnections()
-                        callback(Result.success(Unit))
+                        try {
+                            CallkeepCore.instance.sendTearDownConnections()
+                            callback(Result.success(Unit))
+                        } catch (e: Exception) {
+                            Log.e("WebtritApplication", "endAllCalls failed", e)
+                            callback(Result.failure(e))
+                        }
                     }
 
                     override fun handoffCall(callId: String, callback: (Result<Unit>) -> Unit) {

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -27,7 +27,7 @@ import 'package:webtrit_phone/push_notification/push_notifications.dart';
 import 'package:webtrit_phone/features/system_notifications/services/services.dart';
 
 import 'package:webtrit_phone/features/call/call.dart'
-    show onPushNotificationSyncCallback, onSignalingBackgroundIncomingCall;
+    show onPushNotificationSyncCallback, onSignalingBackgroundCallEvent;
 
 import 'package:drift/isolate.dart';
 
@@ -239,13 +239,13 @@ Future<void> _initCallkeep(FeatureAccess featureAccess) async {
     logger.severe('initializeCallback failed -- push notifications may not work in background', e, s);
   }
 
-  // Registers the top-level callback invoked by the signaling background isolate when an
-  // incoming call arrives in persistent mode (app closed or backgrounded). Must be
-  // annotated @pragma('vm:entry-point').
+  // Registers the top-level callback invoked by the signaling background isolate when a
+  // call-relevant event (IncomingCallEvent, HangupEvent) arrives in persistent mode
+  // (app closed or backgrounded). Must be annotated @pragma('vm:entry-point').
   try {
-    await WebtritSignalingService.setIncomingCallHandler(onSignalingBackgroundIncomingCall);
+    await WebtritSignalingService.setCallEventHandler(onSignalingBackgroundCallEvent);
   } catch (e, s) {
-    logger.severe('setIncomingCallHandler failed -- incoming calls in persistent mode may not work', e, s);
+    logger.severe('setCallEventHandler failed -- call events in persistent mode may not work', e, s);
   }
 
   // Configures Android CallKeep to process incoming SMS messages as call triggers

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -159,36 +159,55 @@ Future<void> onPushNotificationSyncCallback(CallkeepIncomingCallMetadata? metada
   }
 }
 
-/// Called by the [WebtritSignalingService] plugin when an incoming call
-/// arrives via the persistent foreground-service WebSocket connection.
+/// Called by the [WebtritSignalingService] plugin when a call-relevant signaling
+/// event arrives via the persistent foreground-service WebSocket connection.
 ///
 /// Runs inside the foreground-service background isolate. Must be a top-level
 /// function annotated with [@pragma('vm:entry-point')] so that [PluginUtilities]
 /// can serialise its handle.
 ///
-/// Reports the call to the Android telecom framework via [CallkeepHandle] so
-/// the system call UI is shown and the device rings. If reporting fails or
-/// times out, the error is logged and the call is silently dropped on the
-/// UI layer (the signaling session itself stays active).
+/// Handles [IncomingCallEvent] (report call to Android Telecom so the system
+/// call UI is shown) and [HangupEvent] (release the call so Telecom removes it
+/// and the notification is dismissed). Other event types are logged and ignored.
 @pragma('vm:entry-point')
-Future<void> onSignalingBackgroundIncomingCall(IncomingCallEvent event) async {
-  _logger.info('onSignalingBackgroundIncomingCall: callId=${event.callId} caller=${event.caller}');
+Future<void> onSignalingBackgroundCallEvent(Event event) async {
+  _logger.info('onSignalingBackgroundCallEvent: ${event.runtimeType}');
 
-  final error = await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
-      .reportNewIncomingCall(
-        event.callId,
-        CallkeepHandle.number(event.caller),
-        displayName: event.callerDisplayName?.isEmpty == true ? null : event.callerDisplayName,
-      )
-      .timeout(
-        const Duration(seconds: 10),
-        onTimeout: () {
-          _logger.severe('onSignalingBackgroundIncomingCall: reportNewIncomingCall timed out callId=${event.callId}');
-          return null;
-        },
-      );
+  switch (event) {
+    case IncomingCallEvent():
+      final error = await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
+          .reportNewIncomingCall(
+            event.callId,
+            CallkeepHandle.number(event.caller),
+            displayName: event.callerDisplayName?.isEmpty == true ? null : event.callerDisplayName,
+          )
+          .timeout(
+            const Duration(seconds: 10),
+            onTimeout: () {
+              _logger.severe('onSignalingBackgroundCallEvent: reportNewIncomingCall timed out callId=${event.callId}');
+              return null;
+            },
+          );
 
-  if (error != null) {
-    _logger.warning('onSignalingBackgroundIncomingCall: reportNewIncomingCall error=$error callId=${event.callId}');
+      if (error != null) {
+        _logger.warning('onSignalingBackgroundCallEvent: reportNewIncomingCall error=$error callId=${event.callId}');
+      }
+
+    case HangupEvent():
+      try {
+        await AndroidCallkeepServices.backgroundPushNotificationService
+            .releaseCall(event.callId)
+            .timeout(
+              const Duration(seconds: 10),
+              onTimeout: () {
+                _logger.severe('onSignalingBackgroundCallEvent: releaseCall timed out callId=${event.callId}');
+              },
+            );
+      } catch (e) {
+        _logger.warning('onSignalingBackgroundCallEvent: releaseCall error=$e callId=${event.callId}');
+      }
+
+    default:
+      _logger.warning('onSignalingBackgroundCallEvent: unhandled event ${event.runtimeType}');
   }
 }

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -175,7 +175,7 @@ Future<void> onSignalingBackgroundCallEvent(Event event) async {
 
   switch (event) {
     case IncomingCallEvent():
-      // TODO: using backgroundPushNotificationBootstrapService here is a workaround —
+      // TODO: using backgroundPushNotificationBootstrapService here is a workaround -
       // it is the push-notification bootstrap pathway and has a side effect of triggering
       // onPushNotificationSyncCallback via IncomingCallService when the app is in the
       // background. A guard in that callback suppresses it, but the root cause is that

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -175,6 +175,14 @@ Future<void> onSignalingBackgroundCallEvent(Event event) async {
 
   switch (event) {
     case IncomingCallEvent():
+      // TODO: using backgroundPushNotificationBootstrapService here is a workaround —
+      // it is the push-notification bootstrap pathway and has a side effect of triggering
+      // onPushNotificationSyncCallback via IncomingCallService when the app is in the
+      // background. A guard in that callback suppresses it, but the root cause is that
+      // the FGS engine lacks a direct way to trigger the callkeep incoming-call flow
+      // without going through the push-notification machinery. A dedicated API or Pigeon
+      // channel that exposes this to the FGS context without the push-path side effects
+      // should replace this call.
       final error = await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
           .reportNewIncomingCall(
             event.callId,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -45,7 +45,7 @@ final _logger = Logger('WebtritSignalingService');
 /// Static setup (call once during app bootstrap before creating instances):
 ///   - [setModuleFactory] -- registers the [SignalingModule] factory for
 ///     the background isolate.
-///   - [setIncomingCallHandler] -- registers the incoming call callback for
+///   - [setCallEventHandler] -- registers the call-event callback for
 ///     background handling.
 ///   - [updateMode] -- switches the service lifecycle mode.
 class WebtritSignalingService implements SignalingModule {
@@ -220,13 +220,13 @@ class WebtritSignalingService implements SignalingModule {
   static Future<void> setModuleFactory(SignalingModuleFactory factory) =>
       SignalingServicePlatform.instance.setModuleFactory(factory);
 
-  /// Registers the app-side incoming call callback for background handling.
+  /// Registers the app-side call-event callback for background handling.
   ///
   /// [callback] must be a top-level function annotated with
   /// [@pragma('vm:entry-point')]. Must be called before
   /// [WebtritSignalingService.new].
-  static Future<void> setIncomingCallHandler(Function callback) =>
-      SignalingServicePlatform.instance.setIncomingCallHandler(callback);
+  static Future<void> setCallEventHandler(Function callback) =>
+      SignalingServicePlatform.instance.setCallEventHandler(callback);
 
   /// Switches the service lifecycle mode without restarting the connection.
   static Future<void> updateMode(SignalingServiceMode mode) => SignalingServicePlatform.instance.updateMode(mode);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -20,7 +20,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   final List<Request> executedRequests = [];
   Object? executeError;
   final List<SignalingServiceMode> updatedModes = [];
-  final List<Function> incomingCallHandles = [];
+  final List<Function> callEventHandles = [];
   final List<SignalingModuleFactory> moduleFactories = [];
   int disposeCount = 0;
   int stopServiceCount = 0;
@@ -50,7 +50,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   Future<void> updateMode(SignalingServiceMode mode) async => updatedModes.add(mode);
 
   @override
-  Future<void> setIncomingCallHandler(Function callback) async => incomingCallHandles.add(callback);
+  Future<void> setCallEventHandler(Function callback) async => callEventHandles.add(callback);
 
   @override
   Future<void> setModuleFactory(SignalingModuleFactory factory) async => moduleFactories.add(factory);
@@ -288,14 +288,14 @@ void main() {
       expect(platform.moduleFactories, [_dummyFactory]);
     });
 
-    test('setIncomingCallHandler delegates to platform', () async {
-      await WebtritSignalingService.setIncomingCallHandler(_dummyHandler);
-      expect(platform.incomingCallHandles, [_dummyHandler]);
+    test('setCallEventHandler delegates to platform', () async {
+      await WebtritSignalingService.setCallEventHandler(_dummyHandler);
+      expect(platform.callEventHandles, [_dummyHandler]);
     });
 
-    test('setIncomingCallHandler with different callback', () async {
-      await WebtritSignalingService.setIncomingCallHandler(_anotherHandler);
-      expect(platform.incomingCallHandles, [_anotherHandler]);
+    test('setCallEventHandler with different callback', () async {
+      await WebtritSignalingService.setCallEventHandler(_anotherHandler);
+      expect(platform.callEventHandles, [_anotherHandler]);
     });
 
     test('updateMode persistent delegates to platform', () async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/Messages.g.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/Messages.g.kt
@@ -211,13 +211,13 @@ data class PSignalingServiceStatus (
    */
   val trustedCertificatesJson: String? = null,
   /**
-   * Raw handle for the app-side incoming call callback.
+   * Raw handle for the app-side call-event callback.
    *
    * Obtained via [PluginUtilities.getCallbackHandle] in the main isolate and
-   * persisted via [PSignalingServiceHostApi.saveIncomingCallHandler].
+   * persisted via [PSignalingServiceHostApi.saveCallEventHandler].
    * 0 means no handler is registered.
    */
-  val incomingCallHandlerHandle: Long,
+  val callEventHandlerHandle: Long,
   /**
    * Raw handle for the app-side [SignalingModuleFactory] callback.
    *
@@ -234,9 +234,9 @@ data class PSignalingServiceStatus (
       val tenantId = pigeonVar_list[2] as String
       val token = pigeonVar_list[3] as String
       val trustedCertificatesJson = pigeonVar_list[4] as String?
-      val incomingCallHandlerHandle = pigeonVar_list[5] as Long
+      val callEventHandlerHandle = pigeonVar_list[5] as Long
       val moduleFactoryHandle = pigeonVar_list[6] as Long
-      return PSignalingServiceStatus(enabled, coreUrl, tenantId, token, trustedCertificatesJson, incomingCallHandlerHandle, moduleFactoryHandle)
+      return PSignalingServiceStatus(enabled, coreUrl, tenantId, token, trustedCertificatesJson, callEventHandlerHandle, moduleFactoryHandle)
     }
   }
   fun toList(): List<Any?> {
@@ -246,7 +246,7 @@ data class PSignalingServiceStatus (
       tenantId,
       token,
       trustedCertificatesJson,
-      incomingCallHandlerHandle,
+      callEventHandlerHandle,
       moduleFactoryHandle,
     )
   }
@@ -258,7 +258,7 @@ data class PSignalingServiceStatus (
       return true
     }
     val other = other as PSignalingServiceStatus
-    return MessagesPigeonUtils.deepEquals(this.enabled, other.enabled) && MessagesPigeonUtils.deepEquals(this.coreUrl, other.coreUrl) && MessagesPigeonUtils.deepEquals(this.tenantId, other.tenantId) && MessagesPigeonUtils.deepEquals(this.token, other.token) && MessagesPigeonUtils.deepEquals(this.trustedCertificatesJson, other.trustedCertificatesJson) && MessagesPigeonUtils.deepEquals(this.incomingCallHandlerHandle, other.incomingCallHandlerHandle) && MessagesPigeonUtils.deepEquals(this.moduleFactoryHandle, other.moduleFactoryHandle)
+    return MessagesPigeonUtils.deepEquals(this.enabled, other.enabled) && MessagesPigeonUtils.deepEquals(this.coreUrl, other.coreUrl) && MessagesPigeonUtils.deepEquals(this.tenantId, other.tenantId) && MessagesPigeonUtils.deepEquals(this.token, other.token) && MessagesPigeonUtils.deepEquals(this.trustedCertificatesJson, other.trustedCertificatesJson) && MessagesPigeonUtils.deepEquals(this.callEventHandlerHandle, other.callEventHandlerHandle) && MessagesPigeonUtils.deepEquals(this.moduleFactoryHandle, other.moduleFactoryHandle)
   }
 
   override fun hashCode(): Int {
@@ -268,7 +268,7 @@ data class PSignalingServiceStatus (
     result = 31 * result + MessagesPigeonUtils.deepHash(this.tenantId)
     result = 31 * result + MessagesPigeonUtils.deepHash(this.token)
     result = 31 * result + MessagesPigeonUtils.deepHash(this.trustedCertificatesJson)
-    result = 31 * result + MessagesPigeonUtils.deepHash(this.incomingCallHandlerHandle)
+    result = 31 * result + MessagesPigeonUtils.deepHash(this.callEventHandlerHandle)
     result = 31 * result + MessagesPigeonUtils.deepHash(this.moduleFactoryHandle)
     return result
   }
@@ -316,13 +316,13 @@ interface PSignalingServiceHostApi {
    */
   fun saveTrustedCertificates(certificatesJson: String?)
   /**
-   * Persist the raw callback handle for the app-side incoming call handler.
+   * Persist the raw callback handle for the app-side call-event handler.
    *
    * The handle is obtained via [PluginUtilities.getCallbackHandle] on a
    * top-level function annotated with [@pragma('vm:entry-point')].
    * Pass 0 to unregister.
    */
-  fun saveIncomingCallHandler(callbackHandle: Long)
+  fun saveCallEventHandler(callbackHandle: Long)
   /**
    * Persist the raw callback handle for the app-side [SignalingModuleFactory].
    *
@@ -430,13 +430,13 @@ interface PSignalingServiceHostApi {
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_signaling_service_android.PSignalingServiceHostApi.saveIncomingCallHandler$separatedMessageChannelSuffix", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_signaling_service_android.PSignalingServiceHostApi.saveCallEventHandler$separatedMessageChannelSuffix", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val callbackHandleArg = args[0] as Long
             val wrapped: List<Any?> = try {
-              api.saveIncomingCallHandler(callbackHandleArg)
+              api.saveCallEventHandler(callbackHandleArg)
               listOf(null)
             } catch (exception: Throwable) {
               MessagesPigeonUtils.wrapError(exception)

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/SignalingForegroundService.kt
@@ -411,7 +411,7 @@ class SignalingForegroundService : Service() {
                 tenantId = "",
                 token = "",
                 trustedCertificatesJson = null,
-                incomingCallHandlerHandle = 0L,
+                callEventHandlerHandle = 0L,
                 moduleFactoryHandle = 0L,
             ),
         ) { result ->
@@ -461,7 +461,7 @@ class SignalingForegroundService : Service() {
         override fun initializeServiceCallback(callbackDispatcher: Long, onSync: Long) {}
         override fun saveConnectionConfig(coreUrl: String, tenantId: String, token: String) {}
         override fun saveTrustedCertificates(certificatesJson: String?) {}
-        override fun saveIncomingCallHandler(callbackHandle: Long) {}
+        override fun saveCallEventHandler(callbackHandle: Long) {}
         override fun saveModuleFactory(callbackHandle: Long) {}
         override fun configureService(notificationTitle: String, notificationDescription: String) {}
         override fun startService() {}
@@ -501,7 +501,7 @@ class SignalingForegroundService : Service() {
                 tenantId = tenantId,
                 token = token,
                 trustedCertificatesJson = StorageDelegate.getTrustedCertificatesJson(applicationContext),
-                incomingCallHandlerHandle = StorageDelegate.getIncomingCallHandler(applicationContext),
+                callEventHandlerHandle = StorageDelegate.getCallEventHandler(applicationContext),
                 moduleFactoryHandle = StorageDelegate.getModuleFactoryHandle(applicationContext),
             ),
         ) { result ->

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/StorageDelegate.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/StorageDelegate.kt
@@ -13,7 +13,7 @@ object StorageDelegate {
     private const val KEY_CORE_URL = "core_url"
     private const val KEY_TENANT_ID = "tenant_id"
     private const val KEY_TOKEN = "token"
-    private const val KEY_INCOMING_CALL_HANDLER = "incoming_call_handler"
+    private const val KEY_CALL_EVENT_HANDLER = "call_event_handler"
     private const val KEY_MODULE_FACTORY = "module_factory"
     private const val KEY_TRUSTED_CERTIFICATES = "trusted_certificates_json"
 
@@ -44,11 +44,11 @@ object StorageDelegate {
     fun getTenantId(context: Context): String = prefs(context).getString(KEY_TENANT_ID, "") ?: ""
     fun getToken(context: Context): String = prefs(context).getString(KEY_TOKEN, "") ?: ""
 
-    fun saveIncomingCallHandler(context: Context, handle: Long) =
-        prefs(context).edit().putLong(KEY_INCOMING_CALL_HANDLER, handle).apply()
+    fun saveCallEventHandler(context: Context, handle: Long) =
+        prefs(context).edit().putLong(KEY_CALL_EVENT_HANDLER, handle).apply()
 
-    fun getIncomingCallHandler(context: Context): Long =
-        prefs(context).getLong(KEY_INCOMING_CALL_HANDLER, 0L)
+    fun getCallEventHandler(context: Context): Long =
+        prefs(context).getLong(KEY_CALL_EVENT_HANDLER, 0L)
 
     fun saveModuleFactoryHandle(context: Context, handle: Long) =
         prefs(context).edit().putLong(KEY_MODULE_FACTORY, handle).apply()

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/StorageDelegate.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/StorageDelegate.kt
@@ -14,6 +14,7 @@ object StorageDelegate {
     private const val KEY_TENANT_ID = "tenant_id"
     private const val KEY_TOKEN = "token"
     private const val KEY_CALL_EVENT_HANDLER = "call_event_handler"
+    private const val KEY_CALL_EVENT_HANDLER_LEGACY = "incoming_call_handler"
     private const val KEY_MODULE_FACTORY = "module_factory"
     private const val KEY_TRUSTED_CERTIFICATES = "trusted_certificates_json"
 
@@ -47,8 +48,15 @@ object StorageDelegate {
     fun saveCallEventHandler(context: Context, handle: Long) =
         prefs(context).edit().putLong(KEY_CALL_EVENT_HANDLER, handle).apply()
 
-    fun getCallEventHandler(context: Context): Long =
-        prefs(context).getLong(KEY_CALL_EVENT_HANDLER, 0L)
+    fun getCallEventHandler(context: Context): Long {
+        val p = prefs(context)
+        val handle = p.getLong(KEY_CALL_EVENT_HANDLER, 0L)
+        if (handle != 0L) return handle
+        // Fallback: read the pre-rename key written by older app versions and migrate.
+        val legacy = p.getLong(KEY_CALL_EVENT_HANDLER_LEGACY, 0L)
+        if (legacy != 0L) p.edit().putLong(KEY_CALL_EVENT_HANDLER, legacy).apply()
+        return legacy
+    }
 
     fun saveModuleFactoryHandle(context: Context, handle: Long) =
         prefs(context).edit().putLong(KEY_MODULE_FACTORY, handle).apply()

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/android/src/main/kotlin/com/webtrit/signaling_service/WebtritSignalingServicePlugin.kt
@@ -56,9 +56,9 @@ class WebtritSignalingServicePlugin : FlutterPlugin, PSignalingServiceHostApi {
         StorageDelegate.saveConnectionConfig(context, coreUrl, tenantId, token)
     }
 
-    override fun saveIncomingCallHandler(callbackHandle: Long) {
-        Log.d(TAG, "saveIncomingCallHandler handle=$callbackHandle")
-        StorageDelegate.saveIncomingCallHandler(context, callbackHandle)
+    override fun saveCallEventHandler(callbackHandle: Long) {
+        Log.d(TAG, "saveCallEventHandler handle=$callbackHandle")
+        StorageDelegate.saveCallEventHandler(context, callbackHandle)
     }
 
     override fun saveModuleFactory(callbackHandle: Long) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/isolate/signaling_foreground_isolate_manager.dart
@@ -301,7 +301,7 @@ class SignalingForegroundIsolateManager {
   /// The callback is a top-level Dart function annotated with
   /// [@pragma('vm:entry-point')] that the app registered via
   /// [WebtritSignalingService.setCallEventHandler]. It receives a signaling
-  /// [Event] and is responsible for callkeep integration — creating a call for
+  /// [Event] and is responsible for callkeep integration - creating a call for
   /// [IncomingCallEvent] and releasing it for [HangupEvent].
   void _dispatchCallEvent(CallEvent event) {
     if (callEventHandlerHandle == 0) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/isolate/signaling_foreground_isolate_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/isolate/signaling_foreground_isolate_manager.dart
@@ -30,17 +30,18 @@ typedef SignalingHubFactory = SignalingHub Function(SignalingModule module);
 /// is resolved from [PluginUtilities] so the factory can be called in the
 /// background isolate without the main isolate being alive.
 ///
-/// When an [IncomingCallEvent] arrives and [incomingCallHandlerHandle] is
-/// non-zero, the manager resolves the registered Dart callback via
-/// [PluginUtilities.getCallbackFromHandle] and invokes it with the event so
-/// that the app side can trigger callkeep without depending on this plugin.
+/// When an [IncomingCallEvent] or [HangupEvent] arrives and
+/// [callEventHandlerHandle] is non-zero, the manager resolves the registered
+/// Dart callback via [PluginUtilities.getCallbackFromHandle] and invokes it
+/// with the event so that the app side can drive callkeep without depending on
+/// the main isolate being alive.
 class SignalingForegroundIsolateManager {
   SignalingForegroundIsolateManager({
     required this.coreUrl,
     required this.tenantId,
     required this.token,
     this.trustedCertificatesJson,
-    this.incomingCallHandlerHandle = 0,
+    this.callEventHandlerHandle = 0,
     this.moduleFactoryHandle = 0,
     this.safetyReconnectGrace = const Duration(seconds: 2),
     @visibleForTesting SignalingModuleFactory? moduleFactory,
@@ -57,14 +58,14 @@ class SignalingForegroundIsolateManager {
   /// Null when the app uses the default system trust store.
   final String? trustedCertificatesJson;
 
-  /// Raw handle for the app-side incoming call callback.
+  /// Raw handle for the app-side call-event callback.
   ///
-  /// Registered by the app via [WebtritSignalingService.setIncomingCallHandler].
-  /// 0 means no handler is registered -- incoming calls are only forwarded to
-  /// the hub (main isolate) and silently ignored in the background.
+  /// Registered by the app via [WebtritSignalingService.setCallEventHandler].
+  /// 0 means no handler is registered -- call events are only forwarded to the
+  /// hub (main isolate) and silently ignored in the background.
   /// Mutable so it can be updated in-place when the Activity re-registers the
   /// handler without requiring a WebSocket restart.
-  int incomingCallHandlerHandle;
+  int callEventHandlerHandle;
 
   /// Raw handle for the app-side [SignalingModuleFactory] callback.
   ///
@@ -104,16 +105,16 @@ class SignalingForegroundIsolateManager {
 
   /// Updates runtime handles in-place without restarting the WebSocket connection.
   ///
-  /// Called by [SignalingSyncHandler] when only [incomingCallHandlerHandle] or
+  /// Called by [SignalingSyncHandler] when only [callEventHandlerHandle] or
   /// [moduleFactoryHandle] changed — e.g. when the Activity re-registers them
   /// after opening from a push notification. Neither handle affects the live
   /// WebSocket session, so no reconnect is needed.
-  void updateHandles({required int incomingCallHandlerHandle, required int moduleFactoryHandle}) {
-    this.incomingCallHandlerHandle = incomingCallHandlerHandle;
+  void updateHandles({required int callEventHandlerHandle, required int moduleFactoryHandle}) {
+    this.callEventHandlerHandle = callEventHandlerHandle;
     this.moduleFactoryHandle = moduleFactoryHandle;
     _logger.info(
       'SignalingForegroundIsolateManager handles updated in-place '
-      'incomingCallHandlerHandle=$incomingCallHandlerHandle moduleFactoryHandle=$moduleFactoryHandle',
+      'callEventHandlerHandle=$callEventHandlerHandle moduleFactoryHandle=$moduleFactoryHandle',
     );
   }
 
@@ -140,7 +141,7 @@ class SignalingForegroundIsolateManager {
       return;
     }
 
-    _logger.info('SignalingForegroundIsolateManager starting (incomingCallHandler=${incomingCallHandlerHandle != 0})');
+    _logger.info('SignalingForegroundIsolateManager starting (callEventHandler=${callEventHandlerHandle != 0})');
 
     final factory = _testModuleFactory ?? _resolveModuleFactory();
     if (factory == null) return;
@@ -226,8 +227,8 @@ class SignalingForegroundIsolateManager {
         _logger.info('IsolateManager: handshake lines=${handshake.lines}');
       case SignalingProtocolEvent(:final event):
         _logger.info('IsolateManager: protocol event ${event.runtimeType}');
-        if (event is IncomingCallEvent) {
-          _dispatchIncomingCall(event);
+        if (event is IncomingCallEvent || event is HangupEvent) {
+          _dispatchCallEvent(event as CallEvent);
         }
       case SignalingDisconnected(:final code, :final reason, :final recommendedReconnectDelay):
         _logger.info('IsolateManager: disconnected code=$code reason=$reason');
@@ -295,37 +296,38 @@ class SignalingForegroundIsolateManager {
     });
   }
 
-  /// Invokes the app-registered incoming call callback in this background isolate.
+  /// Invokes the app-registered call-event callback in this background isolate.
   ///
   /// The callback is a top-level Dart function annotated with
   /// [@pragma('vm:entry-point')] that the app registered via
-  /// [WebtritSignalingService.setIncomingCallHandler]. It receives the raw
-  /// [IncomingCallEvent] and is responsible for callkeep integration.
-  void _dispatchIncomingCall(IncomingCallEvent event) {
-    if (incomingCallHandlerHandle == 0) {
+  /// [WebtritSignalingService.setCallEventHandler]. It receives a signaling
+  /// [Event] and is responsible for callkeep integration — creating a call for
+  /// [IncomingCallEvent] and releasing it for [HangupEvent].
+  void _dispatchCallEvent(CallEvent event) {
+    if (callEventHandlerHandle == 0) {
       _logger.warning(
-        'IsolateManager: IncomingCallEvent received but no handler registered -- call will be missed in background',
+        'IsolateManager: ${event.runtimeType} received but no call-event handler registered -- event will be ignored in background',
       );
       return;
     }
 
-    final callback = PluginUtilities.getCallbackFromHandle(CallbackHandle.fromRawHandle(incomingCallHandlerHandle));
+    final callback = PluginUtilities.getCallbackFromHandle(CallbackHandle.fromRawHandle(callEventHandlerHandle));
     if (callback == null) {
-      _logger.severe('IsolateManager: could not resolve incoming call handler from handle $incomingCallHandlerHandle');
+      _logger.severe('IsolateManager: could not resolve call-event handler from handle $callEventHandlerHandle');
       return;
     }
 
-    _logger.info('IsolateManager: dispatching IncomingCallEvent callId=${event.callId} to app handler');
+    _logger.info('IsolateManager: dispatching ${event.runtimeType} callId=${event.callId} to app handler');
     try {
       // Use Function.apply so both sync and async callbacks work.
       final dynamic result = Function.apply(callback, [event]);
       if (result is Future<dynamic>) {
         result.catchError((Object e, StackTrace st) {
-          _logger.severe('IsolateManager: incoming call handler async error', e, st);
+          _logger.severe('IsolateManager: call-event handler async error', e, st);
         });
       }
     } catch (e, st) {
-      _logger.severe('IsolateManager: incoming call handler threw', e, st);
+      _logger.severe('IsolateManager: call-event handler threw', e, st);
     }
   }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/isolate/signaling_sync_handler.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/isolate/signaling_sync_handler.dart
@@ -23,17 +23,17 @@ Future<void> pendingSync = Future.value();
 Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
   _logger.info(
     'onSignalingServiceSync enabled=${status.enabled} tenantId=${status.tenantId} '
-    'hasIncomingCallHandler=${status.incomingCallHandlerHandle != 0} '
+    'hasCallEventHandler=${status.callEventHandlerHandle != 0} '
     'hasModuleFactory=${status.moduleFactoryHandle != 0}',
   );
   if (status.enabled) {
     final existing = _manager;
     if (existing != null) {
-      // Handles (incomingCallHandlerHandle, moduleFactoryHandle) are runtime
+      // Handles (callEventHandlerHandle, moduleFactoryHandle) are runtime
       // metadata — they change when the Activity re-registers them after opening
       // from a push notification but do not affect the live WebSocket session.
       final handlesChanged =
-          existing.incomingCallHandlerHandle != status.incomingCallHandlerHandle ||
+          existing.callEventHandlerHandle != status.callEventHandlerHandle ||
           existing.moduleFactoryHandle != status.moduleFactoryHandle;
 
       // Connection params require a new WebSocket session (re-login, token
@@ -50,7 +50,7 @@ Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
         if (handlesChanged) {
           _logger.info('onSignalingServiceSync handles changed during active call — updating in-place');
           existing.updateHandles(
-            incomingCallHandlerHandle: status.incomingCallHandlerHandle,
+            callEventHandlerHandle: status.callEventHandlerHandle,
             moduleFactoryHandle: status.moduleFactoryHandle,
           );
         }
@@ -61,7 +61,7 @@ Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
       } else if (handlesChanged && !connectionConfigChanged) {
         _logger.info('onSignalingServiceSync handles changed — updating in-place, no WebSocket restart');
         existing.updateHandles(
-          incomingCallHandlerHandle: status.incomingCallHandlerHandle,
+          callEventHandlerHandle: status.callEventHandlerHandle,
           moduleFactoryHandle: status.moduleFactoryHandle,
         );
       } else if (connectionConfigChanged) {
@@ -79,7 +79,7 @@ Future<void> onSignalingServiceSync(PSignalingServiceStatus status) async {
       tenantId: status.tenantId,
       token: status.token,
       trustedCertificatesJson: status.trustedCertificatesJson,
-      incomingCallHandlerHandle: status.incomingCallHandlerHandle,
+      callEventHandlerHandle: status.callEventHandlerHandle,
       moduleFactoryHandle: status.moduleFactoryHandle,
     );
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/messages.g.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/messages.g.dart
@@ -114,7 +114,7 @@ class PSignalingServiceStatus {
     required this.tenantId,
     required this.token,
     this.trustedCertificatesJson,
-    required this.incomingCallHandlerHandle,
+    required this.callEventHandlerHandle,
     required this.moduleFactoryHandle,
   });
 
@@ -134,12 +134,12 @@ class PSignalingServiceStatus {
   /// to the main-isolate DI context.
   String? trustedCertificatesJson;
 
-  /// Raw handle for the app-side incoming call callback.
+  /// Raw handle for the app-side call-event callback.
   ///
   /// Obtained via [PluginUtilities.getCallbackHandle] in the main isolate and
-  /// persisted via [PSignalingServiceHostApi.saveIncomingCallHandler].
+  /// persisted via [PSignalingServiceHostApi.saveCallEventHandler].
   /// 0 means no handler is registered.
-  int incomingCallHandlerHandle;
+  int callEventHandlerHandle;
 
   /// Raw handle for the app-side [SignalingModuleFactory] callback.
   ///
@@ -154,7 +154,7 @@ class PSignalingServiceStatus {
       tenantId,
       token,
       trustedCertificatesJson,
-      incomingCallHandlerHandle,
+      callEventHandlerHandle,
       moduleFactoryHandle,
     ];
   }
@@ -170,7 +170,7 @@ class PSignalingServiceStatus {
       tenantId: result[2]! as String,
       token: result[3]! as String,
       trustedCertificatesJson: result[4] as String?,
-      incomingCallHandlerHandle: result[5]! as int,
+      callEventHandlerHandle: result[5]! as int,
       moduleFactoryHandle: result[6]! as int,
     );
   }
@@ -184,7 +184,7 @@ class PSignalingServiceStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(enabled, other.enabled) && _deepEquals(coreUrl, other.coreUrl) && _deepEquals(tenantId, other.tenantId) && _deepEquals(token, other.token) && _deepEquals(trustedCertificatesJson, other.trustedCertificatesJson) && _deepEquals(incomingCallHandlerHandle, other.incomingCallHandlerHandle) && _deepEquals(moduleFactoryHandle, other.moduleFactoryHandle);
+    return _deepEquals(enabled, other.enabled) && _deepEquals(coreUrl, other.coreUrl) && _deepEquals(tenantId, other.tenantId) && _deepEquals(token, other.token) && _deepEquals(trustedCertificatesJson, other.trustedCertificatesJson) && _deepEquals(callEventHandlerHandle, other.callEventHandlerHandle) && _deepEquals(moduleFactoryHandle, other.moduleFactoryHandle);
   }
 
   @override
@@ -295,13 +295,13 @@ class PSignalingServiceHostApi {
     ;
   }
 
-  /// Persist the raw callback handle for the app-side incoming call handler.
+  /// Persist the raw callback handle for the app-side call-event handler.
   ///
   /// The handle is obtained via [PluginUtilities.getCallbackHandle] on a
   /// top-level function annotated with [@pragma('vm:entry-point')].
   /// Pass 0 to unregister.
-  Future<void> saveIncomingCallHandler(int callbackHandle) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_signaling_service_android.PSignalingServiceHostApi.saveIncomingCallHandler$pigeonVar_messageChannelSuffix';
+  Future<void> saveCallEventHandler(int callbackHandle) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_signaling_service_android.PSignalingServiceHostApi.saveCallEventHandler$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -201,16 +201,16 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   }
 
   @override
-  Future<void> setIncomingCallHandler(Function callback) async {
+  Future<void> setCallEventHandler(Function callback) async {
     final handle = PluginUtilities.getCallbackHandle(callback);
     if (handle == null) {
       _logger.warning(
-        'setIncomingCallHandler: could not obtain callback handle -- '
+        'setCallEventHandler: could not obtain callback handle -- '
         'ensure the function is top-level and annotated with @pragma(\'vm:entry-point\')',
       );
       return;
     }
-    await _hostApi.saveIncomingCallHandler(handle.toRawHandle());
+    await _hostApi.saveCallEventHandler(handle.toRawHandle());
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pigeons/signaling.messages.dart
@@ -21,7 +21,7 @@ class PSignalingServiceStatus {
     required this.coreUrl,
     required this.tenantId,
     required this.token,
-    required this.incomingCallHandlerHandle,
+    required this.callEventHandlerHandle,
     required this.moduleFactoryHandle,
     this.trustedCertificatesJson,
   });
@@ -39,12 +39,12 @@ class PSignalingServiceStatus {
   /// to the main-isolate DI context.
   final String? trustedCertificatesJson;
 
-  /// Raw handle for the app-side incoming call callback.
+  /// Raw handle for the app-side call-event callback.
   ///
   /// Obtained via [PluginUtilities.getCallbackHandle] in the main isolate and
-  /// persisted via [PSignalingServiceHostApi.saveIncomingCallHandler].
+  /// persisted via [PSignalingServiceHostApi.saveCallEventHandler].
   /// 0 means no handler is registered.
-  final int incomingCallHandlerHandle;
+  final int callEventHandlerHandle;
 
   /// Raw handle for the app-side [SignalingModuleFactory] callback.
   ///
@@ -74,12 +74,12 @@ abstract class PSignalingServiceHostApi {
   /// so the isolate receives the correct TLS configuration on first sync.
   void saveTrustedCertificates(String? certificatesJson);
 
-  /// Persist the raw callback handle for the app-side incoming call handler.
+  /// Persist the raw callback handle for the app-side call-event handler.
   ///
   /// The handle is obtained via [PluginUtilities.getCallbackHandle] on a
   /// top-level function annotated with [@pragma('vm:entry-point')].
   /// Pass 0 to unregister.
-  void saveIncomingCallHandler(int callbackHandle);
+  void saveCallEventHandler(int callbackHandle);
 
   /// Persist the raw callback handle for the app-side [SignalingModuleFactory].
   ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
@@ -305,14 +305,14 @@ class _TestIsolateManager {
     required this.tenantId,
     required this.token,
     required this.signalingClientFactory,
-    this.incomingCallHandlerHandle = 0,
+    this.callEventHandlerHandle = 0,
   });
 
   final String coreUrl;
   final String tenantId;
   final String token;
   final _SignalingClientFactory signalingClientFactory;
-  final int incomingCallHandlerHandle;
+  final int callEventHandlerHandle;
 
   _SignalingModule? _module;
   SignalingHub? _hub;
@@ -814,14 +814,14 @@ void main() {
     });
 
     test('IncomingCallEvent with no handler registered does not throw', () async {
-      // When incomingCallHandlerHandle == 0 (default), _dispatchIncomingCall logs
+      // When callEventHandlerHandle == 0 (default), _dispatchCallEvent logs
       // a warning but must not throw and must not crash the event pipeline.
       final fakeClient = _FakeSignalingClient();
       final manager = _TestIsolateManager(
         coreUrl: 'https://example.com',
         tenantId: 'tenant',
         token: 'token',
-        incomingCallHandlerHandle: 0, // no handler
+        callEventHandlerHandle: 0, // no handler
         signalingClientFactory: _fakeFactory(fakeClient),
       );
       addTearDown(() => manager.handleStatus(enabled: false));

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
@@ -238,10 +238,10 @@ class _FailingSignalingModule implements SignalingModule {
 
 const _kConfig = SignalingServiceConfig(coreUrl: 'wss://example.com', tenantId: 'tenant', token: 'tok');
 
-// Dummy top-level callbacks used to test setIncomingCallHandler.
+// Dummy top-level callbacks used to test setCallEventHandler.
 // On iOS the method is a no-op, so the actual implementation does not matter.
-Future<void> _dummyIncomingCallHandler(IncomingCallEvent event) async {}
-Future<void> _anotherDummyHandler(IncomingCallEvent event) async {}
+Future<void> _dummyIncomingCallHandler(Event event) async {}
+Future<void> _anotherDummyHandler(Event event) async {}
 
 final _kHandshake = StateHandshake(
   keepaliveInterval: const Duration(seconds: 30),
@@ -517,22 +517,22 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // setIncomingCallHandler() -- no-op on iOS
+  // setCallEventHandler() -- no-op on iOS
   // -------------------------------------------------------------------------
 
-  group('WebtritSignalingServiceIos -- setIncomingCallHandler()', () {
+  group('WebtritSignalingServiceIos -- setCallEventHandler()', () {
     test('completes without error for a callback function', () async {
       final plugin = _buildPlugin(_failingFactory(Exception('x')));
       addTearDown(plugin.dispose);
 
-      await expectLater(plugin.setIncomingCallHandler(_dummyIncomingCallHandler), completes);
+      await expectLater(plugin.setCallEventHandler(_dummyIncomingCallHandler), completes);
     });
 
     test('completes without error for a different callback function', () async {
       final plugin = _buildPlugin(_failingFactory(Exception('x')));
       addTearDown(plugin.dispose);
 
-      await expectLater(plugin.setIncomingCallHandler(_anotherDummyHandler), completes);
+      await expectLater(plugin.setCallEventHandler(_anotherDummyHandler), completes);
     });
 
     test('does not affect the events stream', () async {
@@ -548,7 +548,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // let session buffer replay arrive
       events.clear();
 
-      await plugin.setIncomingCallHandler(_dummyIncomingCallHandler);
+      await plugin.setCallEventHandler(_dummyIncomingCallHandler);
       await Future<void>.delayed(Duration.zero);
 
       expect(events, isEmpty);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -159,7 +159,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
 
   @override
   // ignore: avoid_unused_parameters
-  Future<void> setIncomingCallHandler(Function callback) async {}
+  Future<void> setCallEventHandler(Function callback) async {}
 
   @override
   Future<void> stopService() async {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -50,17 +50,17 @@ abstract class SignalingServicePlatform extends PlatformInterface {
   /// On iOS this is a no-op.
   Future<void> updateMode(SignalingServiceMode mode);
 
-  /// Registers the app-side incoming call callback for background handling.
+  /// Registers the app-side call-event callback for background handling.
   ///
   /// [callback] must be a top-level function annotated with
-  /// [@pragma('vm:entry-point')]. It receives an [IncomingCallEvent] and is
-  /// responsible for triggering callkeep when an incoming call arrives while
-  /// the app is closed.
+  /// [@pragma('vm:entry-point')]. It receives a signaling [Event] (currently
+  /// [IncomingCallEvent] and [HangupEvent]) and is responsible for callkeep
+  /// integration when a call event arrives while the app is closed.
   ///
   /// On Android the raw callback handle is persisted via [PluginUtilities] so
   /// the foreground-service isolate can invoke it without the main isolate being
   /// alive. On iOS this is a no-op.
-  Future<void> setIncomingCallHandler(Function callback);
+  Future<void> setCallEventHandler(Function callback);
 
   /// Registers the factory used to create [SignalingModule] instances.
   ///


### PR DESCRIPTION
## Problem

This PR fixes delayed ringtone/notification dismissal on server hangup in Android persistent (FGS) mode by ensuring the background (FGS) Flutter engine can deliver hangup-related callkeep actions and by expanding the background signaling callback to handle multiple call events.

## Root cause

The FGS Flutter engine runs with `automaticallyRegisterPlugins=false`, so only channels explicitly registered via `onFgsEngineReady` are available. The Bootstrap API (`reportNewIncomingCall`) was registered, but the full Isolate API (`releaseCall`, `endCall`) was not — calls to it timed out silently.

## Fix

- Renamed the FGS background event callback from `incomingCallHandler` to `callEventHandler` so it handles both `IncomingCallEvent` and `HangupEvent`
- Registered `PHostBackgroundPushNotificationIsolateApi` on the FGS engine in `WebtritApplication`, delegating `releaseCall`/`endCall` to `CallkeepCore` — the same path used in push-bound mode via `CallLifecycleHandler`
- Added a TODO to eventually move the FGS channel wiring inside the callkeep plugin itself