### PR TITLE
chore: upgrade dependencies (no API changes)

### DIFF
--- a/packages/_http_client/pubspec.yaml
+++ b/packages/_http_client/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  http: ^1.5.0
+  http: ^1.6.0
 
   ssl_certificates:
     path: ../ssl_certificates

--- a/packages/store_info_extractor/pubspec.yaml
+++ b/packages/store_info_extractor/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  http: ^1.5.0
+  http: ^1.6.0
   pub_semver: ^2.2.0
 
 dev_dependencies:

--- a/packages/webtrit_api/pubspec.yaml
+++ b/packages/webtrit_api/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   freezed_annotation: ^3.1.0
-  http: ^1.5.0
+  http: ^1.6.0
   json_annotation: ^4.9.0
   meta: any
   pub_semver: ^2.2.0

--- a/packages/webtrit_signaling/pubspec.yaml
+++ b/packages/webtrit_signaling/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  equatable: ^2.0.7
+  equatable: ^2.0.8
   logging: ^1.3.0
   logging_appenders: ^1.4.0+1
   meta: any

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   logging: ^1.3.0
   logging_appenders: ^1.4.0+1
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ^7.1.1
   webtrit_signaling:
     path: ../../webtrit_signaling
   webtrit_signaling_service_platform_interface:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1569,10 +1569,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -756,50 +756,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.1.0"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,18 +261,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.1.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   conventional_commit:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: cd83f7d6bd4e4c0b0b4fef802e8796784032e1cc23d7b0e982cf5d05d9bbe182
+      sha256: "8f89e371e2883de35cdc78f648e725fa4da5f3b6c927269f00fa68f1ea92b598"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.66"
+    version: "1.3.71"
   analyzer:
     dependency: transitive
     description:
@@ -501,138 +501,138 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_analytics
-      sha256: "91e2739bad690da2826c0cd5b28328fd15fb87adf54634cded703f34fd797a81"
+      sha256: "56641bc6dd7b6a8c63ad5f5d46664af5b66db452f1c5ad052b1eec0188cf3183"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.1"
+    version: "12.4.1"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: "62fd3f27f342c898bd819fb97fa87c0b971e9fbe03357477282c0e14e1a40c3c"
+      sha256: "432492ba57024a35dfb67ebcf0c64bac31e19d2c46b3dd222bccbc05f8839efe"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.6"
+    version: "6.0.1"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: "8fc488bb008439fc3b850cfac892dec1ff4cd438eee44438919a14c5e61b9828"
+      sha256: e613fca6511ab8f13adb355f7bc486c49fa6aea72fb6703cfb34df29b3b568a6
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+2"
+    version: "0.6.1+7"
   firebase_app_installations:
     dependency: "direct main"
     description:
       name: firebase_app_installations
-      sha256: "4a242ab20ae423ff9d84e2ac257d4a262675c05343a517827159bf0316ff76f9"
+      sha256: "18c6aa1eea4dc2285465c4fa59f7e7081771371c3a35eac4fef557da5c293fdf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0+6"
+    version: "0.4.2+2"
   firebase_app_installations_platform_interface:
     dependency: transitive
     description:
       name: firebase_app_installations_platform_interface
-      sha256: fcc5af54f2cd018453ada243075f463a5da0aaf3779c9cb7d060708910fdc6e5
+      sha256: "0f45a99bae23cd3a01ab2c7ccb30b19b38f9eec96b627f9dfbfcb6f05f5e16dd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4+65"
+    version: "0.1.4+70"
   firebase_app_installations_web:
     dependency: transitive
     description:
       name: firebase_app_installations_web
