### PR TITLE
fix: reset NativeLogForwarder read offset and remainder on start

### DIFF
--- a/lib/repositories/log_records/native_log_forwarder.dart
+++ b/lib/repositories/log_records/native_log_forwarder.dart
@@ -25,6 +25,8 @@ class NativeLogForwarder implements Disposable {
 
   void start() {
     _watchSubscription?.cancel();
+    _readOffset = _file.existsSync() ? _file.lengthSync() : 0;
+    _remainder = '';
     final absolutePath = _file.absolute.path;
     _watchSubscription = _file.parent
         .watch()
@@ -75,7 +77,6 @@ class NativeLogForwarder implements Disposable {
       await raf?.close();
     }
   }
-
 
   @override
   Future<void> dispose() async {


### PR DESCRIPTION
## Summary

- Resets `_readOffset` to the current end of the log file (skipping stale content) and clears `_remainder` each time `start()` is called
- Prevents previously read data from being re-processed on hot-restart or service restart

## Test plan

- [x] Hot-restart app and verify no duplicate log lines are forwarded
- [x] Verify normal log forwarding still works after restart