### PR TITLE
fix: close popups on call compacting (WT-1437)

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -91,6 +91,8 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
         dispatchInteractionDebounce();
       }
     });
+
+    _compactController.addListener(_onCompactChanged);
   }
 
   @override
@@ -103,9 +105,17 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   @override
   void dispose() {
     _disposeRemoteFrameWatcher();
+    _compactController.removeListener(_onCompactChanged);
     _compactController.dispose();
     _debounceByStateSubscription?.cancel();
     super.dispose();
+  }
+
+  void _onCompactChanged() {
+    if (_compactController.compact && mounted) {
+      _logger.finer('_onCompactChanged - closing all popups');
+      Navigator.of(context).popUntil((route) => route is! PopupRoute);
+    }
   }
 
   @override


### PR DESCRIPTION
When the call screen enters compact mode (controls hidden via AnimatedOpacity), any open PopupMenuButton overlay — specifically the transfer action menu — remained visible. This
   happened because PopupMenuButton renders its dropdown by pushing a PopupRoute onto the Navigator overlay, which is completely outside the AnimatedOpacity/IgnorePointer subtree.

  Solution

  Added a ChangeNotifier listener on _compactController in CallActiveScaffoldState. When compact mode activates, it calls Navigator.of(context).popUntil((route) => route is! 
  PopupRoute), which closes any open popup menu routes without affecting the call screen or other named routes.

  The listener is explicitly removed before the controller is disposed to avoid stale callbacks.

  Changes

  - call_active_scaffold.dart — subscribe to _compactController in initState, unsubscribe in dispose, dismiss PopupRoute entries on compact transition