### PR TITLE
feat(signaling): add reregister flag through signaling stack (WT-1467)

### DIFF
--- a/packages/webtrit_signaling/AGENTS.md
+++ b/packages/webtrit_signaling/AGENTS.md
@@ -10,7 +10,9 @@ layer over WebSocket. No Flutter dependency, no code generation.
 `WebtritSignalingClient` is the single public entry point:
 
 ```dart
-// 1. Connect (static factory)
+// 1. Connect (static factory).
+// Optional `reregister: true` asks the server to drop any existing controller
+// and start a fresh SIP registration on the new connection.
 final client = await WebtritSignalingClient.connect(baseUrl, tenantId, token, force);
 
 // 2. Register callbacks (single-use; throws StateError if called twice)
@@ -133,4 +135,4 @@ WEBTRIT_APP_TEST_CALLEE_VERIFY_CREDENTIAL=<callee-password> \
 dart test test/live_call_test.dart --tags live --reporter expanded
 ```
 
-Connection endpoint: `wss://<host>/signaling/v1?token=<token>[&force=<true|false>]`
+Connection endpoint: `wss://<host>/signaling/v1?token=<token>[&force=<true|false>][&reregister=true]`

--- a/packages/webtrit_signaling/AGENTS.md
+++ b/packages/webtrit_signaling/AGENTS.md
@@ -135,4 +135,4 @@ WEBTRIT_APP_TEST_CALLEE_VERIFY_CREDENTIAL=<callee-password> \
 dart test test/live_call_test.dart --tags live --reporter expanded
 ```
 
-Connection endpoint: `wss://<host>/signaling/v1?token=<token>[&force=<true|false>][&reregister=true]`
+Connection endpoint: `wss://<host>/signaling/v1?token=<token>&force=<true|false>[&reregister=true]`

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -83,6 +83,18 @@ class WebtritSignalingClient {
     Uri baseUrl,
     String tenantId,
     String token,
+    // When true, this connect evicts any existing signaling session bound
+    // to the same controller: Core closes the previously attached
+    // WebSocket with `controllerForceAttachClose` (4441) and binds the new
+    // socket to the existing controller. When false, Core rejects the
+    // connect with `controllerAttachedError` (4431) if another session is
+    // already attached.
+    //
+    // Typical use: pass `true` on a reconnect from the app so a stale
+    // session that the server still considers alive (e.g. after a previous
+    // app instance closed without a clean close, or a zombie TCP whose
+    // FIN never reached the server) is replaced rather than blocking the
+    // new one.
     bool force, {
     // When true, the WebSocket connect URL includes `?reregister=true`.
     //

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -127,6 +127,13 @@ class WebtritSignalingClient {
         )
         .toString();
 
+    // Log the public connect parameters so the URL the app builds (host,
+    // force and the optional reregister flag) is traceable alongside the
+    // SignalingClient instance lifecycle. Token is intentionally omitted.
+    Logger('WebtritSignalingClient').fine(
+      'connect: host=${tenantUrl.host} tenant=$tenantId force=$force reregister=$reregister',
+    );
+
     final ws = await connectWebSocket(
       signalingUrl,
       protocols: [subprotocol],

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -79,37 +79,39 @@ class WebtritSignalingClient {
 
   final _transactions = <String, Transaction>{};
 
+  /// Opens a new signaling WebSocket connection to WebTrit Core.
+  ///
+  /// [baseUrl] is the Core HTTP(S) base URL; the scheme is rewritten to
+  /// `ws`/`wss` and the `signaling/v1` path is appended.
+  ///
+  /// [force] - when true, this connect evicts any existing signaling session
+  /// bound to the same controller: Core closes the previously attached
+  /// WebSocket with `controllerForceAttachClose` (4441) and binds the new
+  /// socket to the existing controller. When false, Core rejects the connect
+  /// with `controllerAttachedError` (4431) if another session is already
+  /// attached. Typical use: pass `true` on a reconnect from the app so a
+  /// stale session that the server still considers alive (e.g. after a
+  /// previous app instance closed without a clean close, or a zombie TCP
+  /// whose FIN never reached the server) is replaced rather than blocking
+  /// the new one.
+  ///
+  /// [reregister] - when true, the WebSocket connect URL includes
+  /// `?reregister=true`. Core treats it as a request to drop any existing
+  /// controller for this account (destroying its Janus session) and start a
+  /// fresh one. The result is: a new Janus session, a new SIP REGISTER
+  /// issued over a new TCP connection to the PBX, a new NAT pinhole on the
+  /// server side, and the previous Contact in the registrar replaced.
+  /// Typical use: pass `true` on a connect that follows a network interface
+  /// change on the device (e.g. WiFi to LTE). The previous interface may
+  /// have left a half-open server-side TCP whose registered Contact still
+  /// appears alive to the PBX but no longer reaches Janus; re-registering
+  /// deterministically replaces that stale pinhole before the next incoming
+  /// call is routed to it.
   static Future<WebtritSignalingClient> connect(
     Uri baseUrl,
     String tenantId,
     String token,
-    // When true, this connect evicts any existing signaling session bound
-    // to the same controller: Core closes the previously attached
-    // WebSocket with `controllerForceAttachClose` (4441) and binds the new
-    // socket to the existing controller. When false, Core rejects the
-    // connect with `controllerAttachedError` (4431) if another session is
-    // already attached.
-    //
-    // Typical use: pass `true` on a reconnect from the app so a stale
-    // session that the server still considers alive (e.g. after a previous
-    // app instance closed without a clean close, or a zombie TCP whose
-    // FIN never reached the server) is replaced rather than blocking the
-    // new one.
     bool force, {
-    // When true, the WebSocket connect URL includes `?reregister=true`.
-    //
-    // Core treats it as a request to drop any existing controller for this
-    // account (destroying its Janus session) and start a fresh one. The
-    // result is: a new Janus session, a new SIP REGISTER issued over a new
-    // TCP connection to the PBX, a new NAT pinhole on the server side, and
-    // the previous Contact in the registrar replaced.
-    //
-    // Typical use: pass `true` on a connect that follows a network
-    // interface change on the device (e.g. WiFi to LTE). The previous
-    // interface may have left a half-open server-side TCP whose registered
-    // Contact still appears alive to the PBX but no longer reaches Janus;
-    // re-registering deterministically replaces that stale pinhole before
-    // the next incoming call is routed to it.
     bool reregister = false,
     Duration? connectionTimeout,
     TrustedCertificates certs = TrustedCertificates.empty,

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -84,6 +84,20 @@ class WebtritSignalingClient {
     String tenantId,
     String token,
     bool force, {
+    // When true, the WebSocket connect URL includes `?reregister=true`.
+    //
+    // Core treats it as a request to drop any existing controller for this
+    // account (destroying its Janus session) and start a fresh one. The
+    // result is: a new Janus session, a new SIP REGISTER issued over a new
+    // TCP connection to the PBX, a new NAT pinhole on the server side, and
+    // the previous Contact in the registrar replaced.
+    //
+    // Typical use: pass `true` on a connect that follows a network
+    // interface change on the device (e.g. WiFi to LTE). The previous
+    // interface may have left a half-open server-side TCP whose registered
+    // Contact still appears alive to the PBX but no longer reaches Janus;
+    // re-registering deterministically replaces that stale pinhole before
+    // the next incoming call is routed to it.
     bool reregister = false,
     Duration? connectionTimeout,
     TrustedCertificates certs = TrustedCertificates.empty,

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -84,14 +84,20 @@ class WebtritSignalingClient {
     String tenantId,
     String token,
     bool force, {
+    bool reregister = false,
     Duration? connectionTimeout,
     TrustedCertificates certs = TrustedCertificates.empty,
   }) async {
     final tenantUrl = buildTenantUrl(baseUrl, tenantId);
+    final queryParameters = {
+      'token': token,
+      'force': force.toString(),
+      if (reregister) 'reregister': 'true',
+    };
     final signalingUrl = tenantUrl
         .replace(
           pathSegments: [...tenantUrl.pathSegments, 'signaling', 'v1'],
-          queryParameters: {'token': token, 'force': force.toString()},
+          queryParameters: queryParameters,
         )
         .toString();
 

--- a/packages/webtrit_signaling_service/README.md
+++ b/packages/webtrit_signaling_service/README.md
@@ -420,7 +420,7 @@ await service.dispose();
 | Method / property | Description |
 | --- | --- |
 | `events` | Broadcast `Stream<SignalingModuleEvent>` |
-| `start(config, {mode})` | Starts the platform service; `mode` defaults to `SignalingServiceMode.persistent` |
+| `start(config, {mode, reregister})` | Starts the platform service; `mode` defaults to `SignalingServiceMode.persistent`. `reregister: true` adds `?reregister=true` to the underlying WebSocket connect URL, asking the server to drop the existing controller and start a fresh registration on the new connection. |
 | `attach()` | Connects to an already-running hub without starting a new service |
 | `execute(request)` | Sends a `Request` via the active connection; throws `StateError` when not connected |
 | `updateMode(mode)` | Switches lifecycle mode at runtime without restarting the WebSocket |

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/AGENTS.md
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/AGENTS.md
@@ -61,7 +61,7 @@ await service.dispose();
 |--------|-------------|
 | `events` | Broadcast `Stream<SignalingModuleEvent>` — safe to subscribe before `start()` |
 | `setModuleFactory(factory)` | Registers the app-provided `SignalingModuleFactory`; must be called before `start()` on all platforms |
-| `start(config, {mode})` | Starts the platform service; `mode` defaults to `SignalingServiceMode.persistent` |
+| `start(config, {mode, reregister})` | Starts the platform service; `mode` defaults to `SignalingServiceMode.persistent`. Pass `reregister: true` on a connect that follows a network interface change so the underlying WebSocket URL carries `reregister=true`, asking the server to drop the existing controller and start a fresh registration. |
 | `attach()` | Connects to an already-running hub without starting a new service |
 | `execute(request)` | Sends a `Request` via the active connection; throws when not connected |
 | `updateMode(mode)` | Switches service lifecycle mode at runtime without restarting the WebSocket |

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -128,12 +128,7 @@ class WebtritSignalingService implements SignalingModule {
     if (_isDisposed || _startPending || _isConnected) return;
     _startPending = true;
     _startPendingTimer?.cancel();
-    _startPendingTimer = Timer(_startPendingTimeout, () {
-      _logger.warning('connect: no terminal event after $_startPendingTimeout — resetting and retrying');
-      _startPending = false;
-      _startPendingTimer = null;
-      connect(reregister: reregister);
-    });
+    _startPendingTimer = Timer(_startPendingTimeout, () => _onStartPendingTimeout(reregister));
     SignalingServicePlatform.instance.start(_config, mode: _mode, reregister: reregister).catchError((
       Object e,
       StackTrace s,
@@ -141,6 +136,13 @@ class WebtritSignalingService implements SignalingModule {
       _logger.severe('connect: start() failed', e, s);
       _clearStartPending();
     });
+  }
+
+  void _onStartPendingTimeout(bool reregister) {
+    _logger.warning('connect: no terminal event after $_startPendingTimeout - resetting and retrying');
+    _startPending = false;
+    _startPendingTimer = null;
+    connect(reregister: reregister);
   }
 
   void _clearStartPending() {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -124,7 +124,7 @@ class WebtritSignalingService implements SignalingModule {
   /// The timer is cancelled immediately when a terminal event arrives, so it
   /// has no effect during normal operation.
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_isDisposed || _startPending || _isConnected) return;
     _startPending = true;
     _startPendingTimer?.cancel();
@@ -132,9 +132,12 @@ class WebtritSignalingService implements SignalingModule {
       _logger.warning('connect: no terminal event after $_startPendingTimeout — resetting and retrying');
       _startPending = false;
       _startPendingTimer = null;
-      connect();
+      connect(reregister: reregister);
     });
-    SignalingServicePlatform.instance.start(_config, mode: _mode).catchError((Object e, StackTrace s) {
+    SignalingServicePlatform.instance.start(_config, mode: _mode, reregister: reregister).catchError((
+      Object e,
+      StackTrace s,
+    ) {
       _logger.severe('connect: start() failed', e, s);
       _clearStartPending();
     });

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -25,7 +25,7 @@ class _FakeModule implements SignalingModule {
   bool get isConnected => _connected;
 
   @override
-  void connect() {}
+  void connect({bool reregister = false}) {}
 
   @override
   Future<void> disconnect() async {}
@@ -67,13 +67,17 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   @override
   Stream<SignalingModuleEvent> get events => _eventsController.stream;
 
+  final List<bool> startedReregisters = [];
+
   @override
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
   }) async {
     startedConfigs.add(config);
     startedModes.add(mode);
+    startedReregisters.add(reregister);
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/AGENTS.md
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/AGENTS.md
@@ -92,8 +92,8 @@ what sends the `sub` command that triggers the ack.
 `SignalingModule` implementation backed by a `SignalingHubClient`.
 Used by the main isolate when the hub is already running in the foreground service.
 
-- `connect({reregister})` forwards the `reregister` flag to the hub as a `SignalingHubConnectCommand`; the foreground service applies it to the underlying `SignalingModule.connect`. With `reregister: false` (the default) the call is otherwise a no-op — the hub owns the connection lifecycle.
-- `disconnect()` is a **no-op** — the hub owns the connection lifecycle.
+- `connect({reregister})` forwards the `reregister` flag to the hub as a `SignalingHubConnectCommand`; the foreground service applies it to the underlying `SignalingModule.connect`. With `reregister: false` (the default) the call is otherwise a no-op - the hub owns the connection lifecycle.
+- `disconnect()` is a **no-op** - the hub owns the connection lifecycle.
 - Maintains its own `_sessionBuffer` for late subscribers to the `events` stream.
 - `isConnected` tracks `SignalingConnected` / `SignalingDisconnected` / `SignalingConnectionFailed`.
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/AGENTS.md
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/AGENTS.md
@@ -37,7 +37,7 @@ Registered via `registerWith()` as `SignalingServicePlatform.instance`.
 | Method | Behaviour |
 |--------|-----------|
 | `setModuleFactory(factory)` | Resolves the raw handle via `PluginUtilities.getCallbackHandle(factory)`, persists it via `PSignalingServiceHostApi.saveModuleFactory` → `StorageDelegate` → `SharedPreferences`. The background isolate reads `PSignalingServiceStatus.moduleFactoryHandle` at each sync and resolves the factory via `PluginUtilities.getCallbackFromHandle`. |
-| `start(config, {mode})` | Obtains Dart callback handles, calls `initializeServiceCallback` + `startService(mode)` via Pigeon, removes any stale `kSignalingHubPortName` entry from `IsolateNameServer`, then polls until the hub port appears. The effective mode is taken from `_currentMode` (last explicit mode), not the parameter, so reconnect calls never revert a user-selected `updateMode` change. |
+| `start(config, {mode, reregister})` | Obtains Dart callback handles, calls `initializeServiceCallback` + `startService(mode)` via Pigeon, removes any stale `kSignalingHubPortName` entry from `IsolateNameServer`, then polls until the hub port appears. The effective mode is taken from `_currentMode` (last explicit mode), not the parameter, so reconnect calls never revert a user-selected `updateMode` change. `reregister: true` is forwarded down the connect path (direct service or hub command) so the underlying WebSocket URL carries `reregister=true`. |
 | `attach()` | Connects to an already-running hub without starting a new service; polls `IsolateNameServer` the same way as `start()`. |
 | `execute(request)` | Delegates to the hub module. Throws `StateError` when not connected. |
 | `updateMode(mode)` | Saves new mode to `_currentMode`, calls `_startHubMode(config, mode)`. Both modes use the hub/foreground service — only the Kotlin-side lifecycle flag changes (whether `onTaskRemoved` stops the service). The WebSocket connection is preserved across the mode switch. |
@@ -92,7 +92,8 @@ what sends the `sub` command that triggers the ack.
 `SignalingModule` implementation backed by a `SignalingHubClient`.
 Used by the main isolate when the hub is already running in the foreground service.
 
-- `connect()` / `disconnect()` are **no-ops** — the hub owns the connection lifecycle.
+- `connect({reregister})` forwards the `reregister` flag to the hub as a `SignalingHubConnectCommand`; the foreground service applies it to the underlying `SignalingModule.connect`. With `reregister: false` (the default) the call is otherwise a no-op — the hub owns the connection lifecycle.
+- `disconnect()` is a **no-op** — the hub owns the connection lifecycle.
 - Maintains its own `_sessionBuffer` for late subscribers to the `events` stream.
 - `isConnected` tracks `SignalingConnected` / `SignalingDisconnected` / `SignalingConnectionFailed`.
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
@@ -244,8 +244,8 @@ class SignalingHub {
           _logger.warning('Hub connect: unknown subscriber ${cmd.consumerId}');
           return;
         }
-        _logger.fine('Hub received connect command from ${cmd.consumerId}');
-        _signalingModule.connect();
+        _logger.fine('Hub received connect command from ${cmd.consumerId} (reregister=${cmd.reregister})');
+        _signalingModule.connect(reregister: cmd.reregister);
       case SignalingHubDisconnectCommand():
         if (!_subscribers.containsKey(cmd.consumerId)) {
           _logger.warning('Hub disconnect: unknown subscriber ${cmd.consumerId}');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_client.dart
@@ -163,8 +163,12 @@ class SignalingHubClient {
   /// Fire-and-forget: the hub will call [SignalingModule.connect] in the
   /// background isolate. The resulting [SignalingConnected] event will arrive
   /// on [events] once the connection is established.
-  void sendConnect() {
-    _hubPort.send(SignalingHubConnectCommand(consumerId: consumerId).encode());
+  ///
+  /// When [reregister] is true, the hub calls the underlying
+  /// [SignalingModule.connect] with `reregister: true` so the WebSocket connect
+  /// URL carries `reregister=true`.
+  void sendConnect({bool reregister = false}) {
+    _hubPort.send(SignalingHubConnectCommand(consumerId: consumerId, reregister: reregister).encode());
   }
 
   /// Asks the hub to disconnect the background WebSocket.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_command.dart
@@ -43,7 +43,9 @@ sealed class SignalingHubCommand {
           );
         case _tagConnect:
           if (wire.length < 2) return null;
-          return SignalingHubConnectCommand(consumerId: wire[1] as String);
+          // reregister was added later; older wire payloads omit it.
+          final reregister = wire.length > 2 && wire[2] == true;
+          return SignalingHubConnectCommand(consumerId: wire[1] as String, reregister: reregister);
         case _tagDisconnect:
           if (wire.length < 2) return null;
           return SignalingHubDisconnectCommand(consumerId: wire[1] as String);
@@ -126,11 +128,19 @@ class SignalingHubExecuteCommand extends SignalingHubCommand {
 ///
 /// Sent by [SignalingHubModule.connect] so the main isolate can trigger a
 /// connection attempt without owning the WebSocket directly.
+///
+/// When [reregister] is true, the hub forwards the flag to the underlying
+/// [SignalingModule.connect] so the WebSocket connect URL carries
+/// `reregister=true`, asking Core to tear down the existing controller and
+/// start a fresh SIP registration.
 class SignalingHubConnectCommand extends SignalingHubCommand {
-  const SignalingHubConnectCommand({required String consumerId}) : super(consumerId);
+  const SignalingHubConnectCommand({required String consumerId, this.reregister = false}) : super(consumerId);
+
+  /// When true, the hub calls [SignalingModule.connect] with `reregister: true`.
+  final bool reregister;
 
   @override
-  List<Object?> encode() => [_tagConnect, consumerId];
+  List<Object?> encode() => [_tagConnect, consumerId, reregister];
 }
 
 /// Asks the hub to call [SignalingModule.disconnect] on the background WebSocket.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_module.dart
@@ -72,8 +72,12 @@ class SignalingHubModule implements SignalingModule {
   /// which calls [SignalingModule.connect] on the real WebSocket module.
   /// The resulting [SignalingConnected] event arrives on [events] once the
   /// connection is established.
+  ///
+  /// When [reregister] is true, the flag is carried in the hub command and
+  /// applied to the underlying [SignalingModule.connect] in the foreground
+  /// service, so the WebSocket connect URL includes `reregister=true`.
   @override
-  void connect() => _hubClient.sendConnect();
+  void connect({bool reregister = false}) => _hubClient.sendConnect(reregister: reregister);
 
   /// Asks the hub to disconnect the background WebSocket.
   ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -124,15 +124,16 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
   }) async {
     _isStopped = false;
     _currentConfig = config;
     _currentMode = mode;
     final effectiveMode = mode;
 
-    _logger.info('start effectiveMode=$effectiveMode tenantId=${config.tenantId}');
+    _logger.info('start effectiveMode=$effectiveMode tenantId=${config.tenantId} reregister=$reregister');
 
-    await _startService(config, effectiveMode);
+    await _startService(config, effectiveMode, reregister: reregister);
   }
 
   @override
@@ -296,9 +297,9 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     }
   }
 
-  Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
+  Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode, {bool reregister = false}) async {
     if (mode == SignalingServiceMode.pushBound) {
-      _logger.fine('_startService mode=pushBound -- delegating to direct service');
+      _logger.fine('_startService mode=pushBound -- delegating to direct service (reregister=$reregister)');
       final myToken = _startServiceToken = Object();
 
       // Cancel any existing forwarding subscription before starting the new
@@ -309,7 +310,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       // Start the direct service first so SignalingConnecting is emitted and
       // buffered before we subscribe -- this clears any stale events from a
       // previous session and guarantees the replay on subscribe is fresh.
-      await _directService.start(config, mode: mode);
+      await _directService.start(config, mode: mode, reregister: reregister);
 
       if (_isStopped) {
         _logger.fine('_startService: aborted — stopped during direct start');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -299,7 +299,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
   Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode, {bool reregister = false}) async {
     if (mode == SignalingServiceMode.pushBound) {
-      _logger.fine('_startService mode=pushBound -- delegating to direct service (reregister=$reregister)');
+      _logger.fine('_startService mode=pushBound - delegating to direct service (reregister=$reregister)');
       final myToken = _startServiceToken = Object();
 
       // Cancel any existing forwarding subscription before starting the new

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/hub/signaling_hub_module_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/hub/signaling_hub_module_test.dart
@@ -30,7 +30,7 @@ class _FakeHubClient extends Fake implements SignalingHubClient {
   void start() => started = true;
 
   @override
-  void sendConnect() => connectSent = true;
+  void sendConnect({bool reregister = false}) => connectSent = true;
 
   @override
   void sendDisconnect() => disconnectSent = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/isolate/signaling_foreground_isolate_manager_test.dart
@@ -26,7 +26,7 @@ class _FakeSignalingModule extends Fake implements SignalingModule {
   Stream<SignalingModuleEvent> get events => _controller.stream;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     connectCount++;
     _connected = true;
     _controller.add(SignalingConnected());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
@@ -79,7 +79,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
@@ -75,7 +75,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -76,7 +76,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -43,7 +43,7 @@ class _FakeSignalingModule implements SignalingModule {
   bool get isConnected => _connected;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     _connected = true;
     _emit(SignalingConnecting());
     _emit(SignalingConnected());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
@@ -78,7 +78,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -30,6 +30,7 @@ class _FakeDirectService extends WebtritSignalingServiceDirect {
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.pushBound,
+    bool reregister = false,
   }) async {
     // Only the first call is gated; subsequent calls pass through immediately.
     if (!_gateConsumed && _gate != null) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/AGENTS.md
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/AGENTS.md
@@ -42,7 +42,7 @@ Future<void> dispose();
 | Method | Behaviour |
 |--------|-----------|
 | `setModuleFactory(factory)` | Stores `factory` in `_factory`. Must be called before `start()`. |
-| `start(config, {mode, reregister})` | Disposes any existing module; calls `_factory!(config)` to create a `SignalingModule`; pipes its events to `_eventsController`; calls `connect(reregister: reregister)`. `mode` is accepted for API compatibility — no behavioural difference on iOS. |
+| `start(config, {mode, reregister})` | Disposes any existing module; calls `_factory!(config)` to create a `SignalingModule`; pipes its events to `_eventsController`; calls `connect(reregister: reregister)`. `mode` is accepted for API compatibility - no behavioural difference on iOS. |
 | `attach()` | No-op. Logs a message. No background process exists to attach to. |
 | `execute(request)` | Delegates to the module's `execute`; throws `StateError` when not connected. |
 | `updateMode(mode)` | No-op. Logs a message. Mode switching has no meaning on iOS. |

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/AGENTS.md
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/AGENTS.md
@@ -23,7 +23,11 @@ Inherits the same interface as the Android package:
 ```dart
 Stream<SignalingModuleEvent> get events;
 Future<void> setModuleFactory(SignalingModuleFactory factory);
-Future<void> start(SignalingServiceConfig config, {SignalingServiceMode mode = SignalingServiceMode.persistent});
+Future<void> start(
+  SignalingServiceConfig config, {
+  SignalingServiceMode mode = SignalingServiceMode.persistent,
+  bool reregister = false,
+});
 Future<void> attach();
 Future<void> execute(Request request);
 Future<void> updateMode(SignalingServiceMode mode);
@@ -38,7 +42,7 @@ Future<void> dispose();
 | Method | Behaviour |
 |--------|-----------|
 | `setModuleFactory(factory)` | Stores `factory` in `_factory`. Must be called before `start()`. |
-| `start(config, {mode})` | Disposes any existing module; calls `_factory!(config)` to create a `SignalingModule`; pipes its events to `_eventsController`; calls `connect()`. `mode` is accepted for API compatibility — no behavioural difference on iOS. |
+| `start(config, {mode, reregister})` | Disposes any existing module; calls `_factory!(config)` to create a `SignalingModule`; pipes its events to `_eventsController`; calls `connect(reregister: reregister)`. `mode` is accepted for API compatibility — no behavioural difference on iOS. |
 | `attach()` | No-op. Logs a message. No background process exists to attach to. |
 | `execute(request)` | Delegates to the module's `execute`; throws `StateError` when not connected. |
 | `updateMode(mode)` | No-op. Logs a message. Mode switching has no meaning on iOS. |

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
@@ -73,7 +73,7 @@ class _FakeSignalingModule implements SignalingModule {
   bool get isConnected => _isConnected;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     _buffer.clear();
     _emit(SignalingConnecting());
@@ -188,7 +188,7 @@ class _FailingSignalingModule implements SignalingModule {
   bool get isConnected => false;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     _buffer.clear();
     _emit(SignalingConnecting());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/AGENTS.md
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/AGENTS.md
@@ -15,7 +15,11 @@ abstract class SignalingServicePlatform extends PlatformInterface {
 
   Stream<SignalingModuleEvent> get events;
   Future<void> setModuleFactory(SignalingModuleFactory factory);
-  Future<void> start(SignalingServiceConfig config, {SignalingServiceMode mode = SignalingServiceMode.persistent});
+  Future<void> start(
+    SignalingServiceConfig config, {
+    SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
+  });
   Future<void> attach();
   Future<void> execute(Request request);
   Future<void> updateMode(SignalingServiceMode mode);
@@ -108,7 +112,7 @@ Internal contract shared by `SignalingModuleImpl` and the plugin's `SignalingHub
 abstract interface class SignalingModule {
   Stream<SignalingModuleEvent> get events;
   bool get isConnected;
-  void connect();
+  void connect({bool reregister = false});
   Future<void> disconnect();
   Future<void>? execute(Request request);
   Future<void> dispose();

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
@@ -27,7 +27,13 @@ abstract interface class SignalingModule {
   /// Initiates a new connection attempt. Fire-and-forget.
   ///
   /// On [SignalingHubModule] this is a no-op -- the hub owns the connection.
-  void connect();
+  ///
+  /// When [reregister] is true, the connect URL includes the
+  /// `reregister=true` query parameter, asking Core to tear down the existing
+  /// controller and start a fresh SIP registration on the new connection.
+  /// Pass it on reconnects that follow a network interface change so the
+  /// stale SIP Contact in the registrar is replaced.
+  void connect({bool reregister = false});
 
   /// Gracefully closes the current connection.
   ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -24,6 +24,7 @@ typedef SignalingClientFactory =
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     });
 
 Uri _coreUrlToSignalingUrl(String coreUrl) {
@@ -38,12 +39,14 @@ Future<WebtritSignalingClient> _defaultClientFactory({
   required Duration connectionTimeout,
   required TrustedCertificates certs,
   required bool force,
+  required bool reregister,
 }) {
   return WebtritSignalingClient.connect(
     url,
     tenantId,
     token,
     force,
+    reregister: reregister,
     connectionTimeout: connectionTimeout,
     certs: certs,
   );
@@ -161,6 +164,13 @@ class SignalingModuleImpl implements SignalingModule {
   /// Last connect error as string for deduplication.
   String? _lastConnectErrorString;
 
+  /// Pending reregister flag for the next connect attempt.
+  ///
+  /// Set by [connect] with `reregister: true`. Sticky across failed attempts -
+  /// reset only when a [SignalingConnected] event is emitted, so a transient
+  /// failure does not lose the intent to re-register after a network change.
+  bool _nextConnectReregister = false;
+
   /// Broadcast stream of all module events.
   ///
   /// Each new subscriber immediately receives buffered lifecycle and handshake
@@ -210,8 +220,17 @@ class SignalingModuleImpl implements SignalingModule {
 
   /// Initiates a connection. Fire-and-forget -- result arrives via [events].
   /// Clears the session buffer on each call.
+  ///
+  /// When [reregister] is true, the URL of the next WebSocket connect attempt
+  /// includes `reregister=true`, asking Core to tear down the existing
+  /// controller and start a fresh SIP registration. The flag is sticky across
+  /// failed attempts and consumed when [SignalingConnected] is emitted, so a
+  /// transient failure does not lose the intent.
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
+    if (reregister) {
+      _nextConnectReregister = true;
+    }
     if (_disposed) {
       _logger.fine('connect: skipped — disposed');
       return;
@@ -220,7 +239,9 @@ class SignalingModuleImpl implements SignalingModule {
       _logger.info('connect: skipped — already connecting or connected (connectToken set)');
       return;
     }
-    _logger.info('connect: starting new connect attempt (isConnected=$isConnected)');
+    _logger.info(
+      'connect: starting new connect attempt (isConnected=$isConnected reregister=$_nextConnectReregister)',
+    );
     final token = _connectToken = Object();
     _eventBuffer.clear();
     unawaited(_connectAsync(token));
@@ -306,6 +327,7 @@ class SignalingModuleImpl implements SignalingModule {
           connectionTimeout: connectionTimeout,
           certs: trustedCertificates,
           force: true,
+          reregister: _nextConnectReregister,
         );
 
         if (_connectToken != connectToken || _disposed) {
@@ -348,6 +370,9 @@ class SignalingModuleImpl implements SignalingModule {
         _client = client;
         _errorHandled = false;
         _lastConnectErrorString = null;
+        // Consume the sticky reregister flag once a connection is established;
+        // a subsequent reconnect from a normal disconnect must not carry it.
+        _nextConnectReregister = false;
         _emit(SignalingConnected());
         unawaited(_requestQueue.flush(execute: client.execute, isActive: () => identical(_client, client)));
       } catch (e, s) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -320,6 +320,13 @@ class SignalingModuleImpl implements SignalingModule {
 
       try {
         final url = _coreUrlToSignalingUrl(coreUrl);
+        // Snapshot the sticky reregister flag at the moment this attempt
+        // actually issues the factory call. A late connect(reregister: true)
+        // that arrives while the factory is awaiting sets the flag but does
+        // not get folded into this attempt; keeping a per-attempt snapshot
+        // lets the post-success cleanup leave the flag untouched in that
+        // case so the late intent carries into the next attempt.
+        final reregisterForThisAttempt = _nextConnectReregister;
         final client = await _clientFactory(
           url: url,
           tenantId: tenantId,
@@ -327,7 +334,7 @@ class SignalingModuleImpl implements SignalingModule {
           connectionTimeout: connectionTimeout,
           certs: trustedCertificates,
           force: true,
-          reregister: _nextConnectReregister,
+          reregister: reregisterForThisAttempt,
         );
 
         if (_connectToken != connectToken || _disposed) {
@@ -370,9 +377,12 @@ class SignalingModuleImpl implements SignalingModule {
         _client = client;
         _errorHandled = false;
         _lastConnectErrorString = null;
-        // Consume the sticky reregister flag once a connection is established;
-        // a subsequent reconnect from a normal disconnect must not carry it.
-        _nextConnectReregister = false;
+        // Consume the sticky reregister flag only when this attempt actually
+        // carried it. A late caller that set the flag while the factory was
+        // awaiting must not lose its intent on this attempt's success.
+        if (reregisterForThisAttempt) {
+          _nextConnectReregister = false;
+        }
         _emit(SignalingConnected());
         unawaited(_requestQueue.flush(execute: client.execute, isActive: () => identical(_client, client)));
       } catch (e, s) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -98,6 +98,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     SignalingServiceConfig config, {
     // ignore: avoid_unused_parameters
     SignalingServiceMode mode = SignalingServiceMode.pushBound,
+    bool reregister = false,
   }) async {
     _isStopped = false;
     final myToken = _startToken = Object();
@@ -141,7 +142,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
       },
     );
     _module = module;
-    module.connect();
+    module.connect(reregister: reregister);
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -39,7 +39,16 @@ abstract class SignalingServicePlatform extends PlatformInterface {
   ///   in the main isolate and is not persistent.
   /// - [SignalingServiceMode.pushBound] -- service stops when the app Activity
   ///   is closed, allowing the next push to start a fresh instance.
-  Future<void> start(SignalingServiceConfig config, {SignalingServiceMode mode = SignalingServiceMode.persistent});
+  ///
+  /// When [reregister] is true, the WebSocket connect URL includes
+  /// `reregister=true`, asking Core to tear down the existing controller and
+  /// start a fresh SIP registration on the new connection. Pass it on
+  /// reconnects that follow a network interface change.
+  Future<void> start(
+    SignalingServiceConfig config, {
+    SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
+  });
 
   /// Sends [request] to the server via the active connection.
   Future<void> execute(Request request);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -101,6 +101,7 @@ class _ControlledFactory {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) {
         final c = Completer<WebtritSignalingClient>();
         _calls.add(c);
@@ -137,6 +138,7 @@ SignalingModuleImpl _buildModuleFromClients(List<WebtritSignalingClient> clients
           required Duration connectionTimeout,
           required TrustedCertificates certs,
           required bool force,
+          required bool reregister,
         }) async => clients[index++],
   );
 }

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -95,6 +95,7 @@ SignalingClientFactory _successFactory(_FakeSignalingClient client) {
     required Duration connectionTimeout,
     required TrustedCertificates certs,
     required bool force,
+    required bool reregister,
   }) async => client;
 }
 
@@ -107,6 +108,7 @@ SignalingClientFactory _failingFactory(Object error) {
     required Duration connectionTimeout,
     required TrustedCertificates certs,
     required bool force,
+    required bool reregister,
   }) async => throw error;
 }
 
@@ -122,6 +124,7 @@ class _ControlledFactory {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) {
         _completer = Completer<WebtritSignalingClient>();
         return _completer!.future;
@@ -260,6 +263,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         return callCount == 1 ? firstClient : secondClient;
@@ -625,6 +629,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         if (callCount == 1) throw error;
@@ -788,6 +793,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         return callCount == 1 ? client1 : client2;
@@ -1229,6 +1235,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         call++;
         return call == 1 ? client1 : client2;
@@ -1401,6 +1408,7 @@ void main() {
           required Duration connectionTimeout,
           required TrustedCertificates certs,
           required bool force,
+          required bool reregister,
         }) async => client,
       );
 

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -27,7 +27,7 @@ class _FakeSignalingModule implements SignalingModule {
   void emit(SignalingModuleEvent event) => _controller.add(event);
 
   @override
-  void connect() => connectCalls++;
+  void connect({bool reregister = false}) => connectCalls++;
 
   @override
   Future<void> disconnect() async => disconnectCalls++;


### PR DESCRIPTION
## Goal
Adds a `reregister` named parameter to every layer of the signaling connect path so callers can request that Core tear down the existing controller and start a fresh SIP registration on the new connection (via the `?reregister=true` URL query parameter that Core supports).

**No behaviour change.** All parameters default to `false`; the new API is a no-op for any existing caller. The detection of when to send `reregister=true` (interface-change trigger in `CallBloc`) is intentionally out of scope and will land in a follow-up PR built on top of this one.

## Layers plumbed

- `webtrit_signaling` URL builder (`reregister` query parameter).
- `webtrit_signaling_service_platform_interface`: `SignalingClientFactory` typedef and default factory, `SignalingModuleImpl` (sticky flag, consumed only on `SignalingConnected`), abstract `SignalingModule` and `SignalingServicePlatform`, `SignalingServiceDirect` (covers iOS via inheritance and Android pushBound).
- `webtrit_signaling_service_android`: plugin `start` override, hub command wire format (backward-compatible decode for older 2-element payloads), `SignalingHubClient.sendConnect`, `SignalingHubModule.connect`, `SignalingHub` server-side handler (covers Android persistent FGS path).
- `webtrit_signaling_service`: facade `WebtritSignalingService.connect`.

## Stickiness

Inside `SignalingModuleImpl` the flag is sticky: set once by any `connect(reregister: true)` call, preserved across failed attempts, and consumed only when `SignalingConnected` is emitted. A transient failure between attempts does not lose the intent.

## Tests

- All existing tests pass (`dart analyze`, `flutter test`).
- Test fakes updated for the new signatures (no logic changes).
- Behavioural tests for the trigger come with the follow-up PR.

## Follow-up

Trigger PR (separate branch) will add:
- `InterfaceChangeDetector` utility (with unit tests).
- `SignalingReconnectController.notifyInterfaceChanged()` and the integration with the existing reconnect scheduling.
- `CallBloc` connectivity handler change to detect a real interface change (WiFi <-> LTE) with debounce and call the controller.