-      sha256: "020c73ff3e75f5d10713f2e225451087dc042594c68f6e6a979de69d9d63fe41"
+      sha256: "90fdac5649704b9f22e7ca05a308a6f18a8d0676cde8c0e30267e1006cf8d434"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.7+2"
+    version: "0.1.7+7"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "923085c881663ef685269b013e241b428e1fb03cdd0ebde265d9b40ff18abf80"
+      sha256: "93a5bde9775fd5adcc937f39dfa04ae0bc89c4d79bea6abc49de3f7b049d9ff6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.9.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: cccb4f572325dc14904c02fcc7db6323ad62ba02536833dddb5c02cac7341c64
+      sha256: "4a120366dbf7d5a8ee9438978530b664b855728fb8dcc3a201017660817e555b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "83e7356c704131ca4d8d8dd57e360d8acecbca38b1a3705c7ae46cc34c708084"
+      sha256: "7c98f10b8c8e5adedc0b810b66a877120696675e2c22d9ca9caca092da0d9e57"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.7.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: a6e6cb8b2ea1214533a54e4c1b11b19c40f6a29333f3ab0854a479fdc3237c5b
+      sha256: "9935ea36aaae0dfc789b80a1981fd70c6c7e9956791e9e7c2210ab83f9c963bd"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.7"
+    version: "5.2.2"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: fc6837c4c64c48fa94cab8a872a632b9194fa9208ca76a822f424b3da945584d
+      sha256: ade20d7d86698ded596bf16ab0e7060ef1dae9258ab6705536a39ae047ccef59
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.17"
+    version: "3.8.22"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "06fad40ea14771e969a8f2bbce1944aa20ee2f4f57f4eca5b3ba346b65f3f644"
+      sha256: "8d0dc81a31cd030170508dc3e89bfd14355b20a1b991340af5f018e37daab5d7"
       url: "https://pub.dev"
     source: hosted
-    version: "16.1.1"
+    version: "16.2.2"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "6c49e901c77e6e10e86d98e32056a087eb1ca1b93acdf58524f1961e617657b7"
+      sha256: "37abb0b0535c5497605ee94c12470e1ebbbe47e71a22d0c20bffcc912311f8cb"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.6"
+    version: "4.7.11"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "2756f8fea583ffb9d294d15ddecb3a9ad429b023b70c9990c151fc92c54a32b3"
+      sha256: "54e22b43e2c26a2728a3f68c188de0f9011993ae19ae959a06d476dad935c776"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.2"
+    version: "4.1.7"
   firebase_remote_config:
     dependency: "direct main"
     description:
       name: firebase_remote_config
-      sha256: "6d7be334b726537b3aa3a3ef1db9782951cd93c2b996eebc33f64a9f140e0409"
+      sha256: "5710137e7270ec92236e6ae4d96d36b5c59f5f25ac111d6f77c32e42d4cc01a2"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "6.5.1"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
-      sha256: f895915923bebb9e8b36a6387fac31a9dd36fbb63fa2ee1ea2cbe309634eecdf
+      sha256: "509c6422f38e7c546b96005f0fbb4867c5c28b382717104c6b716fdb275062e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "3.0.1"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
-      sha256: a4de6b86e5eb0416a46948dcb1fa9fce6a71d41f80fa107f6e202ae579ec81b2
+      sha256: "37e3ec0667610e62cac1dd0bdd01d891654e3b196cd8eef45136eac317db3001"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.3"
+    version: "1.10.8"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -900,10 +900,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
+      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "8.1.0"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_session
-      sha256: "8f96a7fecbb718cb093070f868b4cdcb8a9b1053dce342ff8ab2fde10eb9afb7"
+      sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.3"
   auto_route:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: a48653a82055a900b88cd35f92429f068c5a8057ae9b136d197b3d56c57efb81
+      sha256: e03b235924e4f509c27b5d6b2f949200e0a91149a9818b4f65eeb56662b75413
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "9.2.1"
   bloc_concurrency:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -804,10 +804,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "87fbd7c534435b6c5d9d98b01e1fd527812b82e68ddd8bd35fc45ed0fa8f0a95"
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1918,10 +1918,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
+      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.19"
+    version: "1.2.2"
   vector_graphics_codec:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,18 +77,18 @@ packages:
     dependency: "direct main"
     description:
       name: auto_route
-      sha256: "6d3ccc11b520b6eff0ab5a2c3d1c43c46d1486249cc746c4bb14486d876e8b43"
+      sha256: e9acfeb3df33d188fce4ad0239ef4238f333b7aa4d95ec52af3c2b9360dcd969
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.0"
+    version: "11.1.0"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      sha256: "4d78093dc102eef57c9d53e43454d735f1552039dc9c595ef8cfc7445d9017f2"
+      sha256: "04300eaf5821962aae8b5cd94f67013fd2fd326dc3be212d3ec1ae7470f09834"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.6"
+    version: "10.4.0"
   bloc:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,10 +309,10 @@ packages:
     dependency: "direct main"
     description:
       name: cross_file
