### PR TITLE
fix(wt-1525): iOS fresh-login dead signaling subscription

### DIFF
--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -56,22 +56,30 @@ class WebtritSignalingService implements SignalingModule {
   }) : _config = config,
        _mode = mode,
        _startPendingTimeout = startPendingTimeout {
-    _serviceEventsSub = SignalingServicePlatform.instance.events.listen((event) {
-      switch (event) {
-        case SignalingConnected():
-          _isConnected = true;
-          _clearStartPending();
-          unawaited(
-            _requestQueue.flush(execute: SignalingServicePlatform.instance.execute, isActive: () => _isConnected),
-          );
-        case SignalingDisconnected():
-        case SignalingConnectionFailed():
-          _isConnected = false;
-          _clearStartPending();
-        default:
-          break;
-      }
-    });
+    _serviceEventsSub = SignalingServicePlatform.instance.events.listen(
+      (event) {
+        switch (event) {
+          case SignalingConnected():
+            _isConnected = true;
+            _clearStartPending();
+            unawaited(
+              _requestQueue.flush(execute: SignalingServicePlatform.instance.execute, isActive: () => _isConnected),
+            );
+          case SignalingDisconnected():
+          case SignalingConnectionFailed():
+            _isConnected = false;
+            _clearStartPending();
+          default:
+            break;
+        }
+      },
+      onDone: () {
+        _logger.severe(
+          '_serviceEventsSub: stream completed — this WebtritSignalingService instance '
+          'will never receive SignalingConnected; _isConnected stays false forever',
+        );
+      },
+    );
   }
 
   final SignalingServiceConfig _config;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -56,30 +56,7 @@ class WebtritSignalingService implements SignalingModule {
   }) : _config = config,
        _mode = mode,
        _startPendingTimeout = startPendingTimeout {
-    _serviceEventsSub = SignalingServicePlatform.instance.events.listen(
-      (event) {
-        switch (event) {
-          case SignalingConnected():
-            _isConnected = true;
-            _clearStartPending();
-            unawaited(
-              _requestQueue.flush(execute: SignalingServicePlatform.instance.execute, isActive: () => _isConnected),
-            );
-          case SignalingDisconnected():
-          case SignalingConnectionFailed():
-            _isConnected = false;
-            _clearStartPending();
-          default:
-            break;
-        }
-      },
-      onDone: () {
-        _logger.severe(
-          '_serviceEventsSub: stream completed — this WebtritSignalingService instance '
-          'will never receive SignalingConnected; _isConnected stays false forever',
-        );
-      },
-    );
+    _serviceEventsSub = SignalingServicePlatform.instance.events.listen(_onServiceEvent, onDone: _onServiceEventsDone);
   }
 
   final SignalingServiceConfig _config;
