### PR TITLE
chore(deps): bump auto_route 10 -> 11 (WT-1488)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,18 +77,18 @@ packages:
     dependency: "direct main"
     description:
       name: auto_route
-      sha256: "6d3ccc11b520b6eff0ab5a2c3d1c43c46d1486249cc746c4bb14486d876e8b43"
+      sha256: e9acfeb3df33d188fce4ad0239ef4238f333b7aa4d95ec52af3c2b9360dcd969
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.0"
+    version: "11.1.0"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      sha256: "4d78093dc102eef57c9d53e43454d735f1552039dc9c595ef8cfc7445d9017f2"
+      sha256: "04300eaf5821962aae8b5cd94f67013fd2fd326dc3be212d3ec1ae7470f09834"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.6"
+    version: "10.4.0"
   bloc:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  auto_route: ^10.2.0
+  auto_route: ^11.1.0
   bloc: ^9.1.0
   bloc_concurrency: ^0.3.0
   characters: ^1.4.0
@@ -144,7 +144,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  auto_route_generator: ^10.2.5
+  auto_route_generator: ^10.4.0
   l10n_mapper_generator: ^2.2.0
   build_runner: ^2.7.1
   flutter_gen_runner: ^5.12.0


### PR DESCRIPTION
## Summary

First in a series of pub.dev dependency bumps preparing webtrit_phone for the SPM migration tracked in WT-1488.

- `auto_route`: `^10.2.0` -> `^11.1.0`
- `auto_route_generator`: `^10.2.5` -> `^10.4.0`

`auto_route_generator 10.5.0` (latest) is held back because it requires `analyzer ^9` while our current `l10n_mapper_generator 2.2.0` pins `analyzer ^7/^8`. A future PR will bump `l10n_mapper_generator` to 3.x to unblock 10.5.0.

Generator output for our route configuration is unchanged between v10 and v11 — no `.gr.dart` diffs after `dart run build_runner build --delete-conflicting-outputs`.

## Test plan

- [x] `flutter pub get` resolves cleanly
- [x] `dart run build_runner build --delete-conflicting-outputs` produces no `.gr.dart` changes
- [x] `flutter analyze` -> No issues found
- [x] Smoke test on a real device — app launches, navigation works