### PR TITLE
fix(web): sync shareLogRecords web stub with native signature

### DIFF
--- a/lib/features/log_records_console/utils/share_log_records_web.dart
+++ b/lib/features/log_records_console/utils/share_log_records_web.dart
@@ -3,7 +3,12 @@ import 'dart:typed_data';
 
 import 'package:share_plus/share_plus.dart';
 
-Future<ShareResult> shareLogRecords(List<String> logRecords, {required String name}) {
+Future<ShareResult> shareLogRecords(
+  List<String> logRecords, {
+  required String name,
+  String? callkeepLogFilePath,
+  String? callkeepLogName,
+}) {
   final logRecordsBuffer = StringBuffer();
   for (final logRecord in logRecords) {
     logRecordsBuffer.writeln(logRecord);


### PR DESCRIPTION
## Summary

- `shareLogRecords` native implementation (`share_log_records.dart`) has `callkeepLogFilePath` and `callkeepLogName` optional params
- Web stub (`share_log_records_web.dart`) was missing them — web compilation fails with `No named parameter with the name 'callkeepLogFilePath'`
- Adds the missing params to the web stub (ignored at runtime — file paths are not accessible on web)

## Test plan

- [ ] Flutter web app that depends on `webtrit_phone` compiles without errors on Chrome target