### PR TITLE
fix: prevent "add after close" crash during bloc teardown

### DIFF
--- a/lib/blocs/local_contacts_sync/local_contacts_sync_bloc.dart
+++ b/lib/blocs/local_contacts_sync/local_contacts_sync_bloc.dart
@@ -69,7 +69,7 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
 
     _initContactsSubscription();
 
-    add(const LocalContactsSyncRefreshed());
+    await _loadContacts(emit);
   }
 
   void _onRefreshed(LocalContactsSyncRefreshed event, Emitter<LocalContactsSyncState> emit) async {
@@ -98,11 +98,15 @@ class LocalContactsSyncBloc extends Bloc<LocalContactsSyncEvent, LocalContactsSy
 
     _initContactsSubscription();
 
+    await _loadContacts(emit);
+  }
+
+  Future<void> _loadContacts(Emitter<LocalContactsSyncState> emit) async {
     emit(const LocalContactsSyncRefreshInProgress());
     try {
       await localContactsRepository.load();
     } catch (error) {
-      _logger.warning('_onRefreshed error: ', error);
+      _logger.warning('_loadContacts error: ', error);
       if (!isClosed) emit(const LocalContactsSyncRefreshFailure());
     }
   }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -498,6 +498,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     emit(state.copyWith(currentAppLifecycleState: lifecycleState));
     _logger.fine('_onCallStarted initial lifecycle state: $lifecycleState');
 
+    // Subscribe before the first await so close() cancels it reliably and no listener leaks during teardown
+    _connectivityChangedSubscription = Connectivity().onConnectivityChanged.listen(_handleConnectivityChanged);
+
     // Initialize connectivity state
     final connectivityState = (await Connectivity().checkConnectivity()).first;
     emit(
@@ -506,12 +509,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       ),
     );
     _logger.finer('_onCallStarted initial connectivity state: $connectivityState');
-
-    // Subscribe to future connectivity changes
-    _connectivityChangedSubscription = Connectivity().onConnectivityChanged.listen((result) {
-      final currentConnectivityResult = result.first;
-      add(_ConnectivityResultChanged(currentConnectivityResult));
-    });
 
     if (connectivityState == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
@@ -534,6 +531,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _reconnectController.notifyAppResumed();
     }
   }
+
+  void _handleConnectivityChanged(List<ConnectivityResult> result) => add(_ConnectivityResultChanged(result.first));
 
   Future<void> _onConnectivityResultChanged(_ConnectivityResultChanged event, Emitter<CallState> emit) async {
     final connectivityResult = event.result;


### PR DESCRIPTION
## Problem

During a forced logout the app crashed twice with:

```
StateError: Bad state: Cannot add new events after calling close
```

- `LocalContactsSyncBloc._onStarted` → `add(LocalContactsSyncRefreshed())`
- `CallBloc._onCallStarted.<anonymous>` → `add(_ConnectivityResultChanged(...))` inside the `onConnectivityChanged` listener

## Root cause

`Bloc.close()` (bloc 9.x) closes the internal **event** controller first, then awaits in-flight handlers, and only flips the public `isClosed` flag (the **state** controller) last:

```dart
Future<void> close() async {
  await _eventController.close();                    // (1) event controller closed
  ...
  await Future.wait(_emitters.map((e) => e.future)); // (2) awaits in-flight handlers
  ...
  return super.close();                              // (3) isClosed becomes true
}
```

Because step (2) awaits the very handler that is still suspended on an `await`, that handler resumes while `isClosed` is still `false`, then calls `add()` on the already-closed event controller. A guard on `isClosed` is therefore not dependable in this window.

The crash surfaced when an invalid session token forced an immediate logout while the UI thread was heavily loaded (Impeller/Vulkan jank, long GC, Firebase heartbeat contention), delaying the handlers' `await`s by ~10s — right into `close()`.

## Fix

Rather than adding a parallel "closing" flag, fix the lifecycle so `add()` can't be reached after close:

- **`CallBloc._onCallStarted`**: create the `onConnectivityChanged` subscription **before** the first `await`. The existing `close()` cancels `_connectivityChangedSubscription` before the event controller closes, so the listener is torn down in time and can no longer leak or fire `add()` after close. The listener callback no longer needs an `isClosed` guard.
- **`LocalContactsSyncBloc._onStarted`**: load contacts directly via a shared `_loadContacts(emit)` instead of re-dispatching `LocalContactsSyncRefreshed` from inside the handler. This removes the `add()`-after-close path entirely (`_onRefreshed` now shares the same helper).

## Notes

- The same pattern (`add(...)` after an `await` in a handler) may exist elsewhere; a wider sweep can be a separate follow-up.
- No tests added — the race is timing-dependent and hard to reproduce deterministically. Open to a `close()`-during-handler test if wanted.