### PR TITLE
fix(call): allow renegotiation when signalingState is null (WT-1540)

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -556,6 +556,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         ),
                         signalingModule: _signalingModule,
                         peerConnectionManager: peerConnectionManager,
+                        connectivityService: context.read<ConnectivityService>(),
                         onSessionInvalidated: () =>
                             appBloc.add(const AppLogoutRequested(reason: AppLogoutReason.sessionMissed)),
                         foregroundCallPushSignal: RemotePushBroker.pendingCallForegroundPushs,

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -151,6 +151,15 @@ Future<InstanceRegistry> bootstrap() async {
 
   final appLifecycle = await AppLifecycle.initMaster();
 
+  // ConnectivityService - single owner of `Connectivity()` plugin subscription.
+  // Built here (not in RootApp) so the deduplication cache can be seeded via an
+  // awaited `checkConnectivity()` read before any consumer subscribes. This
+  // prevents the listener's first replayed event from being misinterpreted as a
+  // real interface change downstream.
+  final connectivityService = await ConnectivityServiceImpl.create(
+    connectivityChecker: _createConnectivityChecker(apiClientFactory),
+  );
+
   // Register instances into the Registry
 
   // Configuration & Info
@@ -188,12 +197,28 @@ Future<InstanceRegistry> bootstrap() async {
   // Network clients
   registry.register<WebtritApiClientFactory>(apiClientFactory);
   registry.register<RemoteConfigService>(cachedRemoteConfigService);
+  registry.register<ConnectivityService>(connectivityService);
 
   // Final side-effect initializations that rely on registered components
   await _initCallkeep(featureAccess);
   await _initWorkManager();
 
   return registry;
+}
+
+/// Creates the platform [ConnectivityChecker] used by [ConnectivityService]
+/// for HTTP liveness probes. Picks the custom-URL implementation if a
+/// dedicated check endpoint is provided via [EnvironmentConfig], otherwise
+/// falls back to the default API-client-based check.
+ConnectivityChecker _createConnectivityChecker(WebtritApiClientFactory apiClientFactory) {
+  final customUrl = EnvironmentConfig.CONNECTIVITY_CHECK_URL;
+  return switch (customUrl) {
+    String url => CustomConnectivityChecker(
+      connectivityCheckUrl: url,
+      createHttpRequestExecutor: apiClientFactory.createHttpRequestExecutor(),
+    ),
+    null => DefaultConnectivityChecker(apiClient: apiClientFactory.createWebtritApiClient()),
+  };
 }
 
 /// Initializes [AppPermissions] with an exclusion callback.

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -527,11 +527,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       add(_ConnectivityResultChanged(currentConnectivityResult));
     });
 
-    if (connectivityState == ConnectivityResult.none) {
-      _reconnectController.notifyNetworkUnavailable();
-    } else {
-      _reconnectController.notifyNetworkAvailable();
-    }
+    // Initial WS connect is initiated by MainShell `..connect()`; runtime
+    // connectivity changes flow through the subscription above. No bootstrap
+    // call to the reconnect controller is needed - calling notifyNetworkAvailable
+    // here would proactively disconnect a healthy WS that just delivered the
+    // handshake (the disconnect path inside notifyNetworkAvailable assumes a
+    // real interface change, which a bootstrap snapshot is not).
 
     WebRTC.initialize(options: webRtcOptionsBuilder?.build());
   }
@@ -2958,8 +2959,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       return;
     }
 
