### PR TITLE
fix: voicemail unread count glitch (WT-1424)

### DIFF
--- a/lib/repositories/voicemail/voicemail_repository.dart
+++ b/lib/repositories/voicemail/voicemail_repository.dart
@@ -156,8 +156,11 @@ class VoicemailRepositoryImpl
     _fetchingCompleter!.future.ignore();
 
     try {
-      /// Emit unknown status to indicate sync in progress
-      await _emitCachedVoicemails(status: ReadStatus.unknown);
+      /// Do not emit unknown status to show updating state, because it leads to UI flicker on SettingsScreen
+      /// especially on android if user checks status bar and app changes its lifecycle from innactive to resumed (WT-1424)
+      /// 
+      /// Add separate event if needed
+      await _emitCachedVoicemails();
 
       final remoteItems = await _webtritApiClient.getUserVoicemailList(_token, locale: localeCode);
 
@@ -189,12 +192,9 @@ class VoicemailRepositoryImpl
   }
 
   /// Retrieves local voicemails and pushes them to the stream controller.
-  ///
-  /// If [status] is provided, it overrides the items' actual status.
-  /// Otherwise, uses the status stored in the database.
-  Future<void> _emitCachedVoicemails({ReadStatus? status}) async {
+  Future<void> _emitCachedVoicemails() async {
     final dataList = await _appDatabase.voicemailDao.getVoicemailsWithContacts();
-    final items = dataList.map((it) => _voicemailFromDriftWithContact(it, readStatus: status)).toList();
+    final items = dataList.map(_voicemailFromDriftWithContact).toList();
 
     if (items.isNotEmpty) {
       _updatesController?.add(items);

--- a/test/repository/voicemail_repository_test.dart
+++ b/test/repository/voicemail_repository_test.dart
@@ -12,13 +12,13 @@ import '../mocks/voicemails_fixture_factory.dart';
 
 void main() {
   late AppDatabase appDatabase;
-  late VoicemailRepositoryImpl dataSource;
+  late VoicemailRepositoryImpl repo;
   late MockWebtritApiClient apiClient;
 
   setUp(() {
     appDatabase = AppDatabase(NativeDatabase.memory());
     apiClient = MockWebtritApiClient();
-    dataSource = VoicemailRepositoryImpl(
+    repo = VoicemailRepositoryImpl(
       webtritApiClient: apiClient,
       token: 'user_token',
       appDatabase: appDatabase,
@@ -28,6 +28,125 @@ void main() {
 
   tearDown(() async {
     await appDatabase.close();
+  });
+
+  group('watchUnreadVoicemailsCount', () {
+    test('emits 0 when database is empty', () async {
+      expect(await repo.watchUnreadVoicemailsCount().first, equals(0));
+    });
+
+    test('emits total count when all voicemails are unread', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: false),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '2', seen: false),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '3', seen: false),
+      );
+
+      expect(await repo.watchUnreadVoicemailsCount().first, equals(3));
+    });
+
+    test('emits 0 when all voicemails are read', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: true),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '2', seen: true),
+      );
+
+      expect(await repo.watchUnreadVoicemailsCount().first, equals(0));
+    });
+
+    test('emits only the unread count when voicemails are mixed', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: false),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '2', seen: true),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '3', seen: false),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '4', seen: true),
+      );
+
+      expect(await repo.watchUnreadVoicemailsCount().first, equals(2));
+    });
+
+    test('decreases reactively when an unread voicemail is marked as seen', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: false),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '2', seen: false),
+      );
+
+      final future = expectLater(repo.watchUnreadVoicemailsCount(), emitsInOrder([2, 1]));
+      await pumpEventQueue();
+      await repo.updateVoicemailSeenStatus('1', true);
+      await future;
+    });
+
+    test('drops to 0 reactively when the last unread voicemail is marked as seen', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: false),
+      );
+
+      final future = expectLater(repo.watchUnreadVoicemailsCount(), emitsInOrder([1, 0]));
+      await pumpEventQueue();
+      await repo.updateVoicemailSeenStatus('1', true);
+      await future;
+    });
+
+    test('decreases reactively when an unread voicemail is deleted', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: false),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '2', seen: false),
+      );
+
+      final future = expectLater(repo.watchUnreadVoicemailsCount(), emitsInOrder([2, 1]));
+      await pumpEventQueue();
+      await repo.removeVoicemail('1');
+      await future;
+    });
+
+    test('does not change count reactively when a read voicemail is deleted', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: false),
+      );
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '2', seen: true),
+      );
+
+      final events = <int>[];
+      final subscription = repo.watchUnreadVoicemailsCount().listen(events.add);
+      await pumpEventQueue();
+
+      await repo.removeVoicemail('2');
+      await pumpEventQueue();
+
+      expect(events.last, equals(1));
+      await subscription.cancel();
+    });
+
+    test('increases reactively when a new unread voicemail is inserted', () async {
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '1', seen: false),
+      );
+
+      final future = expectLater(repo.watchUnreadVoicemailsCount(), emitsInOrder([1, 2]));
+      await pumpEventQueue();
+      await appDatabase.voicemailDao.insertOrUpdateVoicemail(
+        VoicemailsFixtureFactory.createVoicemail(id: '2', seen: false),
+      );
+      await future;
+    });
   });
 
   group('VoicemailRepository', () {
@@ -47,9 +166,9 @@ void main() {
       expect(voicemails.where((voicemail) => voicemail.seen).length, 2);
       expect(voicemails.where((voicemail) => !voicemail.seen).length, 2);
 
-      await dataSource.updateVoicemailSeenStatus('1', false);
-      await dataSource.updateVoicemailSeenStatus('2', true);
-      await dataSource.updateVoicemailSeenStatus('4', true);
+      await repo.updateVoicemailSeenStatus('1', false);
+      await repo.updateVoicemailSeenStatus('2', true);
+      await repo.updateVoicemailSeenStatus('4', true);
 
       voicemails = await appDatabase.voicemailDao.getAllVoicemails();
       expect(voicemails.where((voicemail) => voicemail.seen).length, 3);
@@ -68,7 +187,7 @@ void main() {
       var voicemails = await appDatabase.voicemailDao.getAllVoicemails();
       expect(voicemails.length, 3);
 
-      await dataSource.removeMultipleVoicemails(['1', '3']);
+      await repo.removeMultipleVoicemails(['1', '3']);
 
       voicemails = await appDatabase.voicemailDao.getAllVoicemails();
       expect(voicemails.length, 1);


### PR DESCRIPTION
 Root cause: fetchVoicemails() called _emitCachedVoicemails(status: ReadStatus.unknown) at the start of every sync, overriding every cached voicemail's read status with
  unknown. 
  - Fix: Removed the status override — cached voicemails are now emitted with their actual seen value from the database, so the unread count stays stable throughout the sync
  cycle.
  - Tests: Added watchUnreadVoicemailsCount test group to test/repository/voicemail_repository_test.dart covering static count accuracy (empty, all-read, all-unread, mixed)
  and reactive updates (mark seen, delete unread/read, insert).