### PR TITLE
chore: add diagnostic logs to signaling connection lifecycle

### DIFF
--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -191,7 +191,7 @@ class SignalingReconnectController {
 
   /// Call when network becomes available ([ConnectivityResult] != none).
   void notifyNetworkAvailable() {
-    _logger.fine('notifyNetworkAvailable');
+    _logger.info('notifyNetworkAvailable: isConnected=${_module.isConnected}');
     _networkActive = true;
     _networkJustRestored = true;
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
@@ -199,7 +199,7 @@ class SignalingReconnectController {
 
   /// Call when network is lost ([ConnectivityResult.none]).
   void notifyNetworkUnavailable() {
-    _logger.fine('notifyNetworkUnavailable');
+    _logger.info('notifyNetworkUnavailable: isConnected=${_module.isConnected}');
     _networkActive = false;
     _disconnect();
     _emitPresence(false);
@@ -319,6 +319,7 @@ class SignalingReconnectController {
         return;
       }
 
+      _logger.info('_scheduleReconnect: calling connect (force=$force isConnected=${_module.isConnected})');
       _module.connect();
     });
   }

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -297,7 +297,9 @@ class WebtritSignalingClient {
   //
 
   void _startKeepaliveTimer() {
-    _keepaliveTimer = Timer(_keepaliveInterval ?? Duration(seconds: 30), _onKeepalive);
+    final interval = _keepaliveInterval ?? const Duration(seconds: 30);
+    _logger.fine('$_id keepalive timer scheduled: $interval');
+    _keepaliveTimer = Timer(interval, _onKeepalive);
   }
 
   void _stopKeepaliveTimer() {
@@ -306,10 +308,12 @@ class WebtritSignalingClient {
 
   void _restartKeepaliveTimer() {
     _stopKeepaliveTimer();
+    _logger.fine('$_id keepalive timer restarted');
     _startKeepaliveTimer();
   }
 
   void _onKeepalive() async {
+    _logger.fine('$_id keepalive firing');
     try {
       final elapsed = await _executeKeepaliveTransaction(defaultExecuteTransactionTimeoutDuration);
       _logger.finest('$_id handshake keepalive latency: $elapsed');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -282,9 +282,7 @@ class SignalingModuleImpl implements SignalingModule {
     try {
       final existing = _client;
       if (existing != null) {
-        _logger.warning(
-          '_connectAsync: found existing _client — must pre-disconnect before connecting (this may block on zombie TCP)',
-        );
+        _logger.warning('_connectAsync: found existing _client — pre-disconnecting before new connect');
         _client = null;
         final preDisconnectStart = DateTime.now();
         try {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -217,9 +217,10 @@ class SignalingModuleImpl implements SignalingModule {
       return;
     }
     if (_connectToken != null) {
-      _logger.fine('connect: skipped — already connecting or connected');
+      _logger.info('connect: skipped — already connecting or connected (connectToken set)');
       return;
     }
+    _logger.info('connect: starting new connect attempt (isConnected=$isConnected)');
     final token = _connectToken = Object();
     _eventBuffer.clear();
     unawaited(_connectAsync(token));
@@ -232,9 +233,11 @@ class SignalingModuleImpl implements SignalingModule {
 
     final client = _client;
     if (client == null) {
+      _logger.info('disconnect: _client already null (hadInFlightConnect=$hadInFlightConnect) — skipping TCP teardown');
       if (hadInFlightConnect) _logger.fine('disconnect: in-flight connect cancelled');
       return;
     }
+    _logger.info('disconnect: clearing _client and initiating TCP teardown');
     _client = null;
     _intentionalDisconnect = true;
     _disconnectAck = Completer<void>();
@@ -279,12 +282,18 @@ class SignalingModuleImpl implements SignalingModule {
     try {
       final existing = _client;
       if (existing != null) {
+        _logger.warning(
+          '_connectAsync: found existing _client — must pre-disconnect before connecting (this may block on zombie TCP)',
+        );
         _client = null;
+        final preDisconnectStart = DateTime.now();
         try {
           await existing.disconnect();
         } catch (e, s) {
           _logger.warning('_connectAsync pre-disconnect error', e, s);
         }
+        final preDisconnectMs = DateTime.now().difference(preDisconnectStart).inMilliseconds;
+        _logger.info('_connectAsync: pre-disconnect completed in ${preDisconnectMs}ms');
       }
 
       if (_connectToken != connectToken || _disposed) return;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -234,7 +234,6 @@ class SignalingModuleImpl implements SignalingModule {
     final client = _client;
     if (client == null) {
       _logger.info('disconnect: _client already null (hadInFlightConnect=$hadInFlightConnect) — skipping TCP teardown');
-      if (hadInFlightConnect) _logger.fine('disconnect: in-flight connect cancelled');
       return;
     }
     _logger.info('disconnect: clearing _client and initiating TCP teardown');


### PR DESCRIPTION
## Summary

Adds diagnostic log lines across the signaling stack to make the connection lifecycle observable in field logs.

**`WebtritSignalingClient`**
- `_startKeepaliveTimer`: logs scheduled interval
- `_restartKeepaliveTimer`: logs when timer is reset
- `_onKeepalive`: logs when keepalive fires

**`SignalingModuleImpl`**
- `connect()`: logs skip reason when already connecting; logs new connect attempt start with `isConnected` state
- `disconnect()`: logs whether client was already null or teardown is initiated
- `_connectAsync`: logs warning when existing client is found; logs pre-disconnect duration

**`SignalingReconnectController`**
- `notifyNetworkAvailable` / `notifyNetworkUnavailable`: upgraded from `fine` to `info`, include `isConnected` state
- `_scheduleReconnect`: logs before calling `connect()`