### PR TITLE
feat: add configurator:generate melos script for local Firebase setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 APP_ID=your-application-id
 
 # JWT token for configurator backend (used by `melos run configurator:generate`)
-TOKEN=your-configurator-token
+CONFIGURATOR_TOKEN=your-configurator-token
 
 # Localizely API token (used by `melos run l10n:push` and `melos run l10n:pull`)
 LOCALIZELY_TOKEN=your-localizely-token

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Configurator application identifier (used by `melos run configurator:generate`)
+APP_ID=your-application-id
+
+# JWT token for configurator backend (used by `melos run configurator:generate`)
+TOKEN=your-configurator-token
+
+# Localizely API token (used by `melos run l10n:push` and `melos run l10n:pull`)
+LOCALIZELY_TOKEN=your-localizely-token

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -388,15 +388,17 @@ melos:
     configurator:generate:
       description: >
         Fetch resources from configurator backend, generate app assets, and run
-        flutterfire configure for all platforms. Requires APP_ID and TOKEN env vars.
+        flutterfire configure for all platforms. Reads APP_ID and TOKEN from .env file.
       run: |
-        KEYSTORE_APP_PATH="../webtrit_phone_keystores/applications/${APP_ID:?APP_ID is required}"
+        APP_ID=$(grep -E '^(export[[:space:]]+)?APP_ID=' .env | cut -d '=' -f2)
+        TOKEN=$(grep -E '^(export[[:space:]]+)?TOKEN=' .env | cut -d '=' -f2)
+        KEYSTORE_APP_PATH="../webtrit_phone_keystores/applications/${APP_ID:?APP_ID not found in .env}"
         CACHE_PATH="$KEYSTORE_APP_PATH/cache_session_data.json"
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-resources \
-          --applicationId=${APP_ID} \
+          --applicationId="$APP_ID" \
           --keystores-path=../webtrit_phone_keystores/applications \
-          --token=${TOKEN:?TOKEN is required}
+          --token="${TOKEN:?TOKEN not found in .env}"
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-generate \
           --cache-session-data-path="$CACHE_PATH"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -382,6 +382,23 @@ melos:
         - splash:generate
 
     # ===========================
+    # Configurator - melos run configurator:generate
+    # ===========================
+
+    configurator:generate:
+      description: Generate app resources and run flutterfire configure for all platforms.
+      run: |
+        dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
+          configurator-generate \
+          --cache-session-data-path ${CACHE_SESSION_DATA_PATH:?CACHE_SESSION_DATA_PATH is required}
+        dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
+          configurator-setup \
+          --platform ios \
+          --platform android \
+          --keystore-path ${KEYSTORE_APP_PATH:?KEYSTORE_APP_PATH is required} \
+          --cache-session-data-path ${CACHE_SESSION_DATA_PATH:?CACHE_SESSION_DATA_PATH is required}
+
+    # ===========================
     # Localization - melos run l10n:push | l10n:pull | l10n:generate | l10n:fetch
     # ===========================
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -393,21 +393,18 @@ melos:
         APP_ID=$(grep -E '^(export[[:space:]]+)?APP_ID=' .env | cut -d '=' -f2)
         TOKEN=$(grep -E '^(export[[:space:]]+)?TOKEN=' .env | cut -d '=' -f2)
         KEYSTORE_APP_PATH="../webtrit_phone_keystores/applications/${APP_ID:?APP_ID not found in .env}"
-        CACHE_PATH="$KEYSTORE_APP_PATH/cache_session_data.json"
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-resources \
           --applicationId="$APP_ID" \
           --keystores-path=../webtrit_phone_keystores/applications \
           --token="${TOKEN:?TOKEN not found in .env}"
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
-          configurator-generate \
-          --cache-session-data-path="$CACHE_PATH"
+          configurator-generate
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-setup \
           --platform ios \
           --platform android \
