### PR TITLE
fix(push): raise local notification channel importance for heads-up alerts (WT-1520)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -75,6 +75,14 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Default channel for FCM notification-payload messages auto-displayed
+             while the app is in background/killed. The backend currently sends a
+             null channelId, so without this they fall back to a default-importance
+             channel (sound, no heads-up, no screen wake). Must match
+             kLocalPushChannelId in local_push_repository.dart. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="app_notifications_channel" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -433,9 +433,26 @@ Future _initLocalPushs() async {
     onDidReceiveBackgroundNotificationResponse: LocalPushsBroker.handleActionReceived,
   );
 
+  await _initAndroidNotificationChannel();
+
   final launchDetails = await FlutterLocalNotificationsPlugin().getNotificationAppLaunchDetails();
   final data = launchDetails?.notificationResponse;
   if (data != null) LocalPushsBroker.handleActionReceived(data);
+}
+
+/// Creates the high-importance local push channel referenced by FCM's
+/// `default_notification_channel_id` and drops the legacy default-importance
+/// channel so heads-up banners and screen wake work for local pushes.
+Future<void> _initAndroidNotificationChannel() async {
+  final androidPlugin = FlutterLocalNotificationsPlugin()
+      .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+  if (androidPlugin == null) return;
+
+  // ignore: deprecated_member_use_from_same_package
+  await androidPlugin.deleteNotificationChannel(kLegacyLocalPushChannelId);
+  await androidPlugin.createNotificationChannel(
+    const AndroidNotificationChannel(kLocalPushChannelId, kLocalPushChannelName, importance: Importance.high),
+  );
 }
 
 // Debugging push notifications

--- a/lib/repositories/push_notifications/local_push_repository.dart
+++ b/lib/repositories/push_notifications/local_push_repository.dart
@@ -74,11 +74,35 @@ class LocalPushRepositoryFLNImpl implements LocalPushRepository {
   }
 }
 
+/// Notification channel id for app-displayed local pushes (messages, missed
+/// calls, system notifications).
+///
+/// Deliberately differs from [kLegacyLocalPushChannelId]: Android caches a
+/// channel's importance at creation time, so raising importance on an existing
+/// channel has no effect for users who already have it. A new id forces the
+/// high-importance channel to be created.
+///
+/// Keep this value in sync with `default_notification_channel_id` in
+/// android/app/src/main/AndroidManifest.xml.
+const kLocalPushChannelId = 'app_notifications_channel';
+
+/// Human-readable name shown for [kLocalPushChannelId] in the system settings.
+const kLocalPushChannelName = 'Notifications';
+
+/// Legacy channel id created with default importance. Deleted on startup so it
+/// no longer lingers in the system notification settings.
+@Deprecated(
+  'Retained only to delete the old default-importance channel on startup. '
+  'Remove this constant together with the deleteNotificationChannel cleanup '
+  'once existing installs have migrated to kLocalPushChannelId.',
+)
+const kLegacyLocalPushChannelId = 'local_channel';
+
 const kAndroidNotificationDetails = AndroidNotificationDetails(
-  'local_channel',
-  'local channel',
-  importance: Importance.defaultImportance,
-  priority: Priority.defaultPriority,
+  kLocalPushChannelId,
+  kLocalPushChannelName,
+  importance: Importance.high,
+  priority: Priority.high,
 );
 const kDarwinNotificationDetails = DarwinNotificationDetails(
   presentAlert: true,


### PR DESCRIPTION
## Problem

The local push channel (`local_channel`) was created with `Importance.defaultImportance`. Per Android's channel spec this level plays a sound but produces no heads-up banner and does not wake the screen. Users heard the notification sound but saw nothing, both on the active and the locked screen.

There are two display paths and both were affected:

- Foreground: the app displays the notification itself via `flutter_local_notifications` (messages, missed calls, system notifications, all via `displayPush`).
- Background / killed: the message carries a `notification` payload, so FCM auto-displays it. A real push log confirms the backend sends `android.channelId: null`, so FCM falls back to a default-importance channel (sound, no heads-up, no screen wake) - the reported cases.

## Fix

- New high-importance channel: recreate the channel under a fresh id (`app_notifications_channel`) with `Importance.high` / `Priority.high`. A channel's importance is cached on the device at creation time, so raising importance on the existing id would have no effect for users who already have it; a new id forces the high-importance channel to be created.
- Explicit channel setup on startup: `_initAndroidNotificationChannel()` creates the new channel and deletes the legacy default-importance one so it no longer lingers in the system notification settings.
- FCM default channel meta-data: declare `com.google.firebase.messaging.default_notification_channel_id` pointing at the new channel, so background/killed auto-displayed messages use the high-importance channel even though the backend sends a null channelId. If the backend later sends a `channelId`, it overrides this default.