### PR TITLE
chore: upgrade Gradle to 8.14 and migrate app to Built-in Kotlin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,7 +3,6 @@ import groovy.json.JsonSlurper
 
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
     id "com.google.gms.google-services"
     id "com.google.firebase.crashlytics"
@@ -234,10 +233,6 @@ android {
         }
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -281,6 +276,12 @@ android {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
     preBuild.dependsOn generateNetworkSecurityConfig
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }
 
 flutter {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,3 +3,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip


### PR DESCRIPTION
## Summary
- Bump Gradle wrapper 8.13 to 8.14 to clear the Flutter deprecation warning about Gradle below 8.14.
- Migrate `android/app/build.gradle` to Built-in Kotlin per the [Flutter migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers): drop the `kotlin-android` plugin and replace `kotlinOptions` with the top-level `kotlin { compilerOptions { jvmTarget = JVM_17 } }` block.
- Keep the `android.builtInKotlin=false` and `android.newDsl=false` suppression flags previously added by the Flutter migrator (still needed while third-party plugins migrate).

Out of scope: the remaining "plugins that apply KGP" warning is from third-party plugins (`audio_session`, `firebase_*`, `flutter_webrtc`, etc.) and a few of our own (`device_auto_rotate`, `webtrit_callkeep_android`, `webtrit_signaling_service_android`) - each needs its own plugin-side migration.

## Test plan
- [x] `flutter build apk` succeeds locally for the deeplinksDisabledsmsReceiverDisabled flavor
- [x] App-level KGP warning no longer printed
- [x] CI green