@@ -201,6 +178,30 @@ class WebtritSignalingService implements SignalingModule {
   @override
   void clearTerminatingMark(String callId) {
     _requestQueue.removeTerminatingMark(callId);
+  }
+
+  void _onServiceEvent(SignalingModuleEvent event) {
+    switch (event) {
+      case SignalingConnected():
+        _isConnected = true;
+        _clearStartPending();
+        unawaited(
+          _requestQueue.flush(execute: SignalingServicePlatform.instance.execute, isActive: () => _isConnected),
+        );
+      case SignalingDisconnected():
+      case SignalingConnectionFailed():
+        _isConnected = false;
+        _clearStartPending();
+      default:
+        break;
+    }
+  }
+
+  void _onServiceEventsDone() {
+    _logger.severe(
+      '_serviceEventsSub: stream completed — this WebtritSignalingService instance '
+      'will never receive SignalingConnected; _isConnected stays false forever',
+    );
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -8,6 +8,41 @@ import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_s
 
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
+class _FakeModule implements SignalingModule {
+  final _ctrl = StreamController<SignalingModuleEvent>.broadcast();
+  bool _connected = false;
+
+  void inject(SignalingModuleEvent event) {
+    if (event is SignalingConnected) _connected = true;
+    if (event is SignalingDisconnected || event is SignalingConnectionFailed) _connected = false;
+    if (!_ctrl.isClosed) _ctrl.add(event);
+  }
+
+  @override
+  Stream<SignalingModuleEvent> get events => _ctrl.stream;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  void connect() {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void>? execute(Request request) => null;
+
+  @override
+  Future<void> dispose() => _ctrl.close();
+
+  @override
+  void cancelRequestsByCallId(String callId) {}
+
+  @override
+  void clearTerminatingMark(String callId) {}
+}
+
 // ---------------------------------------------------------------------------
 // Fake platform implementation
 // ---------------------------------------------------------------------------
@@ -58,7 +93,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   @override
   Future<void> dispose() async {
     disposeCount++;
-    await _eventsController.close();
+    // NOT closed -- mirrors real platform singleton that survives logout/login cycles.
   }
 
   @override
@@ -436,6 +471,61 @@ void main() {
       expect(service.isConnected, isTrue);
       expect(platform.startedConfigs, hasLength(1));
       await service.dispose();
+    });
+  });
+
+  group('WebtritSignalingServiceDirect -- logout+re-login regression (WT-1525)', () {
+    late WebtritSignalingServiceDirect direct;
+    _FakeModule? currentModule;
+
+    setUp(() async {
+      direct = WebtritSignalingServiceDirect();
+      SignalingServicePlatform.instance = direct;
+      currentModule = null;
+      await direct.setModuleFactory((config) {
+        final m = _FakeModule();
+        currentModule = m;
+        return m;
+      });
+    });
+
+    test('isConnected becomes true on second session after dispose+re-login', () async {
+      final service1 = WebtritSignalingService(config: _kConfig);
+      service1.connect();
+      await Future<void>.delayed(Duration.zero);
+      currentModule!.inject(SignalingConnected());
+      await Future<void>.delayed(Duration.zero);
+      expect(service1.isConnected, isTrue);
+
+      await service1.dispose();
+
+      final service2 = WebtritSignalingService(config: _kConfig);
+      expect(service2.isConnected, isFalse);
+
+      service2.connect();
+      await Future<void>.delayed(Duration.zero);
+      currentModule!.inject(SignalingConnected());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service2.isConnected, isTrue);
+
+      await service2.dispose();
+    });
+
+    test('three consecutive sessions all become connected', () async {
+      for (var i = 0; i < 3; i++) {
+        final service = WebtritSignalingService(config: _kConfig);
+        expect(service.isConnected, isFalse, reason: 'session $i: starts disconnected');
+
+        service.connect();
+        await Future<void>.delayed(Duration.zero);
+        currentModule!.inject(SignalingConnected());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(service.isConnected, isTrue, reason: 'session $i: becomes connected');
+
+        await service.dispose();
+      }
     });
   });
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -63,7 +63,10 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
   final PSignalingServiceHostApi _hostApi;
 
-  StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
+  // Fans out SignalingModuleEvents to all subscribers (WebtritSignalingService, CallBloc, etc.).
+  // Intentionally not closed in dispose() -- closing it would deliver onDone to active subscribers,
+  // silently ending their subscriptions and breaking logout+re-login in the same process.
+  final StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
 
   final _eventBuffer = SignalingEventBuffer();
 
@@ -129,10 +132,6 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
     _logger.info('start effectiveMode=$effectiveMode tenantId=${config.tenantId}');
 
-    if (_eventsController.isClosed) {
-      _eventsController = StreamController<SignalingModuleEvent>.broadcast();
-    }
-
     await _startService(config, effectiveMode);
   }
 
@@ -195,8 +194,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     _eventBuffer.clear();
     // NOTE: _eventsController is intentionally NOT closed here.
     // Closing it would deliver onDone to any active subscriber (e.g. CallBloc),
