### PR TITLE
fix: call drop on network interface switch (WiFi <-> LTE)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -516,7 +516,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (connectivityState == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
     } else {
-      await _reconnectController.notifyNetworkAvailable();
+      _reconnectController.notifyNetworkAvailable();
     }
 
     WebRTC.initialize(options: webRtcOptionsBuilder?.build());
@@ -541,7 +541,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (connectivityResult == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
     } else {
-      await _reconnectController.notifyNetworkAvailable();
+      _reconnectController.notifyNetworkAvailable();
 
       // Restart ICE for all active calls to trigger faster recovery from connectivity loss.
       //

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -516,7 +516,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (connectivityState == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
     } else {
-      _reconnectController.notifyNetworkAvailable();
+      await _reconnectController.notifyNetworkAvailable();
     }
 
     WebRTC.initialize(options: webRtcOptionsBuilder?.build());
@@ -541,7 +541,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (connectivityResult == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
     } else {
-      _reconnectController.notifyNetworkAvailable();
+      await _reconnectController.notifyNetworkAvailable();
 
       // Restart ICE for all active calls to trigger faster recovery from connectivity loss.
       //

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2958,6 +2958,20 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         throw result;
       }
     } catch (er, st) {
+      if (er is WebtritSignalingTransactionTerminateByDisconnectException &&
+          pc.connectionState != RTCPeerConnectionState.RTCPeerConnectionStateFailed &&
+          pc.connectionState != RTCPeerConnectionState.RTCPeerConnectionStateClosed) {
+        _logger.warning(
+          '__onMutationRenegotiate: signaling disconnected during renegotiation, rolling back '
+          '(callId=${e.callId}, pcState=${pc.connectionState})',
+        );
+        try {
+          await pc.setLocalDescription(RTCSessionDescription('', 'rollback'));
+          return; // signaling reconnect will re-trigger renegotiation
+        } catch (rollbackError, rollbackSt) {
+          _logger.warning('__onMutationRenegotiate: rollback failed, terminating call', rollbackError, rollbackSt);
+        }
+      }
       callErrorReporter.handle(er, st, '__onMutationRenegotiate failed for callId=${e.callId}');
       _peerConnectionManager.completeError(activeCall.callId, er, st);
       add(_ResetStateEvent.completeCall(activeCall.callId));

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -698,11 +698,24 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> __onSignalingClientEventConnected(_SignalingClientEventConnected event, Emitter<CallState> emit) async {
-    // Renegotiate active calls if there was reconnect
+    // Renegotiate active calls on every signaling reconnect.
     //
-    // Important to do in case if there was connection loss for a while and then webrtc detects network loss and restarts ice e.g
-    // user turn off all network interfaces >> __onPeerConnectionEventIceConnectionStateChanged >> RTCIceConnectionStateFailed >> peerConnection.restartIce() >> onRenegotiationNeeded >> __onMutationRenegotiate >> if(!signalingConnected) return;
-    // user turn on network interfaces >> _onSignalingClientEventConnected >> safeRenegotiate
+    // Covers two paths that both leave the PC in stable state waiting for a fresh offer:
+    //
+    // Path 1 - ICE failure while signaling was down:
+    //   network loss >> RTCIceConnectionStateFailed >> restartIce() >> onRenegotiationNeeded
+    //   >> __onMutationRenegotiate >> signalingConnected==false >> early return (skipped)
+    //   >> signaling restored >> here >> renegotiate() dispatched
+    //
+    // Path 2 - signaling dropped mid-renegotiation (Fix B rollback):
+    //   onRenegotiationNeeded >> __onMutationRenegotiate >> setLocalDescription(offer)
+    //   >> signaling disconnect >> WebtritSignalingTransactionTerminateByDisconnectException
+    //   >> setLocalDescription('rollback') >> PC back to stable
+    //   >> signaling restored >> here >> renegotiate() dispatched
+    //
+    // This is the sole re-trigger mechanism for Path 2 and covers all reconnect causes
+    // (network switch, ping timeout, keepalive timeout, transient WS error) — not just
+    // connectivity events.
     for (final call in state.activeCalls.where((c) => c.processingStatus == CallProcessingStatus.connected)) {
       _logger.warning('__onSignalingClientEventConnected: triggering safe renegotiation for call ${call.callId}');
       add(_CallMutationEvent.renegotiate(call.callId, call.line));
@@ -2967,7 +2980,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         );
         try {
           await pc.setLocalDescription(RTCSessionDescription('', 'rollback'));
-          return; // signaling reconnect will re-trigger renegotiation
+          // __onSignalingClientEventConnected dispatches renegotiate() for every
+          // connected call on each signaling reconnect, so the new offer will be
+          // created and sent once the connection is restored.
+          return;
         } catch (rollbackError, rollbackSt) {
           _logger.warning('__onMutationRenegotiate: rollback failed, terminating call', rollbackError, rollbackSt);
         }

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -191,7 +191,7 @@ class SignalingReconnectController {
 
   /// Call when network becomes available ([ConnectivityResult] != none).
   void notifyNetworkAvailable() {
-    _logger.fine('notifyNetworkAvailable');
+    _logger.info('notifyNetworkAvailable: isConnected=${_module.isConnected}');
     _networkActive = true;
     _networkJustRestored = true;
     // On a network interface change (e.g. WiFi to LTE) the existing TCP connection
@@ -216,7 +216,7 @@ class SignalingReconnectController {
 
   /// Call when network is lost ([ConnectivityResult.none]).
   void notifyNetworkUnavailable() {
-    _logger.fine('notifyNetworkUnavailable');
+    _logger.info('notifyNetworkUnavailable: isConnected=${_module.isConnected}');
     _networkActive = false;
     _disconnect();
     _emitPresence(false);
@@ -336,6 +336,7 @@ class SignalingReconnectController {
         return;
       }
 
+      _logger.info('_scheduleReconnect: calling connect (force=$force isConnected=${_module.isConnected})');
       _module.connect();
     });
   }

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -190,20 +190,26 @@ class SignalingReconnectController {
   }
 
   /// Call when network becomes available ([ConnectivityResult] != none).
-  Future<void> notifyNetworkAvailable() async {
+  void notifyNetworkAvailable() {
     _logger.fine('notifyNetworkAvailable');
     _networkActive = true;
     _networkJustRestored = true;
     // On a network interface change (e.g. WiFi to LTE) the existing TCP connection
     // may appear alive at the socket level while packets are no longer delivered
-    // (zombie connection). Explicitly disconnecting here forces the WebSocket to
-    // reconnect on the new interface immediately, rather than waiting for the
-    // WS ping timeout (~20s) to detect the dead connection. On platforms where
-    // the OS already closes stale sockets on interface change (e.g. Android),
+    // (zombie connection). Disconnecting here forces the WebSocket to reconnect on
+    // the new interface without waiting for the ping timeout (~20s). On platforms
+    // where the OS already closes stale sockets on interface change (e.g. Android),
     // isConnected will already be false and this call is a no-op.
+    //
+    // Fire-and-forget: disconnect() sets _client=null and _connectToken=null
+    // synchronously before its first suspension point, so connect() called by the
+    // timer below proceeds immediately without waiting for TCP teardown. Awaiting
+    // disconnect() would block this handler for up to ~75s on a zombie TCP
+    // (OS-level TCP retransmission timeout) since the close frame cannot be
+    // delivered on the dead interface.
     if (_module.isConnected) {
       _logger.fine('notifyNetworkAvailable: disconnecting stale connection to reconnect on new interface');
-      await _module.disconnect();
+      _module.disconnect().ignore();
     }
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
   }

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -190,10 +190,21 @@ class SignalingReconnectController {
   }
 
   /// Call when network becomes available ([ConnectivityResult] != none).
-  void notifyNetworkAvailable() {
+  Future<void> notifyNetworkAvailable() async {
     _logger.fine('notifyNetworkAvailable');
     _networkActive = true;
     _networkJustRestored = true;
+    // On a network interface change (e.g. WiFi to LTE) the existing TCP connection
+    // may appear alive at the socket level while packets are no longer delivered
+    // (zombie connection). Explicitly disconnecting here forces the WebSocket to
+    // reconnect on the new interface immediately, rather than waiting for the
+    // WS ping timeout (~20s) to detect the dead connection. On platforms where
+    // the OS already closes stale sockets on interface change (e.g. Android),
+    // isConnected will already be false and this call is a no-op.
+    if (_module.isConnected) {
+      _logger.fine('notifyNetworkAvailable: disconnecting stale connection to reconnect on new interface');
+      await _module.disconnect();
+    }
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
   }
 

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -146,12 +146,13 @@ class SignalingReconnectController {
     _logger.fine('notifyAppPaused hasActiveCalls=$hasActiveCalls');
     if (!hasActiveCalls) {
       _appActive = false;
-      // Intentional disconnect on app pause — treat the next reconnect as a
-      // fresh attempt, not a "session lost" event. Without this reset the
-      // first post-unlock connect failure would bypass the consecutive-failure
-      // threshold and immediately fire onConnectionFailed (WT-1221).
+      // Reset state so the first post-resume failure goes through the
+      // consecutive-failure threshold instead of firing immediately (WT-1221).
+      // Do not call _module.disconnect() here -- the service must stay alive
+      // in the background to receive incoming calls via WebSocket.
       _wasConnected = false;
-      _disconnect();
+      _reconnectTimer?.cancel();
+      _consecutiveFailures = 0;
     }
   }
 

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -301,7 +301,9 @@ class WebtritSignalingClient {
   //
 
   void _startKeepaliveTimer() {
-    _keepaliveTimer = Timer(_keepaliveInterval ?? Duration(seconds: 30), _onKeepalive);
+    final interval = _keepaliveInterval ?? const Duration(seconds: 30);
+    _logger.fine('$_id keepalive timer scheduled: $interval');
+    _keepaliveTimer = Timer(interval, _onKeepalive);
   }
 
   void _stopKeepaliveTimer() {
@@ -310,10 +312,12 @@ class WebtritSignalingClient {
 
   void _restartKeepaliveTimer() {
     _stopKeepaliveTimer();
+    _logger.fine('$_id keepalive timer restarted');
     _startKeepaliveTimer();
   }
 
   void _onKeepalive() async {
+    _logger.fine('$_id keepalive firing');
     try {
       final elapsed = await _executeKeepaliveTransaction(defaultExecuteTransactionTimeoutDuration);
       _logger.finest('$_id handshake keepalive latency: $elapsed');

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -54,6 +54,8 @@ class WebtritSignalingClient {
 
   static const defaultExecuteTransactionTimeoutDuration = Duration(milliseconds: 10000);
 
+  static const defaultWsPingInterval = Duration(seconds: 10);
+
   static int _createCounter = 0;
 
   @visibleForTesting
@@ -85,6 +87,7 @@ class WebtritSignalingClient {
     String token,
     bool force, {
     Duration? connectionTimeout,
+    Duration pingInterval = defaultWsPingInterval,
     TrustedCertificates certs = TrustedCertificates.empty,
   }) async {
     final tenantUrl = buildTenantUrl(baseUrl, tenantId);
@@ -99,6 +102,7 @@ class WebtritSignalingClient {
       signalingUrl,
       protocols: [subprotocol],
       connectionTimeout: connectionTimeout,
+      pingInterval: pingInterval,
       certs: certs,
     );
     final wsc = createWebSocketChannel(ws);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -144,10 +144,16 @@ class WebtritSignalingService implements SignalingModule {
     _startPendingTimer = null;
   }
 
-  /// No-op -- intentional. The service stays connected while the app is
-  /// backgrounded so incoming calls arrive via WebSocket without push.
+  /// Resets the connected state so the next [connect] call proceeds past the
+  /// [_isConnected] guard and triggers a fresh WebSocket via [start].
+  ///
+  /// Does not send a close frame -- the platform tears down the existing
+  /// module on the next [start] call, which handles zombie TCP cleanup.
   @override
-  Future<void> disconnect() async {}
+  Future<void> disconnect() async {
+    _isConnected = false;
+    _clearStartPending();
+  }
 
   @override
   Future<void>? execute(Request request) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -22,6 +22,7 @@ typedef SignalingClientFactory =
       required String tenantId,
       required String token,
       required Duration connectionTimeout,
+      required Duration wsPingInterval,
       required TrustedCertificates certs,
       required bool force,
     });
@@ -36,6 +37,7 @@ Future<WebtritSignalingClient> _defaultClientFactory({
   required String tenantId,
   required String token,
   required Duration connectionTimeout,
+  required Duration wsPingInterval,
   required TrustedCertificates certs,
   required bool force,
 }) {
@@ -45,6 +47,7 @@ Future<WebtritSignalingClient> _defaultClientFactory({
     token,
     force,
     connectionTimeout: connectionTimeout,
+    pingInterval: wsPingInterval,
     certs: certs,
   );
 }
@@ -88,6 +91,8 @@ SignalingModule createSignalingModule(SignalingServiceConfig config) {
 /// - [connectionTimeout] -- how long to wait for the initial WebSocket handshake.
 /// - [reconnectDelay] -- delay hint emitted in [SignalingConnectionFailed] and
 ///   [SignalingDisconnected] events; consumers use it to schedule reconnects.
+/// - [wsPingInterval] -- interval for WebSocket protocol-level ping frames; helps detect
+///   zombie TCP connections (e.g. after a network switch on iOS).
 /// - [clientFactory] -- override for testing; defaults to [WebtritSignalingClient.connect].
 class SignalingModuleImpl implements SignalingModule {
   SignalingModuleImpl({
@@ -97,6 +102,7 @@ class SignalingModuleImpl implements SignalingModule {
     required this.trustedCertificates,
     this.connectionTimeout = const Duration(seconds: 10),
     this.reconnectDelay = const Duration(seconds: 3),
+    this.wsPingInterval = WebtritSignalingClient.defaultWsPingInterval,
     SignalingClientFactory? clientFactory,
   }) : _clientFactory = clientFactory ?? _defaultClientFactory;
 
@@ -106,6 +112,7 @@ class SignalingModuleImpl implements SignalingModule {
   final TrustedCertificates trustedCertificates;
   final Duration connectionTimeout;
   final Duration reconnectDelay;
+  final Duration wsPingInterval;
   final SignalingClientFactory _clientFactory;
 
   // sync: true ensures events are delivered to existing listeners in the same
@@ -298,6 +305,7 @@ class SignalingModuleImpl implements SignalingModule {
           tenantId: tenantId,
           token: token,
           connectionTimeout: connectionTimeout,
+          wsPingInterval: wsPingInterval,
           certs: trustedCertificates,
           force: true,
         );
@@ -436,7 +444,7 @@ class SignalingModuleImpl implements SignalingModule {
   /// - null -- do not reconnect (protocol error or intentional close)
   Duration? _reconnectDelay(SignalingDisconnectCode code) {
     if (code == SignalingDisconnectCode.controllerForceAttachClose) return Duration.zero;
-    if (code == SignalingDisconnectCode.protocolError) return null;
+    //if (code == SignalingDisconnectCode.protocolError) return null;
     return reconnectDelay;
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -224,9 +224,10 @@ class SignalingModuleImpl implements SignalingModule {
       return;
     }
     if (_connectToken != null) {
-      _logger.fine('connect: skipped — already connecting or connected');
+      _logger.info('connect: skipped — already connecting or connected (connectToken set)');
       return;
     }
+    _logger.info('connect: starting new connect attempt (isConnected=$isConnected)');
     final token = _connectToken = Object();
     _eventBuffer.clear();
     unawaited(_connectAsync(token));
@@ -239,9 +240,11 @@ class SignalingModuleImpl implements SignalingModule {
 
     final client = _client;
     if (client == null) {
+      _logger.info('disconnect: _client already null (hadInFlightConnect=$hadInFlightConnect) — skipping TCP teardown');
       if (hadInFlightConnect) _logger.fine('disconnect: in-flight connect cancelled');
       return;
     }
+    _logger.info('disconnect: clearing _client and initiating TCP teardown');
     _client = null;
     _intentionalDisconnect = true;
     _disconnectAck = Completer<void>();
@@ -286,12 +289,18 @@ class SignalingModuleImpl implements SignalingModule {
     try {
       final existing = _client;
       if (existing != null) {
+        _logger.warning(
+          '_connectAsync: found existing _client — must pre-disconnect before connecting (this may block on zombie TCP)',
+        );
         _client = null;
+        final preDisconnectStart = DateTime.now();
         try {
           await existing.disconnect();
         } catch (e, s) {
           _logger.warning('_connectAsync pre-disconnect error', e, s);
         }
+        final preDisconnectMs = DateTime.now().difference(preDisconnectStart).inMilliseconds;
+        _logger.info('_connectAsync: pre-disconnect completed in ${preDisconnectMs}ms');
       }
 
       if (_connectToken != connectToken || _disposed) return;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -441,10 +441,9 @@ class SignalingModuleImpl implements SignalingModule {
   ///
   /// - [Duration.zero] -- reconnect immediately (server evicted a duplicate session)
   /// - [reconnectDelay] -- standard slow reconnect
-  /// - null -- do not reconnect (protocol error or intentional close)
+  /// - null -- intentional close only (disconnect() was called by the app)
   Duration? _reconnectDelay(SignalingDisconnectCode code) {
     if (code == SignalingDisconnectCode.controllerForceAttachClose) return Duration.zero;
-    //if (code == SignalingDisconnectCode.protocolError) return null;
     return reconnectDelay;
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -99,6 +99,7 @@ class _ControlledFactory {
         required String tenantId,
         required String token,
         required Duration connectionTimeout,
+        required Duration wsPingInterval,
         required TrustedCertificates certs,
         required bool force,
       }) {
@@ -135,6 +136,7 @@ SignalingModuleImpl _buildModuleFromClients(List<WebtritSignalingClient> clients
           required String tenantId,
           required String token,
           required Duration connectionTimeout,
+          required Duration wsPingInterval,
           required TrustedCertificates certs,
           required bool force,
         }) async => clients[index++],

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -519,11 +519,11 @@ void main() {
       expect(disc.recommendedReconnectDelay, Duration.zero);
     });
 
-    test('protocolError (1002) -> recommendedReconnectDelay is null', () async {
+    test('protocolError (1002) -> recommendedReconnectDelay is kSignalingClientReconnectDelay', () async {
       final disc = await disconnectWith(SignalingDisconnectCode.protocolError.code);
 
       expect(disc.knownCode, SignalingDisconnectCode.protocolError);
-      expect(disc.recommendedReconnectDelay, isNull);
+      expect(disc.recommendedReconnectDelay, kSignalingClientReconnectDelay);
     });
 
     test('normalClosure (1000) -> recommendedReconnectDelay is kSignalingClientReconnectDelay', () async {

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -93,6 +93,7 @@ SignalingClientFactory _successFactory(_FakeSignalingClient client) {
     required String tenantId,
     required String token,
     required Duration connectionTimeout,
+    required Duration wsPingInterval,
     required TrustedCertificates certs,
     required bool force,
   }) async => client;
@@ -105,6 +106,7 @@ SignalingClientFactory _failingFactory(Object error) {
     required String tenantId,
     required String token,
     required Duration connectionTimeout,
+    required Duration wsPingInterval,
     required TrustedCertificates certs,
     required bool force,
   }) async => throw error;
@@ -120,6 +122,7 @@ class _ControlledFactory {
         required String tenantId,
         required String token,
         required Duration connectionTimeout,
+        required Duration wsPingInterval,
         required TrustedCertificates certs,
         required bool force,
       }) {
@@ -258,6 +261,7 @@ void main() {
         required String tenantId,
         required String token,
         required Duration connectionTimeout,
+        required Duration wsPingInterval,
         required TrustedCertificates certs,
         required bool force,
       }) async {
@@ -623,6 +627,7 @@ void main() {
         required String tenantId,
         required String token,
         required Duration connectionTimeout,
+        required Duration wsPingInterval,
         required TrustedCertificates certs,
         required bool force,
       }) async {
@@ -786,6 +791,7 @@ void main() {
         required String tenantId,
         required String token,
         required Duration connectionTimeout,
+        required Duration wsPingInterval,
         required TrustedCertificates certs,
         required bool force,
       }) async {
@@ -1227,6 +1233,7 @@ void main() {
         required String tenantId,
         required String token,
         required Duration connectionTimeout,
+        required Duration wsPingInterval,
         required TrustedCertificates certs,
         required bool force,
       }) async {
@@ -1399,6 +1406,7 @@ void main() {
           required String tenantId,
           required String token,
           required Duration connectionTimeout,
+          required Duration wsPingInterval,
           required TrustedCertificates certs,
           required bool force,
         }) async => client,

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -473,7 +473,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   group('SignalingReconnectController - app lifecycle', () {
-    test('notifyAppPaused without active calls — disconnects and skips reconnect', () {
+    test('notifyAppPaused without active calls — does not disconnect, skips reconnect', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -482,7 +482,7 @@ void main() {
         addTearDown(controller.dispose);
 
         controller.notifyAppPaused(hasActiveCalls: false);
-        expect(module.disconnectCalls, 1);
+        expect(module.disconnectCalls, 0);
 
         module.emit(_failed());
         async.elapse(const Duration(minutes: 1));
@@ -915,12 +915,13 @@ void main() {
         final controller = SignalingReconnectController(signalingModule: module);
         addTearDown(controller.dispose);
 
-        // App goes to background, signaling disconnects intentionally.
+        // App goes to background — timer cancelled, state reset, no disconnect.
         controller.notifyAppPaused(hasActiveCalls: false);
-        expect(module.disconnectCalls, 1);
+        expect(module.disconnectCalls, 0);
 
         // Network drops and restores while offline (e.g. WiFi toggle).
         controller.notifyNetworkUnavailable();
+        expect(module.disconnectCalls, 1);
         controller.notifyNetworkAvailable();
 
         // Must connect after the fast-reconnect delay.

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -706,6 +706,52 @@ void main() {
         expect(module.connectCalls, 1);
       });
     });
+
+    test('notifyNetworkAvailable — disconnects stale connection when isConnected=true', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = true;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyNetworkAvailable();
+
+        expect(module.disconnectCalls, 1);
+      });
+    });
+
+    test('notifyNetworkAvailable — skips disconnect when isConnected=false', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = false;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyNetworkAvailable();
+
+        expect(module.disconnectCalls, 0);
+      });
+    });
+
+    test('notifyNetworkAvailable — disconnect happens before reconnect timer fires', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = true;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyNetworkAvailable();
+        expect(module.disconnectCalls, 1); // disconnect fires synchronously before timer
+        expect(module.connectCalls, 0); // connect not yet called
+
+        module.isConnected = false; // simulate disconnect completing
+        async.elapse(kSignalingClientFastReconnectDelay);
+        expect(module.connectCalls, 1); // connect fires after timer
+      });
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On iOS, when the network interface switches (WiFi → LTE or back), active calls were being dropped. Root cause: the existing TCP/WebSocket connection becomes a **zombie** — appears alive at the socket level but packets are no longer delivered on the new interface. Signaling transactions exhaust their retries and kill the call even though the ICE layer recovers on the new interface.

## Fixes

### Fix D — Proactively kill zombie WebSocket on interface change (root fix)
When `notifyNetworkAvailable()` fires (connectivity plugin detects interface change), explicitly disconnect the stale WebSocket before scheduling a reconnect. Forces a fresh connection on the new interface within ~1–3s instead of waiting for the ping timeout (~20s).

`notifyNetworkAvailable()` is now `Future<void>` so callers can await the disconnect. On Android, where the OS closes stale sockets on interface change, `isConnected` is already false and the call is a no-op.

### Fix C — WebSocket protocol-level ping as fallback
Sets `pingInterval = 10s` on the underlying `io.WebSocket`. The Dart IO layer sends a binary ping frame every 10s and closes the socket (code 1001) if no pong is received before the next ping fires (~20s total). Catches the case where the OS does not emit a network-change event.

`wsPingInterval` exposed as a constructor parameter on `SignalingModuleImpl` (default: `WebtritSignalingClient.defaultWsPingInterval = 10s`) and threaded through `SignalingClientFactory` for test injection.

### Fix B — SDP rollback instead of call termination on signaling disconnect during renegotiation (resilience layer)
During ICE restart renegotiation, the WebSocket may disconnect before the offer transaction completes. Previously this terminated the call via `callErrorReporter`. Now, when `WebtritSignalingTransactionTerminateByDisconnectException` is caught and the PeerConnection state is not Failed/Closed, the local SDP offer is rolled back via `setLocalDescription('', 'rollback')`. This returns the PC to Stable state so that when signaling reconnects and triggers `onRenegotiationNeeded` again, a fresh offer with updated ICE credentials is generated and sent successfully.

## Recovery flow

```
WiFi → LTE switch
  ↓
notifyNetworkAvailable() [Fix D]
  → await module.disconnect() (kills zombie TCP immediately)
  → scheduleReconnect(kSignalingClientFastReconnectDelay)
  → new WS on LTE interface (~1-3s)
  
[If Fix D missed] pingInterval=10s [Fix C]
  → WS closed after ~20s with code 1001
  → SignalingReconnectController schedules reconnect
  
[If signaling disconnected mid-renegotiation] [Fix B]
  → catch WebtritSignalingTransactionTerminateByDisconnectException
  → rollback setLocalDescription
  → wait for signaling reconnect → re-trigger onRenegotiationNeeded
  → fresh ICE restart offer sent
```

## Test plan
- [ ] iOS: make a call, switch WiFi → LTE → call stays active
- [ ] iOS: make a call, switch LTE → WiFi → call stays active
- [ ] Android: regression — call behaviour unchanged on interface switch
- [ ] All unit tests pass (`flutter test`)