### PR TITLE
feat(signaling): reregister on signaling reconnect after network interface change (WT-1467)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -93,6 +93,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   StreamSubscription<void>? _foregroundCallPushSubscription;
   final _iceRestartDebounce = DebounceMap<String>(const Duration(seconds: 2));
 
+  // Tracks the last non-none primary connectivity type so a transition between
+  // two live interfaces (e.g. WiFi -> LTE) is distinguishable from a simple
+  // drop+restore of the same interface. Used to decide when to ask Core for a
+  // full re-registration via [SignalingReconnectController.notifyInterfaceChanged].
+  // Not reset when connectivity goes to none, so the next non-none result can
+  // still be compared against the prior interface.
+  ConnectivityResult? _lastPrimaryNetwork;
+  DateTime? _lastInterfaceChangeAt;
+  static const _interfaceChangeDebounce = Duration(seconds: 2);
+
   late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
   late final SignalingReconnectController _reconnectController;
@@ -541,6 +551,28 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (connectivityResult == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
     } else {
+      // Detect a transition between two live interfaces (e.g. WiFi -> LTE).
+      // The stale TCP that Core holds to PBX may already be a dead NAT pinhole
+      // (WT-1467) - ask Core to tear down the controller and re-REGISTER on a
+      // fresh TCP. Must run before notifyNetworkAvailable so the flag is in
+      // place when the reconnect timer reads it.
+      final previousPrimary = _lastPrimaryNetwork;
+      if (previousPrimary != null && previousPrimary != connectivityResult) {
+        final now = DateTime.now();
+        final lastAt = _lastInterfaceChangeAt;
+        if (lastAt == null || now.difference(lastAt) > _interfaceChangeDebounce) {
+          _lastInterfaceChangeAt = now;
+          _logger.info(
+            '_onConnectivityResultChanged: interface change $previousPrimary -> $connectivityResult, marking reregister',
+          );
+          _reconnectController.notifyInterfaceChanged();
+        } else {
+          _logger.fine(
+            '_onConnectivityResultChanged: interface change $previousPrimary -> $connectivityResult debounced',
+          );
+        }
+      }
+      _lastPrimaryNetwork = connectivityResult;
       _reconnectController.notifyNetworkAvailable();
 
       // Restart ICE for all active calls to trigger faster recovery from connectivity loss.

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -97,8 +97,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   // signaling reconnect that follows can be marked with reregister=true -
   // asking Core to refresh the SIP Contact before any incoming call lands on
   // a stale NAT pinhole. Same-interface drop+restore is not reported as a
-  // change; debounce collapses rapid flapping.
-  final _interfaceChangeDetector = InterfaceChangeDetector();
+  // change; debounce collapses rapid flapping. Injectable so tests can use a
+  // detector with a fake clock or recorded results.
+  final InterfaceChangeDetector _interfaceChangeDetector;
 
   late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
@@ -137,7 +138,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required PeerConnectionManager peerConnectionManager,
     this.onCallEnded,
     Stream<void>? foregroundCallPushSignal,
-  }) : super(const CallState()) {
+    InterfaceChangeDetector? interfaceChangeDetector,
+  }) : _interfaceChangeDetector = interfaceChangeDetector ?? InterfaceChangeDetector(),
+       super(const CallState()) {
     _mediaManager = CallMediaManager(callkeep: callkeep);
     _signalingModule = signalingModule;
     _peerConnectionManager = peerConnectionManager;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -93,15 +93,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   StreamSubscription<void>? _foregroundCallPushSubscription;
   final _iceRestartDebounce = DebounceMap<String>(const Duration(seconds: 2));
 
-  // Tracks the last non-none primary connectivity type so a transition between
-  // two live interfaces (e.g. WiFi -> LTE) is distinguishable from a simple
-  // drop+restore of the same interface. Used to decide when to ask Core for a
-  // full re-registration via [SignalingReconnectController.notifyInterfaceChanged].
-  // Not reset when connectivity goes to none, so the next non-none result can
-  // still be compared against the prior interface.
-  ConnectivityResult? _lastPrimaryNetwork;
-  DateTime? _lastInterfaceChangeAt;
-  static const _interfaceChangeDebounce = Duration(seconds: 2);
+  // Tracks transitions between two live interfaces (e.g. WiFi -> LTE) so the
+  // signaling reconnect that follows can be marked with reregister=true -
+  // asking Core to refresh the SIP Contact before any incoming call lands on
+  // a stale NAT pinhole. Same-interface drop+restore is not reported as a
+  // change; debounce collapses rapid flapping.
+  final _interfaceChangeDetector = InterfaceChangeDetector();
 
   late final SignalingModule _signalingModule;
   late final StreamSubscription<SignalingModuleEvent> _signalingSubscription;
@@ -551,28 +548,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (connectivityResult == ConnectivityResult.none) {
       _reconnectController.notifyNetworkUnavailable();
     } else {
-      // Detect a transition between two live interfaces (e.g. WiFi -> LTE).
       // The stale TCP that Core holds to PBX may already be a dead NAT pinhole
-      // (WT-1467) - ask Core to tear down the controller and re-REGISTER on a
-      // fresh TCP. Must run before notifyNetworkAvailable so the flag is in
-      // place when the reconnect timer reads it.
-      final previousPrimary = _lastPrimaryNetwork;
-      if (previousPrimary != null && previousPrimary != connectivityResult) {
-        final now = DateTime.now();
-        final lastAt = _lastInterfaceChangeAt;
-        if (lastAt == null || now.difference(lastAt) > _interfaceChangeDebounce) {
-          _lastInterfaceChangeAt = now;
-          _logger.info(
-            '_onConnectivityResultChanged: interface change $previousPrimary -> $connectivityResult, marking reregister',
-          );
-          _reconnectController.notifyInterfaceChanged();
-        } else {
-          _logger.fine(
-            '_onConnectivityResultChanged: interface change $previousPrimary -> $connectivityResult debounced',
-          );
-        }
+      // (WT-1467) - on a real interface change ask Core to tear down the
+      // controller and re-REGISTER on a fresh TCP. Must run before
+      // notifyNetworkAvailable so the flag is in place when the reconnect
+      // timer reads it.
+      final change = _interfaceChangeDetector.update(connectivityResult);
+      if (change != null) {
+        _logger.info('_onConnectivityResultChanged: interface change $change, marking reregister');
+        _reconnectController.notifyInterfaceChanged();
       }
-      _lastPrimaryNetwork = connectivityResult;
       _reconnectController.notifyNetworkAvailable();
 
       // Restart ICE for all active calls to trigger faster recovery from connectivity loss.

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -102,6 +102,13 @@ class SignalingReconnectController {
   // the handshake state from Core.
   bool _networkJustRestored = false;
 
+  // Set to true by [notifyInterfaceChanged]; carried into the next
+  // [_module.connect] call and consumed there. Tells Core to tear down the
+  // existing controller and start a fresh SIP registration over a new TCP
+  // connection - the stale Contact left after a network interface change
+  // (e.g. WiFi to LTE) is replaced before the next incoming call arrives.
+  bool _reregisterNext = false;
+
   /// Last value passed to [_onConnectionPresenceChanged].
   /// Starts as `true` (assumed available) to avoid a spurious "available"
   /// callback on the first [SignalingConnected] event.
@@ -217,6 +224,22 @@ class SignalingReconnectController {
       _module.disconnect().ignore();
     }
     _scheduleReconnect(kSignalingClientFastReconnectDelay);
+  }
+
+  /// Call when the device's active network interface changed between two
+  /// live interfaces (e.g. WiFi to LTE, or vice versa).
+  ///
+  /// Marks the next [_module.connect] to include `reregister=true` in its
+  /// URL, asking Core to tear down the existing controller and start a
+  /// fresh SIP registration over a new TCP connection. The stale SIP
+  /// Contact left from the previous interface is replaced before the next
+  /// incoming call can arrive.
+  ///
+  /// Must be called before [notifyNetworkAvailable] for the same event so
+  /// the flag is set when the reconnect timer reads it.
+  void notifyInterfaceChanged() {
+    _logger.info('notifyInterfaceChanged: marking next connect as reregister');
+    _reregisterNext = true;
   }
 
   /// Call when network is lost ([ConnectivityResult.none]).
@@ -341,8 +364,12 @@ class SignalingReconnectController {
         return;
       }
 
-      _logger.info('_scheduleReconnect: calling connect (force=$force isConnected=${_module.isConnected})');
-      _module.connect();
+      final reregister = _reregisterNext;
+      _reregisterNext = false;
+      _logger.info(
+        '_scheduleReconnect: calling connect (force=$force isConnected=${_module.isConnected} reregister=$reregister)',
+      );
+      _module.connect(reregister: reregister);
     });
   }
 