-      sha256: "701dcfc06da0882883a2657c445103380e53e647060ad8d9dfb710c100996608"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+1"
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: "direct main"
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   audio_session:
     dependency: "direct main"
     description:
@@ -437,10 +437,10 @@ packages:
     dependency: "direct main"
     description:
       name: dlibphonenumber
-      sha256: adee790664db23fee3d26d71ef35c57dba5f62e3f20624c29f1e15f1c334734a
+      sha256: "009f91d3409445e09e5b1ff32247ede6dc5f3a3d2ee703e82fd5ab12d8c8064e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.55"
+    version: "1.1.64"
   drift:
     dependency: "direct main"
     description:
@@ -1902,10 +1902,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   validators:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   auto_route: ^11.1.0
   bloc: ^9.2.1
   bloc_concurrency: ^0.3.0
-  characters: ^1.4.0
+  characters: ^1.4.1
   clock: ^1.1.2
   connectivity_plus: ^7.1.1
   cross_file: ^0.3.5
@@ -61,7 +61,7 @@ dependencies:
   flutter_bloc: ^9.1.1
   flutter_contacts: ^1.1.9+2
   flutter_secure_storage: ^9.2.4
-  flutter_svg: ^2.2.2
+  flutter_svg: ^2.3.0
   flutter_webrtc:
     git:
       url: https://github.com/WebTrit/flutter-webrtc.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dependencies:
       ref: main_ext_rebase_06.05.26
   formz: ^0.8.0
   freezed_annotation: ^3.1.0
-  google_fonts: ^6.3.2
+  google_fonts: ^8.1.0
   google_api_availability: ^5.0.1
   intl: any
   json_annotation: ^4.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,7 +103,7 @@ dependencies:
   device_region: ^1.4.0
   html: ^0.15.6
   http: ^1.5.0
-  audio_session: ^0.2.2
+  audio_session: ^0.2.3
   bloc_test: ^10.0.0
   workmanager: ^0.9.0+3
   country_code_picker: ^3.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  auto_route: ^10.2.0
+  auto_route: ^11.1.0
   bloc: ^9.1.0
   bloc_concurrency: ^0.3.0
   characters: ^1.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   cross_file: ^0.3.5
   device_info_plus: ^12.2.0
   drift: ^2.29.0
-  equatable: ^2.0.7
+  equatable: ^2.0.8
   firebase_analytics: ^12.4.1
   firebase_app_installations: ^0.4.2+2
   firebase_core: ^4.9.0
@@ -90,7 +90,7 @@ dependencies:
   shared_preferences: ^2.5.3
   stream_transform: ^2.1.1
   url_launcher: ^6.3.2
-  uuid: ^4.5.2
+  uuid: ^4.5.3
   validators: ^3.0.0
   webview_flutter: ^4.13.0
   webview_flutter_web: ^0.2.3+4
@@ -99,7 +99,7 @@ dependencies:
   flutter_parsed_text: ^2.2.1
   flutter_local_notifications: ^21.0.0
   gravatar_utils: ^1.0.0
-  dlibphonenumber: ^1.1.51
+  dlibphonenumber: ^1.1.64
   device_region: ^1.4.0
   html: ^0.15.6
   http: ^1.5.0
@@ -110,7 +110,7 @@ dependencies:
   icon_decoration: ^2.1.0
   emoji_picker_flutter: ^4.3.0
   mask_text_input_formatter: ^2.9.0
-  async: ^2.13.0
+  async: ^2.13.1
   rxdart: ^0.28.0
 
   webtrit_api:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -108,7 +108,7 @@ dependencies:
   workmanager: ^0.9.0+3
   country_code_picker: ^3.4.1
   icon_decoration: ^2.1.0
-  emoji_picker_flutter: ^4.3.0
+  emoji_picker_flutter: ^4.4.0
   mask_text_input_formatter: ^2.9.0
   async: ^2.13.1
   rxdart: ^0.28.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
   pub_semver: ^2.2.0
   sdp_transform: ^0.3.2
   share_plus: ^12.0.1
-  shared_preferences: ^2.5.3
+  shared_preferences: ^2.5.5
   stream_transform: ^2.1.1
   url_launcher: ^6.3.2
   uuid: ^4.5.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   characters: ^1.4.1
   clock: ^1.1.2
   connectivity_plus: ^7.1.1
