### PR TITLE
fix: guard NativeLogForwarder.start with Platform.isAndroid

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -143,7 +143,10 @@ Future<InstanceRegistry> bootstrap() async {
     nativeLogFilePath: appPath.nativeLogFilePath,
     logger: Logger('callkeep'),
   );
-  // FileSystemEntity.watch is Android-only; not tested on iOS.
+  // FileSystemEntity.watch is not supported on iOS — the Dart SDK only implements
+  // it for Android/Linux (inotify), Windows, and macOS (FSEvents). Calling it on
+  // iOS throws FileSystemException("File system watching is not supported on this
+  // platform"). The Callkeep native log file also only exists on Android.
   if (Platform.isAndroid) nativeLogForwarder.start();
 
   final appLifecycle = await AppLifecycle.initMaster();

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -143,7 +143,7 @@ Future<InstanceRegistry> bootstrap() async {
     nativeLogFilePath: appPath.nativeLogFilePath,
     logger: Logger('callkeep'),
   );
-  // FileSystemEntity.watch is not supported on iOS — the Dart SDK only implements
+  // FileSystemEntity.watch is not supported on iOS: the Dart SDK only implements
   // it for Android/Linux (inotify), Windows, and macOS (FSEvents). Calling it on
   // iOS throws FileSystemException("File system watching is not supported on this
   // platform"). The Callkeep native log file also only exists on Android.

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -142,7 +142,9 @@ Future<InstanceRegistry> bootstrap() async {
   final nativeLogForwarder = NativeLogForwarder(
     nativeLogFilePath: appPath.nativeLogFilePath,
     logger: Logger('callkeep'),
-  )..start();
+  );
+  // FileSystemEntity.watch is Android-only; not tested on iOS.
+  if (Platform.isAndroid) nativeLogForwarder.start();
 
   final appLifecycle = await AppLifecycle.initMaster();
 


### PR DESCRIPTION
## Summary

Guards `NativeLogForwarder.start()` with `Platform.isAndroid` in bootstrap, since `FileSystemEntity.watch()` is unsupported on iOS and the underlying Callkeep native log file is only produced on Android.

**Changes:**
- Split the cascaded `..start()` into a separate conditional invocation.
- Only call `nativeLogForwarder.start()` when running on Android.
- Add a comment explaining the platform restriction.



