### PR TITLE
chore: upgrade flutter_contacts to 2.2.0

### DIFF
--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -68,7 +68,7 @@ class LocalContactsRepository implements ILocalContactsRepository {
         ContactProperty.phone,
         ContactProperty.email,
         ContactProperty.photoThumbnail,
-        if (Platform.isAndroid) ContactProperty.identifiers,
+        if (Platform.isAndroid) ...{ContactProperty.identifiers, ContactProperty.dataMimetypes},
       },
     );
     return contacts

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -1,10 +1,14 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_contacts/flutter_contacts.dart';
 
 import 'package:webtrit_phone/models/models.dart';
 
 import 'local_contacts_repository.dart';
+
+const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
+const _googleAccountType = 'com.google';
 
 class LocalContactsRepository implements ILocalContactsRepository {
   LocalContactsRepository() {
@@ -55,14 +59,27 @@ class LocalContactsRepository implements ILocalContactsRepository {
 
   Future<List<LocalContact>> _listContacts() async {
     final contacts = await FlutterContacts.getAll(
-      properties: {ContactProperty.name, ContactProperty.phone, ContactProperty.email, ContactProperty.photoThumbnail},
+      properties: {
+        ContactProperty.name,
+        ContactProperty.phone,
+        ContactProperty.email,
+        ContactProperty.photoThumbnail,
+        if (Platform.isAndroid) ContactProperty.identifiers,
+      },
     );
-    // Android per-account filtering (mimetypes / com.google) removed: flutter_contacts 2.x
-    // no longer exposes per-contact accounts/mimetypes on `Contact`. If account-scoped
-    // filtering is needed again, switch to `FlutterContacts.accounts.getAll()` and pass
-    // the `account:` parameter to `getAll()`.
     return contacts
-        .where((contact) => contact.id != null)
+        .where((contact) {
+          if (contact.id == null) return false;
+          if (!Platform.isAndroid) return true;
+          // Hides synthetic raw_contacts created by messaging apps (WhatsApp, Viber, Telegram).
+          // Why: pass if any raw_contact has a phone_v2 data row (real telephony entry) OR
+          // belongs to a Google account (WT-432: Android 12+ Google contacts may lack phone_v2).
+          final rawContacts = contact.android?.identifiers?.rawContacts ?? const [];
+          if (rawContacts.isEmpty) return true;
+          return rawContacts.any(
+            (rc) => rc.dataMimetypes.contains(_phoneV2Mimetype) || rc.account?.type == _googleAccountType,
+          );
+        })
         .map(
           (contact) => LocalContact(
             id: contact.id!,

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -43,16 +43,12 @@ class LocalContactsRepository implements ILocalContactsRepository {
   }
 
   void _onListenCallback() {
-    _databaseSubscription = FlutterContacts.onDatabaseChange.listen(_contactDatabaseChangesListener);
+    _databaseSubscription = FlutterContacts.onDatabaseChange.listen((_) => load());
   }
 
   void _onCancelCallback() {
     _databaseSubscription?.cancel();
     _databaseSubscription = null;
-  }
-
-  void _contactDatabaseChangesListener(void _) async {
-    await load();
   }
 
   /// Returns `true` for contacts that should appear in the app's contact list.

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_contacts/flutter_contacts.dart';
 
@@ -6,11 +7,10 @@ import 'package:webtrit_phone/models/models.dart';
 
 import 'local_contacts_repository.dart';
 
-// Filter values passed to FlutterContacts.getAll. The plugin combines them
-// with OR semantics: a contact passes if it has at least one data row with
-// _phoneV2Mimetype OR at least one raw contact in _googleAccountType.
-// Mirrors the 1.x filter behavior. Android-only — iOS ignores both
-// parameters via the androidXxx naming.
+// Hides synthetic raw_contacts created by messaging apps (WhatsApp, Viber,
+// Telegram). Mirrors the 1.x `mimetypes.contains('phone_v2') OR account.type
+// == 'com.google'` filter using RawContact.dataMimetypes (from the WebTrit
+// fork of flutter_contacts). Android only; iOS contacts have no equivalent.
 const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
 const _googleAccountType = 'com.google';
 
@@ -63,12 +63,24 @@ class LocalContactsRepository implements ILocalContactsRepository {
 
   Future<List<LocalContact>> _listContacts() async {
     final contacts = await FlutterContacts.getAll(
-      properties: {ContactProperty.name, ContactProperty.phone, ContactProperty.email, ContactProperty.photoThumbnail},
-      androidRequiredDataMimetypes: const {_phoneV2Mimetype},
-      androidRequiredAccountTypes: const {_googleAccountType},
+      properties: {
+        ContactProperty.name,
+        ContactProperty.phone,
+        ContactProperty.email,
+        ContactProperty.photoThumbnail,
+        if (Platform.isAndroid) ContactProperty.identifiers,
+      },
     );
     return contacts
-        .where((contact) => contact.id != null)
+        .where((contact) {
+          if (contact.id == null) return false;
+          if (!Platform.isAndroid) return true;
+          final rawContacts = contact.android?.identifiers?.rawContacts ?? const [];
+          if (rawContacts.isEmpty) return true;
+          return rawContacts.any(
+            (rc) => rc.dataMimetypes.contains(_phoneV2Mimetype) || rc.account?.type == _googleAccountType,
+          );
+        })
         .map(
           (contact) => LocalContact(
             id: contact.id!,

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:flutter_contacts/flutter_contacts.dart';
 
-import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/models/models.dart' hide Contact;
 
 import 'local_contacts_repository.dart';
 
@@ -61,6 +61,26 @@ class LocalContactsRepository implements ILocalContactsRepository {
     await load();
   }
 
+  /// Returns `true` for contacts that should appear in the app's contact list.
+  ///
+  /// Drops contacts without a stable id (can't build a [LocalContact]). On
+  /// Android additionally hides synthetic raw_contacts written by messaging
+  /// apps (WhatsApp, Viber, Telegram, ...) that do not carry a `phone_v2`
+  /// data row and are not in a trusted account family - mirrors the 1.x
+  /// `account.mimetypes.contains('phone_v2') OR account.type == 'com.google'`
+  /// behaviour. Empty `rawContacts` is treated as a device-local contact and
+  /// passes (some vendor ROMs do not expose account info for those).
+  bool _shouldIncludeContact(Contact contact) {
+    if (contact.id == null) return false;
+    if (!Platform.isAndroid) return true;
+    final rawContacts = contact.android?.identifiers?.rawContacts ?? const [];
+    if (rawContacts.isEmpty) return true;
+    return rawContacts.any(
+      (rawContact) =>
+          rawContact.dataMimetypes.contains(_phoneV2Mimetype) || rawContact.account?.type == _googleAccountType,
+    );
+  }
+
   Future<List<LocalContact>> _listContacts() async {
     final contacts = await FlutterContacts.getAll(
       properties: {
@@ -72,15 +92,7 @@ class LocalContactsRepository implements ILocalContactsRepository {
       },
     );
     return contacts
-        .where((contact) {
-          if (contact.id == null) return false;
-          if (!Platform.isAndroid) return true;
-          final rawContacts = contact.android?.identifiers?.rawContacts ?? const [];
-          if (rawContacts.isEmpty) return true;
-          return rawContacts.any(
-            (rc) => rc.dataMimetypes.contains(_phoneV2Mimetype) || rc.account?.type == _googleAccountType,
-          );
-        })
+        .where(_shouldIncludeContact)
         .map(
           (contact) => LocalContact(
             id: contact.id!,

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -7,8 +7,12 @@ import 'package:webtrit_phone/models/models.dart';
 
 import 'local_contacts_repository.dart';
 
-const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
-const _googleAccountType = 'com.google';
+// Hides synthetic raw_contacts created by messaging apps (WhatsApp, Viber, Telegram).
+// Why: WT-432 + the original 2022 filter. With a direct ContactsContract.Data
+// MIMETYPE query, any contact that has a phone number — Google-synced, SIM, or
+// device-local — has a phone_v2 row, so a single mimetype filter covers both
+// historical cases. Android only; iOS contacts have no equivalent concept.
+const _androidPhoneV2Mimetypes = {'vnd.android.cursor.item/phone_v2'};
 
 class LocalContactsRepository implements ILocalContactsRepository {
   LocalContactsRepository() {
@@ -59,27 +63,11 @@ class LocalContactsRepository implements ILocalContactsRepository {
 
   Future<List<LocalContact>> _listContacts() async {
     final contacts = await FlutterContacts.getAll(
-      properties: {
-        ContactProperty.name,
-        ContactProperty.phone,
-        ContactProperty.email,
-        ContactProperty.photoThumbnail,
-        if (Platform.isAndroid) ContactProperty.identifiers,
-      },
+      properties: {ContactProperty.name, ContactProperty.phone, ContactProperty.email, ContactProperty.photoThumbnail},
+      requiredDataMimetypes: Platform.isAndroid ? _androidPhoneV2Mimetypes : null,
     );
     return contacts
-        .where((contact) {
-          if (contact.id == null) return false;
-          if (!Platform.isAndroid) return true;
-          // Hides synthetic raw_contacts created by messaging apps (WhatsApp, Viber, Telegram).
-          // Why: pass if any raw_contact has a phone_v2 data row (real telephony entry) OR
-          // belongs to a Google account (WT-432: Android 12+ Google contacts may lack phone_v2).
-          final rawContacts = contact.android?.identifiers?.rawContacts ?? const [];
-          if (rawContacts.isEmpty) return true;
-          return rawContacts.any(
-            (rc) => rc.dataMimetypes.contains(_phoneV2Mimetype) || rc.account?.type == _googleAccountType,
-          );
-        })
+        .where((contact) => contact.id != null)
         .map(
           (contact) => LocalContact(
             id: contact.id!,

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -14,6 +14,15 @@ import 'local_contacts_repository.dart';
 const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
 const _googleAccountType = 'com.google';
 
+/// Resolves the human-readable text for a `flutter_contacts` [Label].
+///
+/// Returns the [Label.customLabel] (or empty string when the user did not
+/// supply one) when the enum value matches [customValue]; otherwise returns
+/// the enum's `.name`. Works for any label enum that exposes a "custom"
+/// freeform value (Phone, Email, Address, Event, ...).
+String _resolveLabelText<T extends Enum>(Label<T> label, T customValue) =>
+    label.label == customValue ? (label.customLabel ?? '') : label.label.name;
+
 class LocalContactsRepository implements ILocalContactsRepository {
   LocalContactsRepository() {
     _controller = StreamController<List<LocalContact>>.broadcast(
@@ -92,21 +101,15 @@ class LocalContactsRepository implements ILocalContactsRepository {
             thumbnail: contact.photo?.thumbnail,
             phones: contact.phones
                 .map(
-                  (phone) => LocalContactPhone(
-                    number: phone.number,
-                    label: phone.label.label == PhoneLabel.custom
-                        ? (phone.label.customLabel ?? '')
-                        : phone.label.label.name,
-                  ),
+                  (phone) =>
+                      LocalContactPhone(number: phone.number, label: _resolveLabelText(phone.label, PhoneLabel.custom)),
                 )
                 .toList(),
             emails: contact.emails
                 .map(
                   (email) => LocalContactEmail(
                     address: email.address,
-                    label: email.label.label == EmailLabel.custom
-                        ? (email.label.customLabel ?? '')
-                        : email.label.label.name,
+                    label: _resolveLabelText(email.label, EmailLabel.custom),
                   ),
                 )
                 .toList(),

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -20,11 +20,9 @@ class LocalContactsRepository implements ILocalContactsRepository {
       onListen: _onListenCallback,
       onCancel: _onCancelCallback,
     );
-    _listenedCounter = 0;
   }
 
   late StreamController<List<LocalContact>> _controller;
-  late int _listenedCounter;
   StreamSubscription<void>? _databaseSubscription;
 
   @override
@@ -45,16 +43,12 @@ class LocalContactsRepository implements ILocalContactsRepository {
   }
 
   void _onListenCallback() {
-    if (_listenedCounter++ == 0) {
-      _databaseSubscription = FlutterContacts.onDatabaseChange.listen(_contactDatabaseChangesListener);
-    }
+    _databaseSubscription = FlutterContacts.onDatabaseChange.listen(_contactDatabaseChangesListener);
   }
 
   void _onCancelCallback() {
-    if (--_listenedCounter == 0) {
-      _databaseSubscription?.cancel();
-      _databaseSubscription = null;
-    }
+    _databaseSubscription?.cancel();
+    _databaseSubscription = null;
   }
 
   void _contactDatabaseChangesListener(void _) async {

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -7,15 +7,12 @@ import 'package:webtrit_phone/models/models.dart';
 
 import 'local_contacts_repository.dart';
 
-// Hides synthetic raw_contacts created by messaging apps (WhatsApp, Viber, Telegram).
-// Why: WT-432 + the original 2022 filter. The plugin's requiredDataMimetypes runs a
-// direct ContactsContract.Data MIMETYPE query
-// (see https://github.com/SERDUN/flutter_contacts/commit/b6c1542), so any contact
-// with a phone number — Google-synced, SIM, or device-local — already matches via
-// its phone_v2 row. The 1.x OR `account.type == 'com.google'` fallback is therefore
-// covered at the plugin level and intentionally not duplicated here. Android only;
-// iOS contacts have no equivalent concept.
-const _androidPhoneV2Mimetypes = {'vnd.android.cursor.item/phone_v2'};
+// Filter values passed to FlutterContacts.getAll. The plugin combines them
+// with OR semantics: a contact passes if it has at least one data row with
+// _phoneV2Mimetype OR at least one raw contact in _googleAccountType.
+// Mirrors the 1.x filter behavior. Android only; iOS ignores both.
+const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
+const _googleAccountType = 'com.google';
 
 class LocalContactsRepository implements ILocalContactsRepository {
   LocalContactsRepository() {
@@ -67,7 +64,8 @@ class LocalContactsRepository implements ILocalContactsRepository {
   Future<List<LocalContact>> _listContacts() async {
     final contacts = await FlutterContacts.getAll(
       properties: {ContactProperty.name, ContactProperty.phone, ContactProperty.email, ContactProperty.photoThumbnail},
-      requiredDataMimetypes: Platform.isAndroid ? _androidPhoneV2Mimetypes : null,
+      requiredDataMimetypes: Platform.isAndroid ? const {_phoneV2Mimetype} : null,
+      requiredAccountTypes: Platform.isAndroid ? const {_googleAccountType} : null,
     );
     return contacts
         .where((contact) => contact.id != null)

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -8,10 +8,13 @@ import 'package:webtrit_phone/models/models.dart';
 import 'local_contacts_repository.dart';
 
 // Hides synthetic raw_contacts created by messaging apps (WhatsApp, Viber, Telegram).
-// Why: WT-432 + the original 2022 filter. With a direct ContactsContract.Data
-// MIMETYPE query, any contact that has a phone number — Google-synced, SIM, or
-// device-local — has a phone_v2 row, so a single mimetype filter covers both
-// historical cases. Android only; iOS contacts have no equivalent concept.
+// Why: WT-432 + the original 2022 filter. The plugin's requiredDataMimetypes runs a
+// direct ContactsContract.Data MIMETYPE query
+// (see https://github.com/SERDUN/flutter_contacts/commit/b6c1542), so any contact
+// with a phone number — Google-synced, SIM, or device-local — already matches via
+// its phone_v2 row. The 1.x OR `account.type == 'com.google'` fallback is therefore
+// covered at the plugin level and intentionally not duplicated here. Android only;
+// iOS contacts have no equivalent concept.
 const _androidPhoneV2Mimetypes = {'vnd.android.cursor.item/phone_v2'};
 
 class LocalContactsRepository implements ILocalContactsRepository {

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -14,15 +14,6 @@ import 'local_contacts_repository.dart';
 const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
 const _googleAccountType = 'com.google';
 
-/// Resolves the human-readable text for a `flutter_contacts` [Label].
-///
-/// Returns the [Label.customLabel] (or empty string when the user did not
-/// supply one) when the enum value matches [customValue]; otherwise returns
-/// the enum's `.name`. Works for any label enum that exposes a "custom"
-/// freeform value (Phone, Email, Address, Event, ...).
-String _resolveLabelText<T extends Enum>(Label<T> label, T customValue) =>
-    label.label == customValue ? (label.customLabel ?? '') : label.label.name;
-
 class LocalContactsRepository implements ILocalContactsRepository {
   LocalContactsRepository() {
     _controller = StreamController<List<LocalContact>>.broadcast(
@@ -79,6 +70,15 @@ class LocalContactsRepository implements ILocalContactsRepository {
           rawContact.dataMimetypes.contains(_phoneV2Mimetype) || rawContact.account?.type == _googleAccountType,
     );
   }
+
+  /// Resolves the human-readable text for a `flutter_contacts` [Label].
+  ///
+  /// Returns the [Label.customLabel] (or empty string when the user did not
+  /// supply one) when the enum value matches [customValue]; otherwise returns
+  /// the enum's `.name`. Works for any label enum that exposes a "custom"
+  /// freeform value (Phone, Email, Address, Event, ...).
+  static String _resolveLabelText<T extends Enum>(Label<T> label, T customValue) =>
+      label.label == customValue ? (label.customLabel ?? '') : label.label.name;
 
   Future<List<LocalContact>> _listContacts() async {
     final contacts = await FlutterContacts.getAll(

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_contacts/flutter_contacts.dart';
 
@@ -10,7 +9,8 @@ import 'local_contacts_repository.dart';
 // Filter values passed to FlutterContacts.getAll. The plugin combines them
 // with OR semantics: a contact passes if it has at least one data row with
 // _phoneV2Mimetype OR at least one raw contact in _googleAccountType.
-// Mirrors the 1.x filter behavior. Android only; iOS ignores both.
+// Mirrors the 1.x filter behavior. Android-only — iOS ignores both
+// parameters via the androidXxx naming.
 const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
 const _googleAccountType = 'com.google';
 
@@ -64,8 +64,8 @@ class LocalContactsRepository implements ILocalContactsRepository {
   Future<List<LocalContact>> _listContacts() async {
     final contacts = await FlutterContacts.getAll(
       properties: {ContactProperty.name, ContactProperty.phone, ContactProperty.email, ContactProperty.photoThumbnail},
-      requiredDataMimetypes: Platform.isAndroid ? const {_phoneV2Mimetype} : null,
-      requiredAccountTypes: Platform.isAndroid ? const {_googleAccountType} : null,
+      androidRequiredDataMimetypes: const {_phoneV2Mimetype},
+      androidRequiredAccountTypes: const {_googleAccountType},
     );
     return contacts
         .where((contact) => contact.id != null)

--- a/lib/repositories/contacts/local_contacts_repository_io.dart
+++ b/lib/repositories/contacts/local_contacts_repository_io.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_contacts/flutter_contacts.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 import 'package:webtrit_phone/models/models.dart';
 
@@ -19,14 +17,12 @@ class LocalContactsRepository implements ILocalContactsRepository {
 
   late StreamController<List<LocalContact>> _controller;
   late int _listenedCounter;
+  StreamSubscription<void>? _databaseSubscription;
 
   @override
   Future<bool> requestPermission() async {
-    if (await Permission.contacts.isPermanentlyDenied) {
-      return false;
-    } else {
-      return await FlutterContacts.requestPermission();
-    }
+    final status = await FlutterContacts.permissions.request(PermissionType.readWrite);
+    return status == PermissionStatus.granted || status == PermissionStatus.limited;
   }
 
   @override
@@ -42,47 +38,45 @@ class LocalContactsRepository implements ILocalContactsRepository {
 
   void _onListenCallback() {
     if (_listenedCounter++ == 0) {
-      FlutterContacts.addListener(_contactDatabaseChangesListener);
+      _databaseSubscription = FlutterContacts.onDatabaseChange.listen(_contactDatabaseChangesListener);
     }
   }
 
   void _onCancelCallback() {
     if (--_listenedCounter == 0) {
-      FlutterContacts.removeListener(_contactDatabaseChangesListener);
+      _databaseSubscription?.cancel();
+      _databaseSubscription = null;
     }
   }
 
-  void _contactDatabaseChangesListener() async {
+  void _contactDatabaseChangesListener(void _) async {
     await load();
   }
 
   Future<List<LocalContact>> _listContacts() async {
-    final contacts = await FlutterContacts.getContacts(withProperties: true, withAccounts: true, withThumbnail: true);
+    final contacts = await FlutterContacts.getAll(
+      properties: {ContactProperty.name, ContactProperty.phone, ContactProperty.email, ContactProperty.photoThumbnail},
+    );
+    // Android per-account filtering (mimetypes / com.google) removed: flutter_contacts 2.x
+    // no longer exposes per-contact accounts/mimetypes on `Contact`. If account-scoped
+    // filtering is needed again, switch to `FlutterContacts.accounts.getAll()` and pass
+    // the `account:` parameter to `getAll()`.
     return contacts
-        .where((contact) {
-          if (Platform.isAndroid) {
-            for (final account in contact.accounts) {
-              if (account.mimetypes.contains('vnd.android.cursor.item/phone_v2') || account.type == 'com.google') {
-                return true;
-              }
-            }
-            return false;
-          } else {
-            return true;
-          }
-        })
+        .where((contact) => contact.id != null)
         .map(
           (contact) => LocalContact(
-            id: contact.id,
+            id: contact.id!,
             displayName: contact.displayName,
-            firstName: contact.name.first,
-            lastName: contact.name.last,
-            thumbnail: contact.thumbnail,
+            firstName: contact.name?.first,
+            lastName: contact.name?.last,
+            thumbnail: contact.photo?.thumbnail,
             phones: contact.phones
                 .map(
                   (phone) => LocalContactPhone(
                     number: phone.number,
-                    label: phone.label == PhoneLabel.custom ? phone.customLabel : phone.label.name,
+                    label: phone.label.label == PhoneLabel.custom
+                        ? (phone.label.customLabel ?? '')
+                        : phone.label.label.name,
                   ),
                 )
                 .toList(),
@@ -90,7 +84,9 @@ class LocalContactsRepository implements ILocalContactsRepository {
                 .map(
                   (email) => LocalContactEmail(
                     address: email.address,
-                    label: email.label == EmailLabel.custom ? email.customLabel : email.label.name,
+                    label: email.label.label == EmailLabel.custom
+                        ? (email.label.customLabel ?? '')
+                        : email.label.label.name,
                   ),
                 )
                 .toList(),

--- a/packages/device_auto_rotate/example/pubspec.lock
+++ b/packages/device_auto_rotate/example/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -242,10 +242,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:

--- a/packages/device_auto_rotate/example/pubspec.lock
+++ b/packages/device_auto_rotate/example/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -242,10 +242,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -658,8 +658,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: d68fe4e
-      resolved-ref: d68fe4e637b6dac9ed9e755a8f4078d7ace8886e
+      ref: e60f01d
+      resolved-ref: e60f01dff5379c7e9214065a618366a7db5538f6
       url: "https://github.com/SERDUN/flutter_contacts.git"
     source: git
     version: "2.2.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -658,8 +658,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "96c7a21"
-      resolved-ref: "96c7a211ec0b6fdf09caccdaa9be65ff70d286bf"
+      ref: e4486d7
+      resolved-ref: e4486d7fc60a78fac6b7b3884ef6a1ff41b0c05f
       url: "https://github.com/SERDUN/flutter_contacts.git"
     source: git
     version: "2.2.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -658,8 +658,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: b6c1542
-      resolved-ref: b6c1542c2479a79fbcf26bc640d37ef2cd446567
+      ref: fe3ecb8
+      resolved-ref: fe3ecb8167b90fbcbe71014908b4e01cc0242be9
       url: "https://github.com/SERDUN/flutter_contacts.git"
     source: git
     version: "2.2.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -658,8 +658,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: e60f01d
-      resolved-ref: e60f01dff5379c7e9214065a618366a7db5538f6
+      ref: "96c7a21"
+      resolved-ref: "96c7a211ec0b6fdf09caccdaa9be65ff70d286bf"
       url: "https://github.com/SERDUN/flutter_contacts.git"
     source: git
     version: "2.2.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -657,10 +657,11 @@ packages:
   flutter_contacts:
     dependency: "direct main"
     description:
-      name: flutter_contacts
-      sha256: "558247c39d89ca738aceb7859b6147a0ede0a5084492cffa215db87dea672479"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: b6c1542
+      resolved-ref: b6c1542c2479a79fbcf26bc640d37ef2cd446567
+      url: "https://github.com/SERDUN/flutter_contacts.git"
+    source: git
     version: "2.2.0"
   flutter_driver:
     dependency: "direct dev"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -658,8 +658,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: fe3ecb8
-      resolved-ref: fe3ecb8167b90fbcbe71014908b4e01cc0242be9
+      ref: d68fe4e
+      resolved-ref: d68fe4e637b6dac9ed9e755a8f4078d7ace8886e
       url: "https://github.com/SERDUN/flutter_contacts.git"
     source: git
     version: "2.2.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -658,10 +658,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: "388d32cd33f16640ee169570128c933b45f3259bddbfae7a100bb49e5ffea9ae"
+      sha256: "558247c39d89ca738aceb7859b6147a0ede0a5084492cffa215db87dea672479"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.9+2"
+    version: "2.2.0"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -1185,10 +1185,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1782,26 +1782,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   time:
     dependency: transitive
     description:
@@ -2232,5 +2232,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.10.7 <4.0.0"
-  flutter: ">=3.41.2 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   flutter_contacts:
     git:
       url: https://github.com/SERDUN/flutter_contacts.git
-      ref: b6c1542
+      ref: fe3ecb8
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,10 @@ dependencies:
   firebase_messaging: ^16.2.2
   firebase_remote_config: ^6.5.1
   flutter_bloc: ^9.1.1
-  flutter_contacts: ^2.2.0
+  flutter_contacts:
+    git:
+      url: https://github.com/SERDUN/flutter_contacts.git
+      ref: b6c1542
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,12 +60,12 @@ dependencies:
   firebase_remote_config: ^6.5.1
   flutter_bloc: ^9.1.1
   # TODO: temporary fork pin. Switch back to a pub.dev version constraint once
-  # the androidRequiredDataMimetypes / androidRequiredAccountTypes filters land
-  # upstream (SERDUN/flutter_contacts#1 -> QuisApp/flutter_contacts).
+  # RawContact.dataMimetypes lands upstream
+  # (SERDUN/flutter_contacts#2 -> QuisApp/flutter_contacts).
   flutter_contacts:
     git:
       url: https://github.com/SERDUN/flutter_contacts.git
-      ref: e60f01d
+      ref: 96c7a21
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   flutter_contacts:
     git:
       url: https://github.com/SERDUN/flutter_contacts.git
-      ref: fe3ecb8
+      ref: d68fe4e
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,9 @@ dependencies:
   firebase_messaging: ^16.2.2
   firebase_remote_config: ^6.5.1
   flutter_bloc: ^9.1.1
+  # TODO: temporary fork pin. Switch back to a pub.dev version constraint once
+  # the androidRequiredDataMimetypes / androidRequiredAccountTypes filters land
+  # upstream (SERDUN/flutter_contacts#1 -> QuisApp/flutter_contacts).
   flutter_contacts:
     git:
       url: https://github.com/SERDUN/flutter_contacts.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   flutter_contacts:
     git:
       url: https://github.com/SERDUN/flutter_contacts.git
-      ref: d68fe4e
+      ref: e60f01d
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,7 @@ dependencies:
   firebase_messaging: ^16.2.2
   firebase_remote_config: ^6.5.1
   flutter_bloc: ^9.1.1
-  flutter_contacts: ^1.1.9+2
+  flutter_contacts: ^2.2.0
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   flutter_contacts:
     git:
       url: https://github.com/SERDUN/flutter_contacts.git
-      ref: 96c7a21
+      ref: e4486d7
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:


### PR DESCRIPTION
## Summary

- Bumps `flutter_contacts` from `^1.1.9+2` to `^2.2.0` (complete rewrite in 2.0).
- Migrates `LocalContactsRepository` to the new 2.x API.
- **Temporarily points `flutter_contacts` at a fork** (`SERDUN/flutter_contacts`, ref `f4e605a`) that adds `RawContact.dataMimetypes` so we can restore the 1.x `Account.mimetypes`-based Android filter that was lost in the upstream rewrite. The fork commits are open as an upstream PR (QuisApp/flutter_contacts#237) - once merged this pin goes away.
- Requires Flutter >= 3.44 (already satisfied by f6afa6568).

## API migration

| Old (1.x) | New (2.x) |
|---|---|
| `FlutterContacts.requestPermission()` | `FlutterContacts.permissions.request(PermissionType.readWrite)` -> map `PermissionStatus` to bool |
| `addListener / removeListener` | `StreamSubscription` on `FlutterContacts.onDatabaseChange` |
| `getContacts(withProperties, withAccounts, withThumbnail)` | `getAll(properties: { name, phone, email, photoThumbnail, identifiers, dataMimetypes })` + `.where()` post-filter |
| `contact.thumbnail` | `contact.photo?.thumbnail` |
| `phone.label == PhoneLabel.custom ? phone.customLabel : phone.label.name` | `phone.label.label == PhoneLabel.custom ? (phone.label.customLabel ?? '') : phone.label.label.name` |
| same for `email.label` | same for `email.label` |

`customLabel` is nullable in 2.x; defaults to empty string to keep `LocalContactPhone.label` / `LocalContactEmail.label` non-null.

## Android filter restored (2022 + WT-432 intact)

The 1.x filter was `account.mimetypes.contains('phone_v2') || account.type == 'com.google'`. In stock 2.x neither half is expressible because `Account.mimetypes` was removed in the rewrite.

The fork adds an opt-in `ContactProperty.dataMimetypes` that populates `RawContact.dataMimetypes` (a per-raw-contact list of `Data.MIMETYPE` values). The filter logic stays in `LocalContactsRepository._listContacts()`:

```dart
const _phoneV2Mimetype = 'vnd.android.cursor.item/phone_v2';
const _googleAccountType = 'com.google';

final contacts = await FlutterContacts.getAll(
  properties: {
    ContactProperty.name,
    ContactProperty.phone,
    ContactProperty.email,
    ContactProperty.photoThumbnail,
    if (Platform.isAndroid) ...{
      ContactProperty.identifiers,
      ContactProperty.dataMimetypes,
    },
  },
);
return contacts.where((c) {
  if (c.id == null) return false;
  if (!Platform.isAndroid) return true;
  final raws = c.android?.identifiers?.rawContacts ?? const [];
  if (raws.isEmpty) return true; // device-local; vendor ROMs may not expose account
  return raws.any(
    (rc) => rc.dataMimetypes.contains(_phoneV2Mimetype) || rc.account?.type == _googleAccountType,
  );
}).toList();
```

Mirrors the 1.x semantics verbatim, both incidents fixed:

- **2022 synthetic-messenger filter:** WhatsApp / Viber / Telegram register their own mimetypes and never insert `phone_v2` rows -> excluded.
- **WT-432 (Android 12+ Google contacts):** Google-account raw contacts pass via `account.type == 'com.google'`.

## Temporary dependency

`pubspec.yaml` pins `flutter_contacts` to the fork via `git: ref: f4e605a` with a TODO comment. Once QuisApp/flutter_contacts#237 lands upstream and a release ships to pub.dev, this PR will switch back to a version constraint.

https://github.com/QuisApp/flutter_contacts/pull/237