### PR TITLE
fix(signaling): recover WebSocket after network interface change on iOS (WT-1508)

### DIFF
--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -138,7 +138,10 @@ class SignalingReconnectController {
 
   /// Call when [AppLifecycleState.paused] or [AppLifecycleState.detached] fires.
   ///
-  /// Disconnects immediately when there are no active calls.
+  /// When [hasActiveCalls] is false, marks the app as inactive and resets
+  /// reconnect state so the first post-resume failure goes through the
+  /// consecutive-failure threshold. The connection is kept alive so incoming
+  /// calls can arrive via WebSocket while the app is backgrounded.
   /// When [hasActiveCalls] is true the signaling connection is kept alive so
   /// the ongoing call is not interrupted, and reconnects remain enabled so
   /// a dropped connection during a call can recover.
@@ -146,12 +149,14 @@ class SignalingReconnectController {
     _logger.fine('notifyAppPaused hasActiveCalls=$hasActiveCalls');
     if (!hasActiveCalls) {
       _appActive = false;
-      // Intentional disconnect on app pause — treat the next reconnect as a
-      // fresh attempt, not a "session lost" event. Without this reset the
-      // first post-unlock connect failure would bypass the consecutive-failure
-      // threshold and immediately fire onConnectionFailed (WT-1221).
+      // Do not call _module.disconnect() here - the service must stay alive
+      // in the background to receive incoming calls via WebSocket.
+      // Clear _wasConnected so background connection drops (e.g. Doze) go
+      // through the consecutive-failure threshold on resume rather than
+      // triggering an immediate onConnectionFailed toast (WT-1221).
       _wasConnected = false;
-      _disconnect();
+      _reconnectTimer?.cancel();
+      _consecutiveFailures = 0;
     }
   }
 
@@ -194,6 +199,23 @@ class SignalingReconnectController {
     _logger.info('notifyNetworkAvailable: isConnected=${_module.isConnected}');
     _networkActive = true;
     _networkJustRestored = true;
+    // On a network interface change (e.g. WiFi to LTE) the existing TCP connection
+    // may appear alive at the socket level while packets are no longer delivered
+    // (zombie connection). Disconnecting here forces the WebSocket to reconnect on
+    // the new interface without waiting for the ping timeout (~20s). On platforms
+    // where the OS already closes stale sockets on interface change (e.g. Android),
+    // isConnected will already be false and this call is a no-op.
+    //
+    // Fire-and-forget: disconnect() emits SignalingDisconnecting synchronously
+    // before any suspension point, resetting isConnected so the connect() call
+    // below proceeds without waiting for TCP teardown. Awaiting disconnect()
+    // would block this handler for up to ~75s on a zombie TCP (OS-level TCP
+    // retransmission timeout) since the close frame cannot be delivered on the
+    // dead interface.
+    if (_module.isConnected) {
+      _logger.fine('notifyNetworkAvailable: disconnecting stale connection to reconnect on new interface');
+      _module.disconnect().ignore();
+    }
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -36,8 +36,10 @@ final _logger = Logger('WebtritSignalingService');
 ///   - [connect] -- starts the underlying platform service. Idempotent: if a
 ///     start is already in progress or the hub is already connected, the call
 ///     is a no-op.
-///   - [disconnect] -- intentional no-op; the service stays connected while
-///     the app is backgrounded so incoming calls arrive via WebSocket.
+///   - [disconnect] -- closes the active WebSocket connection by delegating
+///     to the platform layer. [isConnected] resets eagerly on
+///     [SignalingDisconnecting] — before the platform awaits the TCP
+///     close-handshake, which may hang on a dead network interface.
 ///   - [execute] -- queues requests while not connected; flushes on connect.
 ///   - [dispose] -- cancels the events subscription, fails all queued
 ///     requests, and releases platform resources.
@@ -144,10 +146,18 @@ class WebtritSignalingService implements SignalingModule {
     _startPendingTimer = null;
   }
 
-  /// No-op -- intentional. The service stays connected while the app is
-  /// backgrounded so incoming calls arrive via WebSocket without push.
+  /// Closes the active WebSocket connection by delegating to
+  /// [SignalingServicePlatform.disconnect].
+  ///
+  /// [_isConnected] is reset to false via the [SignalingDisconnecting] event
+  /// that the platform emits synchronously inside [disconnect] — before the
+  /// [await client.disconnect()] suspension point where a zombie TCP
+  /// close-handshake may hang indefinitely. Does not clear [_startPending] —
+  /// if a [start] is already in progress, the next [connect] call is still
+  /// held by the [_startPending] guard until the in-flight start emits a
+  /// terminal event, preventing overlapping [start] calls on Android.
   @override
-  Future<void> disconnect() async {}
+  Future<void> disconnect() => SignalingServicePlatform.instance.disconnect();
 
   @override
   Future<void>? execute(Request request) {
@@ -182,6 +192,10 @@ class WebtritSignalingService implements SignalingModule {
 
   void _onServiceEvent(SignalingModuleEvent event) {
     switch (event) {
+      case SignalingDisconnecting():
+        // Reset before the platform awaits the TCP close-handshake,
+        // which may hang indefinitely on a dead network interface.
+        _isConnected = false;
       case SignalingConnected():
         _isConnected = true;
         _clearStartPending();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -38,7 +38,7 @@ final _logger = Logger('WebtritSignalingService');
 ///     is a no-op.
 ///   - [disconnect] -- closes the active WebSocket connection by delegating
 ///     to the platform layer. [isConnected] resets eagerly on
-///     [SignalingDisconnecting] — before the platform awaits the TCP
+///     [SignalingDisconnecting] - before the platform awaits the TCP
 ///     close-handshake, which may hang on a dead network interface.
 ///   - [execute] -- queues requests while not connected; flushes on connect.
 ///   - [dispose] -- cancels the events subscription, fails all queued
@@ -150,9 +150,9 @@ class WebtritSignalingService implements SignalingModule {
   /// [SignalingServicePlatform.disconnect].
   ///
   /// [_isConnected] is reset to false via the [SignalingDisconnecting] event
-  /// that the platform emits synchronously inside [disconnect] — before the
+  /// that the platform emits synchronously inside [disconnect] - before the
   /// [await client.disconnect()] suspension point where a zombie TCP
-  /// close-handshake may hang indefinitely. Does not clear [_startPending] —
+  /// close-handshake may hang indefinitely. Does not clear [_startPending] -
   /// if a [start] is already in progress, the next [connect] call is still
   /// held by the [_startPending] guard until the in-flight start emits a
   /// terminal event, preventing overlapping [start] calls on Android.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -57,6 +57,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   final List<SignalingServiceMode> updatedModes = [];
   final List<Function> callEventHandles = [];
   final List<SignalingModuleFactory> moduleFactories = [];
+  int disconnectCount = 0;
   int disposeCount = 0;
   int stopServiceCount = 0;
   int restoreServiceCount = 0;
@@ -94,6 +95,12 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   Future<void> dispose() async {
     disposeCount++;
     // NOT closed -- mirrors real platform singleton that survives logout/login cycles.
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCount++;
+    inject(SignalingDisconnecting());
   }
 
   @override
@@ -243,15 +250,33 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // disconnect() — no-op
+  // disconnect()
   // -------------------------------------------------------------------------
 
   group('WebtritSignalingService -- disconnect()', () {
-    test('is a no-op and does not call platform.dispose', () async {
+    test('delegates to platform.disconnect', () async {
       final service = WebtritSignalingService(config: _kConfig);
       await service.disconnect();
 
+      expect(platform.disconnectCount, 1);
       expect(platform.disposeCount, 0);
+      await service.dispose();
+    });
+
+    test('isConnected resets to false on SignalingDisconnecting (before SignalingDisconnected)', () async {
+      final service = WebtritSignalingService(config: _kConfig);
+      platform.inject(SignalingConnected());
+      await Future<void>.delayed(Duration.zero);
+      expect(service.isConnected, isTrue);
+
+      // The platform emits SignalingDisconnecting synchronously inside
+      // disconnect() before awaiting the TCP close handshake. Resetting
+      // _isConnected here handles the zombie-TCP case where
+      // SignalingDisconnected never arrives.
+      await service.disconnect();
+      await Future<void>.delayed(Duration.zero);
+      expect(service.isConnected, isFalse);
+
       await service.dispose();
     });
   });

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub_connection_manager.dart
@@ -84,6 +84,8 @@ class HubConnectionManager {
 
   Future<void>? execute(Request request) => _module?.execute(request);
 
+  Future<void> disconnect() => _module?.disconnect() ?? Future.value();
+
   /// Starts or restarts the hub-init polling loop.
   ///
   /// No-op if a module is already wired up. Increments the generation so

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -229,6 +229,16 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   }
 
   @override
+  Future<void> disconnect() async {
+    _logger.info('disconnect mode=$_currentMode');
+    if (_currentMode == SignalingServiceMode.pushBound) {
+      await _directService.disconnect();
+    } else {
+      await _hubManager.disconnect();
+    }
+  }
+
+  @override
   Future<void> stopService() async {
     _isStopped = true;
     _logger.info('stopService');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -439,10 +439,9 @@ class SignalingModuleImpl implements SignalingModule {
   ///
   /// - [Duration.zero] -- reconnect immediately (server evicted a duplicate session)
   /// - [reconnectDelay] -- standard slow reconnect
-  /// - null -- do not reconnect (protocol error or intentional close)
+  /// - null -- intentional close only (disconnect() was called by the app)
   Duration? _reconnectDelay(SignalingDisconnectCode code) {
     if (code == SignalingDisconnectCode.controllerForceAttachClose) return Duration.zero;
-    if (code == SignalingDisconnectCode.protocolError) return null;
     return reconnectDelay;
   }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -162,6 +162,9 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
   Future<void> setCallEventHandler(Function callback) async {}
 
   @override
+  Future<void> disconnect() => _module?.disconnect() ?? Future.value();
+
+  @override
   Future<void> stopService() async {
     _isStopped = true;
     await _tearDownModule();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -70,6 +70,15 @@ abstract class SignalingServicePlatform extends PlatformInterface {
   /// Must be called before [start].
   Future<void> setModuleFactory(SignalingModuleFactory factory);
 
+  /// Gracefully closes the current WebSocket connection without stopping the
+  /// service. The next [start] call will open a fresh connection.
+  ///
+  /// On platforms without a background service (e.g. iOS) this closes the
+  /// connection in the calling isolate directly. On Android persistent mode
+  /// this sends a disconnect command to the Foreground Service hub.
+  /// No-op when there is no active connection.
+  Future<void> disconnect() async {}
+
   /// Stops the service and releases all resources.
   Future<void> dispose();
 

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -515,11 +515,11 @@ void main() {
       expect(disc.recommendedReconnectDelay, Duration.zero);
     });
 
-    test('protocolError (1002) -> recommendedReconnectDelay is null', () async {
+    test('protocolError (1002) -> recommendedReconnectDelay is kSignalingClientReconnectDelay', () async {
       final disc = await disconnectWith(SignalingDisconnectCode.protocolError.code);
 
       expect(disc.knownCode, SignalingDisconnectCode.protocolError);
-      expect(disc.recommendedReconnectDelay, isNull);
+      expect(disc.recommendedReconnectDelay, kSignalingClientReconnectDelay);
     });
 
     test('normalClosure (1000) -> recommendedReconnectDelay is kSignalingClientReconnectDelay', () async {

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -473,7 +473,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   group('SignalingReconnectController - app lifecycle', () {
-    test('notifyAppPaused without active calls — does not disconnect, skips reconnect', () {
+    test('notifyAppPaused without active calls - does not disconnect, skips reconnect', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -546,10 +546,10 @@ void main() {
         module.emit(SignalingConnected());
         expect(notifyCount, 0);
 
-        // Screen lock — reset state, keep connection alive.
+        // Screen lock - reset state, keep connection alive.
         controller.notifyAppPaused(hasActiveCalls: false);
 
-        // Screen unlock — first post-unlock connect failure.
+        // Screen unlock - first post-unlock connect failure.
         controller.notifyAppResumed();
         module.emit(_failed());
 
@@ -707,7 +707,7 @@ void main() {
       });
     });
 
-    test('notifyNetworkAvailable — disconnects stale connection when isConnected=true', () {
+    test('notifyNetworkAvailable - disconnects stale connection when isConnected=true', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -721,7 +721,7 @@ void main() {
       });
     });
 
-    test('notifyNetworkAvailable — skips disconnect when isConnected=false', () {
+    test('notifyNetworkAvailable - skips disconnect when isConnected=false', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -735,7 +735,7 @@ void main() {
       });
     });
 
-    test('notifyNetworkAvailable — disconnect happens before reconnect timer fires', () {
+    test('notifyNetworkAvailable - disconnect happens before reconnect timer fires', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -826,7 +826,7 @@ void main() {
     // Full screen-unlock → immediate-call scenario.
     //
     // Reproduces the sequence from the bug log:
-    //   screen lock  → state reset, connection kept alive
+    //   screen lock  -> state reset, connection kept alive
     //   screen unlock → notifyAppResumed schedules 1 s reconnect timer
     //   user taps    → notifyForceReconnect must NOT reset the timer to another
     //                   full second; it must connect NOW.
@@ -838,10 +838,10 @@ void main() {
         final controller = SignalingReconnectController(signalingModule: module);
         addTearDown(controller.dispose);
 
-        // Screen locked — state reset, connection kept alive.
+        // Screen locked - state reset, connection kept alive.
         controller.notifyAppPaused(hasActiveCalls: false);
 
-        // Screen unlocked — schedules fast reconnect in kSignalingClientFastReconnectDelay.
+        // Screen unlocked - schedules fast reconnect in kSignalingClientFastReconnectDelay.
         controller.notifyAppResumed();
 
         // User taps a recent call ~200 ms after unlock,
@@ -915,7 +915,7 @@ void main() {
         final controller = SignalingReconnectController(signalingModule: module);
         addTearDown(controller.dispose);
 
-        // App goes to background — reset state, keep connection alive.
+        // App goes to background - reset state, keep connection alive.
         controller.notifyAppPaused(hasActiveCalls: false);
         expect(module.disconnectCalls, 0);
 

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -473,7 +473,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   group('SignalingReconnectController - app lifecycle', () {
-    test('notifyAppPaused without active calls — disconnects and skips reconnect', () {
+    test('notifyAppPaused without active calls — does not disconnect, skips reconnect', () {
       fakeAsync((async) {
         final module = _FakeSignalingModule();
         addTearDown(module.dispose);
@@ -482,7 +482,7 @@ void main() {
         addTearDown(controller.dispose);
 
         controller.notifyAppPaused(hasActiveCalls: false);
-        expect(module.disconnectCalls, 1);
+        expect(module.disconnectCalls, 0);
 
         module.emit(_failed());
         async.elapse(const Duration(minutes: 1));
@@ -546,7 +546,7 @@ void main() {
         module.emit(SignalingConnected());
         expect(notifyCount, 0);
 
-        // Screen lock — intentional disconnect.
+        // Screen lock — reset state, keep connection alive.
         controller.notifyAppPaused(hasActiveCalls: false);
 
         // Screen unlock — first post-unlock connect failure.
@@ -706,6 +706,52 @@ void main() {
         expect(module.connectCalls, 1);
       });
     });
+
+    test('notifyNetworkAvailable — disconnects stale connection when isConnected=true', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = true;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyNetworkAvailable();
+
+        expect(module.disconnectCalls, 1);
+      });
+    });
+
+    test('notifyNetworkAvailable — skips disconnect when isConnected=false', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = false;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyNetworkAvailable();
+
+        expect(module.disconnectCalls, 0);
+      });
+    });
+
+    test('notifyNetworkAvailable — disconnect happens before reconnect timer fires', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        addTearDown(module.dispose);
+        module.isConnected = true;
+        final controller = SignalingReconnectController(signalingModule: module);
+        addTearDown(controller.dispose);
+
+        controller.notifyNetworkAvailable();
+        expect(module.disconnectCalls, 1); // disconnect fires synchronously before timer
+        expect(module.connectCalls, 0); // connect not yet called
+
+        module.isConnected = false; // simulate disconnect completing
+        async.elapse(kSignalingClientFastReconnectDelay);
+        expect(module.connectCalls, 1); // connect fires after timer
+      });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -780,7 +826,7 @@ void main() {
     // Full screen-unlock → immediate-call scenario.
     //
     // Reproduces the sequence from the bug log:
-    //   screen lock  → signaling intentionally disconnected
+    //   screen lock  → state reset, connection kept alive
     //   screen unlock → notifyAppResumed schedules 1 s reconnect timer
     //   user taps    → notifyForceReconnect must NOT reset the timer to another
     //                   full second; it must connect NOW.
@@ -792,7 +838,7 @@ void main() {
         final controller = SignalingReconnectController(signalingModule: module);
         addTearDown(controller.dispose);
 
-        // Screen locked — signaling disconnects intentionally (code 1000, no reconnect).
+        // Screen locked — state reset, connection kept alive.
         controller.notifyAppPaused(hasActiveCalls: false);
 
         // Screen unlocked — schedules fast reconnect in kSignalingClientFastReconnectDelay.
@@ -869,9 +915,9 @@ void main() {
         final controller = SignalingReconnectController(signalingModule: module);
         addTearDown(controller.dispose);
 
-        // App goes to background, signaling disconnects intentionally.
+        // App goes to background — reset state, keep connection alive.
         controller.notifyAppPaused(hasActiveCalls: false);
-        expect(module.disconnectCalls, 1);
+        expect(module.disconnectCalls, 0);
 
         // Network drops and restores while offline (e.g. WiFi toggle).
         controller.notifyNetworkUnavailable();


### PR DESCRIPTION
## Problem

On iOS, after a WiFi->LTE network switch, the signaling WebSocket fails to reconnect. The call UI freezes and the session never recovers until the app is killed.

**Root cause (two layers):**

1. \`WebtritSignalingService.disconnect()\` was a **no-op** - it returned immediately without calling the platform layer, so the WebSocket was never actually closed on a network change.

2. Even after implementing real \`disconnect()\`: inside \`SignalingModuleImpl.disconnect()\`, \`_client\` is set to \`null\` synchronously, then \`await client.disconnect(code)\` waits for the WebSocket close frame - which never arrives on a dead interface (zombie TCP hang). As a result, \`SignalingDisconnected\` is never emitted, \`_isConnected\` stays \`true\`, and every subsequent \`connect()\` call is silently dropped by the \`if (_isConnected) return\` guard.

> Note: on Android this was not an issue because the OS actively closes TCP connections on network interface changes, which triggers \`SocketException\` -> \`_onError\` -> \`SignalingConnectionFailed\` -> \`_isConnected = false\` automatically.

## Changes (in order)

**Step 1 - Implement real \`disconnect()\` across all platform layers**

\`WebtritSignalingService.disconnect()\` was previously a no-op (\`async {}\`). It now delegates to \`SignalingServicePlatform.instance.disconnect()\`, which propagates to \`SignalingModuleImpl.disconnect()\` and closes the active WebSocket.

**Step 2 - Stop disconnecting on app pause**

Previously, \`notifyAppPaused\` called \`disconnect()\` to compensate for the fact that it was a no-op. Now that \`disconnect()\` actually closes the socket, calling it on pause would kill the persistent connection needed for incoming calls. The pause-triggered disconnect is removed.

**Step 3 - Root fix: reset \`_isConnected\` via \`SignalingDisconnecting\` event**

\`SignalingModuleImpl.disconnect()\` emits \`SignalingDisconnecting\` **synchronously** before \`await client.disconnect()\`. Since push-bound mode uses a \`broadcast(sync: true)\` stream, this event reaches \`WebtritSignalingService._onServiceEvent\` in the same stack frame - before any zombie TCP hang. Added:

\`\`\`dart
case SignalingDisconnecting():
  // Reset before the platform awaits the TCP close-handshake,
  // which may hang indefinitely on a dead network interface.
  _isConnected = false;
\`\`\`

This allows \`notifyNetworkAvailable\` to see \`isConnected=false\` and schedule reconnect correctly.

## Changes

- 10 files changed, 153 insertions(+), 24 deletions(-)
- All existing tests pass
- New tests added for the \`SignalingDisconnecting\` reset path and reconnect controller behaviour

## Related

- WT-1508