### PR TITLE
refactor(backgroundMessage): expose AppPath in IsolateContext to avoid redundant init calls (WT-1520)

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -374,14 +374,17 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
       time: DateTime.now(),
     );
 
-    await AppDatabaseScope.useOrNull(
-      directoryPath: _isolateContext!.appPath.applicationDocumentsPath,
-      action: (db) async {
-        final repo = ActiveMessagePushsRepositoryDriftImpl(appDatabase: db);
-        await repo.set(activeMessagePush);
-      },
-      onError: (e, st) => logger.warning('MessagePush DB write failed: $e'),
-    );
+    final appPath = _isolateContext!.appPath;
+    if (appPath != null) {
+      await AppDatabaseScope.useOrNull(
+        directoryPath: appPath.applicationDocumentsPath,
+        action: (db) async {
+          final repo = ActiveMessagePushsRepositoryDriftImpl(appDatabase: db);
+          await repo.set(activeMessagePush);
+        },
+        onError: (e, st) => logger.warning('MessagePush DB write failed: $e'),
+      );
+    }
   }
 }
 
@@ -391,8 +394,11 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
 /// when multiple isolates (e.g., background FCM and main app) access the database
 /// concurrently. If any error occurs, the display name from the push payload is returned.
 Future<String> _resolveContactDisplayNameWithFallback(PendingCallPush appPush, Logger logger) async {
+  final appPath = _isolateContext!.appPath;
+  if (appPath == null) return appPush.call.displayName;
+
   return await AppDatabaseScope.useOrNull(
-        directoryPath: _isolateContext!.appPath.applicationDocumentsPath,
+        directoryPath: appPath.applicationDocumentsPath,
         onError: (e, st) {
           logger.severe(
             'Failed to resolve contact name from database for handle: ${appPush.call.handle}. '

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -365,8 +365,6 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
   }
 
   if (appPush is MessagePush) {
-    final appPath = await AppPath.init();
-
     final activeMessagePush = ActiveMessagePush(
       notificationId: appPush.id,
       messageId: appPush.messageId,
@@ -377,7 +375,7 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
     );
 
     await AppDatabaseScope.useOrNull(
-      directoryPath: appPath.applicationDocumentsPath,
+      directoryPath: _isolateContext!.appPath.applicationDocumentsPath,
       action: (db) async {
         final repo = ActiveMessagePushsRepositoryDriftImpl(appDatabase: db);
         await repo.set(activeMessagePush);
@@ -393,10 +391,8 @@ Future<void> _handleBackgroundMessage(RemoteMessage message, Logger logger) asyn
 /// when multiple isolates (e.g., background FCM and main app) access the database
 /// concurrently. If any error occurs, the display name from the push payload is returned.
 Future<String> _resolveContactDisplayNameWithFallback(PendingCallPush appPush, Logger logger) async {
-  final appPath = await AppPath.init();
-
   return await AppDatabaseScope.useOrNull(
-        directoryPath: appPath.applicationDocumentsPath,
+        directoryPath: _isolateContext!.appPath.applicationDocumentsPath,
         onError: (e, st) {
           logger.severe(
             'Failed to resolve contact name from database for handle: ${appPush.call.handle}. '

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -35,8 +35,8 @@ class IsolateContext {
     this.deviceInfo,
     this.packageInfo,
     this.appLabelsProvider,
-    required this.nativeLogForwarder,
-    required this.appPath,
+    this.nativeLogForwarder,
+    this.appPath,
   });
 
   /// Required - credentials for signaling auth. Throws on failure.
@@ -48,8 +48,12 @@ class IsolateContext {
   final DeviceInfo? deviceInfo;
   final PackageInfo? packageInfo;
   final AppMetadataProvider? appLabelsProvider;
-  final NativeLogForwarder nativeLogForwarder;
-  final AppPath appPath;
+
+  /// Nullable - best-effort. Null when [appPath] is unavailable.
+  final NativeLogForwarder? nativeLogForwarder;
+
+  /// Nullable - best-effort. Null when filesystem path is unavailable.
+  final AppPath? appPath;
 
   static Future<IsolateContext> init() async {
     final secureStorage = await SecureStorageImpl.init();
@@ -83,11 +87,10 @@ class IsolateContext {
       Logger.root.warning('IsolateContext: AppLogger init failed, continuing without remote logging', e, st);
     }
 
-    final appPath = await AppPath.init();
-    final nativeLogForwarder = NativeLogForwarder(
-      nativeLogFilePath: appPath.nativeLogFilePath,
-      logger: Logger('callkeep'),
-    )..start();
+    final appPath = await _tryInit(AppPath.init, 'AppPath');
+    final nativeLogForwarder = appPath != null
+        ? (NativeLogForwarder(nativeLogFilePath: appPath.nativeLogFilePath, logger: Logger('callkeep'))..start())
+        : null;
 
     return IsolateContext(
       secureStorage: secureStorage,
@@ -118,15 +121,15 @@ class PushIsolateContext extends IsolateContext {
   PushIsolateContext({
     required super.secureStorage,
     required this.incomingCallTypeRepository,
-    required super.nativeLogForwarder,
     required this.appCertificates,
-    required super.appPath,
+    required this.localPushRepository,
+    super.nativeLogForwarder,
+    super.appPath,
     super.remoteConfigService,
     super.appInfo,
     super.deviceInfo,
     super.packageInfo,
     super.appLabelsProvider,
-    required this.localPushRepository,
     this.appDatabase,
     this.callLogsRepository,
   });
@@ -153,11 +156,16 @@ class PushIsolateContext extends IsolateContext {
     final appCertificates = await AppCertificates.init();
 
     // Phase 2 - best-effort: failures are isolated, flow continues with nulls.
-    Logger.root.info('IsolateDatabase.connectOrCreate call from PushIsolateContext.init');
-    final appDatabase = await _tryInit(
-      () => IsolateDatabase.connectOrCreate(directoryPath: base.appPath.applicationDocumentsPath),
-      'AppDatabase',
-    );
+    AppDatabase? appDatabase;
+    if (base.appPath != null) {
+      Logger.root.info('IsolateDatabase.connectOrCreate call from PushIsolateContext.init');
+      appDatabase = await _tryInit(
+        () => IsolateDatabase.connectOrCreate(directoryPath: base.appPath!.applicationDocumentsPath),
+        'AppDatabase',
+      );
+    } else {
+      Logger.root.warning('PushIsolateContext: AppPath unavailable - skipping DB init');
+    }
 
     final localPushRepository = LocalPushRepositoryFLNImpl();
     final callLogsRepository = appDatabase != null ? CallLogsRepository(appDatabase: appDatabase) : null;
@@ -180,7 +188,7 @@ class PushIsolateContext extends IsolateContext {
   }
 
   Future<void> dispose() async {
-    await nativeLogForwarder.dispose();
+    await nativeLogForwarder?.dispose();
     await appDatabase?.close();
   }
 }

--- a/lib/common/isolate_context.dart
+++ b/lib/common/isolate_context.dart
@@ -36,6 +36,7 @@ class IsolateContext {
     this.packageInfo,
     this.appLabelsProvider,
     required this.nativeLogForwarder,
+    required this.appPath,
   });
 
   /// Required - credentials for signaling auth. Throws on failure.
@@ -48,6 +49,7 @@ class IsolateContext {
   final PackageInfo? packageInfo;
   final AppMetadataProvider? appLabelsProvider;
   final NativeLogForwarder nativeLogForwarder;
+  final AppPath appPath;
 
   static Future<IsolateContext> init() async {
     final secureStorage = await SecureStorageImpl.init();
@@ -95,6 +97,7 @@ class IsolateContext {
       packageInfo: packageInfo,
       appLabelsProvider: appLabelsProvider,
       nativeLogForwarder: nativeLogForwarder,
+      appPath: appPath,
     );
   }
 }
@@ -117,13 +120,13 @@ class PushIsolateContext extends IsolateContext {
     required this.incomingCallTypeRepository,
     required super.nativeLogForwarder,
     required this.appCertificates,
+    required super.appPath,
     super.remoteConfigService,
     super.appInfo,
     super.deviceInfo,
     super.packageInfo,
     super.appLabelsProvider,
     required this.localPushRepository,
-    this.appPath,
     this.appDatabase,
     this.callLogsRepository,
   });
@@ -133,9 +136,6 @@ class PushIsolateContext extends IsolateContext {
 
   /// Required - TLS certificates for WebSocket. Throws on failure.
   final AppCertificates appCertificates;
-
-  /// Nullable - best-effort. Null when filesystem path is unavailable.
-  final AppPath? appPath;
 
   /// Nullable - best-effort. Null when [appPath] or DB open fails.
   final AppDatabase? appDatabase;
@@ -153,18 +153,11 @@ class PushIsolateContext extends IsolateContext {
     final appCertificates = await AppCertificates.init();
 
     // Phase 2 - best-effort: failures are isolated, flow continues with nulls.
-    final appPath = await _tryInit(AppPath.init, 'AppPath');
-
-    AppDatabase? appDatabase;
-    if (appPath != null) {
-      Logger.root.info('IsolateDatabase.connectOrCreate call from PushIsolateContext.init');
-      appDatabase = await _tryInit(
-        () => IsolateDatabase.connectOrCreate(directoryPath: appPath.applicationDocumentsPath),
-        'AppDatabase',
-      );
-    } else {
-      Logger.root.warning('PushIsolateContext: AppPath unavailable - skipping DB init');
-    }
+    Logger.root.info('IsolateDatabase.connectOrCreate call from PushIsolateContext.init');
+    final appDatabase = await _tryInit(
+      () => IsolateDatabase.connectOrCreate(directoryPath: base.appPath.applicationDocumentsPath),
+      'AppDatabase',
+    );
 
     final localPushRepository = LocalPushRepositoryFLNImpl();
     final callLogsRepository = appDatabase != null ? CallLogsRepository(appDatabase: appDatabase) : null;
@@ -179,7 +172,7 @@ class PushIsolateContext extends IsolateContext {
       nativeLogForwarder: base.nativeLogForwarder,
       incomingCallTypeRepository: IncomingCallTypeRepositoryPrefsImpl(appPreferences),
       appCertificates: appCertificates,
-      appPath: appPath,
+      appPath: base.appPath,
       appDatabase: appDatabase,
       localPushRepository: localPushRepository,
       callLogsRepository: callLogsRepository,


### PR DESCRIPTION
## Summary

- `AppPath.init()` can throw, so it is wrapped in `_tryInit` — `appPath` on `IsolateContext` is now nullable
- `NativeLogForwarder` depends on `appPath.nativeLogFilePath`, so it becomes nullable too and is only created when `appPath != null`
- `PushIsolateContext` drops its own `AppPath?` field and redundant `_tryInit(AppPath.init)` call — delegates to `super.appPath`
- `_handleBackgroundMessage` and `_resolveContactDisplayNameWithFallback` no longer call `AppPath.init()` — reuse `_isolateContext.appPath` with null-check

## Test plan

- [x] Incoming call via FCM push — contact name resolves correctly
- [x] `MessagePush` received in background — DB write succeeds
- [x] Build and run on Android