### PR TITLE
fix: allow outgoing calls during re-registration window (WT-1554)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1301,12 +1301,17 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> __onCallControlEventStarted(_CallControlEventStarted event, Emitter<CallState> emit) async {
-    if (state.callServiceState.registration?.status.isRegistered != true) {
-      _logger.info('__onCallControlEventStarted account is not registered');
-      submitNotification(CallWhileUnregisteredNotification());
-      return;
-    }
-
+    // WT-1554: do NOT reject here when not registered.
+    //
+    // The downstream [__onCallPerformEventStarted] path already waits up to
+    // [kOutgoingCallSignalingWaitTimeout] for signaling+registration, triggers
+    // [_reconnectController.notifyForceReconnect], and parks the call in
+    // [CallProcessingStatus.outgoingConnectingToSignaling] so the call screen can
+    // show a "Connecting…" state. Failing fast here prevents that recovery flow
+    // from running (e.g. when the app has just been opened from push mode and
+    // SIP REGISTER has not completed yet) and surfaces an avoidable error to the
+    // user. The unregistered/offline notifications still fire from
+    // [__onCallPerformEventStarted] after the wait truly times out.
     add(
       _CallMutationEvent.controlStart(
         handle: event.handle,
@@ -1486,12 +1491,24 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// Returns true when [__onCallPerformEventStarted] should stop waiting for
   /// signaling readiness.
   ///
-  /// Exits as soon as both the handshake and signaling are established, or when
-  /// the call leaves [CallProcessingStatus.outgoingConnectingToSignaling] — for
-  /// example because the user pressed hangup (status → disconnecting) or
-  /// another code path removed the call entirely.
+  /// Exits as soon as both the handshake and signaling are established AND the
+  /// SIP REGISTER has been accepted (WT-1554 — waiting only on the socket
+  /// allowed the wait to finish while registration was still in progress, and
+  /// the call was then rejected with [CallWhileUnregisteredNotification]).
+  ///
+  /// Also exits fast when registration has definitively failed, so a known-bad
+  /// state does not block the call for the full [kOutgoingCallSignalingWaitTimeout].
+  ///
+  /// Finally exits when the call leaves
+  /// [CallProcessingStatus.outgoingConnectingToSignaling] — for example because
+  /// the user pressed hangup (status → disconnecting) or another code path
+  /// removed the call entirely.
   bool _shouldExitOutgoingSignalingWait(CallState next, String callId) {
-    if (next.isHandshakeEstablished && next.isSignalingEstablished) return true;
+    final registration = next.callServiceState.registration;
+    if (next.isHandshakeEstablished && next.isSignalingEstablished && registration?.status.isRegistered == true) {
+      return true;
+    }
+    if (registration?.status.isFailed == true) return true;
     final call = next.retrieveActiveCall(callId);
     return call == null || call.processingStatus != CallProcessingStatus.outgoingConnectingToSignaling;
   }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1307,7 +1307,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // [kOutgoingCallSignalingWaitTimeout] for signaling+registration, triggers
     // [_reconnectController.notifyForceReconnect], and parks the call in
     // [CallProcessingStatus.outgoingConnectingToSignaling] so the call screen can
-    // show a "Connecting…" state. Failing fast here prevents that recovery flow
+    // show a "Connecting..." state. Failing fast here prevents that recovery flow
     // from running (e.g. when the app has just been opened from push mode and
     // SIP REGISTER has not completed yet) and surfaces an avoidable error to the
     // user. The unregistered/offline notifications still fire from
@@ -1492,7 +1492,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// signaling readiness.
   ///
   /// Exits as soon as both the handshake and signaling are established AND the
-  /// SIP REGISTER has been accepted (WT-1554 — waiting only on the socket
+  /// SIP REGISTER has been accepted (WT-1554 - waiting only on the socket
   /// allowed the wait to finish while registration was still in progress, and
   /// the call was then rejected with [CallWhileUnregisteredNotification]).
   ///
@@ -1500,8 +1500,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// state does not block the call for the full [kOutgoingCallSignalingWaitTimeout].
   ///
   /// Finally exits when the call leaves
-  /// [CallProcessingStatus.outgoingConnectingToSignaling] — for example because
-  /// the user pressed hangup (status → disconnecting) or another code path
+  /// [CallProcessingStatus.outgoingConnectingToSignaling] - for example because
+  /// the user pressed hangup (status -> disconnecting) or another code path
   /// removed the call entirely.
   bool _shouldExitOutgoingSignalingWait(CallState next, String callId) {
     final registration = next.callServiceState.registration;

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -4,10 +4,8 @@ import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
-import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
-import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/services/connectivity_service.dart';
 
 class CallController {
@@ -76,24 +74,23 @@ class CallController {
     bool video = false,
     String? fromNumber,
   }) async {
-    // WT-1554: trust the bloc's authoritative NetworkStatus instead of running
-    // a fresh HTTP connectivity probe.
+    // WT-1554: do NOT pre-check connectivity / NetworkStatus here.
     //
-    // The probe could return a stale "no connection" right after the app
-    // returned from background (cached `_netConnected == false`, platform
-    // connectivity not yet refreshed), and the call was blocked here even when
-    // the bloc already knew the network was available. By the time the call
-    // would reach CallBloc, the existing wait + reconnect flow handles the
-    // genuine-offline case and surfaces the proper notifications after the
-    // 30 s timeout.
-    if (callBloc.state.callServiceState.networkStatus == NetworkStatus.none) {
-      _logger.warning('Cannot create call: no network connectivity.');
-      notificationsBloc.add(const NotificationsSubmitted(NoInternetConnectionNotification()));
-      return;
-    }
+    // The original purpose of this gate was to fast-fail before waiting up to
+    // [kCallRoutingStateTimeout] for routing state when the app had no network
+    // on startup. However it also fired right after the app returned from
+    // background (stale ConnectivityService cache, or transient bloc
+    // NetworkStatus.none while the OS was refreshing) and blocked perfectly
+    // valid calls. The routing-state wait below already handles the only case
+    // that genuinely needs blocking — routing state never initialized — by
+    // emitting [GeneralUnableToCallNotification] after the timeout. For every
+    // other case (network just flapping, signaling reconnecting, registration
+    // re-establishing) we let the call through and let CallBloc's downstream
+    // wait + reconnect flow decide.
 
     // Use current state if available, otherwise wait for the first non-null emission.
-    // Timeout guards against indefinite wait when there is no network on startup.
+    // Timeout guards against indefinite wait when routing state never initializes
+    // (e.g. no network on startup, backend never responded with line config).
     // orElse returns null only if the cubit is closed while waiting (e.g. logout).
     final CallRoutingState? callRoutingState;
     try {

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -7,6 +7,7 @@ import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
 import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/services/connectivity_service.dart';
 
 class CallController {
@@ -75,10 +76,17 @@ class CallController {
     bool video = false,
     String? fromNumber,
   }) async {
-    // Check network connectivity independently before attempting to get routing state,
-    // to provide more accurate notifications to the user.
-    final netConnected = await isNetworkConnected;
-    if (!netConnected) {
+    // WT-1554: trust the bloc's authoritative NetworkStatus instead of running
+    // a fresh HTTP connectivity probe.
+    //
+    // The probe could return a stale "no connection" right after the app
+    // returned from background (cached `_netConnected == false`, platform
+    // connectivity not yet refreshed), and the call was blocked here even when
+    // the bloc already knew the network was available. By the time the call
+    // would reach CallBloc, the existing wait + reconnect flow handles the
+    // genuine-offline case and surfaces the proper notifications after the
+    // 30 s timeout.
+    if (callBloc.state.callServiceState.networkStatus == NetworkStatus.none) {
       _logger.warning('Cannot create call: no network connectivity.');
       notificationsBloc.add(const NotificationsSubmitted(NoInternetConnectionNotification()));
       return;

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -4,8 +4,10 @@ import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
+import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/services/connectivity_service.dart';
 
 class CallController {
@@ -74,19 +76,23 @@ class CallController {
     bool video = false,
     String? fromNumber,
   }) async {
-    // WT-1554: do NOT pre-check connectivity / NetworkStatus here.
+    // WT-1554: fast-fail only in the narrow case where routing state has not
+    // initialized AND the bloc already knows the network is definitively down.
     //
-    // The original purpose of this gate was to fast-fail before waiting up to
-    // [kCallRoutingStateTimeout] for routing state when the app had no network
-    // on startup. However it also fired right after the app returned from
-    // background (stale ConnectivityService cache, or transient bloc
-    // NetworkStatus.none while the OS was refreshing) and blocked perfectly
-    // valid calls. The routing-state wait below already handles the only case
-    // that genuinely needs blocking — routing state never initialized — by
-    // emitting [GeneralUnableToCallNotification] after the timeout. For every
-    // other case (network just flapping, signaling reconnecting, registration
-    // re-establishing) we let the call through and let CallBloc's downstream
-    // wait + reconnect flow decide.
+    // [_waitForRoutingState] below would otherwise sit through the full
+    // [kCallRoutingStateTimeout] (~10 s) while routing state can never arrive
+    // without network, leaving the user with no feedback. We intentionally
+    // require BOTH conditions:
+    //   - callRoutingCubit.state == null  (routing state not yet initialized)
+    //   - networkStatus == NetworkStatus.none  (bloc has a definitive signal)
+    // For "routing state present" / "network just flapping" / "signaling
+    // reconnecting" cases we still let the call through and let CallBloc's
+    // downstream wait + reconnect flow decide.
+    if (callRoutingCubit.state == null && callBloc.state.callServiceState.networkStatus == NetworkStatus.none) {
+      _logger.warning('Cannot create call: routing state not initialized and network is offline.');
+      notificationsBloc.add(const NotificationsSubmitted(NoInternetConnectionNotification()));
+      return;
+    }
 
     // Use current state if available, otherwise wait for the first non-null emission.
     // Timeout guards against indefinite wait when routing state never initializes

--- a/lib/features/call/controllers/call_controller.dart
+++ b/lib/features/call/controllers/call_controller.dart
@@ -76,18 +76,9 @@ class CallController {
     bool video = false,
     String? fromNumber,
   }) async {
-    // WT-1554: fast-fail only in the narrow case where routing state has not
-    // initialized AND the bloc already knows the network is definitively down.
-    //
-    // [_waitForRoutingState] below would otherwise sit through the full
-    // [kCallRoutingStateTimeout] (~10 s) while routing state can never arrive
-    // without network, leaving the user with no feedback. We intentionally
-    // require BOTH conditions:
-    //   - callRoutingCubit.state == null  (routing state not yet initialized)
-    //   - networkStatus == NetworkStatus.none  (bloc has a definitive signal)
-    // For "routing state present" / "network just flapping" / "signaling
-    // reconnecting" cases we still let the call through and let CallBloc's
-    // downstream wait + reconnect flow decide.
+    // WT-1554: fast-fail when routing state has not initialized AND the bloc
+    // already knows we are offline - otherwise [_waitForRoutingState] would
+    // sit through the full [kCallRoutingStateTimeout] (~10 s) with no feedback.
     if (callRoutingCubit.state == null && callBloc.state.callServiceState.networkStatus == NetworkStatus.none) {
       _logger.warning('Cannot create call: routing state not initialized and network is offline.');
       notificationsBloc.add(const NotificationsSubmitted(NoInternetConnectionNotification()));

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -66,6 +66,10 @@ void main() {
     notificationsBloc = _MockNotificationsBloc();
     connectivityService = _MockConnectivityService();
     when(() => callBloc.add(any())).thenReturn(null);
+    // WT-1554: CallController now reads callBloc.state.callServiceState.networkStatus
+    // before dispatching. Default CallState() has networkStatus == null (≠ none),
+    // so the gate passes and the previous test expectations stay valid.
+    when(() => callBloc.state).thenReturn(const CallState());
     when(() => notificationsBloc.add(any())).thenReturn(null);
     when(() => connectivityService.connectionStream).thenAnswer((_) => const Stream<bool>.empty());
     when(() => connectivityService.checkConnection()).thenAnswer((_) async => true);

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -182,7 +182,7 @@ void main() {
 
       test('fast-fails with NoInternetConnectionNotification when bloc reports networkStatus.none', () async {
         // WT-1554: when routing state is not initialized AND the bloc already knows
-        // the network is offline, do not wait the full kCallRoutingStateTimeout —
+        // the network is offline, do not wait the full kCallRoutingStateTimeout -
         // surface NoInternetConnectionNotification immediately.
         when(() => callRoutingCubit.state).thenReturn(null);
         when(

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -7,9 +7,10 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/notifications/bloc/notifications_bloc.dart';
+import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
-import 'package:webtrit_phone/models/lines_state.dart';
+import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/services/connectivity_service.dart';
 
 class _MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {}
@@ -66,6 +67,11 @@ void main() {
     notificationsBloc = _MockNotificationsBloc();
     connectivityService = _MockConnectivityService();
     when(() => callBloc.add(any())).thenReturn(null);
+    // WT-1554: _createCallAsync now reads callBloc.state.callServiceState.networkStatus
+    // as part of the fast-fail check (only triggers when routing state is also null AND
+    // networkStatus == NetworkStatus.none). Default CallState() has networkStatus == null,
+    // so the fast-fail does not fire and the previous test expectations remain valid.
+    when(() => callBloc.state).thenReturn(const CallState());
     when(() => notificationsBloc.add(any())).thenReturn(null);
     when(() => connectivityService.connectionStream).thenAnswer((_) => const Stream<bool>.empty());
     when(() => connectivityService.checkConnection()).thenAnswer((_) async => true);
@@ -172,6 +178,24 @@ void main() {
           expect((captured as NotificationsSubmitted).notification, isA<GeneralUnableToCallNotification>());
           verifyNever(() => callBloc.add(any()));
         });
+      });
+
+      test('fast-fails with NoInternetConnectionNotification when bloc reports networkStatus.none', () async {
+        // WT-1554: when routing state is not initialized AND the bloc already knows
+        // the network is offline, do not wait the full kCallRoutingStateTimeout —
+        // surface NoInternetConnectionNotification immediately.
+        when(() => callRoutingCubit.state).thenReturn(null);
+        when(
+          () => callBloc.state,
+        ).thenReturn(const CallState(callServiceState: CallServiceState(networkStatus: NetworkStatus.none)));
+
+        controller.createCall(destination: '222');
+        await Future<void>.delayed(Duration.zero);
+
+        final captured = verify(() => notificationsBloc.add(captureAny())).captured.single;
+        expect(captured, isA<NotificationsSubmitted>());
+        expect((captured as NotificationsSubmitted).notification, isA<NoInternetConnectionNotification>());
+        verifyNever(() => callBloc.add(any()));
       });
     });
   });

--- a/test/features/call/controllers/call_controller_test.dart
+++ b/test/features/call/controllers/call_controller_test.dart
@@ -66,10 +66,6 @@ void main() {
     notificationsBloc = _MockNotificationsBloc();
     connectivityService = _MockConnectivityService();
     when(() => callBloc.add(any())).thenReturn(null);
-    // WT-1554: CallController now reads callBloc.state.callServiceState.networkStatus
-    // before dispatching. Default CallState() has networkStatus == null (≠ none),
-    // so the gate passes and the previous test expectations stay valid.
-    when(() => callBloc.state).thenReturn(const CallState());
     when(() => notificationsBloc.add(any())).thenReturn(null);
     when(() => connectivityService.connectionStream).thenAnswer((_) => const Stream<bool>.empty());
     when(() => connectivityService.checkConnection()).thenAnswer((_) async => true);


### PR DESCRIPTION
First of a two-part WT-1554 series. This PR is the **minimal in-place fix** that lands the user-visible behaviour change. The follow-up [#1297](https://github.com/WebTrit/webtrit_phone/pull/1297) is the **architectural cleanup** stacked on top of this one.

YouTrack: [WT-1554](https://youtrack.portaone.com/issue/WT-1554)

## Problem

In push mode, after long idle the app loses SIP registration; incoming calls arrive via push (ok). When the user reopens the app and **immediately** taps a recent number (or dialpad / contacts / voicemail / call-pull) - within the few seconds before SIP REGISTER completes - the call is rejected instantly with *"You're currently unable to place calls..."*. 100% reproducible.

A related cold-start scenario (truly offline, routing state never initialised) also blocked the call with a confusing 10 s frozen tap before showing any feedback.

## What this PR changes

Two narrow fixes inside the existing architecture (controller still waits for routing state, bloc keeps the same handler structure):

### Bloc — outgoing-call wait now waits for **registration** too

`lib/features/call/bloc/call_bloc.dart`

- `__onCallControlEventStarted`: remove the hard reject on `!isRegistered`. Previously this was a fail-fast that ran before the existing wait/reconnect path; now the call enters the downstream `outgoingConnectingToSignaling` flow that already exists for native phone-recents / CallKit calls.
- `_shouldExitOutgoingSignalingWait`: require `registration.isRegistered == true` in addition to handshake/signaling readiness. Fail-fast on `registration.isFailed` so a known-bad account does not block the call for the full 30 s timeout.

### Controller — connectivity-probe gate replaced with bloc-state check

`lib/features/call/controllers/call_controller.dart`

The old HTTP-probe-based `isNetworkConnected` getter could return a stale "no connection" right after the app returned from background (cached `_netConnected == false`, OS connectivity not yet refreshed). The probe was replaced in stages:
1. Trust the bloc's authoritative `callBloc.state.callServiceState.networkStatus` instead of the HTTP probe.
2. Drop the connectivity-NetworkStatus pre-check entirely - the routing-state wait below handles the only case that genuinely needs blocking (routing state never initialised).
3. Add a narrow fast-fail back: when routing state is `null` AND `networkStatus == NetworkStatus.none`, surface `NoInternetConnectionNotification` immediately instead of waiting 10 s.

The controller keeps its existing shape: still waits for `CallRoutingCubit` to emit non-null, still does line-availability checks, still resolves `fromNumber` via the cubit.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Push-mode reopen + immediate Recents call | Instant error snackbar | Call screen 'Connecting...', dials once REGISTER completes |
| Airplane mode the whole time | Instant error | 'Connecting...' for up to 30 s, then offline/unregistered error |
| Real account suspended (SIP 401/403) | Instant unregistered error | Fail-fast on `registration.isFailed` - same error within ~1 s |
| Native phone-recents (CallKit / Telecom) | Already used wait flow | Same flow, now also waits for REGISTER |
| Cold start, fully offline, no routing state yet | 10 s frozen tap, generic error | Immediate `NoInternetConnectionNotification` |

## Trade-offs

The architectural shape stays unchanged in this PR. `CallController` is still routing-state-aware; the cubit is still on the call critical path; line-availability checks still live in the controller. That is intentional - keep this PR narrow.

The follow-up [#1297](https://github.com/WebTrit/webtrit_phone/pull/1297) collapses the controller to a thin dispatcher and moves all gating into the bloc. That is a separate review.

## Relationship to #1297

This PR is the **minimum fix** that unblocks the user-visible WT-1554 behaviour. It is safe to land independently.

[#1297](https://github.com/WebTrit/webtrit_phone/pull/1297) stacks on top with the larger refactor: thin `CallController`, bloc owns all gating, caller-ID resolution lifted to an injected callback + extension, named helpers on `CallState`. That PR is a refactor review - no additional user-visible behaviour beyond what this one delivers.