### PR TITLE
chore: upgrade flutter_local_notifications to 21.0.0

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -415,7 +415,7 @@ CallkeepIncomingCallError? _onReportIncomingCallTimeout(Logger logger) {
 
 Future _initLocalPushs() async {
   await FlutterLocalNotificationsPlugin().initialize(
-    const InitializationSettings(
+    settings: const InitializationSettings(
       iOS: DarwinInitializationSettings(
         requestAlertPermission: false,
         requestBadgePermission: false,
@@ -443,7 +443,7 @@ Future<void> _initAndroidNotificationChannel() async {
   if (androidPlugin == null) return;
 
   // ignore: deprecated_member_use_from_same_package
-  await androidPlugin.deleteNotificationChannel(kLegacyLocalPushChannelId);
+  await androidPlugin.deleteNotificationChannel(channelId: kLegacyLocalPushChannelId);
   await androidPlugin.createNotificationChannel(
     const AndroidNotificationChannel(kLocalPushChannelId, kLocalPushChannelName, importance: Importance.high),
   );

--- a/lib/repositories/push_notifications/local_push_repository.dart
+++ b/lib/repositories/push_notifications/local_push_repository.dart
@@ -51,17 +51,17 @@ class LocalPushRepositoryFLNImpl implements LocalPushRepository {
   @override
   Future<void> displayPush(AppLocalPush notification) {
     return FlutterLocalNotificationsPlugin().show(
-      notification.id,
-      notification.title,
-      notification.body,
-      kNotificationDetails,
+      id: notification.id,
+      title: notification.title,
+      body: notification.body,
+      notificationDetails: kNotificationDetails,
       payload: jsonEncode(notification.payload ?? {}),
     );
   }
 
   @override
   Future<void> dissmissById(int id) async {
-    await FlutterLocalNotificationsPlugin().cancel(id);
+    await FlutterLocalNotificationsPlugin().cancel(id: id);
   }
 
   @override
@@ -69,7 +69,7 @@ class LocalPushRepositoryFLNImpl implements LocalPushRepository {
     final active = await FlutterLocalNotificationsPlugin().getActiveNotifications();
     final matched = active.where((n) => n.title == title && n.body == body).toList();
     for (final n in matched) {
-      await FlutterLocalNotificationsPlugin().cancel(n.id ?? 0, tag: n.tag);
+      await FlutterLocalNotificationsPlugin().cancel(id: n.id ?? 0, tag: n.tag);
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -703,34 +703,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "19.5.0"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "11.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1814,10 +1814,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:
@@ -2025,7 +2025,7 @@ packages:
       path: "../webtrit_callkeep/webtrit_callkeep"
       relative: true
     source: path
-    version: "0.0.0+0"
+    version: "1.1.0+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:
@@ -2233,4 +2233,4 @@ packages:
     version: "2.2.4"
 sdks:
   dart: ">=3.10.7 <4.0.0"
-  flutter: ">=3.41.2"
+  flutter: ">=3.41.2 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ version: 0.0.0+0000000
 app_version: 1.15.3+0
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.10.0
   flutter: ^3.41.2
 
 dependencies:
@@ -97,7 +97,7 @@ dependencies:
   collection: ^1.19.1
   quiver: ^3.2.2
   flutter_parsed_text: ^2.2.1
-  flutter_local_notifications: ^19.5.0
+  flutter_local_notifications: ^21.0.0
   gravatar_utils: ^1.0.0
   dlibphonenumber: ^1.1.51
   device_region: ^1.4.0


### PR DESCRIPTION
## Summary

- Bumps `flutter_local_notifications` from `19.5.0` to `21.0.0` (skipping two majors).
- Adapts call sites to the v20 breaking change that converted positional parameters to named ones.
- Raises the Dart SDK constraint to `^3.10.0` (required by v21).

## Breaking-change adaptations

- `initialize()` — first argument is now the named `settings:` parameter.
- `show()` — `id`, `title`, `body`, `notificationDetails` are now named.
- `cancel()` — `id` is now named.
- `deleteNotificationChannel()` — `channelId` is now named.