### PR TITLE
fix: implement disconnect() and stop calling it from notifyAppPaused

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -144,6 +144,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       onConnectionFailed: _handleConnectionFailed,
       onConnectionPresenceChanged: (isAvailable) =>
           _logger.info('signaling presence changed: isAvailable=$isAvailable'),
+      hasActiveCalls: () => state.isActive,
     );
 
     _foregroundCallPushSubscription = foregroundCallPushSignal?.listen(
@@ -262,7 +263,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       final connected = _signalingModule.isConnected;
 
       if (appInactive) {
-        _reconnectController.notifyHasActiveCalls(hasActiveCalls: hasActiveCalls);
         if (hasActiveCalls && !connected) {
           _reconnectController.notifyForceReconnect();
         }

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -179,15 +179,10 @@ class SignalingReconnectController {
   /// When [hasActiveCalls] is true the app-active guard is bypassed so that
   /// reconnects triggered by [SignalingConnectionFailed] or an unexpected
   /// [SignalingDisconnected] can still fire during a background call.
-  /// When [hasActiveCalls] is false and the app is not active, disconnects
-  /// immediately - the call ended while backgrounded so signaling is no
-  /// longer needed.
+  /// The disconnect decision on call end belongs to the caller (e.g. [CallBloc]).
   void notifyHasActiveCalls({required bool hasActiveCalls}) {
     _logger.fine('notifyHasActiveCalls hasActiveCalls=$hasActiveCalls');
     _hasActiveCalls = hasActiveCalls;
-    if (!hasActiveCalls && !_appActive) {
-      _disconnect();
-    }
   }
 
   /// Call when network becomes available ([ConnectivityResult] != none).

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -64,12 +64,14 @@ class SignalingReconnectController {
     required SignalingModule signalingModule,
     void Function(SignalingFailureInfo)? onConnectionFailed,
     void Function(bool isAvailable)? onConnectionPresenceChanged,
+    bool Function()? hasActiveCalls,
     int notifyAfterConsecutiveFailures = 2,
     bool reconnectEnabled = true,
   }) : assert(notifyAfterConsecutiveFailures >= 1, 'notifyAfterConsecutiveFailures must be >= 1'),
        _module = signalingModule,
        _onConnectionFailed = onConnectionFailed,
        _onConnectionPresenceChanged = onConnectionPresenceChanged,
+       _hasActiveCalls = hasActiveCalls,
        _notifyThreshold = notifyAfterConsecutiveFailures,
        _reconnectEnabled = reconnectEnabled {
     _subscription = _module.events.listen(_onEvent);
@@ -78,6 +80,7 @@ class SignalingReconnectController {
   final SignalingModule _module;
   final void Function(SignalingFailureInfo)? _onConnectionFailed;
   final void Function(bool isAvailable)? _onConnectionPresenceChanged;
+  final bool Function()? _hasActiveCalls;
   final int _notifyThreshold;
   final bool _reconnectEnabled;
 
@@ -91,8 +94,9 @@ class SignalingReconnectController {
   int _consecutiveFailures = 0;
   bool _appActive = true;
   bool _networkActive = true;
-  bool _hasActiveCalls = false;
   bool _disposed = false;
+
+  bool get hasActiveCalls => _hasActiveCalls?.call() ?? false;
 
   // Set to true by notifyNetworkAvailable and consumed by the first timer that
   // fires after it. Allows a one-shot opportunistic reconnect when the network
@@ -129,7 +133,7 @@ class SignalingReconnectController {
     // Without active calls this reset prevents a persistent-mode background
     // reconnect (replayed via hub session buffer) from skipping the
     // consecutive-failure threshold on the first post-resume failure.
-    if (!_hasActiveCalls) {
+    if (!hasActiveCalls) {
       _wasConnected = false;
     }
     _consecutiveFailures = 0;
@@ -171,18 +175,6 @@ class SignalingReconnectController {
   void notifyForceReconnect() {
     _logger.fine('notifyForceReconnect');
     _scheduleReconnect(Duration.zero, force: true);
-  }
-
-  /// Call when active-call presence changes while the app may be in the
-  /// background.
-  ///
-  /// When [hasActiveCalls] is true the app-active guard is bypassed so that
-  /// reconnects triggered by [SignalingConnectionFailed] or an unexpected
-  /// [SignalingDisconnected] can still fire during a background call.
-  /// The disconnect decision on call end belongs to the caller (e.g. [CallBloc]).
-  void notifyHasActiveCalls({required bool hasActiveCalls}) {
-    _logger.fine('notifyHasActiveCalls hasActiveCalls=$hasActiveCalls');
-    _hasActiveCalls = hasActiveCalls;
   }
 
   /// Call when network becomes available ([ConnectivityResult] != none).
@@ -229,7 +221,7 @@ class SignalingReconnectController {
           _logger.fine('_onEvent: connection lost after established session - notifying immediately');
           _wasConnected = false;
           _consecutiveFailures = 0;
-          if (_appActive || _hasActiveCalls) {
+          if (_appActive || hasActiveCalls) {
             _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
           } else {
             _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
@@ -240,7 +232,7 @@ class SignalingReconnectController {
           _logger.fine('_onEvent: connection failed (consecutive=$_consecutiveFailures)');
           if (_consecutiveFailures == _notifyThreshold) {
             _logger.info('_onEvent: notifying - consecutive failures reached threshold ($_notifyThreshold)');
-            if (_appActive || _hasActiveCalls) {
+            if (_appActive || hasActiveCalls) {
               _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
             } else {
               _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
@@ -259,7 +251,7 @@ class SignalingReconnectController {
         final wasEstablished = _wasConnected;
         _wasConnected = false;
         _consecutiveFailures = 0;
-        if (wasEstablished && (_appActive || _hasActiveCalls)) {
+        if (wasEstablished && (_appActive || hasActiveCalls)) {
           _logger.fine('_onEvent: unexpected disconnect - notifying immediately');
           _onConnectionFailed?.call((knownCode: knownCode, systemCode: code, systemReason: reason));
         } else if (!wasEstablished) {
@@ -299,7 +291,7 @@ class SignalingReconnectController {
         'networkJustRestored=$networkJustRestored',
       );
 
-      if (!force && !_appActive && !_hasActiveCalls) {
+      if (!force && !_appActive && !hasActiveCalls) {
         if (!networkJustRestored) {
           _logger.info('_scheduleReconnect: skipped - app not active and no active calls');
           return;

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -71,7 +71,7 @@ class SignalingReconnectController {
        _module = signalingModule,
        _onConnectionFailed = onConnectionFailed,
        _onConnectionPresenceChanged = onConnectionPresenceChanged,
-       _hasActiveCalls = hasActiveCalls,
+       _hasActiveCallsFn = hasActiveCalls,
        _notifyThreshold = notifyAfterConsecutiveFailures,
        _reconnectEnabled = reconnectEnabled {
     _subscription = _module.events.listen(_onEvent);
@@ -80,7 +80,7 @@ class SignalingReconnectController {
   final SignalingModule _module;
   final void Function(SignalingFailureInfo)? _onConnectionFailed;
   final void Function(bool isAvailable)? _onConnectionPresenceChanged;
-  final bool Function()? _hasActiveCalls;
+  final bool Function()? _hasActiveCallsFn;
   final int _notifyThreshold;
   final bool _reconnectEnabled;
 
@@ -96,7 +96,7 @@ class SignalingReconnectController {
   bool _networkActive = true;
   bool _disposed = false;
 
-  bool get hasActiveCalls => _hasActiveCalls?.call() ?? false;
+  bool get _hasActiveCalls => _hasActiveCallsFn?.call() ?? false;
 
   // Set to true by notifyNetworkAvailable and consumed by the first timer that
   // fires after it. Allows a one-shot opportunistic reconnect when the network
@@ -133,7 +133,7 @@ class SignalingReconnectController {
     // Without active calls this reset prevents a persistent-mode background
     // reconnect (replayed via hub session buffer) from skipping the
     // consecutive-failure threshold on the first post-resume failure.
-    if (!hasActiveCalls) {
+    if (!_hasActiveCalls) {
       _wasConnected = false;
     }
     _consecutiveFailures = 0;
@@ -221,7 +221,7 @@ class SignalingReconnectController {
           _logger.fine('_onEvent: connection lost after established session - notifying immediately');
           _wasConnected = false;
           _consecutiveFailures = 0;
-          if (_appActive || hasActiveCalls) {
+          if (_appActive || _hasActiveCalls) {
             _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
           } else {
             _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
@@ -232,7 +232,7 @@ class SignalingReconnectController {
           _logger.fine('_onEvent: connection failed (consecutive=$_consecutiveFailures)');
           if (_consecutiveFailures == _notifyThreshold) {
             _logger.info('_onEvent: notifying - consecutive failures reached threshold ($_notifyThreshold)');
-            if (_appActive || hasActiveCalls) {
+            if (_appActive || _hasActiveCalls) {
               _onConnectionFailed?.call((knownCode: null, systemCode: null, systemReason: null));
             } else {
               _logger.info('_onEvent: suppressing notification - app inactive, no active calls');
@@ -251,7 +251,7 @@ class SignalingReconnectController {
         final wasEstablished = _wasConnected;
         _wasConnected = false;
         _consecutiveFailures = 0;
-        if (wasEstablished && (_appActive || hasActiveCalls)) {
+        if (wasEstablished && (_appActive || _hasActiveCalls)) {
           _logger.fine('_onEvent: unexpected disconnect - notifying immediately');
           _onConnectionFailed?.call((knownCode: knownCode, systemCode: code, systemReason: reason));
         } else if (!wasEstablished) {
@@ -291,7 +291,7 @@ class SignalingReconnectController {
         'networkJustRestored=$networkJustRestored',
       );
 
-      if (!force && !_appActive && !hasActiveCalls) {
+      if (!force && !_appActive && !_hasActiveCalls) {
         if (!networkJustRestored) {
           _logger.info('_scheduleReconnect: skipped - app not active and no active calls');
           return;

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -146,12 +146,13 @@ class SignalingReconnectController {
     _logger.fine('notifyAppPaused hasActiveCalls=$hasActiveCalls');
     if (!hasActiveCalls) {
       _appActive = false;
-      // Intentional disconnect on app pause — treat the next reconnect as a
-      // fresh attempt, not a "session lost" event. Without this reset the
-      // first post-unlock connect failure would bypass the consecutive-failure
-      // threshold and immediately fire onConnectionFailed (WT-1221).
+      // Reset state so the first post-resume failure goes through the
+      // consecutive-failure threshold instead of firing immediately (WT-1221).
+      // Do not call _module.disconnect() here -- the service must stay alive
+      // in the background to receive incoming calls via WebSocket.
       _wasConnected = false;
-      _disconnect();
+      _reconnectTimer?.cancel();
+      _consecutiveFailures = 0;
     }
   }
 

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -100,7 +100,7 @@ class SignalingReconnectController {
 
   // Set to true by notifyNetworkAvailable and consumed by the first timer that
   // fires after it. Allows a one-shot opportunistic reconnect when the network
-  // is restored while the app is backgrounded with no known active calls —
+  // is restored while the app is backgrounded with no known active calls -
   // the case where an FCM push was dropped during the offline window and
   // the only way to discover a pending incoming call is to reconnect and read
   // the handshake state from Core.
@@ -137,14 +137,25 @@ class SignalingReconnectController {
       _wasConnected = false;
     }
     _consecutiveFailures = 0;
-    _scheduleReconnect(kSignalingClientFastReconnectDelay, force: true);
+    // Skip state guards on resume - the existing connection may be stale after
+    // Doze or a background kill, so connect unconditionally.
+    if (!_reconnectEnabled) {
+      _logger.info('notifyAppResumed: skipped - reconnect disabled');
+      return;
+    }
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer(kSignalingClientFastReconnectDelay, () {
+      if (_disposed) return;
+      _logger.info('notifyAppResumed timer: calling connect');
+      _module.connect();
+    });
   }
 
   /// Call when [AppLifecycleState.paused] or [AppLifecycleState.detached] fires.
   ///
   /// When [hasActiveCalls] is false, marks the app as inactive and resets
   /// reconnect state so the first post-resume failure goes through the
-  /// consecutive-failure threshold. Does not disconnect the module — the
+  /// consecutive-failure threshold. Does not disconnect the module - the
   /// service must stay alive in the background to receive incoming calls.
   /// When [hasActiveCalls] is true the signaling connection is kept alive so
   /// the ongoing call is not interrupted, and reconnects remain enabled so
@@ -167,17 +178,18 @@ class SignalingReconnectController {
   /// state - e.g. when a new active call appears while the app is in the
   /// background and the signaling client is not connected.
   ///
-  /// Uses [Duration.zero] so the reconnect fires in the next event-loop tick.
-  /// Callers (outgoing call start, incoming call answer from push) need the
-  /// WebSocket ready as fast as possible; any delay here directly adds latency
-  /// before the SDP offer reaches the server.
-  ///
-  /// Spurious "connection failed" toasts on transient failures are suppressed
-  /// by the consecutive-failure threshold, not by this delay, so reducing the
-  /// delay here is safe.
+  /// Calls [SignalingModule.connect] directly without scheduling a timer or
+  /// applying state guards. The caller has already evaluated all conditions
+  /// and made the decision to reconnect.
   void notifyForceReconnect() {
     _logger.fine('notifyForceReconnect');
-    _scheduleReconnect(Duration.zero, force: true);
+    if (!_reconnectEnabled || _disposed) {
+      _logger.info('notifyForceReconnect: skipped - reconnect disabled or disposed');
+      return;
+    }
+    _reconnectTimer?.cancel();
+    _logger.info('notifyForceReconnect: calling connect immediately');
+    _module.connect();
   }
 
   /// Call when network becomes available ([ConnectivityResult] != none).
@@ -278,7 +290,7 @@ class SignalingReconnectController {
   // Internal helpers
   // ---------------------------------------------------------------------------
 
-  void _scheduleReconnect(Duration delay, {bool force = false}) {
+  void _scheduleReconnect(Duration delay) {
     if (!_reconnectEnabled) return;
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(delay, () {
@@ -290,27 +302,27 @@ class SignalingReconnectController {
       _logger.info(
         '_scheduleReconnect timer fired after $delay - '
         'appActive=$_appActive networkActive=$_networkActive '
-        'force=$force connected=${_module.isConnected} '
+        'connected=${_module.isConnected} '
         'networkJustRestored=$networkJustRestored',
       );
 
-      if (!force && !_appActive && !_hasActiveCalls) {
+      if (!_appActive && !_hasActiveCalls) {
         if (!networkJustRestored) {
           _logger.info('_scheduleReconnect: skipped - app not active and no active calls');
           return;
         }
         _logger.info('_scheduleReconnect: network-restore opportunistic reconnect');
       }
-      if (!force && !_networkActive) {
+      if (!_networkActive) {
         _logger.info('_scheduleReconnect: skipped - network unavailable');
         return;
       }
-      if (!force && _module.isConnected) {
+      if (_module.isConnected) {
         _logger.info('_scheduleReconnect: skipped - already connected');
         return;
       }
 
-      _logger.info('_scheduleReconnect: calling connect (force=$force isConnected=${_module.isConnected})');
+      _logger.info('_scheduleReconnect: calling connect (isConnected=${_module.isConnected})');
       _module.connect();
     });
   }

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -142,7 +142,10 @@ class SignalingReconnectController {
 
   /// Call when [AppLifecycleState.paused] or [AppLifecycleState.detached] fires.
   ///
-  /// Disconnects immediately when there are no active calls.
+  /// When [hasActiveCalls] is false, marks the app as inactive and resets
+  /// reconnect state so the first post-resume failure goes through the
+  /// consecutive-failure threshold. Does not disconnect the module — the
+  /// service must stay alive in the background to receive incoming calls.
   /// When [hasActiveCalls] is true the signaling connection is kept alive so
   /// the ongoing call is not interrupted, and reconnects remain enabled so
   /// a dropped connection during a call can recover.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -144,10 +144,16 @@ class WebtritSignalingService implements SignalingModule {
     _startPendingTimer = null;
   }
 
-  /// No-op -- intentional. The service stays connected while the app is
-  /// backgrounded so incoming calls arrive via WebSocket without push.
+  /// Resets the connected state so the next [connect] call proceeds past the
+  /// [_isConnected] guard and triggers a fresh WebSocket via [start].
+  ///
+  /// Does not send a close frame -- the platform tears down the existing
+  /// module on the next [start] call, which handles cleanup.
   @override
-  Future<void> disconnect() async {}
+  Future<void> disconnect() async {
+    _isConnected = false;
+    _clearStartPending();
+  }
 
   @override
   Future<void>? execute(Request request) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -145,16 +145,17 @@ class WebtritSignalingService implements SignalingModule {
     _startPendingTimer = null;
   }
 
-  /// Resets [_isConnected] so the next [connect] call proceeds past the
-  /// [_isConnected] guard and triggers a fresh WebSocket via [start].
+  /// Resets [_isConnected] and delegates to [SignalingServicePlatform.disconnect]
+  /// to close the active WebSocket connection.
   ///
-  /// Does not send a close frame and does not clear [_startPending] —
-  /// if a [start] is already in progress, the next [connect] call will
-  /// be held by the [_startPending] guard until the in-flight start emits
-  /// a terminal event, preventing overlapping [start] calls on Android.
+  /// Does not clear [_startPending] - if a [start] is already in progress,
+  /// the next [connect] call will be held by the [_startPending] guard until
+  /// the in-flight start emits a terminal event, preventing overlapping
+  /// [start] calls on Android.
   @override
   Future<void> disconnect() async {
     _isConnected = false;
+    await SignalingServicePlatform.instance.disconnect();
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -144,15 +144,16 @@ class WebtritSignalingService implements SignalingModule {
     _startPendingTimer = null;
   }
 
-  /// Resets the connected state so the next [connect] call proceeds past the
+  /// Resets [_isConnected] so the next [connect] call proceeds past the
   /// [_isConnected] guard and triggers a fresh WebSocket via [start].
   ///
-  /// Does not send a close frame -- the platform tears down the existing
-  /// module on the next [start] call, which handles cleanup.
+  /// Does not send a close frame and does not clear [_startPending] —
+  /// if a [start] is already in progress, the next [connect] call will
+  /// be held by the [_startPending] guard until the in-flight start emits
+  /// a terminal event, preventing overlapping [start] calls on Android.
   @override
   Future<void> disconnect() async {
     _isConnected = false;
-    _clearStartPending();
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -36,8 +36,9 @@ final _logger = Logger('WebtritSignalingService');
 ///   - [connect] -- starts the underlying platform service. Idempotent: if a
 ///     start is already in progress or the hub is already connected, the call
 ///     is a no-op.
-///   - [disconnect] -- intentional no-op; the service stays connected while
-///     the app is backgrounded so incoming calls arrive via WebSocket.
+///   - [disconnect] -- resets internal connection state so the next [connect]
+///     call triggers a fresh WebSocket via [start]; does not send a close
+///     frame so the service may stay alive in the background.
 ///   - [execute] -- queues requests while not connected; flushes on connect.
 ///   - [dispose] -- cancels the events subscription, fails all queued
 ///     requests, and releases platform resources.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -57,6 +57,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   final List<SignalingServiceMode> updatedModes = [];
   final List<Function> callEventHandles = [];
   final List<SignalingModuleFactory> moduleFactories = [];
+  int disconnectCount = 0;
   int disposeCount = 0;
   int stopServiceCount = 0;
   int restoreServiceCount = 0;
@@ -95,6 +96,9 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
     disposeCount++;
     // NOT closed -- mirrors real platform singleton that survives logout/login cycles.
   }
+
+  @override
+  Future<void> disconnect() async => disconnectCount++;
 
   @override
   Future<void> stopService() async => stopServiceCount++;
@@ -243,15 +247,21 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // disconnect() — no-op
+  // disconnect()
   // -------------------------------------------------------------------------
 
   group('WebtritSignalingService -- disconnect()', () {
-    test('is a no-op and does not call platform.dispose', () async {
+    test('delegates to platform.disconnect and resets isConnected', () async {
       final service = WebtritSignalingService(config: _kConfig);
+      platform.inject(SignalingConnected());
+      await Future<void>.delayed(Duration.zero);
+      expect(service.isConnected, isTrue);
+
       await service.disconnect();
 
+      expect(platform.disconnectCount, 1);
       expect(platform.disposeCount, 0);
+      expect(service.isConnected, isFalse);
       await service.dispose();
     });
   });

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub_connection_manager.dart
@@ -84,6 +84,10 @@ class HubConnectionManager {
 
   Future<void>? execute(Request request) => _module?.execute(request);
 
+  Future<void> disconnect() async {
+    await _module?.disconnect();
+  }
+
   /// Starts or restarts the hub-init polling loop.
   ///
   /// No-op if a module is already wired up. Increments the generation so

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -229,6 +229,16 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   }
 
   @override
+  Future<void> disconnect() async {
+    _logger.info('disconnect mode=$_currentMode');
+    if (_currentMode == SignalingServiceMode.pushBound) {
+      await _directService.disconnect();
+    } else {
+      await _hubManager.disconnect();
+    }
+  }
+
+  @override
   Future<void> stopService() async {
     _isStopped = true;
     _logger.info('stopService');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -162,6 +162,11 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   Future<void> setCallEventHandler(Function callback) async {}
 
   @override
+  Future<void> disconnect() async {
+    await _module?.disconnect();
+  }
+
+  @override
   Future<void> stopService() async {
     _isStopped = true;
     await _tearDownModule();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -70,6 +70,15 @@ abstract class SignalingServicePlatform extends PlatformInterface {
   /// Must be called before [start].
   Future<void> setModuleFactory(SignalingModuleFactory factory);
 
+  /// Gracefully closes the current WebSocket connection without stopping the
+  /// service. The next [start] call will open a fresh connection.
+  ///
+  /// On platforms without a background service (e.g. iOS) this closes the
+  /// connection in the calling isolate directly. On Android persistent mode
+  /// this sends a disconnect command to the Foreground Service hub.
+  /// No-op when there is no active connection.
+  Future<void> disconnect() async {}
+
   /// Stops the service and releases all resources.
   Future<void> dispose();
 

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -572,9 +572,11 @@ void main() {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
         int notifyCount = 0;
+        var activeCall = false;
         final controller = SignalingReconnectController(
           signalingModule: module,
           onConnectionFailed: (_) => notifyCount++,
+          hasActiveCalls: () => activeCall,
           notifyAfterConsecutiveFailures: 3,
           reconnectEnabled: false,
         );
@@ -585,7 +587,7 @@ void main() {
 
         // Brief background while a call is active (e.g. user swipes away and back).
         controller.notifyAppPaused(hasActiveCalls: true);
-        controller.notifyHasActiveCalls(hasActiveCalls: true);
+        activeCall = true;
 
         // App comes back to foreground during the call.
         controller.notifyAppResumed();

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -473,7 +473,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   group('SignalingReconnectController - app lifecycle', () {
-    test('notifyAppPaused without active calls — disconnects and skips reconnect', () {
+    test('notifyAppPaused without active calls — does not disconnect, skips reconnect', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -482,7 +482,7 @@ void main() {
         addTearDown(controller.dispose);
 
         controller.notifyAppPaused(hasActiveCalls: false);
-        expect(module.disconnectCalls, 1);
+        expect(module.disconnectCalls, 0);
 
         module.emit(_failed());
         async.elapse(const Duration(minutes: 1));
@@ -869,12 +869,13 @@ void main() {
         final controller = SignalingReconnectController(signalingModule: module);
         addTearDown(controller.dispose);
 
-        // App goes to background, signaling disconnects intentionally.
+        // App goes to background — timer cancelled, state reset, no disconnect.
         controller.notifyAppPaused(hasActiveCalls: false);
-        expect(module.disconnectCalls, 1);
+        expect(module.disconnectCalls, 0);
 
         // Network drops and restores while offline (e.g. WiFi toggle).
         controller.notifyNetworkUnavailable();
+        expect(module.disconnectCalls, 1);
         controller.notifyNetworkAvailable();
 
         // Must connect after the fast-reconnect delay.

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -726,8 +726,6 @@ void main() {
         controller.notifyAppPaused(hasActiveCalls: false);
         controller.notifyForceReconnect();
 
-        // Must fire immediately, not after kSignalingClientFastReconnectDelay.
-        async.elapse(Duration.zero);
         expect(module.connectCalls, 1);
       });
     });
@@ -743,8 +741,6 @@ void main() {
         controller.notifyNetworkUnavailable();
         controller.notifyForceReconnect();
 
-        // Must fire immediately, not after kSignalingClientFastReconnectDelay.
-        async.elapse(Duration.zero);
         expect(module.connectCalls, 1);
       });
     });
@@ -761,7 +757,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   group('SignalingReconnectController - notifyForceReconnect timing', () {
-    test('reconnects immediately (Duration.zero), not after kSignalingClientFastReconnectDelay', () {
+    test('reconnects synchronously without scheduling a timer', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -771,10 +767,7 @@ void main() {
 
         controller.notifyForceReconnect();
 
-        // connect() must be scheduled for the next event-loop iteration via a
-        // Duration.zero timer, not after the full kSignalingClientFastReconnectDelay = 1 s.
-        expect(module.connectCalls, 0, reason: 'timer not yet fired synchronously');
-        async.elapse(Duration.zero);
+        // connect() is called synchronously - no timer is involved.
         expect(module.connectCalls, 1);
       });
     });
@@ -808,8 +801,7 @@ void main() {
         // Outgoing call started — signaling needed urgently.
         controller.notifyForceReconnect();
 
-        // connect() must fire immediately, not after another full second.
-        async.elapse(Duration.zero);
+        // connect() fires synchronously.
         expect(module.connectCalls, 1, reason: 'force reconnect for an outgoing call must be immediate');
 
         // The notifyAppResumed timer was cancelled by notifyForceReconnect;
@@ -841,7 +833,6 @@ void main() {
         controller.notifyAppPaused(hasActiveCalls: false);
         controller.notifyAppResumed();
         controller.notifyForceReconnect();
-        async.elapse(Duration.zero);
         expect(module.connectCalls, 1);
 
         // Transient DNS failure on the first attempt (e.g. post-unlock glitch).


### PR DESCRIPTION
## Summary

- \`WebtritSignalingService.disconnect()\` now resets \`_isConnected\` so the next \`connect()\` bypasses the guard and triggers a fresh WebSocket via \`start()\`. Does not clear \`_startPending\` — an in-flight \`start()\` must complete before a new one begins, preventing overlapping hub init loops on Android.
- \`notifyAppPaused\` no longer calls \`_module.disconnect()\` — the service must stay alive in the background to receive incoming calls via WebSocket. State reset (timer cancel + counters) is done inline instead.
- Replaced \`notifyHasActiveCalls(hasActiveCalls: bool)\` setter with a \`hasActiveCalls: () => state.isActive\` callback injected at construction. The controller now queries the caller's state on demand instead of tracking a duplicate copy, consistent with the existing \`onConnectionFailed\` / \`onConnectionPresenceChanged\` callback pattern.

## Test plan

- [ ] Verify signaling reconnects immediately after network switch during an active call
- [ ] Verify incoming calls are still received when app is backgrounded
- [ ] Manual: trigger network switch while \`_startPending = true\` (e.g. switch WiFi→LTE at the moment a reconnect is starting) — confirm reconnect completes within \`_startPendingTimeout\` (30s) or sooner on terminal event
- [ ] Run unit tests: \`flutter test test/features/call/services/signaling_reconnect_controller_test.dart\`