-    final sigState = pc.signalingState;
-    if (sigState != null && sigState != RTCSignalingState.RTCSignalingStateStable) {
+    // pc.signalingState is a Dart-side cache populated only after the first
+    // native state event. On a freshly created PC the event may not have
+    // arrived yet; force a platform round-trip in that case so the guard
+    // gets the real native state instead of guessing what null means.
+    final cachedSigState = pc.signalingState;
+    final sigState = cachedSigState ?? await pc.getSignalingState();
+    _logger.info('__onMutationRenegotiate: sigState=$sigState (cache=$cachedSigState)');
+    if (sigState != RTCSignalingState.RTCSignalingStateStable) {
       _logger.fine(() => '__onMutationRenegotiate: pc signalingState is $sigState, skipping renegotiation');
       return;
     }
@@ -2997,6 +3004,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // Dont forget to invoke __onMutationRenegotiate manualy when signaling reconnected to make sure the new offer will be sended
     //
     final signalingConnected = state.isSignalingEstablished;
+    _logger.info(
+      '__onMutationRenegotiate: signaling check'
+      ' signalingConnected=$signalingConnected'
+      ' signalingClientStatus=${state.callServiceState.signalingClientStatus}'
+      ' isHandshakeEstablished=${state.isHandshakeEstablished}'
+      ' registration=${state.callServiceState.registration?.status}'
+      ' networkStatus=${state.callServiceState.networkStatus}'
+      ' linesCount=${state.linesCount}'
+      ' appLifecycle=${state.currentAppLifecycleState}',
+    );
     if (!signalingConnected) {
       _logger.info('__onMutationRenegotiate: signaling not connected, skipping renegotiation');
       return;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2975,13 +2975,26 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       return;
     }
 
-    final offerCandidate = await pc.createOffer();
-
-    // Note: prepare all asychronous info before checking synchrounous state below
-    // to avoid races as possible,
-    // for example:
-    // - while [await _peerConnectionManager.retrieve, await pc.createOffer], activeCall.updating or signalingConnected can be changed
-
+    // All synchronous state guards run BEFORE createOffer.
+    //
+    // createOffer is not a read-only "snapshot the SDP" call: with the default
+    // OfferToReceiveAudio/Video constraints flutter-webrtc instructs the native
+    // PC to add recvonly transceivers if matching ones do not already exist,
+    // which advances the internal mid counter. If we bail after createOffer
+    // (e.g. because signaling is not connected), those transceivers leak onto
+    // the PC. The next renegotiate cycle calls createOffer again and adds
+    // ANOTHER set, eventually emitting an offer whose m-line mids no longer
+    // match what Janus answers with (mid:0 from Asterisk pass-through), so
+    // setRemoteDescription rejects the answer and the PC is stuck in
+    // have-local-offer forever.
+    //
+    // Guard order trade-off: the original author placed createOffer first to
+    // capture "fresh" SDP before checking state, on the assumption that state
+    // could shift during an async wait. That race window still exists between
+    // createOffer and setLocalDescription/execute below, but the cost of
+    // proceeding with stale state there (offer sent to a freshly-closed
+    // signaling channel -> SignalingTransactionTerminateByDisconnect, caught
+    // by the catch block) is far cheaper than the PC corruption above.
     final activeCall = state.retrieveActiveCall(e.callId);
     if (activeCall == null) {
       _logger.info('__onMutationRenegotiate: activeCall disposed, skipping renegotiation');
@@ -3022,6 +3035,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _logger.info('__onMutationRenegotiate: signaling not connected, skipping renegotiation');
       return;
     }
+
+    final offerCandidate = await pc.createOffer();
 
     // If call already in updating state, mostly by remote renegetiation, hold, transfer etc..
     // skip it but schedule another renegotiation in 1 second later to ensure the pending one is finished

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2958,8 +2958,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       return;
     }
 