--- a/lib/utils/interface_change_detector.dart
+++ b/lib/utils/interface_change_detector.dart
@@ -1,0 +1,53 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+/// A primary connectivity transition between two live (non-none) interfaces.
+class NetworkInterfaceChange {
+  const NetworkInterfaceChange({required this.previous, required this.current});
+
+  final ConnectivityResult previous;
+  final ConnectivityResult current;
+
+  @override
+  String toString() => '$previous -> $current';
+}
+
+/// Stateful detector of network interface changes with cooldown debounce.
+///
+/// Feed every primary [ConnectivityResult] (the first non-none entry from
+/// connectivity_plus) into [update]; the detector returns a
+/// [NetworkInterfaceChange] only when the primary moves between two live
+/// interfaces and the previous emission is older than [debounce] - null
+/// otherwise. The previous primary is remembered across `none` results so a
+/// drop+restore of the same interface is not reported as a change; an actual
+/// switch (e.g. WiFi -> LTE) through a brief `none` is.
+class InterfaceChangeDetector {
+  InterfaceChangeDetector({
+    Duration debounce = const Duration(seconds: 2),
+    DateTime Function() now = DateTime.now,
+  }) : _debounce = debounce,
+       _now = now;
+
+  final Duration _debounce;
+  final DateTime Function() _now;
+
+  ConnectivityResult? _lastPrimary;
+  DateTime? _lastChangeAt;
+
+  /// Records [primary] and returns a [NetworkInterfaceChange] when this update
+  /// represents a real interface change (debounced). Returns null otherwise.
+  ///
+  /// Pass [ConnectivityResult.none] for offline events - the last primary is
+  /// preserved so the next non-none result can be compared against the prior
+  /// interface.
+  NetworkInterfaceChange? update(ConnectivityResult primary) {
+    if (primary == ConnectivityResult.none) return null;
+    final previous = _lastPrimary;
+    _lastPrimary = primary;
+    if (previous == null || previous == primary) return null;
+    final now = _now();
+    final lastAt = _lastChangeAt;
+    if (lastAt != null && now.difference(lastAt) <= _debounce) return null;
+    _lastChangeAt = now;
+    return NetworkInterfaceChange(previous: previous, current: primary);
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -13,6 +13,7 @@ export 'expiring_cache.dart';
 export 'fixed_delay_scheduler.dart';
 export 'gravatar.dart';
 export 'ice_checker.dart';
+export 'interface_change_detector.dart';
 export 'jitter.dart';
 export 'multi_tap_trigger.dart';
 export 'og_preview.dart';

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -84,14 +84,20 @@ class WebtritSignalingClient {
     String tenantId,
     String token,
     bool force, {
+    bool reregister = false,
     Duration? connectionTimeout,
     TrustedCertificates certs = TrustedCertificates.empty,
   }) async {
     final tenantUrl = buildTenantUrl(baseUrl, tenantId);
+    final queryParameters = {
+      'token': token,
+      'force': force.toString(),
+      if (reregister) 'reregister': 'true',
+    };
     final signalingUrl = tenantUrl
         .replace(
           pathSegments: [...tenantUrl.pathSegments, 'signaling', 'v1'],
-          queryParameters: {'token': token, 'force': force.toString()},
+          queryParameters: queryParameters,
         )
         .toString();
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -124,7 +124,7 @@ class WebtritSignalingService implements SignalingModule {
   /// The timer is cancelled immediately when a terminal event arrives, so it
   /// has no effect during normal operation.
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_isDisposed || _startPending || _isConnected) return;
     _startPending = true;
     _startPendingTimer?.cancel();
@@ -132,9 +132,12 @@ class WebtritSignalingService implements SignalingModule {
       _logger.warning('connect: no terminal event after $_startPendingTimeout — resetting and retrying');
       _startPending = false;
       _startPendingTimer = null;
-      connect();
+      connect(reregister: reregister);
     });
-    SignalingServicePlatform.instance.start(_config, mode: _mode).catchError((Object e, StackTrace s) {
+    SignalingServicePlatform.instance.start(_config, mode: _mode, reregister: reregister).catchError((
+      Object e,
+      StackTrace s,
+    ) {
       _logger.severe('connect: start() failed', e, s);
       _clearStartPending();
     });

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -25,7 +25,7 @@ class _FakeModule implements SignalingModule {
   bool get isConnected => _connected;
 
   @override
-  void connect() {}
+  void connect({bool reregister = false}) {}
 
   @override
   Future<void> disconnect() async {}
@@ -67,13 +67,17 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   @override
   Stream<SignalingModuleEvent> get events => _eventsController.stream;
 
+  final List<bool> startedReregisters = [];
+
   @override
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
   }) async {
     startedConfigs.add(config);
     startedModes.add(mode);
+    startedReregisters.add(reregister);
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
@@ -244,8 +244,8 @@ class SignalingHub {
           _logger.warning('Hub connect: unknown subscriber ${cmd.consumerId}');
           return;
         }
-        _logger.fine('Hub received connect command from ${cmd.consumerId}');
-        _signalingModule.connect();
+        _logger.fine('Hub received connect command from ${cmd.consumerId} (reregister=${cmd.reregister})');
+        _signalingModule.connect(reregister: cmd.reregister);
       case SignalingHubDisconnectCommand():
         if (!_subscribers.containsKey(cmd.consumerId)) {
           _logger.warning('Hub disconnect: unknown subscriber ${cmd.consumerId}');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_client.dart
@@ -163,8 +163,12 @@ class SignalingHubClient {
   /// Fire-and-forget: the hub will call [SignalingModule.connect] in the
   /// background isolate. The resulting [SignalingConnected] event will arrive
   /// on [events] once the connection is established.
-  void sendConnect() {
-    _hubPort.send(SignalingHubConnectCommand(consumerId: consumerId).encode());
+  ///
+  /// When [reregister] is true, the hub calls the underlying
+  /// [SignalingModule.connect] with `reregister: true` so the WebSocket connect
+  /// URL carries `reregister=true`.
+  void sendConnect({bool reregister = false}) {
+    _hubPort.send(SignalingHubConnectCommand(consumerId: consumerId, reregister: reregister).encode());
   }
 
   /// Asks the hub to disconnect the background WebSocket.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_command.dart
@@ -43,7 +43,9 @@ sealed class SignalingHubCommand {
           );
         case _tagConnect:
           if (wire.length < 2) return null;
-          return SignalingHubConnectCommand(consumerId: wire[1] as String);
+          // reregister was added later; older wire payloads omit it.
+          final reregister = wire.length > 2 && wire[2] == true;
+          return SignalingHubConnectCommand(consumerId: wire[1] as String, reregister: reregister);
         case _tagDisconnect:
           if (wire.length < 2) return null;
           return SignalingHubDisconnectCommand(consumerId: wire[1] as String);
@@ -126,11 +128,19 @@ class SignalingHubExecuteCommand extends SignalingHubCommand {
 ///
 /// Sent by [SignalingHubModule.connect] so the main isolate can trigger a
 /// connection attempt without owning the WebSocket directly.
+///
+/// When [reregister] is true, the hub forwards the flag to the underlying
+/// [SignalingModule.connect] so the WebSocket connect URL carries
+/// `reregister=true`, asking Core to tear down the existing controller and
+/// start a fresh SIP registration.
 class SignalingHubConnectCommand extends SignalingHubCommand {
-  const SignalingHubConnectCommand({required String consumerId}) : super(consumerId);
+  const SignalingHubConnectCommand({required String consumerId, this.reregister = false}) : super(consumerId);
+
+  /// When true, the hub calls [SignalingModule.connect] with `reregister: true`.
+  final bool reregister;
 
   @override
-  List<Object?> encode() => [_tagConnect, consumerId];
+  List<Object?> encode() => [_tagConnect, consumerId, reregister];
 }
 
 /// Asks the hub to call [SignalingModule.disconnect] on the background WebSocket.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_module.dart
@@ -72,8 +72,12 @@ class SignalingHubModule implements SignalingModule {
   /// which calls [SignalingModule.connect] on the real WebSocket module.
   /// The resulting [SignalingConnected] event arrives on [events] once the
   /// connection is established.
+  ///
+  /// When [reregister] is true, the flag is carried in the hub command and
+  /// applied to the underlying [SignalingModule.connect] in the foreground
+  /// service, so the WebSocket connect URL includes `reregister=true`.
   @override
-  void connect() => _hubClient.sendConnect();
+  void connect({bool reregister = false}) => _hubClient.sendConnect(reregister: reregister);
 
   /// Asks the hub to disconnect the background WebSocket.
   ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -124,15 +124,16 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
   }) async {
     _isStopped = false;
     _currentConfig = config;
     _currentMode = mode;
     final effectiveMode = mode;
 
-    _logger.info('start effectiveMode=$effectiveMode tenantId=${config.tenantId}');
+    _logger.info('start effectiveMode=$effectiveMode tenantId=${config.tenantId} reregister=$reregister');
 
-    await _startService(config, effectiveMode);
+    await _startService(config, effectiveMode, reregister: reregister);
   }
 
   @override
@@ -296,9 +297,9 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     }
   }
 
-  Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
+  Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode, {bool reregister = false}) async {
     if (mode == SignalingServiceMode.pushBound) {
-      _logger.fine('_startService mode=pushBound -- delegating to direct service');
+      _logger.fine('_startService mode=pushBound -- delegating to direct service (reregister=$reregister)');
       final myToken = _startServiceToken = Object();
 
       // Cancel any existing forwarding subscription before starting the new
@@ -309,7 +310,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       // Start the direct service first so SignalingConnecting is emitted and
       // buffered before we subscribe -- this clears any stale events from a
       // previous session and guarantees the replay on subscribe is fresh.
-      await _directService.start(config, mode: mode);
+      await _directService.start(config, mode: mode, reregister: reregister);
 
       if (_isStopped) {
         _logger.fine('_startService: aborted — stopped during direct start');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/hub/signaling_hub_module_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/hub/signaling_hub_module_test.dart
@@ -30,7 +30,7 @@ class _FakeHubClient extends Fake implements SignalingHubClient {
   void start() => started = true;
 
   @override
-  void sendConnect() => connectSent = true;
+  void sendConnect({bool reregister = false}) => connectSent = true;
 
   @override
   void sendDisconnect() => disconnectSent = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/isolate/signaling_foreground_isolate_manager_test.dart
@@ -26,7 +26,7 @@ class _FakeSignalingModule extends Fake implements SignalingModule {
   Stream<SignalingModuleEvent> get events => _controller.stream;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     connectCount++;
     _connected = true;
     _controller.add(SignalingConnected());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
@@ -79,7 +79,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
@@ -75,7 +75,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -76,7 +76,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -43,7 +43,7 @@ class _FakeSignalingModule implements SignalingModule {
   bool get isConnected => _connected;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     _connected = true;
     _emit(SignalingConnecting());
     _emit(SignalingConnected());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
@@ -78,7 +78,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -30,6 +30,7 @@ class _FakeDirectService extends WebtritSignalingServiceDirect {
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.pushBound,
+    bool reregister = false,
   }) async {
     // Only the first call is gated; subsequent calls pass through immediately.
     if (!_gateConsumed && _gate != null) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
@@ -73,7 +73,7 @@ class _FakeSignalingModule implements SignalingModule {
   bool get isConnected => _isConnected;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     _buffer.clear();
     _emit(SignalingConnecting());
@@ -188,7 +188,7 @@ class _FailingSignalingModule implements SignalingModule {
   bool get isConnected => false;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     _buffer.clear();
     _emit(SignalingConnecting());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
@@ -27,7 +27,13 @@ abstract interface class SignalingModule {
   /// Initiates a new connection attempt. Fire-and-forget.
   ///
   /// On [SignalingHubModule] this is a no-op -- the hub owns the connection.
-  void connect();
+  ///
+  /// When [reregister] is true, the connect URL includes the
+  /// `reregister=true` query parameter, asking Core to tear down the existing
+  /// controller and start a fresh SIP registration on the new connection.
+  /// Pass it on reconnects that follow a network interface change so the
+  /// stale SIP Contact in the registrar is replaced.
+  void connect({bool reregister = false});
 
   /// Gracefully closes the current connection.
   ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -24,6 +24,7 @@ typedef SignalingClientFactory =
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     });
 
 Uri _coreUrlToSignalingUrl(String coreUrl) {
@@ -38,12 +39,14 @@ Future<WebtritSignalingClient> _defaultClientFactory({
   required Duration connectionTimeout,
   required TrustedCertificates certs,
   required bool force,
+  required bool reregister,
 }) {
   return WebtritSignalingClient.connect(
     url,
     tenantId,
     token,
     force,
+    reregister: reregister,
     connectionTimeout: connectionTimeout,
     certs: certs,
   );
@@ -161,6 +164,13 @@ class SignalingModuleImpl implements SignalingModule {
   /// Last connect error as string for deduplication.
   String? _lastConnectErrorString;
 
+  /// Pending reregister flag for the next connect attempt.
+  ///
+  /// Set by [connect] with `reregister: true`. Sticky across failed attempts -
+  /// reset only when a [SignalingConnected] event is emitted, so a transient
+  /// failure does not lose the intent to re-register after a network change.
+  bool _nextConnectReregister = false;
+
   /// Broadcast stream of all module events.
   ///
   /// Each new subscriber immediately receives buffered lifecycle and handshake
@@ -210,8 +220,17 @@ class SignalingModuleImpl implements SignalingModule {
 
   /// Initiates a connection. Fire-and-forget -- result arrives via [events].
   /// Clears the session buffer on each call.
+  ///
+  /// When [reregister] is true, the URL of the next WebSocket connect attempt
+  /// includes `reregister=true`, asking Core to tear down the existing
+  /// controller and start a fresh SIP registration. The flag is sticky across
+  /// failed attempts and consumed when [SignalingConnected] is emitted, so a
+  /// transient failure does not lose the intent.
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
+    if (reregister) {
+      _nextConnectReregister = true;
+    }
     if (_disposed) {
       _logger.fine('connect: skipped — disposed');
       return;
@@ -220,7 +239,9 @@ class SignalingModuleImpl implements SignalingModule {
       _logger.info('connect: skipped — already connecting or connected (connectToken set)');
       return;
     }
-    _logger.info('connect: starting new connect attempt (isConnected=$isConnected)');
+    _logger.info(
+      'connect: starting new connect attempt (isConnected=$isConnected reregister=$_nextConnectReregister)',
+    );
     final token = _connectToken = Object();
     _eventBuffer.clear();
     unawaited(_connectAsync(token));
@@ -306,6 +327,7 @@ class SignalingModuleImpl implements SignalingModule {
           connectionTimeout: connectionTimeout,
           certs: trustedCertificates,
           force: true,
+          reregister: _nextConnectReregister,
         );
 
         if (_connectToken != connectToken || _disposed) {
@@ -348,6 +370,9 @@ class SignalingModuleImpl implements SignalingModule {
         _client = client;
         _errorHandled = false;
         _lastConnectErrorString = null;
+        // Consume the sticky reregister flag once a connection is established;
+        // a subsequent reconnect from a normal disconnect must not carry it.
+        _nextConnectReregister = false;
         _emit(SignalingConnected());
         unawaited(_requestQueue.flush(execute: client.execute, isActive: () => identical(_client, client)));
       } catch (e, s) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -98,6 +98,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     SignalingServiceConfig config, {
     // ignore: avoid_unused_parameters
     SignalingServiceMode mode = SignalingServiceMode.pushBound,
+    bool reregister = false,
   }) async {
     _isStopped = false;
     final myToken = _startToken = Object();
@@ -141,7 +142,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
       },
     );
     _module = module;
-    module.connect();
+    module.connect(reregister: reregister);
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -39,7 +39,16 @@ abstract class SignalingServicePlatform extends PlatformInterface {
   ///   in the main isolate and is not persistent.
   /// - [SignalingServiceMode.pushBound] -- service stops when the app Activity
   ///   is closed, allowing the next push to start a fresh instance.
-  Future<void> start(SignalingServiceConfig config, {SignalingServiceMode mode = SignalingServiceMode.persistent});
+  ///
+  /// When [reregister] is true, the WebSocket connect URL includes
+  /// `reregister=true`, asking Core to tear down the existing controller and
+  /// start a fresh SIP registration on the new connection. Pass it on
+  /// reconnects that follow a network interface change.
+  Future<void> start(
+    SignalingServiceConfig config, {
+    SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
+  });
 
   /// Sends [request] to the server via the active connection.
   Future<void> execute(Request request);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -101,6 +101,7 @@ class _ControlledFactory {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) {
         final c = Completer<WebtritSignalingClient>();
         _calls.add(c);
@@ -137,6 +138,7 @@ SignalingModuleImpl _buildModuleFromClients(List<WebtritSignalingClient> clients
           required Duration connectionTimeout,
           required TrustedCertificates certs,
           required bool force,
+          required bool reregister,
         }) async => clients[index++],
   );
 }

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -95,6 +95,7 @@ SignalingClientFactory _successFactory(_FakeSignalingClient client) {
     required Duration connectionTimeout,
     required TrustedCertificates certs,
     required bool force,
+    required bool reregister,
   }) async => client;
 }
 
@@ -107,6 +108,7 @@ SignalingClientFactory _failingFactory(Object error) {
     required Duration connectionTimeout,
     required TrustedCertificates certs,
     required bool force,
+    required bool reregister,
   }) async => throw error;
 }
 
@@ -122,6 +124,7 @@ class _ControlledFactory {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) {
         _completer = Completer<WebtritSignalingClient>();
         return _completer!.future;
@@ -260,6 +263,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         return callCount == 1 ? firstClient : secondClient;
@@ -625,6 +629,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         if (callCount == 1) throw error;
@@ -788,6 +793,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         return callCount == 1 ? client1 : client2;
@@ -1229,6 +1235,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         call++;
         return call == 1 ? client1 : client2;
@@ -1401,6 +1408,7 @@ void main() {
           required Duration connectionTimeout,
           required TrustedCertificates certs,
           required bool force,
+          required bool reregister,
         }) async => client,
       );
 

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -26,8 +26,16 @@ class _FakeSignalingModule implements SignalingModule {
 
   void emit(SignalingModuleEvent event) => _controller.add(event);
 
+  /// Records the reregister flag for each [connect] call so tests can assert
+  /// the controller forwards [SignalingReconnectController.notifyInterfaceChanged]
+  /// into the next connect attempt.
+  final List<bool> connectReregisterFlags = [];
+
   @override
-  void connect() => connectCalls++;
+  void connect({bool reregister = false}) {
+    connectCalls++;
+    connectReregisterFlags.add(reregister);
+  }
 
   @override
   Future<void> disconnect() async => disconnectCalls++;

--- a/test/utils/interface_change_detector_test.dart
+++ b/test/utils/interface_change_detector_test.dart
@@ -1,0 +1,88 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/utils/interface_change_detector.dart';
+
+void main() {
+  group('InterfaceChangeDetector', () {
+    test('first update with a live interface returns null (no previous)', () {
+      final detector = InterfaceChangeDetector();
+      expect(detector.update(ConnectivityResult.wifi), isNull);
+    });
+
+    test('same interface twice returns null', () {
+      final detector = InterfaceChangeDetector();
+      detector.update(ConnectivityResult.wifi);
+      expect(detector.update(ConnectivityResult.wifi), isNull);
+    });
+
+    test('switch between two live interfaces returns the change', () {
+      final detector = InterfaceChangeDetector();
+      detector.update(ConnectivityResult.wifi);
+      final change = detector.update(ConnectivityResult.mobile);
+      expect(change, isNotNull);
+      expect(change!.previous, ConnectivityResult.wifi);
+      expect(change.current, ConnectivityResult.mobile);
+    });
+
+    test('drop+restore of the same interface is not a change', () {
+      final detector = InterfaceChangeDetector();
+      detector.update(ConnectivityResult.wifi);
+      detector.update(ConnectivityResult.none);
+      expect(detector.update(ConnectivityResult.wifi), isNull);
+    });
+
+    test('switch through a brief none is detected as a change', () {
+      final detector = InterfaceChangeDetector();
+      detector.update(ConnectivityResult.wifi);
+      detector.update(ConnectivityResult.none);
+      final change = detector.update(ConnectivityResult.mobile);
+      expect(change, isNotNull);
+      expect(change!.previous, ConnectivityResult.wifi);
+      expect(change.current, ConnectivityResult.mobile);
+    });
+
+    test('rapid flap within the debounce window collapses to one change', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final detector = InterfaceChangeDetector(
+        debounce: const Duration(seconds: 2),
+        now: () => fakeNow,
+      );
+      detector.update(ConnectivityResult.wifi);
+      // First switch fires.
+      expect(detector.update(ConnectivityResult.mobile), isNotNull);
+      // Second switch within 2s is suppressed.
+      fakeNow = fakeNow.add(const Duration(milliseconds: 500));
+      expect(detector.update(ConnectivityResult.wifi), isNull);
+      // Third switch still within 2s of the first - also suppressed.
+      fakeNow = fakeNow.add(const Duration(milliseconds: 500));
+      expect(detector.update(ConnectivityResult.mobile), isNull);
+    });
+
+    test('change after the debounce window fires again', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final detector = InterfaceChangeDetector(
+        debounce: const Duration(seconds: 2),
+        now: () => fakeNow,
+      );
+      detector.update(ConnectivityResult.wifi);
+      expect(detector.update(ConnectivityResult.mobile), isNotNull);
+      fakeNow = fakeNow.add(const Duration(seconds: 3));
+      final change = detector.update(ConnectivityResult.wifi);
+      expect(change, isNotNull);
+      expect(change!.previous, ConnectivityResult.mobile);
+      expect(change.current, ConnectivityResult.wifi);
+    });
+
+    test('update with none does not modify the remembered primary', () {
+      final detector = InterfaceChangeDetector();
+      detector.update(ConnectivityResult.wifi);
+      detector.update(ConnectivityResult.none);
+      detector.update(ConnectivityResult.none);
+      // wifi is still the last primary; switching to mobile is detected.
+      final change = detector.update(ConnectivityResult.mobile);
+      expect(change, isNotNull);
+      expect(change!.previous, ConnectivityResult.wifi);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

When the device's active network interface changes (WiFi <-> LTE), the previous signaling WebSocket connection becomes a half-open zombie on the server side. Core never receives a `FIN` over the dead route, so the existing Controller survives the fast reconnect and the new socket simply re-attaches to it (force-attach with code 4441). The stale SIP Contact in PortaSwitch keeps pointing at a dead NAT pinhole, producing stuck calls and ghost incoming calls.

## Change

Add a `reregister` flag to the signaling connect path. When set, the WebSocket connect URL includes `?reregister=true`, asking Core to tear down the existing Controller and start a fresh SIP registration over a new TCP connection — replacing the dead Contact before the next incoming call can arrive.

`CallBloc` detects a real interface change (primary connectivity type moved between two non-none values) with a 2 s cooldown and calls `SignalingReconnectController.notifyInterfaceChanged()` before `notifyNetworkAvailable()`. The reconnect controller forwards the flag into the next `_module.connect()` call. The flag is sticky inside `SignalingModuleImpl` — consumed only on `SignalingConnected`, so a transient failure between attempts does not lose the intent.

## Layers touched

- `webtrit_signaling` URL builder (query parameter).
- `webtrit_signaling_service_platform_interface`: `SignalingClientFactory`, `SignalingModuleImpl`, abstract `SignalingModule` and `SignalingServicePlatform`, `SignalingServiceDirect` (covers iOS via inheritance and Android pushBound).
- `webtrit_signaling_service_android`: plugin `start`, hub command wire format (backward-compatible decode), hub client `sendConnect`, hub module `connect`, hub server-side handler (covers Android persistent FGS path).
- `webtrit_signaling_service`: facade `WebtritSignalingService.connect`.
- App: `CallBloc` connectivity handler and `SignalingReconnectController`.

## Tests

- All existing tests pass (`dart analyze`, `flutter test`).
- Test fakes updated for the new signatures.
- No new behavioural tests in this PR yet — to add as a follow-up.

## How to verify locally

1. Run the app pointing to the local stack.
2. Note baseline: `pjsip show contacts` source port + Janus `session_id`.
3. Trigger a real network interface change (WiFi <-> LTE).
4. Expected: connect URL contains `?reregister=true`; on Core the old controller terminates with `{:shutdown, :unregistered}`, a new Janus session starts, `register SIP user` fires, the Asterisk contact source port changes.

## Out of scope

- UI indicator for the (~100-500 ms) extra handshake latency on a reregister connect.
- Telemetry on reregister frequency.
- Automated iOS instrumentation.