-          --keystore-path="$KEYSTORE_APP_PATH" \
-          --cache-session-data-path="$CACHE_PATH"
+          --keystore-path="$KEYSTORE_APP_PATH"
 
     # ===========================
     # Localization - melos run l10n:push | l10n:pull | l10n:generate | l10n:fetch

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -388,16 +388,18 @@ melos:
     configurator:generate:
       description: >
         Fetch resources from configurator backend, generate app assets, and run
-        flutterfire configure for all platforms. Reads APP_ID and TOKEN from .env file.
+        flutterfire configure for all platforms. Reads APP_ID and CONFIGURATOR_TOKEN from .env file.
       run: |
-        APP_ID=$(grep -E '^(export[[:space:]]+)?APP_ID=' .env | cut -d '=' -f2)
-        TOKEN=$(grep -E '^(export[[:space:]]+)?TOKEN=' .env | cut -d '=' -f2)
+        set -eo pipefail
+        [ -f .env ] || { echo "ERROR: .env not found. Copy .env.example to .env and fill in your credentials." >&2; exit 1; }
+        APP_ID=$(grep -E '^(export[[:space:]]+)?APP_ID=' .env | cut -d '=' -f2-)
+        CONFIGURATOR_TOKEN=$(grep -E '^(export[[:space:]]+)?CONFIGURATOR_TOKEN=' .env | cut -d '=' -f2-)
         KEYSTORE_APP_PATH="../webtrit_phone_keystores/applications/${APP_ID:?APP_ID not found in .env}"
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-resources \
           --applicationId="$APP_ID" \
           --keystores-path=../webtrit_phone_keystores/applications \
-          --token="${TOKEN:?TOKEN not found in .env}"
+          --token="${CONFIGURATOR_TOKEN:?CONFIGURATOR_TOKEN not found in .env}"
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-generate
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -386,17 +386,26 @@ melos:
     # ===========================
 
     configurator:generate:
-      description: Generate app resources and run flutterfire configure for all platforms.
+      description: >
+        Fetch resources from configurator backend, generate app assets, and run
+        flutterfire configure for all platforms. Requires APP_ID and TOKEN env vars.
       run: |
+        KEYSTORE_APP_PATH="../webtrit_phone_keystores/applications/${APP_ID:?APP_ID is required}"
+        CACHE_PATH="$KEYSTORE_APP_PATH/cache_session_data.json"
+        dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
+          configurator-resources \
+          --applicationId=${APP_ID} \
+          --keystores-path=../webtrit_phone_keystores/applications \
+          --token=${TOKEN:?TOKEN is required}
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-generate \
-          --cache-session-data-path ${CACHE_SESSION_DATA_PATH:?CACHE_SESSION_DATA_PATH is required}
+          --cache-session-data-path="$CACHE_PATH"
         dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
           configurator-setup \
           --platform ios \
           --platform android \
-          --keystore-path ${KEYSTORE_APP_PATH:?KEYSTORE_APP_PATH is required} \
-          --cache-session-data-path ${CACHE_SESSION_DATA_PATH:?CACHE_SESSION_DATA_PATH is required}
+          --keystore-path="$KEYSTORE_APP_PATH" \
+          --cache-session-data-path="$CACHE_PATH"
 
     # ===========================
     # Localization - melos run l10n:push | l10n:pull | l10n:generate | l10n:fetch


### PR DESCRIPTION
## Summary

- Adds `configurator:generate` melos script that runs two commands in sequence:
  1. `configurator-generate` — icons, splash, platform identifiers, localization, assets
  2. `configurator-setup --platform ios --platform android` — runs `flutterfire configure` for both platforms

## Usage

```bash
CACHE_SESSION_DATA_PATH=/path/to/cache_session_data.json \
KEYSTORE_APP_PATH=/path/to/keystore/app-id \
melos run configurator:generate
```

## Depends on

- WebTrit/webtrit_phone_tools#42 — `configurator-setup` command

## Why

Previously `flutterfire configure` ran only in CI (inside `prepare_resources`). This script lets developers run the full configuration locally in one command without manually chaining two CLI calls.