-  cross_file: ^0.3.5
+  cross_file: ^0.3.5+2
   device_info_plus: ^12.2.0
   drift: ^2.29.0
   equatable: ^2.0.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   bloc_concurrency: ^0.3.0
   characters: ^1.4.0
   clock: ^1.1.2
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ^7.1.1
   cross_file: ^0.3.5
   device_info_plus: ^12.2.0
   drift: ^2.29.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,7 +102,7 @@ dependencies:
   dlibphonenumber: ^1.1.64
   device_region: ^1.4.0
   html: ^0.15.6
-  http: ^1.5.0
+  http: ^1.6.0
   audio_session: ^0.2.3
   bloc_test: ^10.0.0
   workmanager: ^0.9.0+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
     sdk: flutter
 
   auto_route: ^11.1.0
-  bloc: ^9.1.0
+  bloc: ^9.2.1
   bloc_concurrency: ^0.3.0
   characters: ^1.4.0
   clock: ^1.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,12 +52,12 @@ dependencies:
   device_info_plus: ^12.2.0
   drift: ^2.29.0
   equatable: ^2.0.7
-  firebase_analytics: ^12.0.4
-  firebase_app_installations: ^0.4.0+4
-  firebase_core: ^4.2.1
-  firebase_crashlytics: ^5.0.4
-  firebase_messaging: ^16.0.4
-  firebase_remote_config: ^6.1.1
+  firebase_analytics: ^12.4.1
+  firebase_app_installations: ^0.4.2+2
+  firebase_core: ^4.9.0
+  firebase_crashlytics: ^5.2.2
+  firebase_messaging: ^16.2.2
+  firebase_remote_config: ^6.5.1
   flutter_bloc: ^9.1.1
   flutter_contacts: ^1.1.9+2
   flutter_secure_storage: ^9.2.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,7 +92,7 @@ dependencies:
   url_launcher: ^6.3.2
   uuid: ^4.5.3
   validators: ^3.0.0
-  webview_flutter: ^4.13.0
+  webview_flutter: ^4.13.1
   webview_flutter_web: ^0.2.3+4
   collection: ^1.19.1
   quiver: ^3.2.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,7 +60,7 @@ dependencies:
   firebase_remote_config: ^6.5.1
   flutter_bloc: ^9.1.1
   flutter_contacts: ^1.1.9+2
-  flutter_secure_storage: ^9.2.4
+  flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:
     git:


### PR DESCRIPTION
## Summary

Bumps a batch of dependencies that did not require source code changes.

### App (`pubspec.yaml`)

- `firebase_analytics` 12.0.4 → 12.4.1
- `firebase_app_installations` 0.4.0+4 → 0.4.2+2
- `firebase_core` 4.2.1 → 4.9.0
- `firebase_crashlytics` 5.0.4 → 5.2.2
- `firebase_messaging` 16.0.4 → 16.2.2
- `firebase_remote_config` 6.1.1 → 6.5.1
- `auto_route` 10.2.0 → 11.1.0
- `equatable` 2.0.7 → 2.0.8
- `uuid` 4.5.2 → 4.5.3
- `dlibphonenumber` 1.1.51 → 1.1.64
- `async` 2.13.0 → 2.13.1
- `bloc` 9.1.0 → 9.2.1
- `connectivity_plus` 7.0.0 → 7.1.1
- `google_fonts` 6.3.2 → 8.1.0
- `characters` 1.4.0 → 1.4.1
- `flutter_svg` 2.2.2 → 2.3.0
- `emoji_picker_flutter` 4.3.0 → 4.4.0
- `audio_session` 0.2.2 → 0.2.3
- `http` 1.5.0 → 1.6.0
- `webview_flutter` 4.13.0 → 4.13.1
- `shared_preferences` 2.5.3 → 2.5.5
- `flutter_secure_storage` 9.2.4 → 10.3.1
- `cross_file` 0.3.5 → 0.3.5+2

### Packages

- `http` 1.5.0 → 1.6.0 in `store_info_extractor`, `_http_client`, `webtrit_api`
- `equatable` 2.0.7 → 2.0.8 in `webtrit_signaling`
- `connectivity_plus` 7.0.0 → 7.1.1 in `webtrit_signaling_service_android`