-    if (pc.signalingState != RTCSignalingState.RTCSignalingStateStable) {
-      _logger.fine(() => '__onMutationRenegotiate: pc signalingState is ${pc.signalingState}, skipping renegotiation');
+    final sigState = pc.signalingState;
+    if (sigState != null && sigState != RTCSignalingState.RTCSignalingStateStable) {
+      _logger.fine(() => '__onMutationRenegotiate: pc signalingState is $sigState, skipping renegotiation');
       return;
     }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -25,6 +25,7 @@ import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/push_notification/push_notifications.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/services/services.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
@@ -102,7 +103,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final VoidCallback? onCallEnded;
   final OnDiagnosticReportRequested onDiagnosticReportRequested;
 
-  StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
+  StreamSubscription<ConnectivityResult>? _connectivityChangedSubscription;
   StreamSubscription<void>? _foregroundCallPushSubscription;
   final _iceRestartDebounce = DebounceMap<String>(const Duration(seconds: 2));
 
@@ -113,6 +114,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   late final PeerConnectionManager _peerConnectionManager;
   late final HandshakeProcessor _handshakeProcessor;
+  final ConnectivityService _connectivityService;
 
   final _callkeepSound = WebtritCallkeepSound();
 
@@ -142,9 +144,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     this.peerConnectionPolicyApplier,
     required SignalingModule signalingModule,
     required PeerConnectionManager peerConnectionManager,
+    required ConnectivityService connectivityService,
     this.onCallEnded,
     Stream<void>? foregroundCallPushSignal,
-  }) : super(const CallState()) {
+  }) : _connectivityService = connectivityService,
+       super(const CallState()) {
     _mediaManager = CallMediaManager(callkeep: callkeep);
     _signalingModule = signalingModule;
     _peerConnectionManager = peerConnectionManager;
@@ -512,8 +516,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     emit(state.copyWith(currentAppLifecycleState: lifecycleState));
     _logger.fine('_onCallStarted initial lifecycle state: $lifecycleState');
 
-    // Initialize connectivity state
-    final connectivityState = (await Connectivity().checkConnectivity()).first;
+    // Initialize connectivity state from the centralized service. The service
+    // owns the single subscription to `Connectivity().onConnectivityChanged`
+    // and exposes a deduplicated stream of changes, so the bloc no longer
+    // talks to the plugin directly.
+    final connectivityState = _connectivityService.currentConnectivityResult;
     emit(
       state.copyWith(
         callServiceState: state.callServiceState.copyWith(networkStatus: connectivityState.toNetworkStatus()),
@@ -521,18 +528,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
     _logger.finer('_onCallStarted initial connectivity state: $connectivityState');
 
-    // Subscribe to future connectivity changes
-    _connectivityChangedSubscription = Connectivity().onConnectivityChanged.listen((result) {
-      final currentConnectivityResult = result.first;
-      add(_ConnectivityResultChanged(currentConnectivityResult));
+    // Subscribe to deduplicated future connectivity changes. The first replay
+    // event from `Connectivity().onConnectivityChanged` is already filtered by
+    // the service when it matches the cached initial value, so no bootstrap
+    // call to the reconnect controller is needed here - the initial WS connect
+    // is initiated by MainShell `..connect()` and runtime changes flow through
+    // this subscription.
+    _connectivityChangedSubscription = _connectivityService.connectivityResultStream.listen((result) {
+      add(_ConnectivityResultChanged(result));
     });
-
-    // Initial WS connect is initiated by MainShell `..connect()`; runtime
-    // connectivity changes flow through the subscription above. No bootstrap
-    // call to the reconnect controller is needed - calling notifyNetworkAvailable
-    // here would proactively disconnect a healthy WS that just delivered the
-    // handshake (the disconnect path inside notifyNetworkAvailable assumes a
-    // real interface change, which a bootstrap snapshot is not).
 
     WebRTC.initialize(options: webRtcOptionsBuilder?.build());
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,6 @@ import 'package:webtrit_phone/app/app.dart';
 import 'package:webtrit_phone/bootstrap.dart';
 import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/data/data.dart';
-import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/services/services.dart';
 import 'package:webtrit_phone/utils/utils.dart';
@@ -102,7 +101,7 @@ class RootApp extends StatelessWidget {
         // Provides `AppDatabase` by reading it from `AppDatabaseLifecycleHolder`.
         // When this provider is read, it triggers creation of the holder first (provider is lazy).
         Provider<AppDatabase>(create: (context) => context.read<AppDatabaseLifecycleHolder>().db),
-        Provider<ConnectivityService>(create: _createConnectivityService, dispose: _disposeConnectivityService),
+        Provider<ConnectivityService>(create: (_) => instanceRegistry.get(), dispose: _disposeConnectivityService),
       ],
       child: Builder(
         builder: (context) {
@@ -183,21 +182,6 @@ class RootApp extends StatelessWidget {
 
   Future<void> _disposeAppDatabaseLifecycleHolder(BuildContext _, AppDatabaseLifecycleHolder holder) async {
     await holder.dispose();
-  }
-
-  ConnectivityService _createConnectivityService(BuildContext context) {
-    final customUrl = EnvironmentConfig.CONNECTIVITY_CHECK_URL;
-    final apiFactory = context.read<WebtritApiClientFactory>();
-
-    final connectivityChecker = switch (customUrl) {
-      String url => CustomConnectivityChecker(
-        connectivityCheckUrl: url,
-        createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
-      ),
-      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
-    };
-
-    return ConnectivityServiceImpl(connectivityChecker: connectivityChecker);
   }
 
   void _disposeConnectivityService(BuildContext _, ConnectivityService value) {

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -5,46 +5,87 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 abstract class ConnectivityService {
+  /// Last seen `ConnectivityResult` from any source (initial platform read or
+  /// subsequent change event). Always non-null after the service is created.
+  ConnectivityResult get currentConnectivityResult;
+
+  /// Stream of raw `ConnectivityResult` values, deduplicated against the cached
+  /// current value. Emits only when the OS reports a value different from the
+  /// last accepted one. The first event after subscribe that mirrors the cached
+  /// initial value is filtered out here - this is the bridge that the plugin's
+  /// own `Stream.distinct()` does not cover (plugin compares within stream only;
+  /// it does not know about `checkConnectivity()` snapshot reads).
+  Stream<ConnectivityResult> get connectivityResultStream;
+
+  /// Boolean online-state stream that combines OS connectivity with an HTTP
+  /// liveness probe via [ConnectivityChecker]. Emits on every change event,
+  /// after the probe completes.
   Stream<bool> get connectionStream;
 
+  /// One-shot online check: OS state + HTTP probe.
   Future<bool> checkConnection();
 
   void dispose();
 }
 
 class ConnectivityServiceImpl implements ConnectivityService {
-  ConnectivityServiceImpl({required ConnectivityChecker connectivityChecker})
-    : _connectivityChecker = connectivityChecker {
+  ConnectivityServiceImpl._({
+    required ConnectivityChecker connectivityChecker,
+    required ConnectivityResult initialResult,
+  }) : _connectivityChecker = connectivityChecker,
+       _lastResult = initialResult {
     _connectivitySubscription = _connectivity.onConnectivityChanged.listen(_handleConnectivityChange);
   }
 
-  final Connectivity _connectivity = Connectivity();
-  final StreamController<bool> _controller = StreamController<bool>.broadcast();
-  final ConnectivityChecker _connectivityChecker;
-  late final StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
-
-  @override
-  Stream<bool> get connectionStream => _controller.stream;
-
-  @override
-  Future<bool> checkConnection() async {
-    final result = await _connectivity.checkConnectivity();
-    if (result.contains(ConnectivityResult.none) || result.isEmpty) {
-      return false;
-    }
-
-    return _connectivityChecker.checkConnection();
+  /// Creates a fully-initialised service. Reads the current OS connectivity
+  /// state via `checkConnectivity()` to seed the cache before any consumer
+  /// subscribes. Must be awaited so the listener's first replayed event is
+  /// recognized as a duplicate and filtered.
+  static Future<ConnectivityServiceImpl> create({required ConnectivityChecker connectivityChecker}) async {
+    final initialResult = (await Connectivity().checkConnectivity()).first;
+    return ConnectivityServiceImpl._(connectivityChecker: connectivityChecker, initialResult: initialResult);
   }
 
+  final Connectivity _connectivity = Connectivity();
+  final ConnectivityChecker _connectivityChecker;
+  final StreamController<bool> _onlineController = StreamController<bool>.broadcast();
+  final StreamController<ConnectivityResult> _resultController = StreamController<ConnectivityResult>.broadcast();
+  late final StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
+
+  ConnectivityResult _lastResult;
+
+  @override
+  ConnectivityResult get currentConnectivityResult => _lastResult;
+
+  @override
+  Stream<ConnectivityResult> get connectivityResultStream => _resultController.stream;
+
+  @override
+  Stream<bool> get connectionStream => _onlineController.stream;
+
+  @override
+  Future<bool> checkConnection() => _checkConnection(_lastResult);
+
   Future<void> _handleConnectivityChange(List<ConnectivityResult> result) async {
-    final connected = await checkConnection();
-    _controller.add(connected);
+    final next = result.first;
+    if (next != _lastResult) {
+      _lastResult = next;
+      _resultController.add(next);
+    }
+    final connected = await _checkConnection(next);
+    _onlineController.add(connected);
+  }
+
+  Future<bool> _checkConnection(ConnectivityResult current) async {
+    if (current == ConnectivityResult.none) return false;
+    return _connectivityChecker.checkConnection();
   }
 
   @override
   void dispose() {
     _connectivityChecker.dispose();
     _connectivitySubscription.cancel();
-    _controller.close();
+    _resultController.close();
+    _onlineController.close();
   }
 }

--- a/test/mocks/fake_connectivity_service.dart
+++ b/test/mocks/fake_connectivity_service.dart
@@ -1,18 +1,30 @@
 import 'dart:async';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
+
 import 'package:webtrit_phone/services/services.dart';
 
-/// Lightweight fake ConnectivityService with controllable stream and checkConnection().
+/// Lightweight fake ConnectivityService with controllable streams and checkConnection().
 class FakeConnectivityService implements ConnectivityService {
-  FakeConnectivityService({bool initialConnected = false}) : _connected = initialConnected;
+  FakeConnectivityService({bool initialConnected = false, ConnectivityResult initialResult = ConnectivityResult.none})
+    : _connected = initialConnected,
+      _currentResult = initialResult;
 
   final _controller = StreamController<bool>.broadcast();
+  final _resultController = StreamController<ConnectivityResult>.broadcast();
   bool _connected;
+  ConnectivityResult _currentResult;
 
   int checkCalls = 0;
 
   @override
   Stream<bool> get connectionStream => _controller.stream;
+
+  @override
+  ConnectivityResult get currentConnectivityResult => _currentResult;
+
+  @override
+  Stream<ConnectivityResult> get connectivityResultStream => _resultController.stream;
 
   @override
   Future<bool> checkConnection() async {
@@ -29,8 +41,17 @@ class FakeConnectivityService implements ConnectivityService {
   /// Alias for [setConnected] to keep backward compatibility.
   void push(bool connected) => setConnected(connected);
 
+  /// Set current ConnectivityResult and emit on the deduped stream if different.
+  void setConnectivityResult(ConnectivityResult result) {
+    if (result != _currentResult) {
+      _currentResult = result;
+      _resultController.add(result);
+    }
+  }
+
   @override
   void dispose() {
     _controller.close();
+    _resultController.close();
   }
 }


### PR DESCRIPTION
## Summary
- Treat `pc.signalingState == null` the same as `RTCSignalingStateStable` in `__onMutationRenegotiate`.
- Restores ICE renegotiation on the freshly created PeerConnection in the call restore path.

## WT-1540
After force stopping the app mid call and reopening, the call is restored in `incomingRestoringMedia` but audio never resumes. `flutter_webrtc` returns `null` for `signalingState` on a brand new PeerConnection before the initial state callback fires. The guard added by PR #1220 (WT-1345) skipped renegotiation in that case, so no fresh offer / ICE restart was sent to Janus.