-    // silently ending their subscription. The next start() call creates a fresh
-    // controller only if this one is closed.
+    // silently ending their subscription and breaking logout+re-login in the same process.
     _logger.info('dispose complete');
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -80,12 +80,6 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   @override
   Stream<SignalingModuleEvent> get events {
     return Stream.multi((sink) {
-      if (_eventsController.isClosed) {
-        _logger.severe(
-          'events: _eventsController is closed — new subscriber will receive onDone immediately; '
-          'signaling events will never reach this subscriber',
-        );
-      }
       final sub = _eventsController.stream.listen(sink.add, onError: sink.addError, onDone: sink.close);
       sink.onCancel = sub.cancel;
       for (final event in _eventBuffer.snapshot) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -76,6 +76,12 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   @override
   Stream<SignalingModuleEvent> get events {
     return Stream.multi((sink) {
+      if (_eventsController.isClosed) {
+        _logger.severe(
+          'events: _eventsController is closed — new subscriber will receive onDone immediately; '
+          'signaling events will never reach this subscriber',
+        );
+      }
       final sub = _eventsController.stream.listen(sink.add, onError: sink.addError, onDone: sink.close);
       sink.onCancel = sub.cancel;
       for (final event in _eventBuffer.snapshot) {
@@ -172,6 +178,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     _isStopped = true;
     await _tearDownModule();
     _eventBuffer.clear();
+    _logger.fine('dispose: closing _eventsController permanently');
     await _eventsController.close();
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -51,6 +51,10 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   SignalingModuleFactory? _factory;
   SignalingModule? _module;
   StreamSubscription<SignalingModuleEvent>? _moduleSub;
+
+  // Fans out SignalingModuleEvents to all subscribers (WebtritSignalingService, CallBloc, etc.).
+  // Currently closed permanently in dispose() -- any subscriber created after a logout+re-login
+  // receives onDone immediately and never sees SignalingConnected.
   StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
 
   final _eventBuffer = SignalingEventBuffer();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -55,7 +55,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   // Fans out SignalingModuleEvents to all subscribers (WebtritSignalingService, CallBloc, etc.).
   // Intentionally not closed in dispose() -- closing it would deliver onDone to active subscribers,
   // silently ending their subscriptions and breaking logout+re-login in the same process.
-  StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
+  final StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
 
   final _eventBuffer = SignalingEventBuffer();
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -53,8 +53,8 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   StreamSubscription<SignalingModuleEvent>? _moduleSub;
 
   // Fans out SignalingModuleEvents to all subscribers (WebtritSignalingService, CallBloc, etc.).
-  // Currently closed permanently in dispose() -- any subscriber created after a logout+re-login
-  // receives onDone immediately and never sees SignalingConnected.
+  // Intentionally not closed in dispose() -- closing it would deliver onDone to active subscribers,
+  // silently ending their subscriptions and breaking logout+re-login in the same process.
   StreamController<SignalingModuleEvent> _eventsController = StreamController<SignalingModuleEvent>.broadcast();
 
   final _eventBuffer = SignalingEventBuffer();
@@ -111,10 +111,6 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     final factory = _factory;
     if (factory == null) {
       throw StateError('No SignalingModuleFactory registered — call setModuleFactory() before start()');
-    }
-
-    if (_eventsController.isClosed) {
-      _eventsController = StreamController<SignalingModuleEvent>.broadcast();
     }
 
     await _tearDownModule();
@@ -182,8 +178,9 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     _isStopped = true;
     await _tearDownModule();
     _eventBuffer.clear();
-    _logger.fine('dispose: closing _eventsController permanently');
-    await _eventsController.close();
+    // NOTE: _eventsController is intentionally NOT closed here.
+    // Closing it would deliver onDone to any active subscriber (e.g. WebtritSignalingService),
+    // silently ending their subscription and breaking logout+re-login in the same process.
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

After logout + re-login **within the same app process** (no restart), all signaling requests silently queue and never flush -- calls are impossible until force-quit.

Root cause: `WebtritSignalingServiceDirect` is a singleton. Its `dispose()` permanently closed `_eventsController`. The new `WebtritSignalingService` created on re-login subscribes to the already-closed stream -- `onDone` fires synchronously, the subscription dies before any `SignalingConnected` arrives, and `_isConnected` stays `false` forever. Android was not affected because `WebtritSignalingServiceAndroid` (the actual singleton there) already kept its controller open intentionally.

## Changes

**Fix**
- `signaling_service_direct.dart` -- remove `_eventsController.close()` from `dispose()`, add NOTE explaining why (mirrors what Android already did)
- `signaling_service_direct.dart` -- remove the dead `isClosed` guard from `start()` that only existed because `dispose()` closed the controller
- `plugin.dart` (Android) -- same cleanup: `final`, matching comment, remove dead `isClosed` guard for symmetry

**Refactor / docs**
- `signaling_service.dart` -- extract `_onServiceEvent` and `_onServiceEventsDone` from inline lambdas
- `signaling_service_direct.dart` -- document `_eventsController` field role

**Tests**
- Add `_FakeModule` (fakes only the WebSocket layer, real `WebtritSignalingServiceDirect` is used as the platform singleton)
- Two regression tests: dispose+re-login and three consecutive sessions -- both would fail if `_eventsController.close()` were reintroduced
- Update `_FakePlatform.dispose()` to match fixed real behavior