### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/lib/app/assets.gen.dart
+++ b/lib/app/assets.gen.dart
@@ -1,4 +1,4 @@
-// dart format width=120
+// dart format width=80
 
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
@@ -18,7 +18,8 @@ class $AssetsCallkeepGen {
   const $AssetsCallkeepGen();
 
   /// File path: assets/callkeep/ios_icon_template_image.png
-  AssetGenImage get iosIconTemplateImage => const AssetGenImage('assets/callkeep/ios_icon_template_image.png');
+  AssetGenImage get iosIconTemplateImage =>
+      const AssetGenImage('assets/callkeep/ios_icon_template_image.png');
 
   /// List of all assets
   List<AssetGenImage> get values => [iosIconTemplateImage];
@@ -38,20 +39,26 @@ class $AssetsImagesGen {
   const $AssetsImagesGen();
 
   /// File path: assets/images/primary_onboarding_logo.svg
-  SvgGenImage get primaryOnboardingLogo => const SvgGenImage('assets/images/primary_onboarding_logo.svg');
+  SvgGenImage get primaryOnboardingLogo =>
+      const SvgGenImage('assets/images/primary_onboarding_logo.svg');
 
   /// File path: assets/images/secondary_onboarding_logo.svg
-  SvgGenImage get secondaryOnboardingLogo => const SvgGenImage('assets/images/secondary_onboarding_logo.svg');
+  SvgGenImage get secondaryOnboardingLogo =>
+      const SvgGenImage('assets/images/secondary_onboarding_logo.svg');
 
   /// List of all assets
-  List<SvgGenImage> get values => [primaryOnboardingLogo, secondaryOnboardingLogo];
+  List<SvgGenImage> get values => [
+    primaryOnboardingLogo,
+    secondaryOnboardingLogo,
+  ];
 }
 
 class $AssetsLoginGen {
   const $AssetsLoginGen();
 
   /// File path: assets/login/onboarding-1.svg
-  SvgGenImage get onboarding1 => const SvgGenImage('assets/login/onboarding-1.svg');
+  SvgGenImage get onboarding1 =>
+      const SvgGenImage('assets/login/onboarding-1.svg');
 
   /// List of all assets
   List<SvgGenImage> get values => [onboarding1];
@@ -83,22 +90,28 @@ class $AssetsThemesGen {
   String get customSignup => 'assets/themes/custom_signup.html';
 
   /// File path: assets/themes/original.color_scheme.dark.config.json
-  String get originalColorSchemeDarkConfig => 'assets/themes/original.color_scheme.dark.config.json';
+  String get originalColorSchemeDarkConfig =>
+      'assets/themes/original.color_scheme.dark.config.json';
 
   /// File path: assets/themes/original.color_scheme.light.config.json
-  String get originalColorSchemeLightConfig => 'assets/themes/original.color_scheme.light.config.json';
+  String get originalColorSchemeLightConfig =>
+      'assets/themes/original.color_scheme.light.config.json';
 
   /// File path: assets/themes/original.page.dark.config.json
-  String get originalPageDarkConfig => 'assets/themes/original.page.dark.config.json';
+  String get originalPageDarkConfig =>
+      'assets/themes/original.page.dark.config.json';
 
   /// File path: assets/themes/original.page.light.config.json
-  String get originalPageLightConfig => 'assets/themes/original.page.light.config.json';
+  String get originalPageLightConfig =>
+      'assets/themes/original.page.light.config.json';
 
   /// File path: assets/themes/original.widget.dark.config.json
-  String get originalWidgetDarkConfig => 'assets/themes/original.widget.dark.config.json';
+  String get originalWidgetDarkConfig =>
+      'assets/themes/original.widget.dark.config.json';
 
   /// File path: assets/themes/original.widget.light.config.json
-  String get originalWidgetLightConfig => 'assets/themes/original.widget.light.config.json';
+  String get originalWidgetLightConfig =>
+      'assets/themes/original.widget.light.config.json';
 
   /// List of all assets
   List<String> get values => [
@@ -130,7 +143,12 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}, this.animation});
+  const AssetGenImage(
+    this._assetName, {
+    this.size,
+    this.flavors = const {},
+    this.animation,
+  });
 
   final String _assetName;
 
@@ -201,7 +219,11 @@ class AssetGenImage {
 }
 
 class AssetGenImageAnimation {
-  const AssetGenImageAnimation({required this.isAnimation, required this.duration, required this.frames});
+  const AssetGenImageAnimation({
+    required this.isAnimation,
+    required this.duration,
+    required this.frames,
+  });
 
   final bool isAnimation;
   final Duration duration;
@@ -209,9 +231,11 @@ class AssetGenImageAnimation {
 }
 
 class SvgGenImage {
-  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}}) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}}) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -241,7 +265,11 @@ class SvgGenImage {
   }) {
     final _svg.BytesLoader loader;
     if (_isVecFormat) {
-      loader = _vg.AssetBytesLoader(_assetName, assetBundle: bundle, packageName: package);
+      loader = _vg.AssetBytesLoader(
+        _assetName,
+        assetBundle: bundle,
+        packageName: package,
+      );
     } else {
       loader = _svg.SvgAssetLoader(
         _assetName,
@@ -263,7 +291,9 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ?? (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
+      colorFilter:
+          colorFilter ??
+          (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,
     );

--- a/lib/common/logging/filtered_logz_io_appender.dart
+++ b/lib/common/logging/filtered_logz_io_appender.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 
-// ignore: depend_on_referenced_packages
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+
+import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:logging_appenders/base_remote_appender.dart';
 import 'package:logging_appenders/logging_appenders.dart';
@@ -25,32 +26,33 @@ class FilteredLogzIoAppender extends LogzIoApiAppender {
   bool _isConnectionLost = false;
 
   @override
-  Future<void> sendLogEventsWithDio(
+  Future<void> sendLogEventsWithHttp(
     List<LogEntry> entries,
     Map<String, String> userProperties,
-    CancelToken cancelToken,
+    Future<void> cancelToken,
   ) async {
     try {
-      await super.sendLogEventsWithDio(entries, userProperties, cancelToken);
+      await super.sendLogEventsWithHttp(entries, userProperties, cancelToken);
 
       if (_isConnectionLost) {
         _isConnectionLost = false;
-        // Print the message *once* when the connection is back.
         debugPrint('FilteredLogzIoAppender: Connection restored. Resuming remote logging.');
       }
-    } on DioException catch (e) {
-      if (RemoteLogFilter._shouldIgnoreDioConnectionError(e, url)) {
-        // Print the message if this is the *first time* we`ve seen it.
-        if (!_isConnectionLost) {
-          _isConnectionLost = true;
-          debugPrint('FilteredLogzIoAppender: Connection lost. Pausing remote logging. Will retry silently.');
-        }
-      } else {
-        debugPrint('FilteredLogzIoAppender: Unhandled DioException: $e');
-      }
+    } on http.ClientException catch (e) {
+      _markConnectionLostOnce('ClientException: $e');
+    } on SocketException catch (e) {
+      _markConnectionLostOnce('SocketException: $e');
+    } on TimeoutException catch (e) {
+      _markConnectionLostOnce('TimeoutException: $e');
     } catch (e, stackTrace) {
       debugPrint('FilteredLogzIoAppender: Unhandled Exception: $e\n$stackTrace');
     }
+  }
+
+  void _markConnectionLostOnce(String details) {
+    if (_isConnectionLost) return;
+    _isConnectionLost = true;
+    debugPrint('FilteredLogzIoAppender: Connection lost. Pausing remote logging. Will retry silently. $details');
   }
 
   @override
@@ -63,41 +65,24 @@ class FilteredLogzIoAppender extends LogzIoApiAppender {
 
 class RemoteLogFilter {
   static bool shouldLog(LogRecord record, String url, {Level? minLevel}) {
-    // Check minimum level
     if (minLevel != null && record.level < minLevel) {
       return false;
     }
 
-    // Allow all non-Dio errors
-    if (record.error == null || record.error is! DioException) {
-      return true;
+    final error = record.error;
+    if (error is http.ClientException) {
+      return !_isErrorForLoggerHost(error, url);
     }
-
-    // Filter specific Dio errors
-    final dioError = record.error as DioException;
-    return !_shouldIgnoreDioConnectionError(dioError, url);
+    return true;
   }
 
-  /// Decides whether a [DioException] should be ignored.
-  /// We only ignore *connection* errors to the *logger's* own host,
-  /// derived from the provided [url].
-  static bool _shouldIgnoreDioConnectionError(DioException dioError, String url) {
-    final Uri? loggerUri = Uri.tryParse(url);
-    final String? loggerHost = loggerUri?.host;
-
+  /// Skip records whose error is a network failure to the logger's own host —
+  /// avoids logging cycles when the logger itself is unreachable.
+  static bool _isErrorForLoggerHost(http.ClientException error, String url) {
+    final loggerHost = Uri.tryParse(url)?.host;
     if (loggerHost == null) {
       return false;
     }
-
-    final String requestHost = dioError.requestOptions.uri.host;
-
-    if (requestHost == loggerHost) {
-      return switch (dioError.type) {
-        DioExceptionType.connectionError || DioExceptionType.connectionTimeout || DioExceptionType.sendTimeout => true,
-        _ => false,
-      };
-    }
-
-    return false;
+    return error.uri?.host == loggerHost;
   }
 }

--- a/lib/data/app_metadata_provider.dart
+++ b/lib/data/app_metadata_provider.dart
@@ -75,8 +75,8 @@ class DefaultAppMetadataProvider implements AppMetadataProvider {
       'osVersion': _deviceInfo.systemVersion,
       'authorization': token != null ? 'authorized' : 'unauthorized',
       if (urls != null && urls.isNotEmpty) 'embeddedUrls': urls.join(', '),
-      if (coreUrl != null) 'coreUrl': coreUrl,
-      if (tenantId != null) 'tenantId': tenantId,
+      'coreUrl': ?coreUrl,
+      'tenantId': ?tenantId,
     };
   }
 

--- a/lib/features/call/utils/webrtc_options_builder.dart
+++ b/lib/features/call/utils/webrtc_options_builder.dart
@@ -19,6 +19,6 @@ class WebrtcOptionsWithAppSettingsBuilder implements WebrtcOptionsBuilder {
     final settings = _audioProcessingSettingsRepository.getAudioProcessingSettings();
     final bypassVoiceProcessing = settings.bypassVoiceProcessing;
 
-    return {if (bypassVoiceProcessing != null) 'bypassVoiceProcessing': bypassVoiceProcessing};
+    return {'bypassVoiceProcessing': ?bypassVoiceProcessing};
   }
 }

--- a/lib/features/contacts/view/contacts_screen.dart
+++ b/lib/features/contacts/view/contacts_screen.dart
@@ -132,7 +132,7 @@ class _ContactsScreenState extends State<ContactsScreen> with SingleTickerProvid
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,
             ),
-            child: Column(children: [if (tabBar != null) tabBar, search]),
+            child: Column(children: [?tabBar, search]),
           ),
         ),
         body: MediaQuery(

--- a/lib/features/contacts/widgets/contact_tile.dart
+++ b/lib/features/contacts/widgets/contact_tile.dart
@@ -84,7 +84,7 @@ class ContactTile extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(title, maxLines: subtitle != null ? 1 : 2, overflow: TextOverflow.ellipsis, style: textTheme.titleMedium),
-        if (subtitle != null) subtitle,
+        ?subtitle,
       ],
     );
 

--- a/lib/features/login/view/login_switch_screen.dart
+++ b/lib/features/login/view/login_switch_screen.dart
@@ -34,7 +34,7 @@ class LoginSwitchScreen extends StatelessWidget {
       appBar: appBar,
       body: Column(
         children: [
-          if (header != null) header!,
+          ?header,
           if (supportedLoginTypes.length > 1) ...[
             SegmentedButton<LoginType>(
               style: localStyle?.segmentButtonStyle,

--- a/lib/features/messaging/features/conversations/view/conversations_screen.dart
+++ b/lib/features/messaging/features/conversations/view/conversations_screen.dart
@@ -254,7 +254,7 @@ class _ConversationsScreenState extends State<ConversationsScreen> with SingleTi
             preferredSize: Size.fromHeight(
               (tabBar != null ? kMainAppBarBottomTabHeight : 0) + kMainAppBarBottomSearchHeight,
             ),
-            child: Column(children: [if (tabBar != null) tabBar, search]),
+            child: Column(children: [?tabBar, search]),
           ),
         ),
         body: MessagingStateWrapper(

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -14,1801 +14,1685 @@ extension BuildContextExtension on BuildContext {
   Locale get locale => Localizations.localeOf(this);
   String? parseL10n(String translationKey, {List<Object>? arguments}) {
     final localizations = AppLocalizations.of(this)!;
-    return L10nHelper.parseL10n(
-      localizations,
-      translationKey,
-      arguments: arguments,
-    );
+    return localizations.parseL10n(translationKey, arguments: arguments);
   }
 }
 
 extension AppLocalizationsExtension on AppLocalizations {
-  String? parseL10n(String translationKey, {List<Object>? arguments}) {
-    return L10nHelper.parseL10n(this, translationKey, arguments: arguments);
-  }
-}
-
-class L10nHelper {
-  // Cache to store localization maps per locale
-  static final Map<String, Map<String, dynamic>> _cache = {};
-
-  static String? parseL10n(
-    AppLocalizations localizations,
-    String translationKey, {
-    List<Object>? arguments,
-  }) {
-    // Get or create cached map for this locale
-    final localeName = localizations.localeName;
-    final cachedMap = _cache[localeName];
-
-    final map =
-        cachedMap ??
-        () {
-          const mapper = AppLocalizationsMapper();
-          final newMap = mapper.toLocalizationMap(localizations);
-          _cache[localeName] = newMap;
-          return newMap;
-        }();
-
-    final object = map[translationKey];
-    if (object is String || object == null) return object;
-    assert(arguments != null, 'Arguments should not be null!');
-    assert(arguments!.isNotEmpty, 'Arguments should not be empty!');
-    return Function.apply(object, arguments);
-  }
-
-  /// Clear the cache for a specific locale or all locales
-  static void clearCache([String? localeName]) {
-    if (localeName != null) {
-      _cache.remove(localeName);
-    } else {
-      _cache.clear();
-    }
-  }
-}
-
-class AppLocalizationsMapper {
-  const AppLocalizationsMapper();
-  Map<String, dynamic> toLocalizationMap(AppLocalizations localizations) {
-    return {
-      'localeName': localizations.localeName,
-      'account_selfCarePasswordExpired_message':
-          localizations.account_selfCarePasswordExpired_message,
-      'alertDialogActions_no': localizations.alertDialogActions_no,
-      'alertDialogActions_ok': localizations.alertDialogActions_ok,
-      'alertDialogActions_yes': localizations.alertDialogActions_yes,
-      'autoprovision_errorSnackBar_invalidToken':
-          localizations.autoprovision_errorSnackBar_invalidToken,
-      'autoprovision_ReloginDialog_confirm':
-          localizations.autoprovision_ReloginDialog_confirm,
-      'autoprovision_ReloginDialog_decline':
-          localizations.autoprovision_ReloginDialog_decline,
-      'autoprovision_ReloginDialog_text':
-          localizations.autoprovision_ReloginDialog_text,
-      'autoprovision_ReloginDialog_title':
-          localizations.autoprovision_ReloginDialog_title,
-      'autoprovision_successSnackBar_used':
-          localizations.autoprovision_successSnackBar_used,
-      'call_CallActionsTooltip_accept':
-          localizations.call_CallActionsTooltip_accept,
-      'call_CallActionsTooltip_accept_inviteToAttendedTransfer':
-          localizations.call_CallActionsTooltip_accept_inviteToAttendedTransfer,
-      'call_CallActionsTooltip_attended_transfer':
-          localizations.call_CallActionsTooltip_attended_transfer,
-      'call_CallActionsTooltip_changeAudioDevice':
-          localizations.call_CallActionsTooltip_changeAudioDevice,
-      'call_CallActionsTooltip_decline_inviteToAttendedTransfer': localizations
-          .call_CallActionsTooltip_decline_inviteToAttendedTransfer,
-      'call_CallActionsTooltip_device_bluetooth':
-          localizations.call_CallActionsTooltip_device_bluetooth,
-      'call_CallActionsTooltip_device_earpiece':
-          localizations.call_CallActionsTooltip_device_earpiece,
-      'call_CallActionsTooltip_device_speaker':
-          localizations.call_CallActionsTooltip_device_speaker,
-      'call_CallActionsTooltip_device_streaming':
-          localizations.call_CallActionsTooltip_device_streaming,
-      'call_CallActionsTooltip_device_unknown':
-          localizations.call_CallActionsTooltip_device_unknown,
-      'call_CallActionsTooltip_device_wiredHeadset':
-          localizations.call_CallActionsTooltip_device_wiredHeadset,
-      'call_CallActionsTooltip_disableCamera':
-          localizations.call_CallActionsTooltip_disableCamera,
-      'call_CallActionsTooltip_disableSpeaker':
-          localizations.call_CallActionsTooltip_disableSpeaker,
-      'call_CallActionsTooltip_enableCamera':
-          localizations.call_CallActionsTooltip_enableCamera,
-      'call_CallActionsTooltip_enableSpeaker':
-          localizations.call_CallActionsTooltip_enableSpeaker,
-      'call_CallActionsTooltip_hangup':
-          localizations.call_CallActionsTooltip_hangup,
-      'call_CallActionsTooltip_hangupAndAccept':
-          localizations.call_CallActionsTooltip_hangupAndAccept,
-      'call_CallActionsTooltip_hideKeypad':
-          localizations.call_CallActionsTooltip_hideKeypad,
-      'call_CallActionsTooltip_hold':
-          localizations.call_CallActionsTooltip_hold,
-      'call_CallActionsTooltip_holdAndAccept':
-          localizations.call_CallActionsTooltip_holdAndAccept,
-      'call_CallActionsTooltip_mute':
-          localizations.call_CallActionsTooltip_mute,
-      'call_CallActionsTooltip_showKeypad':
-          localizations.call_CallActionsTooltip_showKeypad,
-      'call_CallActionsTooltip_swap':
-          localizations.call_CallActionsTooltip_swap,
-      'call_CallActionsTooltip_transfer':
-          localizations.call_CallActionsTooltip_transfer,
-      'call_CallActionsTooltip_transfer_choose':
-          localizations.call_CallActionsTooltip_transfer_choose,
-      'call_CallActionsTooltip_unattended_transfer':
-          localizations.call_CallActionsTooltip_unattended_transfer,
-      'call_CallActionsTooltip_unhold':
-          localizations.call_CallActionsTooltip_unhold,
-      'call_CallActionsTooltip_unmute':
-          localizations.call_CallActionsTooltip_unmute,
-      'call_description_held': localizations.call_description_held,
-      'call_description_incoming': localizations.call_description_incoming,
-      'call_description_inviteToAttendedTransfer':
-          localizations.call_description_inviteToAttendedTransfer,
-      'call_description_outgoing': localizations.call_description_outgoing,
-      'call_description_requestToAttendedTransfer':
-          localizations.call_description_requestToAttendedTransfer,
-      'call_description_transferProcessing':
-          localizations.call_description_transferProcessing,
-      'call_errorRegisteringSelfManagedPhoneAccount':
-          localizations.call_errorRegisteringSelfManagedPhoneAccount,
-      'call_FailureAcknowledgeDialog_title':
-          localizations.call_FailureAcknowledgeDialog_title,
-      'callProcessingStatus_answering':
-          localizations.callProcessingStatus_answering,
-      'callProcessingStatus_disconnecting':
-          localizations.callProcessingStatus_disconnecting,
-      'callProcessingStatus_init_media':
-          localizations.callProcessingStatus_init_media,
-      'callProcessingStatus_invite': localizations.callProcessingStatus_invite,
-      'callProcessingStatus_preparing':
-          localizations.callProcessingStatus_preparing,
-      'callProcessingStatus_ringing':
-          localizations.callProcessingStatus_ringing,
-      'callProcessingStatus_routing':
-          localizations.callProcessingStatus_routing,
-      'callProcessingStatus_signaling_connecting':
-          localizations.callProcessingStatus_signaling_connecting,
-      'iceConnectionIssue_iceFail': localizations.iceConnectionIssue_iceFail,
-      'iceConnectionIssue_iceFailNoIcePath':
-          localizations.iceConnectionIssue_iceFailNoIcePath,
-      'iceConnectionIssue_iceFailNoIcePathViaVpn':
-          localizations.iceConnectionIssue_iceFailNoIcePathViaVpn,
-      'callPullBadge_dialogTitle': localizations.callPullBadge_dialogTitle,
-      'callPullBadge_pickupButtonTitle':
-          localizations.callPullBadge_pickupButtonTitle,
-      'call_settings_additional_options':
-          localizations.call_settings_additional_options,
-      'callStatus_appUnregistered': localizations.callStatus_appUnregistered,
-      'callStatus_connectError': localizations.callStatus_connectError,
-      'callStatus_connectIssue': localizations.callStatus_connectIssue,
-      'callStatus_connectivityNone': localizations.callStatus_connectivityNone,
-      'callStatus_inProgress': localizations.callStatus_inProgress,
-      'callStatus_ready': localizations.callStatus_ready,
-      'call_SystemErrorDialog_description':
-          localizations.call_SystemErrorDialog_description,
-      'call_SystemErrorDialog_title':
-          localizations.call_SystemErrorDialog_title,
-      'call_ThumbnailAvatar_currentlyNoActiveCall':
-          localizations.call_ThumbnailAvatar_currentlyNoActiveCall,
-      'call_videoBackground_actionLabel_disableBlur':
-          localizations.call_videoBackground_actionLabel_disableBlur,
-      'call_videoBackground_actionLabel_enableBlur':
-          localizations.call_videoBackground_actionLabel_enableBlur,
-      'call_videoView_actionLabel_cover':
-          localizations.call_videoView_actionLabel_cover,
-      'call_videoView_actionLabel_fit':
-          localizations.call_videoView_actionLabel_fit,
-      'cdrs_noMissedCalls_message': localizations.cdrs_noMissedCalls_message,
-      'cdrs_noRecentCalls_message': localizations.cdrs_noRecentCalls_message,
-      'common_noInternetConnection_message':
-          localizations.common_noInternetConnection_message,
-      'common_noInternetConnection_retryButton':
-          localizations.common_noInternetConnection_retryButton,
-      'common_noInternetConnection_title':
-          localizations.common_noInternetConnection_title,
-      'common_problemWithLoadingPage':
-          localizations.common_problemWithLoadingPage,
-      'contacts_agreement_button_text':
-          localizations.contacts_agreement_button_text,
-      'contacts_agreement_checkbox_text':
-          localizations.contacts_agreement_checkbox_text,
-      'contacts_agreement_description':
-          localizations.contacts_agreement_description,
-      'contacts_agreement_title': localizations.contacts_agreement_title,
-      'contacts_ExternalTabButton_refresh':
-          localizations.contacts_ExternalTabButton_refresh,
-      'contacts_ExternalTabText_empty':
-          localizations.contacts_ExternalTabText_empty,
-      'contacts_ExternalTabText_emptyOnSearching':
-          localizations.contacts_ExternalTabText_emptyOnSearching,
-      'contacts_ExternalTabText_failure':
-          localizations.contacts_ExternalTabText_failure,
-      'contacts_LocalTabButton_contactsAgreement':
-          localizations.contacts_LocalTabButton_contactsAgreement,
-      'contacts_LocalTabButton_openAppSettings':
-          localizations.contacts_LocalTabButton_openAppSettings,
-      'contacts_LocalTabButton_refresh':
-          localizations.contacts_LocalTabButton_refresh,
-      'contacts_LocalTabText_contactsAgreementFailure':
-          localizations.contacts_LocalTabText_contactsAgreementFailure,
-      'contacts_LocalTabText_empty': localizations.contacts_LocalTabText_empty,
-      'contacts_LocalTabText_emptyOnSearching':
-          localizations.contacts_LocalTabText_emptyOnSearching,
-      'contacts_LocalTabText_failure':
-          localizations.contacts_LocalTabText_failure,
-      'contacts_LocalTabText_permissionFailure':
-          localizations.contacts_LocalTabText_permissionFailure,
-      'contactsSourceExternal': localizations.contactsSourceExternal,
-      'contactsSourceLocal': localizations.contactsSourceLocal,
-      'contacts_Text_blingTransferInitiated':
-          localizations.contacts_Text_blingTransferInitiated,
-      'contacts_DialogsInfoView_title':
-          localizations.contacts_DialogsInfoView_title,
-      'contacts_ContactScreen_options':
-          localizations.contacts_ContactScreen_options,
-      'contacts_ContactScreen_presenceViaSip':
-          localizations.contacts_ContactScreen_presenceViaSip,
-      'contacts_ContactScreen_presenceViaSip_tooltip':
-          localizations.contacts_ContactScreen_presenceViaSip_tooltip,
-      'contacts_ContactScreen_dialogsViaSipBlf':
-          localizations.contacts_ContactScreen_dialogsViaSipBlf,
-      'contacts_ContactScreen_dialogsViaSipBlf_tooltip':
-          localizations.contacts_ContactScreen_dialogsViaSipBlf_tooltip,
-      'copyToClipboard_floatingSnackBar':
-          localizations.copyToClipboard_floatingSnackBar,
-      'copyToClipboard_popupMenuItem':
-          localizations.copyToClipboard_popupMenuItem,
-      'default_CannotRemoveOwnerMessagingSocketException':
-          localizations.default_CannotRemoveOwnerMessagingSocketException,
-      'default_ChatMemberNotFoundMessagingSocketException':
-          localizations.default_ChatMemberNotFoundMessagingSocketException,
-      'default_ChatNotFoundMessagingSocketException':
-          localizations.default_ChatNotFoundMessagingSocketException,
-      'default_ClientExceptionError':
-          localizations.default_ClientExceptionError,
-      'default_ErrorDetails': localizations.default_ErrorDetails,
-      'default_ErrorMessage': localizations.default_ErrorMessage,
-      'default_ErrorPath': localizations.default_ErrorPath,
-      'default_ErrorTransactionId': localizations.default_ErrorTransactionId,
-      'default_ForbiddenMessagingSocketException':
-          localizations.default_ForbiddenMessagingSocketException,
-      'default_FormatExceptionError':
-          localizations.default_FormatExceptionError,
-      'default_InternalErrorMessagingSocketException':
-          localizations.default_InternalErrorMessagingSocketException,
-      'default_InvalidChatTypeMessagingSocketException':
-          localizations.default_InvalidChatTypeMessagingSocketException,
-      'default_JoinCrashedMessagingSocketException':
-          localizations.default_JoinCrashedMessagingSocketException,
-      'default_MessagingSocketException':
-          localizations.default_MessagingSocketException,
-      'default_RequestFailureError': localizations.default_RequestFailureError,
-      'default_SelfAuthorityAssignmentForbiddenMessagingSocketException':
-          localizations
-              .default_SelfAuthorityAssignmentForbiddenMessagingSocketException,
-      'default_SelfRemovalForbiddenMessagingSocketException':
-          localizations.default_SelfRemovalForbiddenMessagingSocketException,
-      'default_SmsConversationNotFoundMessagingSocketException':
-          localizations.default_SmsConversationNotFoundMessagingSocketException,
-      'default_TimeoutExceptionError':
-          localizations.default_TimeoutExceptionError,
-      'default_TimeoutMessagingSocketException':
-          localizations.default_TimeoutMessagingSocketException,
-      'default_TlsExceptionError': localizations.default_TlsExceptionError,
-      'default_TypeErrorError': localizations.default_TypeErrorError,
-      'default_UnauthorizedMessagingSocketException':
-          localizations.default_UnauthorizedMessagingSocketException,
-      'default_UnauthorizedRequestFailureError':
-          localizations.default_UnauthorizedRequestFailureError,
-      'default_UserAlreadyInChatMessagingSocketException':
-          localizations.default_UserAlreadyInChatMessagingSocketException,
-      'diagnostic_AppBar_title': localizations.diagnostic_AppBar_title,
-      'diagnostic_battery_groupTitle':
-          localizations.diagnostic_battery_groupTitle,
-      'diagnostic_batteryMode_optimized_description':
-          localizations.diagnostic_batteryMode_optimized_description,
-      'diagnostic_batteryMode_optimized_title':
-          localizations.diagnostic_batteryMode_optimized_title,
-      'diagnostic_batteryMode_restricted_description':
-          localizations.diagnostic_batteryMode_restricted_description,
-      'diagnostic_batteryMode_restricted_title':
-          localizations.diagnostic_batteryMode_restricted_title,
-      'diagnostic_batteryMode_unknown_description':
-          localizations.diagnostic_batteryMode_unknown_description,
-      'diagnostic_batteryMode_unknown_title':
-          localizations.diagnostic_batteryMode_unknown_title,
-      'diagnostic_batteryMode_unrestricted_description':
-          localizations.diagnostic_batteryMode_unrestricted_description,
-      'diagnostic_batteryMode_unrestricted_title':
-          localizations.diagnostic_batteryMode_unrestricted_title,
-      'diagnostic_battery_navigate_section':
-          localizations.diagnostic_battery_navigate_section,
-      'diagnostic_battery_tile_title':
-          localizations.diagnostic_battery_tile_title,
-      'diagnostic_permission_camera_description':
-          localizations.diagnostic_permission_camera_description,
-      'diagnostic_permission_camera_title':
-          localizations.diagnostic_permission_camera_title,
-      'diagnostic_permission_contacts_description':
-          localizations.diagnostic_permission_contacts_description,
-      'diagnostic_permission_contacts_title':
-          localizations.diagnostic_permission_contacts_title,
-      'diagnosticPermissionDetails_button_managePermission':
-          localizations.diagnosticPermissionDetails_button_managePermission,
-      'diagnosticPermissionDetails_button_requestPermission':
-          localizations.diagnosticPermissionDetails_button_requestPermission,
-      'diagnosticPermissionDetails_title_statusPermission':
-          localizations.diagnosticPermissionDetails_title_statusPermission,
-      'diagnostic_permission_microphone_description':
-          localizations.diagnostic_permission_microphone_description,
-      'diagnostic_permission_microphone_title':
-          localizations.diagnostic_permission_microphone_title,
-      'diagnostic_permission_notification_description':
-          localizations.diagnostic_permission_notification_description,
-      'diagnostic_permission_notification_title':
-          localizations.diagnostic_permission_notification_title,
-      'diagnostic_permissionStatus_denied':
-          localizations.diagnostic_permissionStatus_denied,
-      'diagnostic_permissionStatus_granted':
-          localizations.diagnostic_permissionStatus_granted,
-      'diagnostic_permissionStatus_limited':
-          localizations.diagnostic_permissionStatus_limited,
-      'diagnostic_permissionStatus_permanentlyDenied':
-          localizations.diagnostic_permissionStatus_permanentlyDenied,
-      'diagnostic_permissionStatus_provisional':
-          localizations.diagnostic_permissionStatus_provisional,
-      'diagnostic_permissionStatus_restricted':
-          localizations.diagnostic_permissionStatus_restricted,
-      'diagnosticPushDetails_configuration_title':
-          localizations.diagnosticPushDetails_configuration_title,
-      'diagnosticPushDetails_errorMessage_intro':
-          localizations.diagnosticPushDetails_errorMessage_intro,
-      'diagnosticPushDetails_errorMessage_step1':
-          localizations.diagnosticPushDetails_errorMessage_step1,
-      'diagnosticPushDetails_errorMessage_step2':
-          localizations.diagnosticPushDetails_errorMessage_step2,
-      'diagnosticPushDetails_errorMessage_step3':
-          localizations.diagnosticPushDetails_errorMessage_step3,
-      'diagnosticPushDetails_errorMessage_step4':
-          localizations.diagnosticPushDetails_errorMessage_step4,
-      'diagnosticPushDetails_errorMessage_step5':
-          localizations.diagnosticPushDetails_errorMessage_step5,
-      'diagnosticPushDetails_successMessage':
-          localizations.diagnosticPushDetails_successMessage,
-      'diagnostic_pushTokenStatusType_progress':
-          localizations.diagnostic_pushTokenStatusType_progress,
-      'diagnostic_pushTokenStatusType_success':
-          localizations.diagnostic_pushTokenStatusType_success,
-      'diagnosticReportDialogAddNoteExpansionTileTitle':
-          localizations.diagnosticReportDialogAddNoteExpansionTileTitle,
-      'diagnosticReportDialogCancelButtonLabel':
-          localizations.diagnosticReportDialogCancelButtonLabel,
-      'diagnosticReportDialogCommentTextFieldHintText':
-          localizations.diagnosticReportDialogCommentTextFieldHintText,
-      'diagnosticReportDialogContent':
-          localizations.diagnosticReportDialogContent,
-      'diagnosticReportDialogIncludeSystemLogsSwitchTileSubtitle': localizations
-          .diagnosticReportDialogIncludeSystemLogsSwitchTileSubtitle,
-      'diagnosticReportDialogIncludeSystemLogsSwitchTileTitle':
-          localizations.diagnosticReportDialogIncludeSystemLogsSwitchTileTitle,
-      'diagnosticReportDialogSendReportButtonLabel':
-          localizations.diagnosticReportDialogSendReportButtonLabel,
-      'diagnosticReportDialogTitle': localizations.diagnosticReportDialogTitle,
-      'diagnosticScreen_contacts_agreement_description':
-          localizations.diagnosticScreen_contacts_agreement_description,
-      'diagnosticScreen_contacts_agreement_group_title':
-          localizations.diagnosticScreen_contacts_agreement_group_title,
-      'diagnosticScreen_contacts_agreement_title':
-          localizations.diagnosticScreen_contacts_agreement_title,
-      'diagnosticScreen_permissionsGroup_title':
-          localizations.diagnosticScreen_permissionsGroup_title,
-      'diagnosticScreen_pushNotificationService_title':
-          localizations.diagnosticScreen_pushNotificationService_title,
-      'diagnostic_network_groupTitle':
-          localizations.diagnostic_network_groupTitle,
-      'diagnosticNetworkTest_status_offline':
-          localizations.diagnosticNetworkTest_status_offline,
-      'diagnosticNetworkTest_status_reachable':
-          localizations.diagnosticNetworkTest_status_reachable,
-      'diagnosticNetworkTest_status_restricted':
-          localizations.diagnosticNetworkTest_status_restricted,
-      'diagnosticNetworkTest_status_checking':
-          localizations.diagnosticNetworkTest_status_checking,
-      'diagnosticNetworkTest_status_unreachable':
-          localizations.diagnosticNetworkTest_status_unreachable,
-      'diagnosticNetworkTestItem_subtitle_noNetwork':
-          localizations.diagnosticNetworkTestItem_subtitle_noNetwork,
-      'diagnosticNetworkTestItem_subtitle_stunBlocked':
-          localizations.diagnosticNetworkTestItem_subtitle_stunBlocked,
-      'diagnosticNetworkTestItem_subtitle_stunUnreachable':
-          localizations.diagnosticNetworkTestItem_subtitle_stunUnreachable,
-      'diagnosticNetworkTestItem_subtitle_noCandidates':
-          localizations.diagnosticNetworkTestItem_subtitle_noCandidates,
-      'diagnosticNetworkTestItem_network_wifi':
-          localizations.diagnosticNetworkTestItem_network_wifi,
-      'diagnosticNetworkTestItem_network_mobile':
-          localizations.diagnosticNetworkTestItem_network_mobile,
-      'diagnosticNetworkTestItem_network_ethernet':
-          localizations.diagnosticNetworkTestItem_network_ethernet,
-      'diagnosticNetworkTestItem_network_vpn':
-          localizations.diagnosticNetworkTestItem_network_vpn,
-      'diagnosticNetworkTestDetails_title':
-          localizations.diagnosticNetworkTestDetails_title,
-      'diagnosticNetworkTestDetails_description':
-          localizations.diagnosticNetworkTestDetails_description,
-      'diagnosticNetworkTestDetails_status':
-          localizations.diagnosticNetworkTestDetails_status,
-      'diagnosticNetworkTestDetails_candidates':
-          localizations.diagnosticNetworkTestDetails_candidates,
-      'diagnosticNetworkTestDetails_noNetwork':
-          localizations.diagnosticNetworkTestDetails_noNetwork,
-      'diagnosticNetworkTestDetails_noCandidates':
-          localizations.diagnosticNetworkTestDetails_noCandidates,
-      'favorites_BodyCenter_empty': localizations.favorites_BodyCenter_empty,
-      'favorites_DeleteConfirmDialog_content':
-          localizations.favorites_DeleteConfirmDialog_content,
-      'favorites_DeleteConfirmDialog_title':
-          localizations.favorites_DeleteConfirmDialog_title,
-      'favorites_Text_blingTransferInitiated':
-          localizations.favorites_Text_blingTransferInitiated,
-      'locale_default': localizations.locale_default,
-      'locale_en': localizations.locale_en,
-      'locale_it': localizations.locale_it,
-      'locale_uk': localizations.locale_uk,
-      'login_Button_coreUrlAssignProceed':
-          localizations.login_Button_coreUrlAssignProceed,
-      'login_Button_otpSigninRequestProceed':
-          localizations.login_Button_otpSigninRequestProceed,
-      'login_Button_otpSigninVerifyProceed':
-          localizations.login_Button_otpSigninVerifyProceed,
-      'login_Button_otpSigninVerifyRepeat':
-          localizations.login_Button_otpSigninVerifyRepeat,
-      'login_Button_passwordSigninProceed':
-          localizations.login_Button_passwordSigninProceed,
-      'login_Button_signIn': localizations.login_Button_signIn,
-      'login_Button_signupRequestProceed':
-          localizations.login_Button_signupRequestProceed,
-      'login_Button_signUpToDemoInstance':
-          localizations.login_Button_signUpToDemoInstance,
-      'login_Button_signupVerifyProceed':
-          localizations.login_Button_signupVerifyProceed,
-      'login_Button_signupVerifyRepeat':
-          localizations.login_Button_signupVerifyRepeat,
-      'login_ButtonTooltip_signInToYourInstance':
-          localizations.login_ButtonTooltip_signInToYourInstance,
-      'login_RequestFailureEmptyEmailError':
-          localizations.login_RequestFailureEmptyEmailError,
-      'login_RequestFailureIdentifierIsNotValid':
-          localizations.login_RequestFailureIdentifierIsNotValid,
-      'login_RequestFailureIncorrectOtpCodeError':
-          localizations.login_RequestFailureIncorrectOtpCodeError,
-      'login_RequestFailureOtpAlreadyVerifiedError':
-          localizations.login_RequestFailureOtpAlreadyVerifiedError,
-      'login_RequestFailureOtpExpiredError':
-          localizations.login_RequestFailureOtpExpiredError,
-      'login_RequestFailureOtpNotFoundError':
-          localizations.login_RequestFailureOtpNotFoundError,
-      'login_RequestFailureOtpVerificationAttemptsExceededError': localizations
-          .login_RequestFailureOtpVerificationAttemptsExceededError,
-      'login_RequestFailureParametersApplyIssueError':
-          localizations.login_RequestFailureParametersApplyIssueError,
-      'login_RequestFailurePhoneNotFoundError':
-          localizations.login_RequestFailurePhoneNotFoundError,
-      'login_RequestFailureIncorrectCredentialsError':
-          localizations.login_RequestFailureIncorrectCredentialsError,
-      'login_RequestFailureUserNotFoundError':
-          localizations.login_RequestFailureUserNotFoundError,
-      'login_RequestFailureUnconfiguredBundleIdError':
-          localizations.login_RequestFailureUnconfiguredBundleIdError,
-      'login_SupportedLoginTypeMissedExceptionError':
-          localizations.login_SupportedLoginTypeMissedExceptionError,
-      'login_Text_coreUrlAssignPreDescription':
-          localizations.login_Text_coreUrlAssignPreDescription,
-      'login_TextFieldLabelText_coreUrlAssign':
-          localizations.login_TextFieldLabelText_coreUrlAssign,
-      'login_TextFieldLabelText_otpSigninCode':
-          localizations.login_TextFieldLabelText_otpSigninCode,
-      'login_TextFieldLabelText_otpSigninUserRef':
-          localizations.login_TextFieldLabelText_otpSigninUserRef,
-      'login_TextFieldLabelText_otpSigninUserRefPhone':
-          localizations.login_TextFieldLabelText_otpSigninUserRefPhone,
-      'login_TextFieldLabelText_otpSigninUserRefEmail':
-          localizations.login_TextFieldLabelText_otpSigninUserRefEmail,
-      'login_TextFieldLabelText_passwordSigninPassword':
-          localizations.login_TextFieldLabelText_passwordSigninPassword,
-      'login_TextFieldLabelText_passwordSigninUserRef':
-          localizations.login_TextFieldLabelText_passwordSigninUserRef,
-      'login_TextFieldLabelText_signupCode':
-          localizations.login_TextFieldLabelText_signupCode,
-      'login_TextFieldLabelText_signupEmail':
-          localizations.login_TextFieldLabelText_signupEmail,
-      'login_Text_otpSigninRequestPostDescription':
-          localizations.login_Text_otpSigninRequestPostDescription,
-      'login_Text_otpSigninRequestPreDescription':
-          localizations.login_Text_otpSigninRequestPreDescription,
-      'login_Text_otpSigninVerifyPostDescriptionGeneral':
-          localizations.login_Text_otpSigninVerifyPostDescriptionGeneral,
-      'login_Text_passwordSigninPostDescription':
-          localizations.login_Text_passwordSigninPostDescription,
-      'login_Text_passwordSigninPreDescription':
-          localizations.login_Text_passwordSigninPreDescription,
-      'login_Text_signupRequestPostDescription':
-          localizations.login_Text_signupRequestPostDescription,
-      'login_Text_signupRequestPostDescriptionDemo':
-          localizations.login_Text_signupRequestPostDescriptionDemo,
-      'login_Text_signupRequestPreDescription':
-          localizations.login_Text_signupRequestPreDescription,
-      'login_Text_signupRequestPreDescriptionDemo':
-          localizations.login_Text_signupRequestPreDescriptionDemo,
-      'login_Text_signupVerifyPostDescriptionGeneral':
-          localizations.login_Text_signupVerifyPostDescriptionGeneral,
-      'loginType_otpSignin': localizations.loginType_otpSignin,
-      'loginType_passwordSignin': localizations.loginType_passwordSignin,
-      'loginType_signup': localizations.loginType_signup,
-      'login_validationCoreUrlError':
-          localizations.login_validationCoreUrlError,
-      'login_validationEmailError': localizations.login_validationEmailError,
-      'login_validationPhoneError': localizations.login_validationPhoneError,
-      'login_validationUserRefError':
-          localizations.login_validationUserRefError,
-      'logRecordsConsole_AppBarTitle':
-          localizations.logRecordsConsole_AppBarTitle,
-      'logRecordsConsole_Button_failureRefresh':
-          localizations.logRecordsConsole_Button_failureRefresh,
-      'logRecordsConsole_Text_failure':
-          localizations.logRecordsConsole_Text_failure,
-      'logRecordsConsole_Button_infoClose':
-          localizations.logRecordsConsole_Button_infoClose,
-      'logRecordsConsole_PopupMenuItem_info':
-          localizations.logRecordsConsole_PopupMenuItem_info,
-      'logRecordsConsole_PopupMenuItem_clear':
-          localizations.logRecordsConsole_PopupMenuItem_clear,
-      'main_BottomNavigationBarItemLabel_chats':
-          localizations.main_BottomNavigationBarItemLabel_chats,
-      'main_BottomNavigationBarItemLabel_contacts':
-          localizations.main_BottomNavigationBarItemLabel_contacts,
-      'main_BottomNavigationBarItemLabel_favorites':
-          localizations.main_BottomNavigationBarItemLabel_favorites,
-      'main_BottomNavigationBarItemLabel_keypad':
-          localizations.main_BottomNavigationBarItemLabel_keypad,
-      'main_BottomNavigationBarItemLabel_recents':
-          localizations.main_BottomNavigationBarItemLabel_recents,
-      'main_CompatibilityIssueDialogActions_logout':
-          localizations.main_CompatibilityIssueDialogActions_logout,
-      'main_CompatibilityIssueDialogActions_update':
-          localizations.main_CompatibilityIssueDialogActions_update,
-      'main_CompatibilityIssueDialog_title':
-          localizations.main_CompatibilityIssueDialog_title,
-      'messaging_ActionBtn_retry': localizations.messaging_ActionBtn_retry,
-      'messaging_ChooseContact_cancel':
-          localizations.messaging_ChooseContact_cancel,
-      'messaging_ChooseContact_empty':
-          localizations.messaging_ChooseContact_empty,
-      'messaging_ChooseContact_title':
-          localizations.messaging_ChooseContact_title,
-      'messaging_ConfirmDialog_ask': localizations.messaging_ConfirmDialog_ask,
-      'messaging_ConfirmDialog_cancel':
-          localizations.messaging_ConfirmDialog_cancel,
-      'messaging_ConfirmDialog_confirm':
-          localizations.messaging_ConfirmDialog_confirm,
-      'messaging_ConversationBuilders_back':
-          localizations.messaging_ConversationBuilders_back,
-      'messaging_ConversationBuilders_cancel':
-          localizations.messaging_ConversationBuilders_cancel,
-      'messaging_ConversationBuilders_contactOrNumberSearch_hint': localizations
-          .messaging_ConversationBuilders_contactOrNumberSearch_hint,
-      'messaging_ConversationBuilders_contactSearch_hint':
-          localizations.messaging_ConversationBuilders_contactSearch_hint,
-      'messaging_ConversationBuilders_create':
-          localizations.messaging_ConversationBuilders_create,
-      'messaging_ConversationBuilders_createGroup':
-          localizations.messaging_ConversationBuilders_createGroup,
-      'messaging_ConversationBuilders_externalContacts_heading':
-          localizations.messaging_ConversationBuilders_externalContacts_heading,
-      'messaging_ConversationBuilders_invalidNumber_message1':
-          localizations.messaging_ConversationBuilders_invalidNumber_message1,
-      'messaging_ConversationBuilders_invalidNumber_message2':
-          localizations.messaging_ConversationBuilders_invalidNumber_message2,
-      'messaging_ConversationBuilders_invalidNumber_ok':
-          localizations.messaging_ConversationBuilders_invalidNumber_ok,
-      'messaging_ConversationBuilders_invalidNumber_title':
-          localizations.messaging_ConversationBuilders_invalidNumber_title,
-      'messaging_ConversationBuilders_invite_heading':
-          localizations.messaging_ConversationBuilders_invite_heading,
-      'messaging_ConversationBuilders_localContacts_heading':
-          localizations.messaging_ConversationBuilders_localContacts_heading,
-      'messaging_ConversationBuilders_membersHeadline':
-          localizations.messaging_ConversationBuilders_membersHeadline,
-      'messaging_ConversationBuilders_nameFieldEmpty':
-          localizations.messaging_ConversationBuilders_nameFieldEmpty,
-      'messaging_ConversationBuilders_nameFieldLabel':
-          localizations.messaging_ConversationBuilders_nameFieldLabel,
-      'messaging_ConversationBuilders_nameFieldShort':
-          localizations.messaging_ConversationBuilders_nameFieldShort,
-      'messaging_ConversationBuilders_next_action':
-          localizations.messaging_ConversationBuilders_next_action,
-      'messaging_ConversationBuilders_noContacts':
-          localizations.messaging_ConversationBuilders_noContacts,
-      'messaging_ConversationBuilders_numberFormatExample':
-          localizations.messaging_ConversationBuilders_numberFormatExample,
-      'messaging_ConversationBuilders_numberSearch_errorError':
-          localizations.messaging_ConversationBuilders_numberSearch_errorError,
-      'messaging_ConversationBuilders_numberSearch_errorHint':
-          localizations.messaging_ConversationBuilders_numberSearch_errorHint,
-      'messaging_ConversationBuilders_title_group':
-          localizations.messaging_ConversationBuilders_title_group,
-      'messaging_ConversationBuilders_title_new':
-          localizations.messaging_ConversationBuilders_title_new,
-      'messaging_Conversation_failure':
-          localizations.messaging_Conversation_failure,
-      'messaging_ConversationScreen_titleAvailable':
-          localizations.messaging_ConversationScreen_titleAvailable,
-      'messaging_ConversationScreen_titlePrefix':
-          localizations.messaging_ConversationScreen_titlePrefix,
-      'messaging_ConversationsScreen_chatsSearch_hint':
-          localizations.messaging_ConversationsScreen_chatsSearch_hint,
-      'messaging_ConversationsScreen_empty':
-          localizations.messaging_ConversationsScreen_empty,
-      'messaging_ConversationsScreen_messages_title':
-          localizations.messaging_ConversationsScreen_messages_title,
-      'messaging_ConversationsScreen_noNumberAlert_text':
-          localizations.messaging_ConversationsScreen_noNumberAlert_text,
-      'messaging_ConversationsScreen_noNumberAlert_title':
-          localizations.messaging_ConversationsScreen_noNumberAlert_title,
-      'messaging_ConversationsScreen_selectNumberSheet_title':
-          localizations.messaging_ConversationsScreen_selectNumberSheet_title,
-      'messaging_ConversationsScreen_smses_title':
-          localizations.messaging_ConversationsScreen_smses_title,
-      'messaging_ConversationsScreen_smssSearch_hint':
-          localizations.messaging_ConversationsScreen_smssSearch_hint,
-      'messaging_ConversationsScreen_unsupported':
-          localizations.messaging_ConversationsScreen_unsupported,
-      'messaging_Conversations_tile_empty':
-          localizations.messaging_Conversations_tile_empty,
-      'messaging_Conversations_tile_you':
-          localizations.messaging_Conversations_tile_you,
-      'messaging_DialogInfo_deleteAsk':
-          localizations.messaging_DialogInfo_deleteAsk,
-      'messaging_DialogInfo_deleteBtn':
-          localizations.messaging_DialogInfo_deleteBtn,
-      'messaging_DialogInfo_title': localizations.messaging_DialogInfo_title,
-      'messaging_GroupAuthorities_moderator':
-          localizations.messaging_GroupAuthorities_moderator,
-      'messaging_GroupAuthorities_noauthorities':
-          localizations.messaging_GroupAuthorities_noauthorities,
-      'messaging_GroupAuthorities_owner':
-          localizations.messaging_GroupAuthorities_owner,
-      'messaging_GroupInfo_addUserBtnText':
-          localizations.messaging_GroupInfo_addUserBtnText,
-      'messaging_GroupInfo_deleteLeaveBtnText':
-          localizations.messaging_GroupInfo_deleteLeaveBtnText,
-      'messaging_GroupInfo_groupMembersHeadline':
-          localizations.messaging_GroupInfo_groupMembersHeadline,
-      'messaging_GroupInfo_leaveAndDeleteAsk':
-          localizations.messaging_GroupInfo_leaveAndDeleteAsk,
-      'messaging_GroupInfo_leaveAsk':
-          localizations.messaging_GroupInfo_leaveAsk,
-      'messaging_GroupInfo_leaveBtnText':
-          localizations.messaging_GroupInfo_leaveBtnText,
-      'messaging_GroupInfo_makeModeratorAsk':
-          localizations.messaging_GroupInfo_makeModeratorAsk,
-      'messaging_GroupInfo_makeModeratorBtnText':
-          localizations.messaging_GroupInfo_makeModeratorBtnText,
-      'messaging_GroupInfo_removeModeratorAsk':
-          localizations.messaging_GroupInfo_removeModeratorAsk,
-      'messaging_GroupInfo_removeUserAsk':
-          localizations.messaging_GroupInfo_removeUserAsk,
-      'messaging_GroupInfo_removeUserBtnText':
-          localizations.messaging_GroupInfo_removeUserBtnText,
-      'messaging_GroupInfo_title': localizations.messaging_GroupInfo_title,
-      'messaging_GroupInfo_titlePrefix':
-          localizations.messaging_GroupInfo_titlePrefix,
-      'messaging_GroupInfo_unmakeModeratorBtnText':
-          localizations.messaging_GroupInfo_unmakeModeratorBtnText,
-      'messaging_MessageField_hint': localizations.messaging_MessageField_hint,
-      'messaging_MessageListView_typingTrail':
-          localizations.messaging_MessageListView_typingTrail,
-      'messaging_MessageView_delete':
-          localizations.messaging_MessageView_delete,
-      'messaging_MessageView_deleted':
-          localizations.messaging_MessageView_deleted,
-      'messaging_MessageView_edit': localizations.messaging_MessageView_edit,
-      'messaging_MessageView_edited':
-          localizations.messaging_MessageView_edited,
-      'messaging_MessageView_forward':
-          localizations.messaging_MessageView_forward,
-      'messaging_MessageView_reply': localizations.messaging_MessageView_reply,
-      'messaging_MessageView_textcopy':
-          localizations.messaging_MessageView_textcopy,
-      'messaging_MessageView_today': localizations.messaging_MessageView_today,
-      'messaging_MessageView_yesterday':
-          localizations.messaging_MessageView_yesterday,
-      'messaging_ParticipantName_unknown':
-          localizations.messaging_ParticipantName_unknown,
-      'messaging_ParticipantName_you':
-          localizations.messaging_ParticipantName_you,
-      'messaging_SmsSendingStatus_delivered':
-          localizations.messaging_SmsSendingStatus_delivered,
-      'messaging_SmsSendingStatus_failed':
-          localizations.messaging_SmsSendingStatus_failed,
-      'messaging_SmsSendingStatus_sent':
-          localizations.messaging_SmsSendingStatus_sent,
-      'messaging_SmsSendingStatus_waiting':
-          localizations.messaging_SmsSendingStatus_waiting,
-      'messaging_StateBar_connecting':
-          localizations.messaging_StateBar_connecting,
-      'messaging_StateBar_error': localizations.messaging_StateBar_error,
-      'messaging_StateBar_initializing':
-          localizations.messaging_StateBar_initializing,
-      'notifications_errorSnackBarAction_callSdpConfiguration':
-          localizations.notifications_errorSnackBarAction_callSdpConfiguration,
-      'notifications_errorSnackBarAction_callUserMedia':
-          localizations.notifications_errorSnackBarAction_callUserMedia,
-      'notifications_errorSnackBar_activeLineBlindTransferWarning':
-          localizations
-              .notifications_errorSnackBar_activeLineBlindTransferWarning,
-      'notifications_errorSnackBar_blindTransferFailed':
-          localizations.notifications_errorSnackBar_blindTransferFailed,
-      'notifications_errorSnackBar_appOffline':
-          localizations.notifications_errorSnackBar_appOffline,
-      'notifications_errorSnackBar_appOnline':
-          localizations.notifications_errorSnackBar_appOnline,
-      'notifications_errorSnackBar_appUnregistered':
-          localizations.notifications_errorSnackBar_appUnregistered,
-      'notifications_errorSnackBar_callConnect':
-          localizations.notifications_errorSnackBar_callConnect,
-      'notifications_errorSnackBar_callNegotiationTimeout':
-          localizations.notifications_errorSnackBar_callNegotiationTimeout,
-      'notifications_errorSnackBar_generalUnableToCall':
-          localizations.notifications_errorSnackBar_generalUnableToCall,
-      'notifications_errorSnackBar_callServiceBusyLine':
-          localizations.notifications_errorSnackBar_callServiceBusyLine,
-      'notifications_errorSnackBar_callSignalingClientNotConnect': localizations
-          .notifications_errorSnackBar_callSignalingClientNotConnect,
-      'notifications_errorSnackBar_callSignalingClientSessionMissed':
-          localizations
-              .notifications_errorSnackBar_callSignalingClientSessionMissed,
-      'notifications_errorSnackBar_callUndefinedLine':
-          localizations.notifications_errorSnackBar_callUndefinedLine,
-      'notifications_errorSnackBar_callMediaTrackSetup':
-          localizations.notifications_errorSnackBar_callMediaTrackSetup,
-      'notifications_errorSnackBar_callUserMedia':
-          localizations.notifications_errorSnackBar_callUserMedia,
-      'notifications_errorSnackBar_callWhileOffline':
-          localizations.notifications_errorSnackBar_callWhileOffline,
-      'notifications_errorSnackBar_callWhileUnregistered':
-          localizations.notifications_errorSnackBar_callWhileUnregistered,
-      'notifications_errorSnackBar_sessionExpired':
-          localizations.notifications_errorSnackBar_sessionExpired,
-      'notifications_errorSnackBar_SignalingConnectFailed':
-          localizations.notifications_errorSnackBar_SignalingConnectFailed,
-      'notifications_errorSnackBar_SignalingSessionMissed':
-          localizations.notifications_errorSnackBar_SignalingSessionMissed,
-      'notifications_errorSnackBar_sipRegistrationFailed_Unavailable':
-          localizations
-              .notifications_errorSnackBar_sipRegistrationFailed_Unavailable,
-      'notifications_errorSnackBar_sipRegistrationFailed_Unexpected':
-          localizations
-              .notifications_errorSnackBar_sipRegistrationFailed_Unexpected,
-      'notifications_errorSnackBar_sipServiceUnavailable':
-          localizations.notifications_errorSnackBar_sipServiceUnavailable,
-      'notifications_messageSnackBar_appOffline':
-          localizations.notifications_messageSnackBar_appOffline,
-      'notifications_successSnackBar_appOnline':
-          localizations.notifications_successSnackBar_appOnline,
-      'numberActions_audioCall': localizations.numberActions_audioCall,
-      'numberActions_callLog': localizations.numberActions_callLog,
-      'numberActions_chat': localizations.numberActions_chat,
-      'numberActions_copyCallId': localizations.numberActions_copyCallId,
-      'numberActions_copyNumber': localizations.numberActions_copyNumber,
-      'numberActions_delete': localizations.numberActions_delete,
-      'numberActions_sendSms': localizations.numberActions_sendSms,
-      'numberActions_transfer': localizations.numberActions_transfer,
-      'numberActions_videoCall': localizations.numberActions_videoCall,
-      'numberActions_viewContact': localizations.numberActions_viewContact,
-      'permission_Button_request': localizations.permission_Button_request,
-      'permission_manageFullScreenNotificationInstructions_step1': localizations
-          .permission_manageFullScreenNotificationInstructions_step1,
-      'permission_manageFullScreenNotificationInstructions_step2': localizations
-          .permission_manageFullScreenNotificationInstructions_step2,
-      'permission_manageFullScreenNotificationInstructions_step3': localizations
-          .permission_manageFullScreenNotificationInstructions_step3,
-      'permission_manageFullScreenNotificationInstructions_step4': localizations
-          .permission_manageFullScreenNotificationInstructions_step4,
-      'permission_manageFullScreenNotificationInstructions_step5': localizations
-          .permission_manageFullScreenNotificationInstructions_step5,
-      'permission_manageFullScreenNotificationPermissions':
-          localizations.permission_manageFullScreenNotificationPermissions,
-      'permission_manufacturer_Button_gotIt':
-          localizations.permission_manufacturer_Button_gotIt,
-      'permission_manufacturer_Button_toSettings':
-          localizations.permission_manufacturer_Button_toSettings,
-      'permission_manufacturer_Text_heading':
-          localizations.permission_manufacturer_Text_heading,
-      'permission_manufacturer_Text_trailing':
-          localizations.permission_manufacturer_Text_trailing,
-      'permission_manufacturer_Text_xiaomi_tip1':
-          localizations.permission_manufacturer_Text_xiaomi_tip1,
-      'permission_manufacturer_Text_xiaomi_tip2':
-          localizations.permission_manufacturer_Text_xiaomi_tip2,
-      'permission_Text_description': localizations.permission_Text_description,
-      'persistentConnectionReminderContent':
-          localizations.persistentConnectionReminderContent,
-      'persistentConnectionReminderTitle':
-          localizations.persistentConnectionReminderTitle,
-      'batteryOptimizationWarningTitle':
-          localizations.batteryOptimizationWarningTitle,
-      'batteryOptimizationWarningContent':
-          localizations.batteryOptimizationWarningContent,
-      'batteryOptimizationWarningOpenSettings':
-          localizations.batteryOptimizationWarningOpenSettings,
-      'presence_activity_appointment_name':
-          localizations.presence_activity_appointment_name,
-      'presence_activity_away_name': localizations.presence_activity_away_name,
-      'presence_activity_busy_name': localizations.presence_activity_busy_name,
-      'presence_activity_doNotDisturb_name':
-          localizations.presence_activity_doNotDisturb_name,
-      'presence_activity_inTransit_name':
-          localizations.presence_activity_inTransit_name,
-      'presence_activity_meal_name': localizations.presence_activity_meal_name,
-      'presence_activity_meeting_name':
-          localizations.presence_activity_meeting_name,
-      'presence_activity_none_name': localizations.presence_activity_none_name,
-      'presence_activity_onThePhone_name':
-          localizations.presence_activity_onThePhone_name,
-      'presence_activity_permanentAbsence_name':
-          localizations.presence_activity_permanentAbsence_name,
-      'presence_activity_sleeping_name':
-          localizations.presence_activity_sleeping_name,
-      'presence_activity_travel_name':
-          localizations.presence_activity_travel_name,
-      'presence_activity_vacation_name':
-          localizations.presence_activity_vacation_name,
-      'presence_infoView_activity': localizations.presence_infoView_activity,
-      'presence_infoView_available': localizations.presence_infoView_available,
-      'presence_infoView_available_false':
-          localizations.presence_infoView_available_false,
-      'presence_infoView_available_true':
-          localizations.presence_infoView_available_true,
-      'presence_infoView_client': localizations.presence_infoView_client,
-      'presence_infoView_device': localizations.presence_infoView_device,
-      'presence_infoView_localTime': localizations.presence_infoView_localTime,
-      'presence_infoView_note': localizations.presence_infoView_note,
-      'presence_infoView_statusIcon':
-          localizations.presence_infoView_statusIcon,
-      'presence_infoView_timeZone': localizations.presence_infoView_timeZone,
-      'presence_infoView_title': localizations.presence_infoView_title,
-      'presence_infoView_updated': localizations.presence_infoView_updated,
-      'presence_infoView_source_direct':
-          localizations.presence_infoView_source_direct,
-      'presence_infoView_source_sip':
-          localizations.presence_infoView_source_sip,
-      'presence_infoView_source_sipAndDirect':
-          localizations.presence_infoView_source_sipAndDirect,
-      'presence_preset_absent_name': localizations.presence_preset_absent_name,
-      'presence_preset_absent_note': localizations.presence_preset_absent_note,
-      'presence_preset_appointment_name':
-          localizations.presence_preset_appointment_name,
-      'presence_preset_appointment_note':
-          localizations.presence_preset_appointment_note,
-      'presence_preset_available_name':
-          localizations.presence_preset_available_name,
-      'presence_preset_away_name': localizations.presence_preset_away_name,
-      'presence_preset_away_note': localizations.presence_preset_away_note,
-      'presence_preset_dnd_name': localizations.presence_preset_dnd_name,
-      'presence_preset_dnd_note': localizations.presence_preset_dnd_note,
-      'presence_preset_inTransit_name':
-          localizations.presence_preset_inTransit_name,
-      'presence_preset_inTransit_note':
-          localizations.presence_preset_inTransit_note,
-      'presence_preset_meal_name': localizations.presence_preset_meal_name,
-      'presence_preset_meal_note': localizations.presence_preset_meal_note,
-      'presence_preset_meeting_name':
-          localizations.presence_preset_meeting_name,
-      'presence_preset_meeting_note':
-          localizations.presence_preset_meeting_note,
-      'presence_preset_sleeping_name':
-          localizations.presence_preset_sleeping_name,
-      'presence_preset_sleeping_note':
-          localizations.presence_preset_sleeping_note,
-      'presence_preset_travel_name': localizations.presence_preset_travel_name,
-      'presence_preset_travel_note': localizations.presence_preset_travel_note,
-      'presence_preset_unavailable_name':
-          localizations.presence_preset_unavailable_name,
-      'presence_preset_vacation_name':
-          localizations.presence_preset_vacation_name,
-      'presence_preset_vacation_note':
-          localizations.presence_preset_vacation_note,
-      'presence_settings_activity_label':
-          localizations.presence_settings_activity_label,
-      'presence_settings_activity_tooltip':
-          localizations.presence_settings_activity_tooltip,
-      'presence_settings_availability_title':
-          localizations.presence_settings_availability_title,
-      'presence_settings_availability_tooltip':
-          localizations.presence_settings_availability_tooltip,
-      'presence_settings_config_title':
-          localizations.presence_settings_config_title,
-      'presence_settings_dnd_title': localizations.presence_settings_dnd_title,
-      'presence_settings_dnd_tooltip':
-          localizations.presence_settings_dnd_tooltip,
-      'presence_settings_note_label':
-          localizations.presence_settings_note_label,
-      'presence_settings_note_tooltip':
-          localizations.presence_settings_note_tooltip,
-      'presence_settings_presets_label':
-          localizations.presence_settings_presets_label,
-      'presence_settings_presets_label_custom':
-          localizations.presence_settings_presets_label_custom,
-      'presence_settings_presets_title':
-          localizations.presence_settings_presets_title,
-      'presence_settings_statusIcon_none':
-          localizations.presence_settings_statusIcon_none,
-      'presence_settings_statusIcon_title':
-          localizations.presence_settings_statusIcon_title,
-      'recents_DeleteConfirmDialog_content':
-          localizations.recents_DeleteConfirmDialog_content,
-      'recents_DeleteConfirmDialog_title':
-          localizations.recents_DeleteConfirmDialog_title,
-      'recents_HistoryTile_missedCallText':
-          localizations.recents_HistoryTile_missedCallText,
-      'recents_Text_blingTransferInitiated':
-          localizations.recents_Text_blingTransferInitiated,
-      'recentsVisibilityFilter_all': localizations.recentsVisibilityFilter_all,
-      'recentsVisibilityFilter_all_preposit':
-          localizations.recentsVisibilityFilter_all_preposit,
-      'recentsVisibilityFilter_incoming':
-          localizations.recentsVisibilityFilter_incoming,
-      'recentsVisibilityFilter_incoming_preposit':
-          localizations.recentsVisibilityFilter_incoming_preposit,
-      'recentsVisibilityFilter_missed':
-          localizations.recentsVisibilityFilter_missed,
-      'recentsVisibilityFilter_missed_preposit':
-          localizations.recentsVisibilityFilter_missed_preposit,
-      'recentsVisibilityFilter_outgoing':
-          localizations.recentsVisibilityFilter_outgoing,
-      'recentsVisibilityFilter_outgoing_preposit':
-          localizations.recentsVisibilityFilter_outgoing_preposit,
-      'request_Id': localizations.request_Id,
-      'request_StatusCode': localizations.request_StatusCode,
-      'request_StatusName': localizations.request_StatusName,
-      'sessionStatus_AppBar_waitingForNetwork':
-          localizations.sessionStatus_AppBar_waitingForNetwork,
-      'sessionStatus_AppBar_waitingForConnection':
-          localizations.sessionStatus_AppBar_waitingForConnection,
-      'sessionStatus_AppBar_disconnected':
-          localizations.sessionStatus_AppBar_disconnected,
-      'sessionStatus_AppBar_connecting':
-          localizations.sessionStatus_AppBar_connecting,
-      'sessionStatus_pushNotificationServiceProblem':
-          localizations.sessionStatus_pushNotificationServiceProblem,
-      'session_Teardown_progressText':
-          localizations.session_Teardown_progressText,
-      'settings_AboutText_ApplicationEmbeddedLinks':
-          localizations.settings_AboutText_ApplicationEmbeddedLinks,
-      'settings_AboutText_AppSessionIdentifier':
-          localizations.settings_AboutText_AppSessionIdentifier,
-      'settings_AboutText_AppVersion':
-          localizations.settings_AboutText_AppVersion,
-      'settings_AboutText_CoreVersion':
-          localizations.settings_AboutText_CoreVersion,
-      'settings_AboutText_CoreVersionUndefined':
-          localizations.settings_AboutText_CoreVersionUndefined,
-      'settings_AboutText_FCMPushNotificationToken':
-          localizations.settings_AboutText_FCMPushNotificationToken,
-      'settings_AboutText_StoreVersion':
-          localizations.settings_AboutText_StoreVersion,
-      'settings_AccountDeleteConfirmDialog_content':
-          localizations.settings_AccountDeleteConfirmDialog_content,
-      'settings_AccountDeleteConfirmDialog_title':
-          localizations.settings_AccountDeleteConfirmDialog_title,
-      'settings_AccountDeleteNotSupported_message':
-          localizations.settings_AccountDeleteNotSupported_message,
-      'settings_AppBarTitle_myAccount':
-          localizations.settings_AppBarTitle_myAccount,
-      'settings_audioProcessing_Section_AGC_title':
-          localizations.settings_audioProcessing_Section_AGC_title,
-      'settings_audioProcessing_Section_AM_title':
-          localizations.settings_audioProcessing_Section_AM_title,
-      'settings_audioProcessing_Section_EC_title':
-          localizations.settings_audioProcessing_Section_EC_title,
-      'settings_audioProcessing_Section_HPF_title':
-          localizations.settings_audioProcessing_Section_HPF_title,
-      'settings_audioProcessing_Section_NS_title':
-          localizations.settings_audioProcessing_Section_NS_title,
-      'settings_audioProcessing_Section_title':
-          localizations.settings_audioProcessing_Section_title,
-      'settings_audioProcessing_Section_tooltip':
-          localizations.settings_audioProcessing_Section_tooltip,
-      'settings_audioProcessing_Section_VP_title':
-          localizations.settings_audioProcessing_Section_VP_title,
-      'settings_call_codecs_preferred_audio_default':
-          localizations.settings_call_codecs_preferred_audio_default,
-      'settings_call_codecs_preferred_audio_tip':
-          localizations.settings_call_codecs_preferred_audio_tip,
-      'settings_call_codecs_preferred_audio_title':
-          localizations.settings_call_codecs_preferred_audio_title,
-      'settings_call_codecs_preferred_video_default':
-          localizations.settings_call_codecs_preferred_video_default,
-      'settings_call_codecs_preferred_video_tip':
-          localizations.settings_call_codecs_preferred_video_tip,
-      'settings_call_codecs_preferred_video_title':
-          localizations.settings_call_codecs_preferred_video_title,
-      'settings_callerId_cancel_button':
-          localizations.settings_callerId_cancel_button,
-      'settings_callerId_defaultTitle':
-          localizations.settings_callerId_defaultTitle,
-      'settings_callerId_dialcode': localizations.settings_callerId_dialcode,
-      'settings_callerId_dialCodeMatching_title':
-          localizations.settings_callerId_dialCodeMatching_title,
-      'settings_callerId_duplicate_dialcode_error':
-          localizations.settings_callerId_duplicate_dialcode_error,
-      'settings_callerId_number': localizations.settings_callerId_number,
-      'settings_callerId_number_hint':
-          localizations.settings_callerId_number_hint,
-      'settings_callerId_save_button':
-          localizations.settings_callerId_save_button,
-      'settings_connectionSection_title':
-          localizations.settings_connectionSection_title,
-      'settings_connectionSection_tooltip':
-          localizations.settings_connectionSection_tooltip,
-      'settings_encoding_AppBar_reset_tooltip':
-          localizations.settings_encoding_AppBar_reset_tooltip,
-      'settings_encoding_Section_audio_ptime':
-          localizations.settings_encoding_Section_audio_ptime,
-      'settings_encoding_Section_audio_ptime_limit':
-          localizations.settings_encoding_Section_audio_ptime_limit,
-      'settings_encoding_Section_bandwidth_prefix':
-          localizations.settings_encoding_Section_bandwidth_prefix,
-      'settings_encoding_Section_bitrate_prefix':
-          localizations.settings_encoding_Section_bitrate_prefix,
-      'settings_encoding_Section_bitrate_title':
-          localizations.settings_encoding_Section_bitrate_title,
-      'settings_encoding_Section_bitrate_tooltip':
-          localizations.settings_encoding_Section_bitrate_tooltip,
-      'settings_encoding_Section_extra_sdp_mod_removeREMBFeedback':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeREMBFeedback,
-      'settings_encoding_Section_extra_sdp_mod_removeREMBFeedback_tooltip':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeREMBFeedback_tooltip,
-      'settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback,
-      'settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback_tooltip':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback_tooltip,
-      'settings_encoding_Section_rtp_extensions_title':
-          localizations.settings_encoding_Section_rtp_extensions_title,
-      'settings_encoding_Section_rtp_extensions_tooltip':
-          localizations.settings_encoding_Section_rtp_extensions_tooltip,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_twcc': localizations
-          .settings_encoding_Section_extra_sdp_mod_removeExtmap_twcc,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_absSendTime':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_absSendTime,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_playoutDelay':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_playoutDelay,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_videoContentType':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_videoContentType,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_videoTiming':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_videoTiming,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_colorSpace':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_colorSpace,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_audioLevel':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_audioLevel,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_tOffset':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_tOffset,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_videoOrientation':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_videoOrientation,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_rtpStreamId':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_rtpStreamId,
-      'settings_encoding_Section_extra_sdp_mod_removeExtmap_repairedRtpStreamId':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeExtmap_repairedRtpStreamId,
-      'settings_encoding_Section_extra_sdp_mod_remapTE8':
-          localizations.settings_encoding_Section_extra_sdp_mod_remapTE8,
-      'settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip': localizations
-          .settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip,
-      'settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps,
-      'settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip':
-          localizations
-              .settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip,
-      'settings_encoding_Section_extra_sdp_mod_title':
-          localizations.settings_encoding_Section_extra_sdp_mod_title,
-      'settings_encoding_Section_measure_hz':
-          localizations.settings_encoding_Section_measure_hz,
-      'settings_encoding_Section_measure_kbps':
-          localizations.settings_encoding_Section_measure_kbps,
-      'settings_encoding_Section_measure_ms':
-          localizations.settings_encoding_Section_measure_ms,
-      'settings_encoding_Section_opus_bandwidth':
-          localizations.settings_encoding_Section_opus_bandwidth,
-      'settings_encoding_Section_opus_bitrate':
-          localizations.settings_encoding_Section_opus_bitrate,
-      'settings_encoding_Section_opus_channels':
-          localizations.settings_encoding_Section_opus_channels,
-      'settings_encoding_Section_opus_dtx':
-          localizations.settings_encoding_Section_opus_dtx,
-      'settings_encoding_Section_opus_samplingRate':
-          localizations.settings_encoding_Section_opus_samplingRate,
-      'settings_encoding_Section_opus_title':
-          localizations.settings_encoding_Section_opus_title,
-      'settings_encoding_Section_opus_tooltip':
-          localizations.settings_encoding_Section_opus_tooltip,
-      'settings_encoding_Section_packetization_title':
-          localizations.settings_encoding_Section_packetization_title,
-      'settings_encoding_Section_packetization_tooltip':
-          localizations.settings_encoding_Section_packetization_tooltip,
-      'settings_encoding_Section_packetization_warning_title':
-          localizations.settings_encoding_Section_packetization_warning_title,
-      'settings_encoding_Section_packetization_warning_message':
-          localizations.settings_encoding_Section_packetization_warning_message,
-      'settings_encoding_Section_preset':
-          localizations.settings_encoding_Section_preset,
-      'settings_encoding_Section_preset_balance':
-          localizations.settings_encoding_Section_preset_balance,
-      'settings_encoding_Section_preset_balance_tooltip':
-          localizations.settings_encoding_Section_preset_balance_tooltip,
-      'settings_encoding_Section_preset_eco':
-          localizations.settings_encoding_Section_preset_eco,
-      'settings_encoding_Section_preset_eco_tooltip':
-          localizations.settings_encoding_Section_preset_eco_tooltip,
-      'settings_encoding_Section_preset_custom':
-          localizations.settings_encoding_Section_preset_custom,
-      'settings_encoding_Section_preset_custom_tooltip':
-          localizations.settings_encoding_Section_preset_custom_tooltip,
-      'settings_encoding_Section_preset_default':
-          localizations.settings_encoding_Section_preset_default,
-      'settings_encoding_Section_preset_default_tooltip':
-          localizations.settings_encoding_Section_preset_default_tooltip,
-      'settings_encoding_Section_preset_bypass':
-          localizations.settings_encoding_Section_preset_bypass,
-      'settings_encoding_Section_preset_bypass_tooltip':
-          localizations.settings_encoding_Section_preset_bypass_tooltip,
-      'settings_encoding_Section_preset_full_flex':
-          localizations.settings_encoding_Section_preset_full_flex,
-      'settings_encoding_Section_preset_quality':
-          localizations.settings_encoding_Section_preset_quality,
-      'settings_encoding_Section_preset_quality_tooltip':
-          localizations.settings_encoding_Section_preset_quality_tooltip,
-      'settings_encoding_Section_preset_title':
-          localizations.settings_encoding_Section_preset_title,
-      'settings_encoding_Section_preset_tooltip':
-          localizations.settings_encoding_Section_preset_tooltip,
-      'settings_encoding_Section_ptime_prefix':
-          localizations.settings_encoding_Section_ptime_prefix,
-      'settings_encoding_Section_rtp_override_audio':
-          localizations.settings_encoding_Section_rtp_override_audio,
-      'settings_encoding_Section_rtp_override_title':
-          localizations.settings_encoding_Section_rtp_override_title,
-      'settings_encoding_Section_rtp_override_tooltip':
-          localizations.settings_encoding_Section_rtp_override_tooltip,
-      'settings_encoding_Section_rtp_override_video':
-          localizations.settings_encoding_Section_rtp_override_video,
-      'settings_encoding_Section_rtp_override_warning_message':
-          localizations.settings_encoding_Section_rtp_override_warning_message,
-      'settings_encoding_Section_rtp_override_warning_title':
-          localizations.settings_encoding_Section_rtp_override_warning_title,
-      'settings_encoding_Section_target_audio_bitrate':
-          localizations.settings_encoding_Section_target_audio_bitrate,
-      'settings_encoding_Section_target_video_bitrate':
-          localizations.settings_encoding_Section_target_video_bitrate,
-      'settings_encoding_Section_value_auto':
-          localizations.settings_encoding_Section_value_auto,
-      'settings_encoding_Section_value_disable':
-          localizations.settings_encoding_Section_value_disable,
-      'settings_encoding_Section_value_enable':
-          localizations.settings_encoding_Section_value_enable,
-      'settings_encoding_Section_value_mono':
-          localizations.settings_encoding_Section_value_mono,
-      'settings_encoding_Section_value_off':
-          localizations.settings_encoding_Section_value_off,
-      'settings_encoding_Section_value_on':
-          localizations.settings_encoding_Section_value_on,
-      'settings_encoding_Section_value_stereo':
-          localizations.settings_encoding_Section_value_stereo,
-      'settings_iceSettings_Section_netfilter_skipv4':
-          localizations.settings_iceSettings_Section_netfilter_skipv4,
-      'settings_iceSettings_Section_netfilter_skipv6':
-          localizations.settings_iceSettings_Section_netfilter_skipv6,
-      'settings_iceSettings_Section_netfilter_title':
-          localizations.settings_iceSettings_Section_netfilter_title,
-      'settings_iceSettings_Section_noskip':
-          localizations.settings_iceSettings_Section_noskip,
-      'settings_iceSettings_Section_title':
-          localizations.settings_iceSettings_Section_title,
-      'settings_iceSettings_Section_tooltip':
-          localizations.settings_iceSettings_Section_tooltip,
-      'settings_iceSettings_Section_trfilter_skipTcp':
-          localizations.settings_iceSettings_Section_trfilter_skipTcp,
-      'settings_iceSettings_Section_trfilter_skipUdp':
-          localizations.settings_iceSettings_Section_trfilter_skipUdp,
-      'settings_iceSettings_Section_trfilter_title':
-          localizations.settings_iceSettings_Section_trfilter_title,
-      'settings_ListViewTileTitle_about':
-          localizations.settings_ListViewTileTitle_about,
-      'settings_ListViewTileTitle_accountDelete':
-          localizations.settings_ListViewTileTitle_accountDelete,
-      'settings_ListViewTileTitle_call_codecs':
-          localizations.settings_ListViewTileTitle_call_codecs,
-      'settings_ListViewTileTitle_callerId':
-          localizations.settings_ListViewTileTitle_callerId,
-      'settings_ListViewTileTitle_encoding':
-          localizations.settings_ListViewTileTitle_encoding,
-      'settings_ListViewTileTitle_features':
-          localizations.settings_ListViewTileTitle_features,
-      'settings_ListViewTileTitle_help':
-          localizations.settings_ListViewTileTitle_help,
-      'settings_ListViewTileTitle_language':
-          localizations.settings_ListViewTileTitle_language,
-      'settings_ListViewTileTitle_logout':
-          localizations.settings_ListViewTileTitle_logout,
-      'settings_ListViewTileTitle_logRecordsConsole':
-          localizations.settings_ListViewTileTitle_logRecordsConsole,
-      'settings_ListViewTileTitle_mediaSettings':
-          localizations.settings_ListViewTileTitle_mediaSettings,
-      'settings_ListViewTileTitle_network':
-          localizations.settings_ListViewTileTitle_network,
-      'settings_ListViewTileTitle_presence':
-          localizations.settings_ListViewTileTitle_presence,
-      'settings_ListViewTileTitle_registered':
-          localizations.settings_ListViewTileTitle_registered,
-      'settings_ListViewTileTitle_self_config':
-          localizations.settings_ListViewTileTitle_self_config,
-      'settings_ListViewTileTitle_settings':
-          localizations.settings_ListViewTileTitle_settings,
-      'settings_ListViewTileTitle_termsConditions':
-          localizations.settings_ListViewTileTitle_termsConditions,
-      'settings_ListViewTileTitle_themeMode':
-          localizations.settings_ListViewTileTitle_themeMode,
-      'settings_ListViewTileTitle_toolbox':
-          localizations.settings_ListViewTileTitle_toolbox,
-      'settings_ListViewTileTitle_voicemail':
-          localizations.settings_ListViewTileTitle_voicemail,
-      'settings_LogoutConfirmDialog_content':
-          localizations.settings_LogoutConfirmDialog_content,
-      'settings_LogoutConfirmDialog_title':
-          localizations.settings_LogoutConfirmDialog_title,
-      'settings_missingMicrophoneIndicator_title':
-          localizations.settings_missingMicrophoneIndicator_title,
-      'settings_network_fallbackCalls_description':
-          localizations.settings_network_fallbackCalls_description,
-      'settings_network_fallbackCalls_title':
-          localizations.settings_network_fallbackCalls_title,
-      'settings_network_incomingCallType_pushNotification_description':
-          localizations
-              .settings_network_incomingCallType_pushNotification_description,
-      'settings_network_incomingCallType_pushNotification_title': localizations
-          .settings_network_incomingCallType_pushNotification_title,
-      'settings_network_incomingCallType_socket_description':
-          localizations.settings_network_incomingCallType_socket_description,
-      'settings_network_incomingCallType_socket_title':
-          localizations.settings_network_incomingCallType_socket_title,
-      'settings_network_incomingCallType_title':
-          localizations.settings_network_incomingCallType_title,
-      'settings_network_smsFallback_toggle':
-          localizations.settings_network_smsFallback_toggle,
-      'settings_videoCapturing_Section_framerate_prefix':
-          localizations.settings_videoCapturing_Section_framerate_prefix,
-      'settings_videoCapturing_Section_framerate_title':
-          localizations.settings_videoCapturing_Section_framerate_title,
-      'settings_videoCapturing_Section_resolution_prefix':
-          localizations.settings_videoCapturing_Section_resolution_prefix,
-      'settings_videoCapturing_Section_resolution_title':
-          localizations.settings_videoCapturing_Section_resolution_title,
-      'settings_videoCapturing_Section_title':
-          localizations.settings_videoCapturing_Section_title,
-      'settings_videoCapturing_Section_tooltip':
-          localizations.settings_videoCapturing_Section_tooltip,
-      'settings_videoOffer_option_ignore':
-          localizations.settings_videoOffer_option_ignore,
-      'settings_videoOffer_option_includeInactive':
-          localizations.settings_videoOffer_option_includeInactive,
-      'settings_videoOffer_title': localizations.settings_videoOffer_title,
-      'signalingResponseCode_ambiguousRequest':
-          localizations.signalingResponseCode_ambiguousRequest,
-      'signalingResponseCode_busyEverywhere':
-          localizations.signalingResponseCode_busyEverywhere,
-      'signalingResponseCode_callNotExist':
-          localizations.signalingResponseCode_callNotExist,
-      'signalingResponseCode_declineCall':
-          localizations.signalingResponseCode_declineCall,
-      'signalingResponseCode_errorAttachingPlugin':
-          localizations.signalingResponseCode_errorAttachingPlugin,
-      'signalingResponseCode_errorDetachingPlugin':
-          localizations.signalingResponseCode_errorDetachingPlugin,
-      'signalingResponseCode_errorSendingMessage':
-          localizations.signalingResponseCode_errorSendingMessage,
-      'signalingResponseCode_exchangeRoutingError':
-          localizations.signalingResponseCode_exchangeRoutingError,
-      'signalingResponseCode_handleNotFound':
-          localizations.signalingResponseCode_handleNotFound,
-      'signalingResponseCode_incompatibleDestination':
-          localizations.signalingResponseCode_incompatibleDestination,
-      'signalingResponseCode_invalidElementType':
-          localizations.signalingResponseCode_invalidElementType,
-      'signalingResponseCode_invalidJson':
-          localizations.signalingResponseCode_invalidJson,
-      'signalingResponseCode_invalidJsonObject':
-          localizations.signalingResponseCode_invalidJsonObject,
-      'signalingResponseCode_invalidNumberFormat':
-          localizations.signalingResponseCode_invalidNumberFormat,
-      'signalingResponseCode_invalidPath':
-          localizations.signalingResponseCode_invalidPath,
-      'signalingResponseCode_invalidSdp':
-          localizations.signalingResponseCode_invalidSdp,
-      'signalingResponseCode_invalidStream':
-          localizations.signalingResponseCode_invalidStream,
-      'signalingResponseCode_loopDetected':
-          localizations.signalingResponseCode_loopDetected,
-      'signalingResponseCode_missingMandatoryElement':
-          localizations.signalingResponseCode_missingMandatoryElement,
-      'signalingResponseCode_missingRequest':
-          localizations.signalingResponseCode_missingRequest,
-      'signalingResponseCode_normalUnspecified':
-          localizations.signalingResponseCode_normalUnspecified,
-      'signalingResponseCode_notAcceptable':
-          localizations.signalingResponseCode_notAcceptable,
-      'signalingResponseCode_notAcceptingNewSessions':
-          localizations.signalingResponseCode_notAcceptingNewSessions,
-      'signalingResponseCode_notFoundRoutesInReplyFromBE':
-          localizations.signalingResponseCode_notFoundRoutesInReplyFromBE,
-      'signalingResponseCode_pluginNotFound':
-          localizations.signalingResponseCode_pluginNotFound,
-      'signalingResponseCode_rejected':
-          localizations.signalingResponseCode_rejected,
-      'signalingResponseCode_requestTerminated':
-          localizations.signalingResponseCode_requestTerminated,
-      'signalingResponseCode_sessionIdInUse':
-          localizations.signalingResponseCode_sessionIdInUse,
-      'signalingResponseCode_sessionNotFound':
-          localizations.signalingResponseCode_sessionNotFound,
-      'signalingResponseCode_tokenNotFound':
-          localizations.signalingResponseCode_tokenNotFound,
-      'signalingResponseCode_transportSpecificError':
-          localizations.signalingResponseCode_transportSpecificError,
-      'signalingResponseCodeType_callHangup':
-          localizations.signalingResponseCodeType_callHangup,
-      'signalingResponseCodeType_plugin':
-          localizations.signalingResponseCodeType_plugin,
-      'signalingResponseCodeType_request':
-          localizations.signalingResponseCodeType_request,
-      'signalingResponseCodeType_session':
-          localizations.signalingResponseCodeType_session,
-      'signalingResponseCodeType_token':
-          localizations.signalingResponseCodeType_token,
-      'signalingResponseCodeType_transport':
-          localizations.signalingResponseCodeType_transport,
-      'signalingResponseCodeType_unauthorized':
-          localizations.signalingResponseCodeType_unauthorized,
-      'signalingResponseCodeType_unknown':
-          localizations.signalingResponseCodeType_unknown,
-      'signalingResponseCodeType_webrtc':
-          localizations.signalingResponseCodeType_webrtc,
-      'signalingResponseCode_unauthorizedAccess':
-          localizations.signalingResponseCode_unauthorizedAccess,
-      'signalingResponseCode_unauthorizedRequest':
-          localizations.signalingResponseCode_unauthorizedRequest,
-      'signalingResponseCode_unexpectedAnswer':
-          localizations.signalingResponseCode_unexpectedAnswer,
-      'signalingResponseCode_unknownError':
-          localizations.signalingResponseCode_unknownError,
-      'signalingResponseCode_unknownRequest':
-          localizations.signalingResponseCode_unknownRequest,
-      'signalingResponseCode_unsupportedJsepType':
-          localizations.signalingResponseCode_unsupportedJsepType,
-      'signalingResponseCode_unwanted':
-          localizations.signalingResponseCode_unwanted,
-      'signalingResponseCode_userBusy':
-          localizations.signalingResponseCode_userBusy,
-      'signalingResponseCode_userNotExist':
-          localizations.signalingResponseCode_userNotExist,
-      'signalingResponseCode_wrongWebrtcState':
-          localizations.signalingResponseCode_wrongWebrtcState,
-      'socketError_connectionRefused':
-          localizations.socketError_connectionRefused,
-      'socketError_connectionRefusedDescription':
-          localizations.socketError_connectionRefusedDescription,
-      'socketError_connectionReset': localizations.socketError_connectionReset,
-      'socketError_connectionResetDescription':
-          localizations.socketError_connectionResetDescription,
-      'socketError_connectionTimedOut':
-          localizations.socketError_connectionTimedOut,
-      'socketError_connectionTimedOutDescription':
-          localizations.socketError_connectionTimedOutDescription,
-      'socketError_default': localizations.socketError_default,
-      'socketError_networkUnreachable':
-          localizations.socketError_networkUnreachable,
-      'socketError_networkUnreachableDescription':
-          localizations.socketError_networkUnreachableDescription,
-      'socketError_serverUnreachable':
-          localizations.socketError_serverUnreachable,
-      'socketError_serverUnreachableDescription':
-          localizations.socketError_serverUnreachableDescription,
-      'system_notifications_screen_list_empty':
-          localizations.system_notifications_screen_list_empty,
-      'system_notifications_screen_title':
-          localizations.system_notifications_screen_title,
-      'themeMode_dark': localizations.themeMode_dark,
-      'themeMode_light': localizations.themeMode_light,
-      'themeMode_system': localizations.themeMode_system,
-      'undefined_autoprovision_invalidToken':
-          localizations.undefined_autoprovision_invalidToken,
-      'undefined_autoprovision_invalidToken_title':
-          localizations.undefined_autoprovision_invalidToken_title,
-      'undefined_stackScreenNotSupported':
-          localizations.undefined_stackScreenNotSupported,
-      'undefined_stackScreenNotSupported_title':
-          localizations.undefined_stackScreenNotSupported_title,
-      'user_agreement_agrement_link':
-          localizations.user_agreement_agrement_link,
-      'user_agreement_button_text': localizations.user_agreement_button_text,
-      'validationBlankError': localizations.validationBlankError,
-      'voicemail_Description_notSupported':
-          localizations.voicemail_Description_notSupported,
-      'voicemail_Dialog_deleteSelectedContent':
-          localizations.voicemail_Dialog_deleteSelectedContent,
-      'voicemail_Dialog_deleteSelectedTitle':
-          localizations.voicemail_Dialog_deleteSelectedTitle,
-      'voicemail_Dialog_deleteSingleContent':
-          localizations.voicemail_Dialog_deleteSingleContent,
-      'voicemail_Dialog_deleteSingleTitle':
-          localizations.voicemail_Dialog_deleteSingleTitle,
-      'voicemail_Label_call': localizations.voicemail_Label_call,
-      'voicemail_Label_delete': localizations.voicemail_Label_delete,
-      'voicemail_Label_deleteAll': localizations.voicemail_Label_deleteAll,
-      'voicemail_Label_deleteAllDescription':
-          localizations.voicemail_Label_deleteAllDescription,
-      'voicemail_Label_empty': localizations.voicemail_Label_empty,
-      'voicemail_Label_markAsHeard': localizations.voicemail_Label_markAsHeard,
-      'voicemail_Label_markAsNew': localizations.voicemail_Label_markAsNew,
-      'voicemail_Label_playbackError':
-          localizations.voicemail_Label_playbackError,
-      'voicemail_Label_retry': localizations.voicemail_Label_retry,
-      'voicemail_Snackbar_notConfigured':
-          localizations.voicemail_Snackbar_notConfigured,
-      'voicemail_Title_notSupported':
-          localizations.voicemail_Title_notSupported,
-      'voicemail_Widget_screenTitle':
-          localizations.voicemail_Widget_screenTitle,
-      'webRegistration_ErrorAcknowledgeDialogActions_retry':
-          localizations.webRegistration_ErrorAcknowledgeDialogActions_retry,
-      'webRegistration_ErrorAcknowledgeDialogActions_skip':
-          localizations.webRegistration_ErrorAcknowledgeDialogActions_skip,
-      'webRegistration_ErrorAcknowledgeDialog_title':
-          localizations.webRegistration_ErrorAcknowledgeDialog_title,
-      'webview_defaultError_reload': localizations.webview_defaultError_reload,
-      'webview_defaultError_title': localizations.webview_defaultError_title,
-      'webview_sslError_details': localizations.webview_sslError_details,
-      'webview_sslError_details_type':
-          localizations.webview_sslError_details_type,
-      'webview_sslError_details_url':
-          localizations.webview_sslError_details_url,
-      'webview_sslError_message': localizations.webview_sslError_message,
-      'webview_sslError_title': localizations.webview_sslError_title,
-      'webview_sslError_tryAgain': localizations.webview_sslError_tryAgain,
-      'cdr_disconnectReason_unknown':
-          localizations.cdr_disconnectReason_unknown,
-      'cdr_disconnectReason_validCauseCodeNotYetReceived':
-          localizations.cdr_disconnectReason_validCauseCodeNotYetReceived,
-      'cdr_disconnectReason_unallocatedNumber':
-          localizations.cdr_disconnectReason_unallocatedNumber,
-      'cdr_disconnectReason_noRouteToSpecifiedTransitNetworkWan': localizations
-          .cdr_disconnectReason_noRouteToSpecifiedTransitNetworkWan,
-      'cdr_disconnectReason_noRouteToDestination':
-          localizations.cdr_disconnectReason_noRouteToDestination,
-      'cdr_disconnectReason_sendSpecialInformationTone':
-          localizations.cdr_disconnectReason_sendSpecialInformationTone,
-      'cdr_disconnectReason_misdialledTrunkPrefix':
-          localizations.cdr_disconnectReason_misdialledTrunkPrefix,
-      'cdr_disconnectReason_channelUnacceptable':
-          localizations.cdr_disconnectReason_channelUnacceptable,
-      'cdr_disconnectReason_callAwardedAndBeingDeliveredInAnEstablishedChannel':
-          localizations
-              .cdr_disconnectReason_callAwardedAndBeingDeliveredInAnEstablishedChannel,
-      'cdr_disconnectReason_prefix0DialedButNotAllowedPreemption': localizations
-          .cdr_disconnectReason_prefix0DialedButNotAllowedPreemption,
-      'cdr_disconnectReason_prefix1DialedButNotAllowedPreemptionReserved':
-          localizations
-              .cdr_disconnectReason_prefix1DialedButNotAllowedPreemptionReserved,
-      'cdr_disconnectReason_prefix1DialedButNotRequired':
-          localizations.cdr_disconnectReason_prefix1DialedButNotRequired,
-      'cdr_disconnectReason_moreDigitsReceivedThanAllowedCallIsProceeding':
-          localizations
-              .cdr_disconnectReason_moreDigitsReceivedThanAllowedCallIsProceeding,
-      'cdr_disconnectReason_normalCallClearing':
-          localizations.cdr_disconnectReason_normalCallClearing,
-      'cdr_disconnectReason_userBusy':
-          localizations.cdr_disconnectReason_userBusy,
-      'cdr_disconnectReason_noUserResponding':
-          localizations.cdr_disconnectReason_noUserResponding,
-      'cdr_disconnectReason_noAnswerFromUser':
-          localizations.cdr_disconnectReason_noAnswerFromUser,
-      'cdr_disconnectReason_subscriberIsAbsent':
-          localizations.cdr_disconnectReason_subscriberIsAbsent,
-      'cdr_disconnectReason_callRejected':
-          localizations.cdr_disconnectReason_callRejected,
-      'cdr_disconnectReason_numberChanged':
-          localizations.cdr_disconnectReason_numberChanged,
-      'cdr_disconnectReason_reverseChargingRejected':
-          localizations.cdr_disconnectReason_reverseChargingRejected,
-      'cdr_disconnectReason_callSuspended':
-          localizations.cdr_disconnectReason_callSuspended,
-      'cdr_disconnectReason_callResumed':
-          localizations.cdr_disconnectReason_callResumed,
-      'cdr_disconnectReason_nonSelectedUserClearing':
-          localizations.cdr_disconnectReason_nonSelectedUserClearing,
-      'cdr_disconnectReason_destinationOutOfOrder':
-          localizations.cdr_disconnectReason_destinationOutOfOrder,
-      'cdr_disconnectReason_invalidNumberFormatIncompleteNumber': localizations
-          .cdr_disconnectReason_invalidNumberFormatIncompleteNumber,
-      'cdr_disconnectReason_facilityRejected':
-          localizations.cdr_disconnectReason_facilityRejected,
-      'cdr_disconnectReason_responseToStatusEnquiry':
-          localizations.cdr_disconnectReason_responseToStatusEnquiry,
-      'cdr_disconnectReason_normalUnspecified':
-          localizations.cdr_disconnectReason_normalUnspecified,
-      'cdr_disconnectReason_circuitOutOfOrder':
-          localizations.cdr_disconnectReason_circuitOutOfOrder,
-      'cdr_disconnectReason_noCircuitChannelAvailable':
-          localizations.cdr_disconnectReason_noCircuitChannelAvailable,
-      'cdr_disconnectReason_destinationUnattainableRequireVpciVciIsNotAvailable':
-          localizations
-              .cdr_disconnectReason_destinationUnattainableRequireVpciVciIsNotAvailable,
-      'cdr_disconnectReason_vpciVciAssignmentFailure':
-          localizations.cdr_disconnectReason_vpciVciAssignmentFailure,
-      'cdr_disconnectReason_degradedServiceCallRateIsnNotValid':
-          localizations.cdr_disconnectReason_degradedServiceCallRateIsnNotValid,
-      'cdr_disconnectReason_networkWanOutOfOrder':
-          localizations.cdr_disconnectReason_networkWanOutOfOrder,
-      'cdr_disconnectReason_transitDelayRangeCannotBeAchievedPermanentFrameModeIsOutOfService':
-          localizations
-              .cdr_disconnectReason_transitDelayRangeCannotBeAchievedPermanentFrameModeIsOutOfService,
-      'cdr_disconnectReason_throughputRangeCannotBeAchievedPermanentFrameModeIsOperational':
-          localizations
-              .cdr_disconnectReason_throughputRangeCannotBeAchievedPermanentFrameModeIsOperational,
-      'cdr_disconnectReason_temporaryFailure':
-          localizations.cdr_disconnectReason_temporaryFailure,
-      'cdr_disconnectReason_switchingEquipmentCongestion':
-          localizations.cdr_disconnectReason_switchingEquipmentCongestion,
-      'cdr_disconnectReason_accessInformationDiscarded':
-          localizations.cdr_disconnectReason_accessInformationDiscarded,
-      'cdr_disconnectReason_requestedCircuitChannelNotAvailable': localizations
-          .cdr_disconnectReason_requestedCircuitChannelNotAvailable,
-      'cdr_disconnectReason_preEmptedNoVpciVciIsAvailable':
-          localizations.cdr_disconnectReason_preEmptedNoVpciVciIsAvailable,
-      'cdr_disconnectReason_precedenceCallBlocked':
-          localizations.cdr_disconnectReason_precedenceCallBlocked,
-      'cdr_disconnectReason_resourceUnavailableUnspecified':
-          localizations.cdr_disconnectReason_resourceUnavailableUnspecified,
-      'cdr_disconnectReason_dspError':
-          localizations.cdr_disconnectReason_dspError,
-      'cdr_disconnectReason_qualityOfServiceUnavailable':
-          localizations.cdr_disconnectReason_qualityOfServiceUnavailable,
-      'cdr_disconnectReason_requestedFacilityNotSubscribed':
-          localizations.cdr_disconnectReason_requestedFacilityNotSubscribed,
-      'cdr_disconnectReason_reverseChargingNotAllowed':
-          localizations.cdr_disconnectReason_reverseChargingNotAllowed,
-      'cdr_disconnectReason_outgoingCallsBarred':
-          localizations.cdr_disconnectReason_outgoingCallsBarred,
-      'cdr_disconnectReason_outgoingCallsBarredWithinCug':
-          localizations.cdr_disconnectReason_outgoingCallsBarredWithinCug,
-      'cdr_disconnectReason_incomingCallsBarred':
-          localizations.cdr_disconnectReason_incomingCallsBarred,
-      'cdr_disconnectReason_incomingCallsBarredWithinCug':
-          localizations.cdr_disconnectReason_incomingCallsBarredWithinCug,
-      'cdr_disconnectReason_callWaitingNotSubscribed':
-          localizations.cdr_disconnectReason_callWaitingNotSubscribed,
-      'cdr_disconnectReason_bearerCapabilityNotAuthorized':
-          localizations.cdr_disconnectReason_bearerCapabilityNotAuthorized,
-      'cdr_disconnectReason_bearerCapabilityNotPresentlyAvailable':
-          localizations
-              .cdr_disconnectReason_bearerCapabilityNotPresentlyAvailable,
-      'cdr_disconnectReason_inconsistancyInTheInformationAndClass':
-          localizations
-              .cdr_disconnectReason_inconsistancyInTheInformationAndClass,
-      'cdr_disconnectReason_serviceOrOptionNotAvailableUnspecified':
-          localizations
-              .cdr_disconnectReason_serviceOrOptionNotAvailableUnspecified,
-      'cdr_disconnectReason_bearerServiceNotImplemented':
-          localizations.cdr_disconnectReason_bearerServiceNotImplemented,
-      'cdr_disconnectReason_channelTypeNotImplemented':
-          localizations.cdr_disconnectReason_channelTypeNotImplemented,
-      'cdr_disconnectReason_transitNetworkSelectionNotImplemented':
-          localizations
-              .cdr_disconnectReason_transitNetworkSelectionNotImplemented,
-      'cdr_disconnectReason_messageNotImplemented':
-          localizations.cdr_disconnectReason_messageNotImplemented,
-      'cdr_disconnectReason_requestedFacilityNotImplemented':
-          localizations.cdr_disconnectReason_requestedFacilityNotImplemented,
-      'cdr_disconnectReason_onlyRestrictedDigitalInformationBearerCapabilityIsAvailable':
-          localizations
-              .cdr_disconnectReason_onlyRestrictedDigitalInformationBearerCapabilityIsAvailable,
-      'cdr_disconnectReason_serviceOrOptionNotImplementedUnspecified':
-          localizations
-              .cdr_disconnectReason_serviceOrOptionNotImplementedUnspecified,
-      'cdr_disconnectReason_invalidCallReferenceValue':
-          localizations.cdr_disconnectReason_invalidCallReferenceValue,
-      'cdr_disconnectReason_identifiedChannelDoesNotExist':
-          localizations.cdr_disconnectReason_identifiedChannelDoesNotExist,
-      'cdr_disconnectReason_aSuspendedCallExistsButThisCallIdentityDoesNot':
-          localizations
-              .cdr_disconnectReason_aSuspendedCallExistsButThisCallIdentityDoesNot,
-      'cdr_disconnectReason_callIdentityInUse':
-          localizations.cdr_disconnectReason_callIdentityInUse,
-      'cdr_disconnectReason_noCallSuspended':
-          localizations.cdr_disconnectReason_noCallSuspended,
-      'cdr_disconnectReason_callHavingTheRequestedCallIdentityHasBeenCleared':
-          localizations
-              .cdr_disconnectReason_callHavingTheRequestedCallIdentityHasBeenCleared,
-      'cdr_disconnectReason_calledUserNotMemberOfCug':
-          localizations.cdr_disconnectReason_calledUserNotMemberOfCug,
-      'cdr_disconnectReason_incompatibleDestination':
-          localizations.cdr_disconnectReason_incompatibleDestination,
-      'cdr_disconnectReason_nonExistentAbbreviatedAddressEntry':
-          localizations.cdr_disconnectReason_nonExistentAbbreviatedAddressEntry,
-      'cdr_disconnectReason_destinationAddressMissingAndDirectCallNotSubscribed':
-          localizations
-              .cdr_disconnectReason_destinationAddressMissingAndDirectCallNotSubscribed,
-      'cdr_disconnectReason_invalidTransitNetworkSelectionNationalUse':
-          localizations
-              .cdr_disconnectReason_invalidTransitNetworkSelectionNationalUse,
-      'cdr_disconnectReason_invalidFacilityParameter':
-          localizations.cdr_disconnectReason_invalidFacilityParameter,
-      'cdr_disconnectReason_mandatoryInformationElementIsMissingAalParameterIsNotSupported':
-          localizations
-              .cdr_disconnectReason_mandatoryInformationElementIsMissingAalParameterIsNotSupported,
-      'cdr_disconnectReason_invalidMessageUnspecified':
-          localizations.cdr_disconnectReason_invalidMessageUnspecified,
-      'cdr_disconnectReason_mandatoryInformationElementIsMissing': localizations
-          .cdr_disconnectReason_mandatoryInformationElementIsMissing,
-      'cdr_disconnectReason_messageTypeNonExistentOrNotImplemented':
-          localizations
-              .cdr_disconnectReason_messageTypeNonExistentOrNotImplemented,
-      'cdr_disconnectReason_messageNotCompatibleWithCallStateOrMessageTypeNonExistentOrNotImplemented':
-          localizations
-              .cdr_disconnectReason_messageNotCompatibleWithCallStateOrMessageTypeNonExistentOrNotImplemented,
-      'cdr_disconnectReason_informationElementNonexistantOrNotImplemented':
-          localizations
-              .cdr_disconnectReason_informationElementNonexistantOrNotImplemented,
-      'cdr_disconnectReason_invalidInformationElementContents':
-          localizations.cdr_disconnectReason_invalidInformationElementContents,
-      'cdr_disconnectReason_messageNotCompatibleWithCallState':
-          localizations.cdr_disconnectReason_messageNotCompatibleWithCallState,
-      'cdr_disconnectReason_recoveryOnTimerExpiry':
-          localizations.cdr_disconnectReason_recoveryOnTimerExpiry,
-      'cdr_disconnectReason_parameterNonExistentOrNotImplementedPassedOn':
-          localizations
-              .cdr_disconnectReason_parameterNonExistentOrNotImplementedPassedOn,
-      'cdr_disconnectReason_urecognizedParameterMessageDiscarded': localizations
-          .cdr_disconnectReason_urecognizedParameterMessageDiscarded,
-      'cdr_disconnectReason_protocolErrorUnspecified':
-          localizations.cdr_disconnectReason_protocolErrorUnspecified,
-      'cdr_disconnectReason_internetworkingUnspecified':
-          localizations.cdr_disconnectReason_internetworkingUnspecified,
-      'cdr_disconnectReason_nextNodeIsUnreachable':
-          localizations.cdr_disconnectReason_nextNodeIsUnreachable,
-      'cdr_disconnectReason_holstTelephonyServiceProviderModuleHtspmIsOutOfService':
-          localizations
-              .cdr_disconnectReason_holstTelephonyServiceProviderModuleHtspmIsOutOfService,
-      'cdr_disconnectReason_dtlTransitIsNotMyNodeId':
-          localizations.cdr_disconnectReason_dtlTransitIsNotMyNodeId,
-      'devTools_AppBarTitle': localizations.devTools_AppBarTitle,
-      'devTools_signalingService_groupTitle':
-          localizations.devTools_signalingService_groupTitle,
-      'devTools_signalingService_simulateKill_title':
-          localizations.devTools_signalingService_simulateKill_title,
-      'devTools_signalingService_simulateKill_subtitle':
-          localizations.devTools_signalingService_simulateKill_subtitle,
-      'devTools_signalingService_simulateKill_confirmMessage':
-          localizations.devTools_signalingService_simulateKill_confirmMessage,
-      'devTools_signalingService_simulateKill_confirm':
-          localizations.devTools_signalingService_simulateKill_confirm,
-      'devTools_signalingService_simulateKill_cancel':
-          localizations.devTools_signalingService_simulateKill_cancel,
-      'agoTicker_daysAgo': (days) => localizations.agoTicker_daysAgo(days),
-      'agoTicker_hoursAgo': (hours) => localizations.agoTicker_hoursAgo(hours),
-      'agoTicker_minutesAgo': (minutes) =>
-          localizations.agoTicker_minutesAgo(minutes),
-      'agoTicker_secondsAgo': (seconds) =>
-          localizations.agoTicker_secondsAgo(seconds),
-      'contacts_ContactTile_inCall': (destination) =>
-          localizations.contacts_ContactTile_inCall(destination),
-      'default_UnknownExceptionError': (error) =>
-          localizations.default_UnknownExceptionError(error),
-      'diagnosticNetworkTestItem_subtitle_publicIps': (ips) =>
-          localizations.diagnosticNetworkTestItem_subtitle_publicIps(ips),
-      'favorites_SnackBar_deleted': (name) =>
-          localizations.favorites_SnackBar_deleted(name),
-      'formatPhone': (style, main, ext) =>
-          localizations.formatPhone(style, main, ext),
-      'login_Button_otpSigninVerifyRepeatInterval': (seconds) =>
-          localizations.login_Button_otpSigninVerifyRepeatInterval(seconds),
-      'login_Button_signupVerifyRepeatInterval': (seconds) =>
-          localizations.login_Button_signupVerifyRepeatInterval(seconds),
-      'login_CoreVersionUnsupportedExceptionError':
-          (actual, supportedConstraint) =>
-              localizations.login_CoreVersionUnsupportedExceptionError(
-                actual,
-                supportedConstraint,
-              ),
-      'login_Text_coreUrlAssignPostDescription': (email) =>
-          localizations.login_Text_coreUrlAssignPostDescription(email),
-      'login_Text_otpSigninVerifyPostDescriptionFromEmail': (email) =>
-          localizations.login_Text_otpSigninVerifyPostDescriptionFromEmail(
-            email,
+  Object? lookupKey(String key, [List<Object>? args]) {
+    return switch (key) {
+      'localeName' => localeName,
+      'account_selfCarePasswordExpired_message' =>
+        account_selfCarePasswordExpired_message,
+      'alertDialogActions_no' => alertDialogActions_no,
+      'alertDialogActions_ok' => alertDialogActions_ok,
+      'alertDialogActions_yes' => alertDialogActions_yes,
+      'autoprovision_errorSnackBar_invalidToken' =>
+        autoprovision_errorSnackBar_invalidToken,
+      'autoprovision_ReloginDialog_confirm' =>
+        autoprovision_ReloginDialog_confirm,
+      'autoprovision_ReloginDialog_decline' =>
+        autoprovision_ReloginDialog_decline,
+      'autoprovision_ReloginDialog_text' => autoprovision_ReloginDialog_text,
+      'autoprovision_ReloginDialog_title' => autoprovision_ReloginDialog_title,
+      'autoprovision_successSnackBar_used' =>
+        autoprovision_successSnackBar_used,
+      'call_CallActionsTooltip_accept' => call_CallActionsTooltip_accept,
+      'call_CallActionsTooltip_accept_inviteToAttendedTransfer' =>
+        call_CallActionsTooltip_accept_inviteToAttendedTransfer,
+      'call_CallActionsTooltip_attended_transfer' =>
+        call_CallActionsTooltip_attended_transfer,
+      'call_CallActionsTooltip_changeAudioDevice' =>
+        call_CallActionsTooltip_changeAudioDevice,
+      'call_CallActionsTooltip_decline_inviteToAttendedTransfer' =>
+        call_CallActionsTooltip_decline_inviteToAttendedTransfer,
+      'call_CallActionsTooltip_device_bluetooth' =>
+        call_CallActionsTooltip_device_bluetooth,
+      'call_CallActionsTooltip_device_earpiece' =>
+        call_CallActionsTooltip_device_earpiece,
+      'call_CallActionsTooltip_device_speaker' =>
+        call_CallActionsTooltip_device_speaker,
+      'call_CallActionsTooltip_device_streaming' =>
+        call_CallActionsTooltip_device_streaming,
+      'call_CallActionsTooltip_device_unknown' =>
+        call_CallActionsTooltip_device_unknown,
+      'call_CallActionsTooltip_device_wiredHeadset' =>
+        call_CallActionsTooltip_device_wiredHeadset,
+      'call_CallActionsTooltip_disableCamera' =>
+        call_CallActionsTooltip_disableCamera,
+      'call_CallActionsTooltip_disableSpeaker' =>
+        call_CallActionsTooltip_disableSpeaker,
+      'call_CallActionsTooltip_enableCamera' =>
+        call_CallActionsTooltip_enableCamera,
+      'call_CallActionsTooltip_enableSpeaker' =>
+        call_CallActionsTooltip_enableSpeaker,
+      'call_CallActionsTooltip_hangup' => call_CallActionsTooltip_hangup,
+      'call_CallActionsTooltip_hangupAndAccept' =>
+        call_CallActionsTooltip_hangupAndAccept,
+      'call_CallActionsTooltip_hideKeypad' =>
+        call_CallActionsTooltip_hideKeypad,
+      'call_CallActionsTooltip_hold' => call_CallActionsTooltip_hold,
+      'call_CallActionsTooltip_holdAndAccept' =>
+        call_CallActionsTooltip_holdAndAccept,
+      'call_CallActionsTooltip_mute' => call_CallActionsTooltip_mute,
+      'call_CallActionsTooltip_showKeypad' =>
+        call_CallActionsTooltip_showKeypad,
+      'call_CallActionsTooltip_swap' => call_CallActionsTooltip_swap,
+      'call_CallActionsTooltip_transfer' => call_CallActionsTooltip_transfer,
+      'call_CallActionsTooltip_transfer_choose' =>
+        call_CallActionsTooltip_transfer_choose,
+      'call_CallActionsTooltip_unattended_transfer' =>
+        call_CallActionsTooltip_unattended_transfer,
+      'call_CallActionsTooltip_unhold' => call_CallActionsTooltip_unhold,
+      'call_CallActionsTooltip_unmute' => call_CallActionsTooltip_unmute,
+      'call_description_held' => call_description_held,
+      'call_description_incoming' => call_description_incoming,
+      'call_description_inviteToAttendedTransfer' =>
+        call_description_inviteToAttendedTransfer,
+      'call_description_outgoing' => call_description_outgoing,
+      'call_description_requestToAttendedTransfer' =>
+        call_description_requestToAttendedTransfer,
+      'call_description_transferProcessing' =>
+        call_description_transferProcessing,
+      'call_errorRegisteringSelfManagedPhoneAccount' =>
+        call_errorRegisteringSelfManagedPhoneAccount,
+      'call_FailureAcknowledgeDialog_title' =>
+        call_FailureAcknowledgeDialog_title,
+      'callProcessingStatus_answering' => callProcessingStatus_answering,
+      'callProcessingStatus_disconnecting' =>
+        callProcessingStatus_disconnecting,
+      'callProcessingStatus_init_media' => callProcessingStatus_init_media,
+      'callProcessingStatus_invite' => callProcessingStatus_invite,
+      'callProcessingStatus_preparing' => callProcessingStatus_preparing,
+      'callProcessingStatus_ringing' => callProcessingStatus_ringing,
+      'callProcessingStatus_routing' => callProcessingStatus_routing,
+      'callProcessingStatus_signaling_connecting' =>
+        callProcessingStatus_signaling_connecting,
+      'iceConnectionIssue_iceFail' => iceConnectionIssue_iceFail,
+      'iceConnectionIssue_iceFailNoIcePath' =>
+        iceConnectionIssue_iceFailNoIcePath,
+      'iceConnectionIssue_iceFailNoIcePathViaVpn' =>
+        iceConnectionIssue_iceFailNoIcePathViaVpn,
+      'callPullBadge_dialogTitle' => callPullBadge_dialogTitle,
+      'callPullBadge_pickupButtonTitle' => callPullBadge_pickupButtonTitle,
+      'call_settings_additional_options' => call_settings_additional_options,
+      'callStatus_appUnregistered' => callStatus_appUnregistered,
+      'callStatus_connectError' => callStatus_connectError,
+      'callStatus_connectIssue' => callStatus_connectIssue,
+      'callStatus_connectivityNone' => callStatus_connectivityNone,
+      'callStatus_inProgress' => callStatus_inProgress,
+      'callStatus_ready' => callStatus_ready,
+      'call_SystemErrorDialog_description' =>
+        call_SystemErrorDialog_description,
+      'call_SystemErrorDialog_title' => call_SystemErrorDialog_title,
+      'call_ThumbnailAvatar_currentlyNoActiveCall' =>
+        call_ThumbnailAvatar_currentlyNoActiveCall,
+      'call_videoBackground_actionLabel_disableBlur' =>
+        call_videoBackground_actionLabel_disableBlur,
+      'call_videoBackground_actionLabel_enableBlur' =>
+        call_videoBackground_actionLabel_enableBlur,
+      'call_videoView_actionLabel_cover' => call_videoView_actionLabel_cover,
+      'call_videoView_actionLabel_fit' => call_videoView_actionLabel_fit,
+      'cdrs_noMissedCalls_message' => cdrs_noMissedCalls_message,
+      'cdrs_noRecentCalls_message' => cdrs_noRecentCalls_message,
+      'common_noInternetConnection_message' =>
+        common_noInternetConnection_message,
+      'common_noInternetConnection_retryButton' =>
+        common_noInternetConnection_retryButton,
+      'common_noInternetConnection_title' => common_noInternetConnection_title,
+      'common_problemWithLoadingPage' => common_problemWithLoadingPage,
+      'contacts_agreement_button_text' => contacts_agreement_button_text,
+      'contacts_agreement_checkbox_text' => contacts_agreement_checkbox_text,
+      'contacts_agreement_description' => contacts_agreement_description,
+      'contacts_agreement_title' => contacts_agreement_title,
+      'contacts_ExternalTabButton_refresh' =>
+        contacts_ExternalTabButton_refresh,
+      'contacts_ExternalTabText_empty' => contacts_ExternalTabText_empty,
+      'contacts_ExternalTabText_emptyOnSearching' =>
+        contacts_ExternalTabText_emptyOnSearching,
+      'contacts_ExternalTabText_failure' => contacts_ExternalTabText_failure,
+      'contacts_LocalTabButton_contactsAgreement' =>
+        contacts_LocalTabButton_contactsAgreement,
+      'contacts_LocalTabButton_openAppSettings' =>
+        contacts_LocalTabButton_openAppSettings,
+      'contacts_LocalTabButton_refresh' => contacts_LocalTabButton_refresh,
+      'contacts_LocalTabText_contactsAgreementFailure' =>
+        contacts_LocalTabText_contactsAgreementFailure,
+      'contacts_LocalTabText_empty' => contacts_LocalTabText_empty,
+      'contacts_LocalTabText_emptyOnSearching' =>
+        contacts_LocalTabText_emptyOnSearching,
+      'contacts_LocalTabText_failure' => contacts_LocalTabText_failure,
+      'contacts_LocalTabText_permissionFailure' =>
+        contacts_LocalTabText_permissionFailure,
+      'contactsSourceExternal' => contactsSourceExternal,
+      'contactsSourceLocal' => contactsSourceLocal,
+      'contacts_Text_blingTransferInitiated' =>
+        contacts_Text_blingTransferInitiated,
+      'contacts_DialogsInfoView_title' => contacts_DialogsInfoView_title,
+      'contacts_ContactScreen_options' => contacts_ContactScreen_options,
+      'contacts_ContactScreen_presenceViaSip' =>
+        contacts_ContactScreen_presenceViaSip,
+      'contacts_ContactScreen_presenceViaSip_tooltip' =>
+        contacts_ContactScreen_presenceViaSip_tooltip,
+      'contacts_ContactScreen_dialogsViaSipBlf' =>
+        contacts_ContactScreen_dialogsViaSipBlf,
+      'contacts_ContactScreen_dialogsViaSipBlf_tooltip' =>
+        contacts_ContactScreen_dialogsViaSipBlf_tooltip,
+      'copyToClipboard_floatingSnackBar' => copyToClipboard_floatingSnackBar,
+      'copyToClipboard_popupMenuItem' => copyToClipboard_popupMenuItem,
+      'default_CannotRemoveOwnerMessagingSocketException' =>
+        default_CannotRemoveOwnerMessagingSocketException,
+      'default_ChatMemberNotFoundMessagingSocketException' =>
+        default_ChatMemberNotFoundMessagingSocketException,
+      'default_ChatNotFoundMessagingSocketException' =>
+        default_ChatNotFoundMessagingSocketException,
+      'default_ClientExceptionError' => default_ClientExceptionError,
+      'default_ErrorDetails' => default_ErrorDetails,
+      'default_ErrorMessage' => default_ErrorMessage,
+      'default_ErrorPath' => default_ErrorPath,
+      'default_ErrorTransactionId' => default_ErrorTransactionId,
+      'default_ForbiddenMessagingSocketException' =>
+        default_ForbiddenMessagingSocketException,
+      'default_FormatExceptionError' => default_FormatExceptionError,
+      'default_InternalErrorMessagingSocketException' =>
+        default_InternalErrorMessagingSocketException,
+      'default_InvalidChatTypeMessagingSocketException' =>
+        default_InvalidChatTypeMessagingSocketException,
+      'default_JoinCrashedMessagingSocketException' =>
+        default_JoinCrashedMessagingSocketException,
+      'default_MessagingSocketException' => default_MessagingSocketException,
+      'default_RequestFailureError' => default_RequestFailureError,
+      'default_SelfAuthorityAssignmentForbiddenMessagingSocketException' =>
+        default_SelfAuthorityAssignmentForbiddenMessagingSocketException,
+      'default_SelfRemovalForbiddenMessagingSocketException' =>
+        default_SelfRemovalForbiddenMessagingSocketException,
+      'default_SmsConversationNotFoundMessagingSocketException' =>
+        default_SmsConversationNotFoundMessagingSocketException,
+      'default_TimeoutExceptionError' => default_TimeoutExceptionError,
+      'default_TimeoutMessagingSocketException' =>
+        default_TimeoutMessagingSocketException,
+      'default_TlsExceptionError' => default_TlsExceptionError,
+      'default_TypeErrorError' => default_TypeErrorError,
+      'default_UnauthorizedMessagingSocketException' =>
+        default_UnauthorizedMessagingSocketException,
+      'default_UnauthorizedRequestFailureError' =>
+        default_UnauthorizedRequestFailureError,
+      'default_UserAlreadyInChatMessagingSocketException' =>
+        default_UserAlreadyInChatMessagingSocketException,
+      'diagnostic_AppBar_title' => diagnostic_AppBar_title,
+      'diagnostic_battery_groupTitle' => diagnostic_battery_groupTitle,
+      'diagnostic_batteryMode_optimized_description' =>
+        diagnostic_batteryMode_optimized_description,
+      'diagnostic_batteryMode_optimized_title' =>
+        diagnostic_batteryMode_optimized_title,
+      'diagnostic_batteryMode_restricted_description' =>
+        diagnostic_batteryMode_restricted_description,
+      'diagnostic_batteryMode_restricted_title' =>
+        diagnostic_batteryMode_restricted_title,
+      'diagnostic_batteryMode_unknown_description' =>
+        diagnostic_batteryMode_unknown_description,
+      'diagnostic_batteryMode_unknown_title' =>
+        diagnostic_batteryMode_unknown_title,
+      'diagnostic_batteryMode_unrestricted_description' =>
+        diagnostic_batteryMode_unrestricted_description,
+      'diagnostic_batteryMode_unrestricted_title' =>
+        diagnostic_batteryMode_unrestricted_title,
+      'diagnostic_battery_navigate_section' =>
+        diagnostic_battery_navigate_section,
+      'diagnostic_battery_tile_title' => diagnostic_battery_tile_title,
+      'diagnostic_permission_camera_description' =>
+        diagnostic_permission_camera_description,
+      'diagnostic_permission_camera_title' =>
+        diagnostic_permission_camera_title,
+      'diagnostic_permission_contacts_description' =>
+        diagnostic_permission_contacts_description,
+      'diagnostic_permission_contacts_title' =>
+        diagnostic_permission_contacts_title,
+      'diagnosticPermissionDetails_button_managePermission' =>
+        diagnosticPermissionDetails_button_managePermission,
+      'diagnosticPermissionDetails_button_requestPermission' =>
+        diagnosticPermissionDetails_button_requestPermission,
+      'diagnosticPermissionDetails_title_statusPermission' =>
+        diagnosticPermissionDetails_title_statusPermission,
+      'diagnostic_permission_microphone_description' =>
+        diagnostic_permission_microphone_description,
+      'diagnostic_permission_microphone_title' =>
+        diagnostic_permission_microphone_title,
+      'diagnostic_permission_notification_description' =>
+        diagnostic_permission_notification_description,
+      'diagnostic_permission_notification_title' =>
+        diagnostic_permission_notification_title,
+      'diagnostic_permissionStatus_denied' =>
+        diagnostic_permissionStatus_denied,
+      'diagnostic_permissionStatus_granted' =>
+        diagnostic_permissionStatus_granted,
+      'diagnostic_permissionStatus_limited' =>
+        diagnostic_permissionStatus_limited,
+      'diagnostic_permissionStatus_permanentlyDenied' =>
+        diagnostic_permissionStatus_permanentlyDenied,
+      'diagnostic_permissionStatus_provisional' =>
+        diagnostic_permissionStatus_provisional,
+      'diagnostic_permissionStatus_restricted' =>
+        diagnostic_permissionStatus_restricted,
+      'diagnosticPushDetails_configuration_title' =>
+        diagnosticPushDetails_configuration_title,
+      'diagnosticPushDetails_errorMessage_intro' =>
+        diagnosticPushDetails_errorMessage_intro,
+      'diagnosticPushDetails_errorMessage_step1' =>
+        diagnosticPushDetails_errorMessage_step1,
+      'diagnosticPushDetails_errorMessage_step2' =>
+        diagnosticPushDetails_errorMessage_step2,
+      'diagnosticPushDetails_errorMessage_step3' =>
+        diagnosticPushDetails_errorMessage_step3,
+      'diagnosticPushDetails_errorMessage_step4' =>
+        diagnosticPushDetails_errorMessage_step4,
+      'diagnosticPushDetails_errorMessage_step5' =>
+        diagnosticPushDetails_errorMessage_step5,
+      'diagnosticPushDetails_successMessage' =>
+        diagnosticPushDetails_successMessage,
+      'diagnostic_pushTokenStatusType_progress' =>
+        diagnostic_pushTokenStatusType_progress,
+      'diagnostic_pushTokenStatusType_success' =>
+        diagnostic_pushTokenStatusType_success,
+      'diagnosticReportDialogAddNoteExpansionTileTitle' =>
+        diagnosticReportDialogAddNoteExpansionTileTitle,
+      'diagnosticReportDialogCancelButtonLabel' =>
+        diagnosticReportDialogCancelButtonLabel,
+      'diagnosticReportDialogCommentTextFieldHintText' =>
+        diagnosticReportDialogCommentTextFieldHintText,
+      'diagnosticReportDialogContent' => diagnosticReportDialogContent,
+      'diagnosticReportDialogIncludeSystemLogsSwitchTileSubtitle' =>
+        diagnosticReportDialogIncludeSystemLogsSwitchTileSubtitle,
+      'diagnosticReportDialogIncludeSystemLogsSwitchTileTitle' =>
+        diagnosticReportDialogIncludeSystemLogsSwitchTileTitle,
+      'diagnosticReportDialogSendReportButtonLabel' =>
+        diagnosticReportDialogSendReportButtonLabel,
+      'diagnosticReportDialogTitle' => diagnosticReportDialogTitle,
+      'diagnosticScreen_contacts_agreement_description' =>
+        diagnosticScreen_contacts_agreement_description,
+      'diagnosticScreen_contacts_agreement_group_title' =>
+        diagnosticScreen_contacts_agreement_group_title,
+      'diagnosticScreen_contacts_agreement_title' =>
+        diagnosticScreen_contacts_agreement_title,
+      'diagnosticScreen_permissionsGroup_title' =>
+        diagnosticScreen_permissionsGroup_title,
+      'diagnosticScreen_pushNotificationService_title' =>
+        diagnosticScreen_pushNotificationService_title,
+      'diagnostic_network_groupTitle' => diagnostic_network_groupTitle,
+      'diagnosticNetworkTest_status_offline' =>
+        diagnosticNetworkTest_status_offline,
+      'diagnosticNetworkTest_status_reachable' =>
+        diagnosticNetworkTest_status_reachable,
+      'diagnosticNetworkTest_status_restricted' =>
+        diagnosticNetworkTest_status_restricted,
+      'diagnosticNetworkTest_status_checking' =>
+        diagnosticNetworkTest_status_checking,
+      'diagnosticNetworkTest_status_unreachable' =>
+        diagnosticNetworkTest_status_unreachable,
+      'diagnosticNetworkTestItem_subtitle_noNetwork' =>
+        diagnosticNetworkTestItem_subtitle_noNetwork,
+      'diagnosticNetworkTestItem_subtitle_stunBlocked' =>
+        diagnosticNetworkTestItem_subtitle_stunBlocked,
+      'diagnosticNetworkTestItem_subtitle_stunUnreachable' =>
+        diagnosticNetworkTestItem_subtitle_stunUnreachable,
+      'diagnosticNetworkTestItem_subtitle_noCandidates' =>
+        diagnosticNetworkTestItem_subtitle_noCandidates,
+      'diagnosticNetworkTestItem_network_wifi' =>
+        diagnosticNetworkTestItem_network_wifi,
+      'diagnosticNetworkTestItem_network_mobile' =>
+        diagnosticNetworkTestItem_network_mobile,
+      'diagnosticNetworkTestItem_network_ethernet' =>
+        diagnosticNetworkTestItem_network_ethernet,
+      'diagnosticNetworkTestItem_network_vpn' =>
+        diagnosticNetworkTestItem_network_vpn,
+      'diagnosticNetworkTestDetails_title' =>
+        diagnosticNetworkTestDetails_title,
+      'diagnosticNetworkTestDetails_description' =>
+        diagnosticNetworkTestDetails_description,
+      'diagnosticNetworkTestDetails_status' =>
+        diagnosticNetworkTestDetails_status,
+      'diagnosticNetworkTestDetails_candidates' =>
+        diagnosticNetworkTestDetails_candidates,
+      'diagnosticNetworkTestDetails_noNetwork' =>
+        diagnosticNetworkTestDetails_noNetwork,
+      'diagnosticNetworkTestDetails_noCandidates' =>
+        diagnosticNetworkTestDetails_noCandidates,
+      'favorites_BodyCenter_empty' => favorites_BodyCenter_empty,
+      'favorites_DeleteConfirmDialog_content' =>
+        favorites_DeleteConfirmDialog_content,
+      'favorites_DeleteConfirmDialog_title' =>
+        favorites_DeleteConfirmDialog_title,
+      'favorites_Text_blingTransferInitiated' =>
+        favorites_Text_blingTransferInitiated,
+      'locale_default' => locale_default,
+      'locale_en' => locale_en,
+      'locale_it' => locale_it,
+      'locale_uk' => locale_uk,
+      'login_Button_coreUrlAssignProceed' => login_Button_coreUrlAssignProceed,
+      'login_Button_otpSigninRequestProceed' =>
+        login_Button_otpSigninRequestProceed,
+      'login_Button_otpSigninVerifyProceed' =>
+        login_Button_otpSigninVerifyProceed,
+      'login_Button_otpSigninVerifyRepeat' =>
+        login_Button_otpSigninVerifyRepeat,
+      'login_Button_passwordSigninProceed' =>
+        login_Button_passwordSigninProceed,
+      'login_Button_signIn' => login_Button_signIn,
+      'login_Button_signupRequestProceed' => login_Button_signupRequestProceed,
+      'login_Button_signUpToDemoInstance' => login_Button_signUpToDemoInstance,
+      'login_Button_signupVerifyProceed' => login_Button_signupVerifyProceed,
+      'login_Button_signupVerifyRepeat' => login_Button_signupVerifyRepeat,
+      'login_ButtonTooltip_signInToYourInstance' =>
+        login_ButtonTooltip_signInToYourInstance,
+      'login_RequestFailureEmptyEmailError' =>
+        login_RequestFailureEmptyEmailError,
+      'login_RequestFailureIdentifierIsNotValid' =>
+        login_RequestFailureIdentifierIsNotValid,
+      'login_RequestFailureIncorrectOtpCodeError' =>
+        login_RequestFailureIncorrectOtpCodeError,
+      'login_RequestFailureOtpAlreadyVerifiedError' =>
+        login_RequestFailureOtpAlreadyVerifiedError,
+      'login_RequestFailureOtpExpiredError' =>
+        login_RequestFailureOtpExpiredError,
+      'login_RequestFailureOtpNotFoundError' =>
+        login_RequestFailureOtpNotFoundError,
+      'login_RequestFailureOtpVerificationAttemptsExceededError' =>
+        login_RequestFailureOtpVerificationAttemptsExceededError,
+      'login_RequestFailureParametersApplyIssueError' =>
+        login_RequestFailureParametersApplyIssueError,
+      'login_RequestFailurePhoneNotFoundError' =>
+        login_RequestFailurePhoneNotFoundError,
+      'login_RequestFailureIncorrectCredentialsError' =>
+        login_RequestFailureIncorrectCredentialsError,
+      'login_RequestFailureUserNotFoundError' =>
+        login_RequestFailureUserNotFoundError,
+      'login_RequestFailureUnconfiguredBundleIdError' =>
+        login_RequestFailureUnconfiguredBundleIdError,
+      'login_SupportedLoginTypeMissedExceptionError' =>
+        login_SupportedLoginTypeMissedExceptionError,
+      'login_Text_coreUrlAssignPreDescription' =>
+        login_Text_coreUrlAssignPreDescription,
+      'login_TextFieldLabelText_coreUrlAssign' =>
+        login_TextFieldLabelText_coreUrlAssign,
+      'login_TextFieldLabelText_otpSigninCode' =>
+        login_TextFieldLabelText_otpSigninCode,
+      'login_TextFieldLabelText_otpSigninUserRef' =>
+        login_TextFieldLabelText_otpSigninUserRef,
+      'login_TextFieldLabelText_otpSigninUserRefPhone' =>
+        login_TextFieldLabelText_otpSigninUserRefPhone,
+      'login_TextFieldLabelText_otpSigninUserRefEmail' =>
+        login_TextFieldLabelText_otpSigninUserRefEmail,
+      'login_TextFieldLabelText_passwordSigninPassword' =>
+        login_TextFieldLabelText_passwordSigninPassword,
+      'login_TextFieldLabelText_passwordSigninUserRef' =>
+        login_TextFieldLabelText_passwordSigninUserRef,
+      'login_TextFieldLabelText_signupCode' =>
+        login_TextFieldLabelText_signupCode,
+      'login_TextFieldLabelText_signupEmail' =>
+        login_TextFieldLabelText_signupEmail,
+      'login_Text_otpSigninRequestPostDescription' =>
+        login_Text_otpSigninRequestPostDescription,
+      'login_Text_otpSigninRequestPreDescription' =>
+        login_Text_otpSigninRequestPreDescription,
+      'login_Text_otpSigninVerifyPostDescriptionGeneral' =>
+        login_Text_otpSigninVerifyPostDescriptionGeneral,
+      'login_Text_passwordSigninPostDescription' =>
+        login_Text_passwordSigninPostDescription,
+      'login_Text_passwordSigninPreDescription' =>
+        login_Text_passwordSigninPreDescription,
+      'login_Text_signupRequestPostDescription' =>
+        login_Text_signupRequestPostDescription,
+      'login_Text_signupRequestPostDescriptionDemo' =>
+        login_Text_signupRequestPostDescriptionDemo,
+      'login_Text_signupRequestPreDescription' =>
+        login_Text_signupRequestPreDescription,
+      'login_Text_signupRequestPreDescriptionDemo' =>
+        login_Text_signupRequestPreDescriptionDemo,
+      'login_Text_signupVerifyPostDescriptionGeneral' =>
+        login_Text_signupVerifyPostDescriptionGeneral,
+      'loginType_otpSignin' => loginType_otpSignin,
+      'loginType_passwordSignin' => loginType_passwordSignin,
+      'loginType_signup' => loginType_signup,
+      'login_validationCoreUrlError' => login_validationCoreUrlError,
+      'login_validationEmailError' => login_validationEmailError,
+      'login_validationPhoneError' => login_validationPhoneError,
+      'login_validationUserRefError' => login_validationUserRefError,
+      'logRecordsConsole_AppBarTitle' => logRecordsConsole_AppBarTitle,
+      'logRecordsConsole_Button_failureRefresh' =>
+        logRecordsConsole_Button_failureRefresh,
+      'logRecordsConsole_Text_failure' => logRecordsConsole_Text_failure,
+      'logRecordsConsole_Button_infoClose' =>
+        logRecordsConsole_Button_infoClose,
+      'logRecordsConsole_PopupMenuItem_info' =>
+        logRecordsConsole_PopupMenuItem_info,
+      'logRecordsConsole_PopupMenuItem_clear' =>
+        logRecordsConsole_PopupMenuItem_clear,
+      'main_BottomNavigationBarItemLabel_chats' =>
+        main_BottomNavigationBarItemLabel_chats,
+      'main_BottomNavigationBarItemLabel_contacts' =>
+        main_BottomNavigationBarItemLabel_contacts,
+      'main_BottomNavigationBarItemLabel_favorites' =>
+        main_BottomNavigationBarItemLabel_favorites,
+      'main_BottomNavigationBarItemLabel_keypad' =>
+        main_BottomNavigationBarItemLabel_keypad,
+      'main_BottomNavigationBarItemLabel_recents' =>
+        main_BottomNavigationBarItemLabel_recents,
+      'main_CompatibilityIssueDialogActions_logout' =>
+        main_CompatibilityIssueDialogActions_logout,
+      'main_CompatibilityIssueDialogActions_update' =>
+        main_CompatibilityIssueDialogActions_update,
+      'main_CompatibilityIssueDialog_title' =>
+        main_CompatibilityIssueDialog_title,
+      'messaging_ActionBtn_retry' => messaging_ActionBtn_retry,
+      'messaging_ChooseContact_cancel' => messaging_ChooseContact_cancel,
+      'messaging_ChooseContact_empty' => messaging_ChooseContact_empty,
+      'messaging_ChooseContact_title' => messaging_ChooseContact_title,
+      'messaging_ConfirmDialog_ask' => messaging_ConfirmDialog_ask,
+      'messaging_ConfirmDialog_cancel' => messaging_ConfirmDialog_cancel,
+      'messaging_ConfirmDialog_confirm' => messaging_ConfirmDialog_confirm,
+      'messaging_ConversationBuilders_back' =>
+        messaging_ConversationBuilders_back,
+      'messaging_ConversationBuilders_cancel' =>
+        messaging_ConversationBuilders_cancel,
+      'messaging_ConversationBuilders_contactOrNumberSearch_hint' =>
+        messaging_ConversationBuilders_contactOrNumberSearch_hint,
+      'messaging_ConversationBuilders_contactSearch_hint' =>
+        messaging_ConversationBuilders_contactSearch_hint,
+      'messaging_ConversationBuilders_create' =>
+        messaging_ConversationBuilders_create,
+      'messaging_ConversationBuilders_createGroup' =>
+        messaging_ConversationBuilders_createGroup,
+      'messaging_ConversationBuilders_externalContacts_heading' =>
+        messaging_ConversationBuilders_externalContacts_heading,
+      'messaging_ConversationBuilders_invalidNumber_message1' =>
+        messaging_ConversationBuilders_invalidNumber_message1,
+      'messaging_ConversationBuilders_invalidNumber_message2' =>
+        messaging_ConversationBuilders_invalidNumber_message2,
+      'messaging_ConversationBuilders_invalidNumber_ok' =>
+        messaging_ConversationBuilders_invalidNumber_ok,
+      'messaging_ConversationBuilders_invalidNumber_title' =>
+        messaging_ConversationBuilders_invalidNumber_title,
+      'messaging_ConversationBuilders_invite_heading' =>
+        messaging_ConversationBuilders_invite_heading,
+      'messaging_ConversationBuilders_localContacts_heading' =>
+        messaging_ConversationBuilders_localContacts_heading,
+      'messaging_ConversationBuilders_membersHeadline' =>
+        messaging_ConversationBuilders_membersHeadline,
+      'messaging_ConversationBuilders_nameFieldEmpty' =>
+        messaging_ConversationBuilders_nameFieldEmpty,
+      'messaging_ConversationBuilders_nameFieldLabel' =>
+        messaging_ConversationBuilders_nameFieldLabel,
+      'messaging_ConversationBuilders_nameFieldShort' =>
+        messaging_ConversationBuilders_nameFieldShort,
+      'messaging_ConversationBuilders_next_action' =>
+        messaging_ConversationBuilders_next_action,
+      'messaging_ConversationBuilders_noContacts' =>
+        messaging_ConversationBuilders_noContacts,
+      'messaging_ConversationBuilders_numberFormatExample' =>
+        messaging_ConversationBuilders_numberFormatExample,
+      'messaging_ConversationBuilders_numberSearch_errorError' =>
+        messaging_ConversationBuilders_numberSearch_errorError,
+      'messaging_ConversationBuilders_numberSearch_errorHint' =>
+        messaging_ConversationBuilders_numberSearch_errorHint,
+      'messaging_ConversationBuilders_title_group' =>
+        messaging_ConversationBuilders_title_group,
+      'messaging_ConversationBuilders_title_new' =>
+        messaging_ConversationBuilders_title_new,
+      'messaging_Conversation_failure' => messaging_Conversation_failure,
+      'messaging_ConversationScreen_titleAvailable' =>
+        messaging_ConversationScreen_titleAvailable,
+      'messaging_ConversationScreen_titlePrefix' =>
+        messaging_ConversationScreen_titlePrefix,
+      'messaging_ConversationsScreen_chatsSearch_hint' =>
+        messaging_ConversationsScreen_chatsSearch_hint,
+      'messaging_ConversationsScreen_empty' =>
+        messaging_ConversationsScreen_empty,
+      'messaging_ConversationsScreen_messages_title' =>
+        messaging_ConversationsScreen_messages_title,
+      'messaging_ConversationsScreen_noNumberAlert_text' =>
+        messaging_ConversationsScreen_noNumberAlert_text,
+      'messaging_ConversationsScreen_noNumberAlert_title' =>
+        messaging_ConversationsScreen_noNumberAlert_title,
+      'messaging_ConversationsScreen_selectNumberSheet_title' =>
+        messaging_ConversationsScreen_selectNumberSheet_title,
+      'messaging_ConversationsScreen_smses_title' =>
+        messaging_ConversationsScreen_smses_title,
+      'messaging_ConversationsScreen_smssSearch_hint' =>
+        messaging_ConversationsScreen_smssSearch_hint,
+      'messaging_ConversationsScreen_unsupported' =>
+        messaging_ConversationsScreen_unsupported,
+      'messaging_Conversations_tile_empty' =>
+        messaging_Conversations_tile_empty,
+      'messaging_Conversations_tile_you' => messaging_Conversations_tile_you,
+      'messaging_DialogInfo_deleteAsk' => messaging_DialogInfo_deleteAsk,
+      'messaging_DialogInfo_deleteBtn' => messaging_DialogInfo_deleteBtn,
+      'messaging_DialogInfo_title' => messaging_DialogInfo_title,
+      'messaging_GroupAuthorities_moderator' =>
+        messaging_GroupAuthorities_moderator,
+      'messaging_GroupAuthorities_noauthorities' =>
+        messaging_GroupAuthorities_noauthorities,
+      'messaging_GroupAuthorities_owner' => messaging_GroupAuthorities_owner,
+      'messaging_GroupInfo_addUserBtnText' =>
+        messaging_GroupInfo_addUserBtnText,
+      'messaging_GroupInfo_deleteLeaveBtnText' =>
+        messaging_GroupInfo_deleteLeaveBtnText,
+      'messaging_GroupInfo_groupMembersHeadline' =>
+        messaging_GroupInfo_groupMembersHeadline,
+      'messaging_GroupInfo_leaveAndDeleteAsk' =>
+        messaging_GroupInfo_leaveAndDeleteAsk,
+      'messaging_GroupInfo_leaveAsk' => messaging_GroupInfo_leaveAsk,
+      'messaging_GroupInfo_leaveBtnText' => messaging_GroupInfo_leaveBtnText,
+      'messaging_GroupInfo_makeModeratorAsk' =>
+        messaging_GroupInfo_makeModeratorAsk,
+      'messaging_GroupInfo_makeModeratorBtnText' =>
+        messaging_GroupInfo_makeModeratorBtnText,
+      'messaging_GroupInfo_removeModeratorAsk' =>
+        messaging_GroupInfo_removeModeratorAsk,
+      'messaging_GroupInfo_removeUserAsk' => messaging_GroupInfo_removeUserAsk,
+      'messaging_GroupInfo_removeUserBtnText' =>
+        messaging_GroupInfo_removeUserBtnText,
+      'messaging_GroupInfo_title' => messaging_GroupInfo_title,
+      'messaging_GroupInfo_titlePrefix' => messaging_GroupInfo_titlePrefix,
+      'messaging_GroupInfo_unmakeModeratorBtnText' =>
+        messaging_GroupInfo_unmakeModeratorBtnText,
+      'messaging_MessageField_hint' => messaging_MessageField_hint,
+      'messaging_MessageListView_typingTrail' =>
+        messaging_MessageListView_typingTrail,
+      'messaging_MessageView_delete' => messaging_MessageView_delete,
+      'messaging_MessageView_deleted' => messaging_MessageView_deleted,
+      'messaging_MessageView_edit' => messaging_MessageView_edit,
+      'messaging_MessageView_edited' => messaging_MessageView_edited,
+      'messaging_MessageView_forward' => messaging_MessageView_forward,
+      'messaging_MessageView_reply' => messaging_MessageView_reply,
+      'messaging_MessageView_textcopy' => messaging_MessageView_textcopy,
+      'messaging_MessageView_today' => messaging_MessageView_today,
+      'messaging_MessageView_yesterday' => messaging_MessageView_yesterday,
+      'messaging_ParticipantName_unknown' => messaging_ParticipantName_unknown,
+      'messaging_ParticipantName_you' => messaging_ParticipantName_you,
+      'messaging_SmsSendingStatus_delivered' =>
+        messaging_SmsSendingStatus_delivered,
+      'messaging_SmsSendingStatus_failed' => messaging_SmsSendingStatus_failed,
+      'messaging_SmsSendingStatus_sent' => messaging_SmsSendingStatus_sent,
+      'messaging_SmsSendingStatus_waiting' =>
+        messaging_SmsSendingStatus_waiting,
+      'messaging_StateBar_connecting' => messaging_StateBar_connecting,
+      'messaging_StateBar_error' => messaging_StateBar_error,
+      'messaging_StateBar_initializing' => messaging_StateBar_initializing,
+      'notifications_errorSnackBarAction_callSdpConfiguration' =>
+        notifications_errorSnackBarAction_callSdpConfiguration,
+      'notifications_errorSnackBarAction_callUserMedia' =>
+        notifications_errorSnackBarAction_callUserMedia,
+      'notifications_errorSnackBar_activeLineBlindTransferWarning' =>
+        notifications_errorSnackBar_activeLineBlindTransferWarning,
+      'notifications_errorSnackBar_blindTransferFailed' =>
+        notifications_errorSnackBar_blindTransferFailed,
+      'notifications_errorSnackBar_appOffline' =>
+        notifications_errorSnackBar_appOffline,
+      'notifications_errorSnackBar_appOnline' =>
+        notifications_errorSnackBar_appOnline,
+      'notifications_errorSnackBar_appUnregistered' =>
+        notifications_errorSnackBar_appUnregistered,
+      'notifications_errorSnackBar_callConnect' =>
+        notifications_errorSnackBar_callConnect,
+      'notifications_errorSnackBar_callNegotiationTimeout' =>
+        notifications_errorSnackBar_callNegotiationTimeout,
+      'notifications_errorSnackBar_generalUnableToCall' =>
+        notifications_errorSnackBar_generalUnableToCall,
+      'notifications_errorSnackBar_callServiceBusyLine' =>
+        notifications_errorSnackBar_callServiceBusyLine,
+      'notifications_errorSnackBar_callSignalingClientNotConnect' =>
+        notifications_errorSnackBar_callSignalingClientNotConnect,
+      'notifications_errorSnackBar_callSignalingClientSessionMissed' =>
+        notifications_errorSnackBar_callSignalingClientSessionMissed,
+      'notifications_errorSnackBar_callUndefinedLine' =>
+        notifications_errorSnackBar_callUndefinedLine,
+      'notifications_errorSnackBar_callMediaTrackSetup' =>
+        notifications_errorSnackBar_callMediaTrackSetup,
+      'notifications_errorSnackBar_callUserMedia' =>
+        notifications_errorSnackBar_callUserMedia,
+      'notifications_errorSnackBar_callWhileOffline' =>
+        notifications_errorSnackBar_callWhileOffline,
+      'notifications_errorSnackBar_callWhileUnregistered' =>
+        notifications_errorSnackBar_callWhileUnregistered,
+      'notifications_errorSnackBar_sessionExpired' =>
+        notifications_errorSnackBar_sessionExpired,
+      'notifications_errorSnackBar_SignalingConnectFailed' =>
+        notifications_errorSnackBar_SignalingConnectFailed,
+      'notifications_errorSnackBar_SignalingSessionMissed' =>
+        notifications_errorSnackBar_SignalingSessionMissed,
+      'notifications_errorSnackBar_sipRegistrationFailed_Unavailable' =>
+        notifications_errorSnackBar_sipRegistrationFailed_Unavailable,
+      'notifications_errorSnackBar_sipRegistrationFailed_Unexpected' =>
+        notifications_errorSnackBar_sipRegistrationFailed_Unexpected,
+      'notifications_errorSnackBar_sipServiceUnavailable' =>
+        notifications_errorSnackBar_sipServiceUnavailable,
+      'notifications_messageSnackBar_appOffline' =>
+        notifications_messageSnackBar_appOffline,
+      'notifications_successSnackBar_appOnline' =>
+        notifications_successSnackBar_appOnline,
+      'numberActions_audioCall' => numberActions_audioCall,
+      'numberActions_callLog' => numberActions_callLog,
+      'numberActions_chat' => numberActions_chat,
+      'numberActions_copyCallId' => numberActions_copyCallId,
+      'numberActions_copyNumber' => numberActions_copyNumber,
+      'numberActions_delete' => numberActions_delete,
+      'numberActions_sendSms' => numberActions_sendSms,
+      'numberActions_transfer' => numberActions_transfer,
+      'numberActions_videoCall' => numberActions_videoCall,
+      'numberActions_viewContact' => numberActions_viewContact,
+      'permission_Button_request' => permission_Button_request,
+      'permission_manageFullScreenNotificationInstructions_step1' =>
+        permission_manageFullScreenNotificationInstructions_step1,
+      'permission_manageFullScreenNotificationInstructions_step2' =>
+        permission_manageFullScreenNotificationInstructions_step2,
+      'permission_manageFullScreenNotificationInstructions_step3' =>
+        permission_manageFullScreenNotificationInstructions_step3,
+      'permission_manageFullScreenNotificationInstructions_step4' =>
+        permission_manageFullScreenNotificationInstructions_step4,
+      'permission_manageFullScreenNotificationInstructions_step5' =>
+        permission_manageFullScreenNotificationInstructions_step5,
+      'permission_manageFullScreenNotificationPermissions' =>
+        permission_manageFullScreenNotificationPermissions,
+      'permission_manufacturer_Button_gotIt' =>
+        permission_manufacturer_Button_gotIt,
+      'permission_manufacturer_Button_toSettings' =>
+        permission_manufacturer_Button_toSettings,
+      'permission_manufacturer_Text_heading' =>
+        permission_manufacturer_Text_heading,
+      'permission_manufacturer_Text_trailing' =>
+        permission_manufacturer_Text_trailing,
+      'permission_manufacturer_Text_xiaomi_tip1' =>
+        permission_manufacturer_Text_xiaomi_tip1,
+      'permission_manufacturer_Text_xiaomi_tip2' =>
+        permission_manufacturer_Text_xiaomi_tip2,
+      'permission_Text_description' => permission_Text_description,
+      'persistentConnectionReminderContent' =>
+        persistentConnectionReminderContent,
+      'persistentConnectionReminderTitle' => persistentConnectionReminderTitle,
+      'batteryOptimizationWarningTitle' => batteryOptimizationWarningTitle,
+      'batteryOptimizationWarningContent' => batteryOptimizationWarningContent,
+      'batteryOptimizationWarningOpenSettings' =>
+        batteryOptimizationWarningOpenSettings,
+      'presence_activity_appointment_name' =>
+        presence_activity_appointment_name,
+      'presence_activity_away_name' => presence_activity_away_name,
+      'presence_activity_busy_name' => presence_activity_busy_name,
+      'presence_activity_doNotDisturb_name' =>
+        presence_activity_doNotDisturb_name,
+      'presence_activity_inTransit_name' => presence_activity_inTransit_name,
+      'presence_activity_meal_name' => presence_activity_meal_name,
+      'presence_activity_meeting_name' => presence_activity_meeting_name,
+      'presence_activity_none_name' => presence_activity_none_name,
+      'presence_activity_onThePhone_name' => presence_activity_onThePhone_name,
+      'presence_activity_permanentAbsence_name' =>
+        presence_activity_permanentAbsence_name,
+      'presence_activity_sleeping_name' => presence_activity_sleeping_name,
+      'presence_activity_travel_name' => presence_activity_travel_name,
+      'presence_activity_vacation_name' => presence_activity_vacation_name,
+      'presence_infoView_activity' => presence_infoView_activity,
+      'presence_infoView_available' => presence_infoView_available,
+      'presence_infoView_available_false' => presence_infoView_available_false,
+      'presence_infoView_available_true' => presence_infoView_available_true,
+      'presence_infoView_client' => presence_infoView_client,
+      'presence_infoView_device' => presence_infoView_device,
+      'presence_infoView_localTime' => presence_infoView_localTime,
+      'presence_infoView_note' => presence_infoView_note,
+      'presence_infoView_statusIcon' => presence_infoView_statusIcon,
+      'presence_infoView_timeZone' => presence_infoView_timeZone,
+      'presence_infoView_title' => presence_infoView_title,
+      'presence_infoView_updated' => presence_infoView_updated,
+      'presence_infoView_source_direct' => presence_infoView_source_direct,
+      'presence_infoView_source_sip' => presence_infoView_source_sip,
+      'presence_infoView_source_sipAndDirect' =>
+        presence_infoView_source_sipAndDirect,
+      'presence_preset_absent_name' => presence_preset_absent_name,
+      'presence_preset_absent_note' => presence_preset_absent_note,
+      'presence_preset_appointment_name' => presence_preset_appointment_name,
+      'presence_preset_appointment_note' => presence_preset_appointment_note,
+      'presence_preset_available_name' => presence_preset_available_name,
+      'presence_preset_away_name' => presence_preset_away_name,
+      'presence_preset_away_note' => presence_preset_away_note,
+      'presence_preset_dnd_name' => presence_preset_dnd_name,
+      'presence_preset_dnd_note' => presence_preset_dnd_note,
+      'presence_preset_inTransit_name' => presence_preset_inTransit_name,
+      'presence_preset_inTransit_note' => presence_preset_inTransit_note,
+      'presence_preset_meal_name' => presence_preset_meal_name,
+      'presence_preset_meal_note' => presence_preset_meal_note,
+      'presence_preset_meeting_name' => presence_preset_meeting_name,
+      'presence_preset_meeting_note' => presence_preset_meeting_note,
+      'presence_preset_sleeping_name' => presence_preset_sleeping_name,
+      'presence_preset_sleeping_note' => presence_preset_sleeping_note,
+      'presence_preset_travel_name' => presence_preset_travel_name,
+      'presence_preset_travel_note' => presence_preset_travel_note,
+      'presence_preset_unavailable_name' => presence_preset_unavailable_name,
+      'presence_preset_vacation_name' => presence_preset_vacation_name,
+      'presence_preset_vacation_note' => presence_preset_vacation_note,
+      'presence_settings_activity_label' => presence_settings_activity_label,
+      'presence_settings_activity_tooltip' =>
+        presence_settings_activity_tooltip,
+      'presence_settings_availability_title' =>
+        presence_settings_availability_title,
+      'presence_settings_availability_tooltip' =>
+        presence_settings_availability_tooltip,
+      'presence_settings_config_title' => presence_settings_config_title,
+      'presence_settings_dnd_title' => presence_settings_dnd_title,
+      'presence_settings_dnd_tooltip' => presence_settings_dnd_tooltip,
+      'presence_settings_note_label' => presence_settings_note_label,
+      'presence_settings_note_tooltip' => presence_settings_note_tooltip,
+      'presence_settings_presets_label' => presence_settings_presets_label,
+      'presence_settings_presets_label_custom' =>
+        presence_settings_presets_label_custom,
+      'presence_settings_presets_title' => presence_settings_presets_title,
+      'presence_settings_statusIcon_none' => presence_settings_statusIcon_none,
+      'presence_settings_statusIcon_title' =>
+        presence_settings_statusIcon_title,
+      'recents_DeleteConfirmDialog_content' =>
+        recents_DeleteConfirmDialog_content,
+      'recents_DeleteConfirmDialog_title' => recents_DeleteConfirmDialog_title,
+      'recents_HistoryTile_missedCallText' =>
+        recents_HistoryTile_missedCallText,
+      'recents_Text_blingTransferInitiated' =>
+        recents_Text_blingTransferInitiated,
+      'recentsVisibilityFilter_all' => recentsVisibilityFilter_all,
+      'recentsVisibilityFilter_all_preposit' =>
+        recentsVisibilityFilter_all_preposit,
+      'recentsVisibilityFilter_incoming' => recentsVisibilityFilter_incoming,
+      'recentsVisibilityFilter_incoming_preposit' =>
+        recentsVisibilityFilter_incoming_preposit,
+      'recentsVisibilityFilter_missed' => recentsVisibilityFilter_missed,
+      'recentsVisibilityFilter_missed_preposit' =>
+        recentsVisibilityFilter_missed_preposit,
+      'recentsVisibilityFilter_outgoing' => recentsVisibilityFilter_outgoing,
+      'recentsVisibilityFilter_outgoing_preposit' =>
+        recentsVisibilityFilter_outgoing_preposit,
+      'request_Id' => request_Id,
+      'request_StatusCode' => request_StatusCode,
+      'request_StatusName' => request_StatusName,
+      'sessionStatus_AppBar_waitingForNetwork' =>
+        sessionStatus_AppBar_waitingForNetwork,
+      'sessionStatus_AppBar_waitingForConnection' =>
+        sessionStatus_AppBar_waitingForConnection,
+      'sessionStatus_AppBar_disconnected' => sessionStatus_AppBar_disconnected,
+      'sessionStatus_AppBar_connecting' => sessionStatus_AppBar_connecting,
+      'sessionStatus_pushNotificationServiceProblem' =>
+        sessionStatus_pushNotificationServiceProblem,
+      'session_Teardown_progressText' => session_Teardown_progressText,
+      'settings_AboutText_ApplicationEmbeddedLinks' =>
+        settings_AboutText_ApplicationEmbeddedLinks,
+      'settings_AboutText_AppSessionIdentifier' =>
+        settings_AboutText_AppSessionIdentifier,
+      'settings_AboutText_AppVersion' => settings_AboutText_AppVersion,
+      'settings_AboutText_CoreVersion' => settings_AboutText_CoreVersion,
+      'settings_AboutText_CoreVersionUndefined' =>
+        settings_AboutText_CoreVersionUndefined,
+      'settings_AboutText_FCMPushNotificationToken' =>
+        settings_AboutText_FCMPushNotificationToken,
+      'settings_AboutText_StoreVersion' => settings_AboutText_StoreVersion,
+      'settings_AccountDeleteConfirmDialog_content' =>
+        settings_AccountDeleteConfirmDialog_content,
+      'settings_AccountDeleteConfirmDialog_title' =>
+        settings_AccountDeleteConfirmDialog_title,
+      'settings_AccountDeleteNotSupported_message' =>
+        settings_AccountDeleteNotSupported_message,
+      'settings_AppBarTitle_myAccount' => settings_AppBarTitle_myAccount,
+      'settings_audioProcessing_Section_AGC_title' =>
+        settings_audioProcessing_Section_AGC_title,
+      'settings_audioProcessing_Section_AM_title' =>
+        settings_audioProcessing_Section_AM_title,
+      'settings_audioProcessing_Section_EC_title' =>
+        settings_audioProcessing_Section_EC_title,
+      'settings_audioProcessing_Section_HPF_title' =>
+        settings_audioProcessing_Section_HPF_title,
+      'settings_audioProcessing_Section_NS_title' =>
+        settings_audioProcessing_Section_NS_title,
+      'settings_audioProcessing_Section_title' =>
+        settings_audioProcessing_Section_title,
+      'settings_audioProcessing_Section_tooltip' =>
+        settings_audioProcessing_Section_tooltip,
+      'settings_audioProcessing_Section_VP_title' =>
+        settings_audioProcessing_Section_VP_title,
+      'settings_call_codecs_preferred_audio_default' =>
+        settings_call_codecs_preferred_audio_default,
+      'settings_call_codecs_preferred_audio_tip' =>
+        settings_call_codecs_preferred_audio_tip,
+      'settings_call_codecs_preferred_audio_title' =>
+        settings_call_codecs_preferred_audio_title,
+      'settings_call_codecs_preferred_video_default' =>
+        settings_call_codecs_preferred_video_default,
+      'settings_call_codecs_preferred_video_tip' =>
+        settings_call_codecs_preferred_video_tip,
+      'settings_call_codecs_preferred_video_title' =>
+        settings_call_codecs_preferred_video_title,
+      'settings_callerId_cancel_button' => settings_callerId_cancel_button,
+      'settings_callerId_defaultTitle' => settings_callerId_defaultTitle,
+      'settings_callerId_dialcode' => settings_callerId_dialcode,
+      'settings_callerId_dialCodeMatching_title' =>
+        settings_callerId_dialCodeMatching_title,
+      'settings_callerId_duplicate_dialcode_error' =>
+        settings_callerId_duplicate_dialcode_error,
+      'settings_callerId_number' => settings_callerId_number,
+      'settings_callerId_number_hint' => settings_callerId_number_hint,
+      'settings_callerId_save_button' => settings_callerId_save_button,
+      'settings_connectionSection_title' => settings_connectionSection_title,
+      'settings_connectionSection_tooltip' =>
+        settings_connectionSection_tooltip,
+      'settings_encoding_AppBar_reset_tooltip' =>
+        settings_encoding_AppBar_reset_tooltip,
+      'settings_encoding_Section_audio_ptime' =>
+        settings_encoding_Section_audio_ptime,
+      'settings_encoding_Section_audio_ptime_limit' =>
+        settings_encoding_Section_audio_ptime_limit,
+      'settings_encoding_Section_bandwidth_prefix' =>
+        settings_encoding_Section_bandwidth_prefix,
+      'settings_encoding_Section_bitrate_prefix' =>
+        settings_encoding_Section_bitrate_prefix,
+      'settings_encoding_Section_bitrate_title' =>
+        settings_encoding_Section_bitrate_title,
+      'settings_encoding_Section_bitrate_tooltip' =>
+        settings_encoding_Section_bitrate_tooltip,
+      'settings_encoding_Section_extra_sdp_mod_removeREMBFeedback' =>
+        settings_encoding_Section_extra_sdp_mod_removeREMBFeedback,
+      'settings_encoding_Section_extra_sdp_mod_removeREMBFeedback_tooltip' =>
+        settings_encoding_Section_extra_sdp_mod_removeREMBFeedback_tooltip,
+      'settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback' =>
+        settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback,
+      'settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback_tooltip' =>
+        settings_encoding_Section_extra_sdp_mod_removeTWCCFeedback_tooltip,
+      'settings_encoding_Section_rtp_extensions_title' =>
+        settings_encoding_Section_rtp_extensions_title,
+      'settings_encoding_Section_rtp_extensions_tooltip' =>
+        settings_encoding_Section_rtp_extensions_tooltip,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_twcc' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_twcc,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_absSendTime' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_absSendTime,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_playoutDelay' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_playoutDelay,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_videoContentType' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_videoContentType,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_videoTiming' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_videoTiming,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_colorSpace' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_colorSpace,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_audioLevel' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_audioLevel,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_tOffset' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_tOffset,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_videoOrientation' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_videoOrientation,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_rtpStreamId' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_rtpStreamId,
+      'settings_encoding_Section_extra_sdp_mod_removeExtmap_repairedRtpStreamId' =>
+        settings_encoding_Section_extra_sdp_mod_removeExtmap_repairedRtpStreamId,
+      'settings_encoding_Section_extra_sdp_mod_remapTE8' =>
+        settings_encoding_Section_extra_sdp_mod_remapTE8,
+      'settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip' =>
+        settings_encoding_Section_extra_sdp_mod_remapTE8_tooltip,
+      'settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps' =>
+        settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps,
+      'settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip' =>
+        settings_encoding_Section_extra_sdp_mod_removeStaticRtpmaps_tooltip,
+      'settings_encoding_Section_extra_sdp_mod_title' =>
+        settings_encoding_Section_extra_sdp_mod_title,
+      'settings_encoding_Section_measure_hz' =>
+        settings_encoding_Section_measure_hz,
+      'settings_encoding_Section_measure_kbps' =>
+        settings_encoding_Section_measure_kbps,
+      'settings_encoding_Section_measure_ms' =>
+        settings_encoding_Section_measure_ms,
+      'settings_encoding_Section_opus_bandwidth' =>
+        settings_encoding_Section_opus_bandwidth,
+      'settings_encoding_Section_opus_bitrate' =>
+        settings_encoding_Section_opus_bitrate,
+      'settings_encoding_Section_opus_channels' =>
+        settings_encoding_Section_opus_channels,
+      'settings_encoding_Section_opus_dtx' =>
+        settings_encoding_Section_opus_dtx,
+      'settings_encoding_Section_opus_samplingRate' =>
+        settings_encoding_Section_opus_samplingRate,
+      'settings_encoding_Section_opus_title' =>
+        settings_encoding_Section_opus_title,
+      'settings_encoding_Section_opus_tooltip' =>
+        settings_encoding_Section_opus_tooltip,
+      'settings_encoding_Section_packetization_title' =>
+        settings_encoding_Section_packetization_title,
+      'settings_encoding_Section_packetization_tooltip' =>
+        settings_encoding_Section_packetization_tooltip,
+      'settings_encoding_Section_packetization_warning_title' =>
+        settings_encoding_Section_packetization_warning_title,
+      'settings_encoding_Section_packetization_warning_message' =>
+        settings_encoding_Section_packetization_warning_message,
+      'settings_encoding_Section_preset' => settings_encoding_Section_preset,
+      'settings_encoding_Section_preset_balance' =>
+        settings_encoding_Section_preset_balance,
+      'settings_encoding_Section_preset_balance_tooltip' =>
+        settings_encoding_Section_preset_balance_tooltip,
+      'settings_encoding_Section_preset_eco' =>
+        settings_encoding_Section_preset_eco,
+      'settings_encoding_Section_preset_eco_tooltip' =>
+        settings_encoding_Section_preset_eco_tooltip,
+      'settings_encoding_Section_preset_custom' =>
+        settings_encoding_Section_preset_custom,
+      'settings_encoding_Section_preset_custom_tooltip' =>
+        settings_encoding_Section_preset_custom_tooltip,
+      'settings_encoding_Section_preset_default' =>
+        settings_encoding_Section_preset_default,
+      'settings_encoding_Section_preset_default_tooltip' =>
+        settings_encoding_Section_preset_default_tooltip,
+      'settings_encoding_Section_preset_bypass' =>
+        settings_encoding_Section_preset_bypass,
+      'settings_encoding_Section_preset_bypass_tooltip' =>
+        settings_encoding_Section_preset_bypass_tooltip,
+      'settings_encoding_Section_preset_full_flex' =>
+        settings_encoding_Section_preset_full_flex,
+      'settings_encoding_Section_preset_quality' =>
+        settings_encoding_Section_preset_quality,
+      'settings_encoding_Section_preset_quality_tooltip' =>
+        settings_encoding_Section_preset_quality_tooltip,
+      'settings_encoding_Section_preset_title' =>
+        settings_encoding_Section_preset_title,
+      'settings_encoding_Section_preset_tooltip' =>
+        settings_encoding_Section_preset_tooltip,
+      'settings_encoding_Section_ptime_prefix' =>
+        settings_encoding_Section_ptime_prefix,
+      'settings_encoding_Section_rtp_override_audio' =>
+        settings_encoding_Section_rtp_override_audio,
+      'settings_encoding_Section_rtp_override_title' =>
+        settings_encoding_Section_rtp_override_title,
+      'settings_encoding_Section_rtp_override_tooltip' =>
+        settings_encoding_Section_rtp_override_tooltip,
+      'settings_encoding_Section_rtp_override_video' =>
+        settings_encoding_Section_rtp_override_video,
+      'settings_encoding_Section_rtp_override_warning_message' =>
+        settings_encoding_Section_rtp_override_warning_message,
+      'settings_encoding_Section_rtp_override_warning_title' =>
+        settings_encoding_Section_rtp_override_warning_title,
+      'settings_encoding_Section_target_audio_bitrate' =>
+        settings_encoding_Section_target_audio_bitrate,
+      'settings_encoding_Section_target_video_bitrate' =>
+        settings_encoding_Section_target_video_bitrate,
+      'settings_encoding_Section_value_auto' =>
+        settings_encoding_Section_value_auto,
+      'settings_encoding_Section_value_disable' =>
+        settings_encoding_Section_value_disable,
+      'settings_encoding_Section_value_enable' =>
+        settings_encoding_Section_value_enable,
+      'settings_encoding_Section_value_mono' =>
+        settings_encoding_Section_value_mono,
+      'settings_encoding_Section_value_off' =>
+        settings_encoding_Section_value_off,
+      'settings_encoding_Section_value_on' =>
+        settings_encoding_Section_value_on,
+      'settings_encoding_Section_value_stereo' =>
+        settings_encoding_Section_value_stereo,
+      'settings_iceSettings_Section_netfilter_skipv4' =>
+        settings_iceSettings_Section_netfilter_skipv4,
+      'settings_iceSettings_Section_netfilter_skipv6' =>
+        settings_iceSettings_Section_netfilter_skipv6,
+      'settings_iceSettings_Section_netfilter_title' =>
+        settings_iceSettings_Section_netfilter_title,
+      'settings_iceSettings_Section_noskip' =>
+        settings_iceSettings_Section_noskip,
+      'settings_iceSettings_Section_title' =>
+        settings_iceSettings_Section_title,
+      'settings_iceSettings_Section_tooltip' =>
+        settings_iceSettings_Section_tooltip,
+      'settings_iceSettings_Section_trfilter_skipTcp' =>
+        settings_iceSettings_Section_trfilter_skipTcp,
+      'settings_iceSettings_Section_trfilter_skipUdp' =>
+        settings_iceSettings_Section_trfilter_skipUdp,
+      'settings_iceSettings_Section_trfilter_title' =>
+        settings_iceSettings_Section_trfilter_title,
+      'settings_ListViewTileTitle_about' => settings_ListViewTileTitle_about,
+      'settings_ListViewTileTitle_accountDelete' =>
+        settings_ListViewTileTitle_accountDelete,
+      'settings_ListViewTileTitle_call_codecs' =>
+        settings_ListViewTileTitle_call_codecs,
+      'settings_ListViewTileTitle_callerId' =>
+        settings_ListViewTileTitle_callerId,
+      'settings_ListViewTileTitle_encoding' =>
+        settings_ListViewTileTitle_encoding,
+      'settings_ListViewTileTitle_features' =>
+        settings_ListViewTileTitle_features,
+      'settings_ListViewTileTitle_help' => settings_ListViewTileTitle_help,
+      'settings_ListViewTileTitle_language' =>
+        settings_ListViewTileTitle_language,
+      'settings_ListViewTileTitle_logout' => settings_ListViewTileTitle_logout,
+      'settings_ListViewTileTitle_logRecordsConsole' =>
+        settings_ListViewTileTitle_logRecordsConsole,
+      'settings_ListViewTileTitle_mediaSettings' =>
+        settings_ListViewTileTitle_mediaSettings,
+      'settings_ListViewTileTitle_network' =>
+        settings_ListViewTileTitle_network,
+      'settings_ListViewTileTitle_presence' =>
+        settings_ListViewTileTitle_presence,
+      'settings_ListViewTileTitle_registered' =>
+        settings_ListViewTileTitle_registered,
+      'settings_ListViewTileTitle_self_config' =>
+        settings_ListViewTileTitle_self_config,
+      'settings_ListViewTileTitle_settings' =>
+        settings_ListViewTileTitle_settings,
+      'settings_ListViewTileTitle_termsConditions' =>
+        settings_ListViewTileTitle_termsConditions,
+      'settings_ListViewTileTitle_themeMode' =>
+        settings_ListViewTileTitle_themeMode,
+      'settings_ListViewTileTitle_toolbox' =>
+        settings_ListViewTileTitle_toolbox,
+      'settings_ListViewTileTitle_voicemail' =>
+        settings_ListViewTileTitle_voicemail,
+      'settings_LogoutConfirmDialog_content' =>
+        settings_LogoutConfirmDialog_content,
+      'settings_LogoutConfirmDialog_title' =>
+        settings_LogoutConfirmDialog_title,
+      'settings_missingMicrophoneIndicator_title' =>
+        settings_missingMicrophoneIndicator_title,
+      'settings_network_fallbackCalls_description' =>
+        settings_network_fallbackCalls_description,
+      'settings_network_fallbackCalls_title' =>
+        settings_network_fallbackCalls_title,
+      'settings_network_incomingCallType_pushNotification_description' =>
+        settings_network_incomingCallType_pushNotification_description,
+      'settings_network_incomingCallType_pushNotification_title' =>
+        settings_network_incomingCallType_pushNotification_title,
+      'settings_network_incomingCallType_socket_description' =>
+        settings_network_incomingCallType_socket_description,
+      'settings_network_incomingCallType_socket_title' =>
+        settings_network_incomingCallType_socket_title,
+      'settings_network_incomingCallType_title' =>
+        settings_network_incomingCallType_title,
+      'settings_network_smsFallback_toggle' =>
+        settings_network_smsFallback_toggle,
+      'settings_videoCapturing_Section_framerate_prefix' =>
+        settings_videoCapturing_Section_framerate_prefix,
+      'settings_videoCapturing_Section_framerate_title' =>
+        settings_videoCapturing_Section_framerate_title,
+      'settings_videoCapturing_Section_resolution_prefix' =>
+        settings_videoCapturing_Section_resolution_prefix,
+      'settings_videoCapturing_Section_resolution_title' =>
+        settings_videoCapturing_Section_resolution_title,
+      'settings_videoCapturing_Section_title' =>
+        settings_videoCapturing_Section_title,
+      'settings_videoCapturing_Section_tooltip' =>
+        settings_videoCapturing_Section_tooltip,
+      'settings_videoOffer_option_ignore' => settings_videoOffer_option_ignore,
+      'settings_videoOffer_option_includeInactive' =>
+        settings_videoOffer_option_includeInactive,
+      'settings_videoOffer_title' => settings_videoOffer_title,
+      'signalingResponseCode_ambiguousRequest' =>
+        signalingResponseCode_ambiguousRequest,
+      'signalingResponseCode_busyEverywhere' =>
+        signalingResponseCode_busyEverywhere,
+      'signalingResponseCode_callNotExist' =>
+        signalingResponseCode_callNotExist,
+      'signalingResponseCode_declineCall' => signalingResponseCode_declineCall,
+      'signalingResponseCode_errorAttachingPlugin' =>
+        signalingResponseCode_errorAttachingPlugin,
+      'signalingResponseCode_errorDetachingPlugin' =>
+        signalingResponseCode_errorDetachingPlugin,
+      'signalingResponseCode_errorSendingMessage' =>
+        signalingResponseCode_errorSendingMessage,
+      'signalingResponseCode_exchangeRoutingError' =>
+        signalingResponseCode_exchangeRoutingError,
+      'signalingResponseCode_handleNotFound' =>
+        signalingResponseCode_handleNotFound,
+      'signalingResponseCode_incompatibleDestination' =>
+        signalingResponseCode_incompatibleDestination,
+      'signalingResponseCode_invalidElementType' =>
+        signalingResponseCode_invalidElementType,
+      'signalingResponseCode_invalidJson' => signalingResponseCode_invalidJson,
+      'signalingResponseCode_invalidJsonObject' =>
+        signalingResponseCode_invalidJsonObject,
+      'signalingResponseCode_invalidNumberFormat' =>
+        signalingResponseCode_invalidNumberFormat,
+      'signalingResponseCode_invalidPath' => signalingResponseCode_invalidPath,
+      'signalingResponseCode_invalidSdp' => signalingResponseCode_invalidSdp,
+      'signalingResponseCode_invalidStream' =>
+        signalingResponseCode_invalidStream,
+      'signalingResponseCode_loopDetected' =>
+        signalingResponseCode_loopDetected,
+      'signalingResponseCode_missingMandatoryElement' =>
+        signalingResponseCode_missingMandatoryElement,
+      'signalingResponseCode_missingRequest' =>
+        signalingResponseCode_missingRequest,
+      'signalingResponseCode_normalUnspecified' =>
+        signalingResponseCode_normalUnspecified,
+      'signalingResponseCode_notAcceptable' =>
+        signalingResponseCode_notAcceptable,
+      'signalingResponseCode_notAcceptingNewSessions' =>
+        signalingResponseCode_notAcceptingNewSessions,
+      'signalingResponseCode_notFoundRoutesInReplyFromBE' =>
+        signalingResponseCode_notFoundRoutesInReplyFromBE,
+      'signalingResponseCode_pluginNotFound' =>
+        signalingResponseCode_pluginNotFound,
+      'signalingResponseCode_rejected' => signalingResponseCode_rejected,
+      'signalingResponseCode_requestTerminated' =>
+        signalingResponseCode_requestTerminated,
+      'signalingResponseCode_sessionIdInUse' =>
+        signalingResponseCode_sessionIdInUse,
+      'signalingResponseCode_sessionNotFound' =>
+        signalingResponseCode_sessionNotFound,
+      'signalingResponseCode_tokenNotFound' =>
+        signalingResponseCode_tokenNotFound,
+      'signalingResponseCode_transportSpecificError' =>
+        signalingResponseCode_transportSpecificError,
+      'signalingResponseCodeType_callHangup' =>
+        signalingResponseCodeType_callHangup,
+      'signalingResponseCodeType_plugin' => signalingResponseCodeType_plugin,
+      'signalingResponseCodeType_request' => signalingResponseCodeType_request,
+      'signalingResponseCodeType_session' => signalingResponseCodeType_session,
+      'signalingResponseCodeType_token' => signalingResponseCodeType_token,
+      'signalingResponseCodeType_transport' =>
+        signalingResponseCodeType_transport,
+      'signalingResponseCodeType_unauthorized' =>
+        signalingResponseCodeType_unauthorized,
+      'signalingResponseCodeType_unknown' => signalingResponseCodeType_unknown,
+      'signalingResponseCodeType_webrtc' => signalingResponseCodeType_webrtc,
+      'signalingResponseCode_unauthorizedAccess' =>
+        signalingResponseCode_unauthorizedAccess,
+      'signalingResponseCode_unauthorizedRequest' =>
+        signalingResponseCode_unauthorizedRequest,
+      'signalingResponseCode_unexpectedAnswer' =>
+        signalingResponseCode_unexpectedAnswer,
+      'signalingResponseCode_unknownError' =>
+        signalingResponseCode_unknownError,
+      'signalingResponseCode_unknownRequest' =>
+        signalingResponseCode_unknownRequest,
+      'signalingResponseCode_unsupportedJsepType' =>
+        signalingResponseCode_unsupportedJsepType,
+      'signalingResponseCode_unwanted' => signalingResponseCode_unwanted,
+      'signalingResponseCode_userBusy' => signalingResponseCode_userBusy,
+      'signalingResponseCode_userNotExist' =>
+        signalingResponseCode_userNotExist,
+      'signalingResponseCode_wrongWebrtcState' =>
+        signalingResponseCode_wrongWebrtcState,
+      'socketError_connectionRefused' => socketError_connectionRefused,
+      'socketError_connectionRefusedDescription' =>
+        socketError_connectionRefusedDescription,
+      'socketError_connectionReset' => socketError_connectionReset,
+      'socketError_connectionResetDescription' =>
+        socketError_connectionResetDescription,
+      'socketError_connectionTimedOut' => socketError_connectionTimedOut,
+      'socketError_connectionTimedOutDescription' =>
+        socketError_connectionTimedOutDescription,
+      'socketError_default' => socketError_default,
+      'socketError_networkUnreachable' => socketError_networkUnreachable,
+      'socketError_networkUnreachableDescription' =>
+        socketError_networkUnreachableDescription,
+      'socketError_serverUnreachable' => socketError_serverUnreachable,
+      'socketError_serverUnreachableDescription' =>
+        socketError_serverUnreachableDescription,
+      'system_notifications_screen_list_empty' =>
+        system_notifications_screen_list_empty,
+      'system_notifications_screen_title' => system_notifications_screen_title,
+      'themeMode_dark' => themeMode_dark,
+      'themeMode_light' => themeMode_light,
+      'themeMode_system' => themeMode_system,
+      'undefined_autoprovision_invalidToken' =>
+        undefined_autoprovision_invalidToken,
+      'undefined_autoprovision_invalidToken_title' =>
+        undefined_autoprovision_invalidToken_title,
+      'undefined_stackScreenNotSupported' => undefined_stackScreenNotSupported,
+      'undefined_stackScreenNotSupported_title' =>
+        undefined_stackScreenNotSupported_title,
+      'user_agreement_agrement_link' => user_agreement_agrement_link,
+      'user_agreement_button_text' => user_agreement_button_text,
+      'validationBlankError' => validationBlankError,
+      'voicemail_Description_notSupported' =>
+        voicemail_Description_notSupported,
+      'voicemail_Dialog_deleteSelectedContent' =>
+        voicemail_Dialog_deleteSelectedContent,
+      'voicemail_Dialog_deleteSelectedTitle' =>
+        voicemail_Dialog_deleteSelectedTitle,
+      'voicemail_Dialog_deleteSingleContent' =>
+        voicemail_Dialog_deleteSingleContent,
+      'voicemail_Dialog_deleteSingleTitle' =>
+        voicemail_Dialog_deleteSingleTitle,
+      'voicemail_Label_call' => voicemail_Label_call,
+      'voicemail_Label_delete' => voicemail_Label_delete,
+      'voicemail_Label_deleteAll' => voicemail_Label_deleteAll,
+      'voicemail_Label_deleteAllDescription' =>
+        voicemail_Label_deleteAllDescription,
+      'voicemail_Label_empty' => voicemail_Label_empty,
+      'voicemail_Label_markAsHeard' => voicemail_Label_markAsHeard,
+      'voicemail_Label_markAsNew' => voicemail_Label_markAsNew,
+      'voicemail_Label_playbackError' => voicemail_Label_playbackError,
+      'voicemail_Label_retry' => voicemail_Label_retry,
+      'voicemail_Snackbar_notConfigured' => voicemail_Snackbar_notConfigured,
+      'voicemail_Title_notSupported' => voicemail_Title_notSupported,
+      'voicemail_Widget_screenTitle' => voicemail_Widget_screenTitle,
+      'webRegistration_ErrorAcknowledgeDialogActions_retry' =>
+        webRegistration_ErrorAcknowledgeDialogActions_retry,
+      'webRegistration_ErrorAcknowledgeDialogActions_skip' =>
+        webRegistration_ErrorAcknowledgeDialogActions_skip,
+      'webRegistration_ErrorAcknowledgeDialog_title' =>
+        webRegistration_ErrorAcknowledgeDialog_title,
+      'webview_defaultError_reload' => webview_defaultError_reload,
+      'webview_defaultError_title' => webview_defaultError_title,
+      'webview_sslError_details' => webview_sslError_details,
+      'webview_sslError_details_type' => webview_sslError_details_type,
+      'webview_sslError_details_url' => webview_sslError_details_url,
+      'webview_sslError_message' => webview_sslError_message,
+      'webview_sslError_title' => webview_sslError_title,
+      'webview_sslError_tryAgain' => webview_sslError_tryAgain,
+      'cdr_disconnectReason_unknown' => cdr_disconnectReason_unknown,
+      'cdr_disconnectReason_validCauseCodeNotYetReceived' =>
+        cdr_disconnectReason_validCauseCodeNotYetReceived,
+      'cdr_disconnectReason_unallocatedNumber' =>
+        cdr_disconnectReason_unallocatedNumber,
+      'cdr_disconnectReason_noRouteToSpecifiedTransitNetworkWan' =>
+        cdr_disconnectReason_noRouteToSpecifiedTransitNetworkWan,
+      'cdr_disconnectReason_noRouteToDestination' =>
+        cdr_disconnectReason_noRouteToDestination,
+      'cdr_disconnectReason_sendSpecialInformationTone' =>
+        cdr_disconnectReason_sendSpecialInformationTone,
+      'cdr_disconnectReason_misdialledTrunkPrefix' =>
+        cdr_disconnectReason_misdialledTrunkPrefix,
+      'cdr_disconnectReason_channelUnacceptable' =>
+        cdr_disconnectReason_channelUnacceptable,
+      'cdr_disconnectReason_callAwardedAndBeingDeliveredInAnEstablishedChannel' =>
+        cdr_disconnectReason_callAwardedAndBeingDeliveredInAnEstablishedChannel,
+      'cdr_disconnectReason_prefix0DialedButNotAllowedPreemption' =>
+        cdr_disconnectReason_prefix0DialedButNotAllowedPreemption,
+      'cdr_disconnectReason_prefix1DialedButNotAllowedPreemptionReserved' =>
+        cdr_disconnectReason_prefix1DialedButNotAllowedPreemptionReserved,
+      'cdr_disconnectReason_prefix1DialedButNotRequired' =>
+        cdr_disconnectReason_prefix1DialedButNotRequired,
+      'cdr_disconnectReason_moreDigitsReceivedThanAllowedCallIsProceeding' =>
+        cdr_disconnectReason_moreDigitsReceivedThanAllowedCallIsProceeding,
+      'cdr_disconnectReason_normalCallClearing' =>
+        cdr_disconnectReason_normalCallClearing,
+      'cdr_disconnectReason_userBusy' => cdr_disconnectReason_userBusy,
+      'cdr_disconnectReason_noUserResponding' =>
+        cdr_disconnectReason_noUserResponding,
+      'cdr_disconnectReason_noAnswerFromUser' =>
+        cdr_disconnectReason_noAnswerFromUser,
+      'cdr_disconnectReason_subscriberIsAbsent' =>
+        cdr_disconnectReason_subscriberIsAbsent,
+      'cdr_disconnectReason_callRejected' => cdr_disconnectReason_callRejected,
+      'cdr_disconnectReason_numberChanged' =>
+        cdr_disconnectReason_numberChanged,
+      'cdr_disconnectReason_reverseChargingRejected' =>
+        cdr_disconnectReason_reverseChargingRejected,
+      'cdr_disconnectReason_callSuspended' =>
+        cdr_disconnectReason_callSuspended,
+      'cdr_disconnectReason_callResumed' => cdr_disconnectReason_callResumed,
+      'cdr_disconnectReason_nonSelectedUserClearing' =>
+        cdr_disconnectReason_nonSelectedUserClearing,
+      'cdr_disconnectReason_destinationOutOfOrder' =>
+        cdr_disconnectReason_destinationOutOfOrder,
+      'cdr_disconnectReason_invalidNumberFormatIncompleteNumber' =>
+        cdr_disconnectReason_invalidNumberFormatIncompleteNumber,
+      'cdr_disconnectReason_facilityRejected' =>
+        cdr_disconnectReason_facilityRejected,
+      'cdr_disconnectReason_responseToStatusEnquiry' =>
+        cdr_disconnectReason_responseToStatusEnquiry,
+      'cdr_disconnectReason_normalUnspecified' =>
+        cdr_disconnectReason_normalUnspecified,
+      'cdr_disconnectReason_circuitOutOfOrder' =>
+        cdr_disconnectReason_circuitOutOfOrder,
+      'cdr_disconnectReason_noCircuitChannelAvailable' =>
+        cdr_disconnectReason_noCircuitChannelAvailable,
+      'cdr_disconnectReason_destinationUnattainableRequireVpciVciIsNotAvailable' =>
+        cdr_disconnectReason_destinationUnattainableRequireVpciVciIsNotAvailable,
+      'cdr_disconnectReason_vpciVciAssignmentFailure' =>
+        cdr_disconnectReason_vpciVciAssignmentFailure,
+      'cdr_disconnectReason_degradedServiceCallRateIsnNotValid' =>
+        cdr_disconnectReason_degradedServiceCallRateIsnNotValid,
+      'cdr_disconnectReason_networkWanOutOfOrder' =>
+        cdr_disconnectReason_networkWanOutOfOrder,
+      'cdr_disconnectReason_transitDelayRangeCannotBeAchievedPermanentFrameModeIsOutOfService' =>
+        cdr_disconnectReason_transitDelayRangeCannotBeAchievedPermanentFrameModeIsOutOfService,
+      'cdr_disconnectReason_throughputRangeCannotBeAchievedPermanentFrameModeIsOperational' =>
+        cdr_disconnectReason_throughputRangeCannotBeAchievedPermanentFrameModeIsOperational,
+      'cdr_disconnectReason_temporaryFailure' =>
+        cdr_disconnectReason_temporaryFailure,
+      'cdr_disconnectReason_switchingEquipmentCongestion' =>
+        cdr_disconnectReason_switchingEquipmentCongestion,
+      'cdr_disconnectReason_accessInformationDiscarded' =>
+        cdr_disconnectReason_accessInformationDiscarded,
+      'cdr_disconnectReason_requestedCircuitChannelNotAvailable' =>
+        cdr_disconnectReason_requestedCircuitChannelNotAvailable,
+      'cdr_disconnectReason_preEmptedNoVpciVciIsAvailable' =>
+        cdr_disconnectReason_preEmptedNoVpciVciIsAvailable,
+      'cdr_disconnectReason_precedenceCallBlocked' =>
+        cdr_disconnectReason_precedenceCallBlocked,
+      'cdr_disconnectReason_resourceUnavailableUnspecified' =>
+        cdr_disconnectReason_resourceUnavailableUnspecified,
+      'cdr_disconnectReason_dspError' => cdr_disconnectReason_dspError,
+      'cdr_disconnectReason_qualityOfServiceUnavailable' =>
+        cdr_disconnectReason_qualityOfServiceUnavailable,
+      'cdr_disconnectReason_requestedFacilityNotSubscribed' =>
+        cdr_disconnectReason_requestedFacilityNotSubscribed,
+      'cdr_disconnectReason_reverseChargingNotAllowed' =>
+        cdr_disconnectReason_reverseChargingNotAllowed,
+      'cdr_disconnectReason_outgoingCallsBarred' =>
+        cdr_disconnectReason_outgoingCallsBarred,
+      'cdr_disconnectReason_outgoingCallsBarredWithinCug' =>
+        cdr_disconnectReason_outgoingCallsBarredWithinCug,
+      'cdr_disconnectReason_incomingCallsBarred' =>
+        cdr_disconnectReason_incomingCallsBarred,
+      'cdr_disconnectReason_incomingCallsBarredWithinCug' =>
+        cdr_disconnectReason_incomingCallsBarredWithinCug,
+      'cdr_disconnectReason_callWaitingNotSubscribed' =>
+        cdr_disconnectReason_callWaitingNotSubscribed,
+      'cdr_disconnectReason_bearerCapabilityNotAuthorized' =>
+        cdr_disconnectReason_bearerCapabilityNotAuthorized,
+      'cdr_disconnectReason_bearerCapabilityNotPresentlyAvailable' =>
+        cdr_disconnectReason_bearerCapabilityNotPresentlyAvailable,
+      'cdr_disconnectReason_inconsistancyInTheInformationAndClass' =>
+        cdr_disconnectReason_inconsistancyInTheInformationAndClass,
+      'cdr_disconnectReason_serviceOrOptionNotAvailableUnspecified' =>
+        cdr_disconnectReason_serviceOrOptionNotAvailableUnspecified,
+      'cdr_disconnectReason_bearerServiceNotImplemented' =>
+        cdr_disconnectReason_bearerServiceNotImplemented,
+      'cdr_disconnectReason_channelTypeNotImplemented' =>
+        cdr_disconnectReason_channelTypeNotImplemented,
+      'cdr_disconnectReason_transitNetworkSelectionNotImplemented' =>
+        cdr_disconnectReason_transitNetworkSelectionNotImplemented,
+      'cdr_disconnectReason_messageNotImplemented' =>
+        cdr_disconnectReason_messageNotImplemented,
+      'cdr_disconnectReason_requestedFacilityNotImplemented' =>
+        cdr_disconnectReason_requestedFacilityNotImplemented,
+      'cdr_disconnectReason_onlyRestrictedDigitalInformationBearerCapabilityIsAvailable' =>
+        cdr_disconnectReason_onlyRestrictedDigitalInformationBearerCapabilityIsAvailable,
+      'cdr_disconnectReason_serviceOrOptionNotImplementedUnspecified' =>
+        cdr_disconnectReason_serviceOrOptionNotImplementedUnspecified,
+      'cdr_disconnectReason_invalidCallReferenceValue' =>
+        cdr_disconnectReason_invalidCallReferenceValue,
+      'cdr_disconnectReason_identifiedChannelDoesNotExist' =>
+        cdr_disconnectReason_identifiedChannelDoesNotExist,
+      'cdr_disconnectReason_aSuspendedCallExistsButThisCallIdentityDoesNot' =>
+        cdr_disconnectReason_aSuspendedCallExistsButThisCallIdentityDoesNot,
+      'cdr_disconnectReason_callIdentityInUse' =>
+        cdr_disconnectReason_callIdentityInUse,
+      'cdr_disconnectReason_noCallSuspended' =>
+        cdr_disconnectReason_noCallSuspended,
+      'cdr_disconnectReason_callHavingTheRequestedCallIdentityHasBeenCleared' =>
+        cdr_disconnectReason_callHavingTheRequestedCallIdentityHasBeenCleared,
+      'cdr_disconnectReason_calledUserNotMemberOfCug' =>
+        cdr_disconnectReason_calledUserNotMemberOfCug,
+      'cdr_disconnectReason_incompatibleDestination' =>
+        cdr_disconnectReason_incompatibleDestination,
+      'cdr_disconnectReason_nonExistentAbbreviatedAddressEntry' =>
+        cdr_disconnectReason_nonExistentAbbreviatedAddressEntry,
+      'cdr_disconnectReason_destinationAddressMissingAndDirectCallNotSubscribed' =>
+        cdr_disconnectReason_destinationAddressMissingAndDirectCallNotSubscribed,
+      'cdr_disconnectReason_invalidTransitNetworkSelectionNationalUse' =>
+        cdr_disconnectReason_invalidTransitNetworkSelectionNationalUse,
+      'cdr_disconnectReason_invalidFacilityParameter' =>
+        cdr_disconnectReason_invalidFacilityParameter,
+      'cdr_disconnectReason_mandatoryInformationElementIsMissingAalParameterIsNotSupported' =>
+        cdr_disconnectReason_mandatoryInformationElementIsMissingAalParameterIsNotSupported,
+      'cdr_disconnectReason_invalidMessageUnspecified' =>
+        cdr_disconnectReason_invalidMessageUnspecified,
+      'cdr_disconnectReason_mandatoryInformationElementIsMissing' =>
+        cdr_disconnectReason_mandatoryInformationElementIsMissing,
+      'cdr_disconnectReason_messageTypeNonExistentOrNotImplemented' =>
+        cdr_disconnectReason_messageTypeNonExistentOrNotImplemented,
+      'cdr_disconnectReason_messageNotCompatibleWithCallStateOrMessageTypeNonExistentOrNotImplemented' =>
+        cdr_disconnectReason_messageNotCompatibleWithCallStateOrMessageTypeNonExistentOrNotImplemented,
+      'cdr_disconnectReason_informationElementNonexistantOrNotImplemented' =>
+        cdr_disconnectReason_informationElementNonexistantOrNotImplemented,
+      'cdr_disconnectReason_invalidInformationElementContents' =>
+        cdr_disconnectReason_invalidInformationElementContents,
+      'cdr_disconnectReason_messageNotCompatibleWithCallState' =>
+        cdr_disconnectReason_messageNotCompatibleWithCallState,
+      'cdr_disconnectReason_recoveryOnTimerExpiry' =>
+        cdr_disconnectReason_recoveryOnTimerExpiry,
+      'cdr_disconnectReason_parameterNonExistentOrNotImplementedPassedOn' =>
+        cdr_disconnectReason_parameterNonExistentOrNotImplementedPassedOn,
+      'cdr_disconnectReason_urecognizedParameterMessageDiscarded' =>
+        cdr_disconnectReason_urecognizedParameterMessageDiscarded,
+      'cdr_disconnectReason_protocolErrorUnspecified' =>
+        cdr_disconnectReason_protocolErrorUnspecified,
+      'cdr_disconnectReason_internetworkingUnspecified' =>
+        cdr_disconnectReason_internetworkingUnspecified,
+      'cdr_disconnectReason_nextNodeIsUnreachable' =>
+        cdr_disconnectReason_nextNodeIsUnreachable,
+      'cdr_disconnectReason_holstTelephonyServiceProviderModuleHtspmIsOutOfService' =>
+        cdr_disconnectReason_holstTelephonyServiceProviderModuleHtspmIsOutOfService,
+      'cdr_disconnectReason_dtlTransitIsNotMyNodeId' =>
+        cdr_disconnectReason_dtlTransitIsNotMyNodeId,
+      'devTools_AppBarTitle' => devTools_AppBarTitle,
+      'devTools_signalingService_groupTitle' =>
+        devTools_signalingService_groupTitle,
+      'devTools_signalingService_simulateKill_title' =>
+        devTools_signalingService_simulateKill_title,
+      'devTools_signalingService_simulateKill_subtitle' =>
+        devTools_signalingService_simulateKill_subtitle,
+      'devTools_signalingService_simulateKill_confirmMessage' =>
+        devTools_signalingService_simulateKill_confirmMessage,
+      'devTools_signalingService_simulateKill_confirm' =>
+        devTools_signalingService_simulateKill_confirm,
+      'devTools_signalingService_simulateKill_cancel' =>
+        devTools_signalingService_simulateKill_cancel,
+      'agoTicker_daysAgo' => switch (args) {
+        [final int days] => agoTicker_daysAgo(days),
+        _ => throw ArgumentError('agoTicker_daysAgo requires 1 arguments'),
+      },
+      'agoTicker_hoursAgo' => switch (args) {
+        [final int hours] => agoTicker_hoursAgo(hours),
+        _ => throw ArgumentError('agoTicker_hoursAgo requires 1 arguments'),
+      },
+      'agoTicker_minutesAgo' => switch (args) {
+        [final int minutes] => agoTicker_minutesAgo(minutes),
+        _ => throw ArgumentError('agoTicker_minutesAgo requires 1 arguments'),
+      },
+      'agoTicker_secondsAgo' => switch (args) {
+        [final num seconds] => agoTicker_secondsAgo(seconds),
+        _ => throw ArgumentError('agoTicker_secondsAgo requires 1 arguments'),
+      },
+      'contacts_ContactTile_inCall' => switch (args) {
+        [final Object destination] => contacts_ContactTile_inCall(destination),
+        _ => throw ArgumentError(
+          'contacts_ContactTile_inCall requires 1 arguments',
+        ),
+      },
+      'default_UnknownExceptionError' => switch (args) {
+        [final String error] => default_UnknownExceptionError(error),
+        _ => throw ArgumentError(
+          'default_UnknownExceptionError requires 1 arguments',
+        ),
+      },
+      'diagnosticNetworkTestItem_subtitle_publicIps' => switch (args) {
+        [final String ips] => diagnosticNetworkTestItem_subtitle_publicIps(ips),
+        _ => throw ArgumentError(
+          'diagnosticNetworkTestItem_subtitle_publicIps requires 1 arguments',
+        ),
+      },
+      'favorites_SnackBar_deleted' => switch (args) {
+        [final String name] => favorites_SnackBar_deleted(name),
+        _ => throw ArgumentError(
+          'favorites_SnackBar_deleted requires 1 arguments',
+        ),
+      },
+      'formatPhone' => switch (args) {
+        [final String style, final String main, final String ext] =>
+          formatPhone(style, main, ext),
+        _ => throw ArgumentError('formatPhone requires 3 arguments'),
+      },
+      'login_Button_otpSigninVerifyRepeatInterval' => switch (args) {
+        [final int seconds] => login_Button_otpSigninVerifyRepeatInterval(
+          seconds,
+        ),
+        _ => throw ArgumentError(
+          'login_Button_otpSigninVerifyRepeatInterval requires 1 arguments',
+        ),
+      },
+      'login_Button_signupVerifyRepeatInterval' => switch (args) {
+        [final int seconds] => login_Button_signupVerifyRepeatInterval(seconds),
+        _ => throw ArgumentError(
+          'login_Button_signupVerifyRepeatInterval requires 1 arguments',
+        ),
+      },
+      'login_CoreVersionUnsupportedExceptionError' => switch (args) {
+        [final String actual, final String supportedConstraint] =>
+          login_CoreVersionUnsupportedExceptionError(
+            actual,
+            supportedConstraint,
           ),
-      'login_Text_otpSigninVerifyPreDescriptionUserRef': (userRef) =>
-          localizations.login_Text_otpSigninVerifyPreDescriptionUserRef(
-            userRef,
+        _ => throw ArgumentError(
+          'login_CoreVersionUnsupportedExceptionError requires 2 arguments',
+        ),
+      },
+      'login_Text_coreUrlAssignPostDescription' => switch (args) {
+        [final Object email] => login_Text_coreUrlAssignPostDescription(email),
+        _ => throw ArgumentError(
+          'login_Text_coreUrlAssignPostDescription requires 1 arguments',
+        ),
+      },
+      'login_Text_otpSigninVerifyPostDescriptionFromEmail' => switch (args) {
+        [final String email] =>
+          login_Text_otpSigninVerifyPostDescriptionFromEmail(email),
+        _ => throw ArgumentError(
+          'login_Text_otpSigninVerifyPostDescriptionFromEmail requires 1 arguments',
+        ),
+      },
+      'login_Text_otpSigninVerifyPreDescriptionUserRef' => switch (args) {
+        [final String userRef] =>
+          login_Text_otpSigninVerifyPreDescriptionUserRef(userRef),
+        _ => throw ArgumentError(
+          'login_Text_otpSigninVerifyPreDescriptionUserRef requires 1 arguments',
+        ),
+      },
+      'login_Text_signupVerifyPostDescriptionFromEmail' => switch (args) {
+        [final String email] => login_Text_signupVerifyPostDescriptionFromEmail(
+          email,
+        ),
+        _ => throw ArgumentError(
+          'login_Text_signupVerifyPostDescriptionFromEmail requires 1 arguments',
+        ),
+      },
+      'login_Text_signupVerifyPreDescriptionEmail' => switch (args) {
+        [final String email] => login_Text_signupVerifyPreDescriptionEmail(
+          email,
+        ),
+        _ => throw ArgumentError(
+          'login_Text_signupVerifyPreDescriptionEmail requires 1 arguments',
+        ),
+      },
+      'logRecordsConsole_Text_recordsCountHint' => switch (args) {
+        [final int count] => logRecordsConsole_Text_recordsCountHint(count),
+        _ => throw ArgumentError(
+          'logRecordsConsole_Text_recordsCountHint requires 1 arguments',
+        ),
+      },
+      'main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError' =>
+        switch (args) {
+          [final String actual, final String supportedConstraint] =>
+            main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
+              actual,
+              supportedConstraint,
+            ),
+          _ => throw ArgumentError(
+            'main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError requires 2 arguments',
           ),
-      'login_Text_signupVerifyPostDescriptionFromEmail': (email) =>
-          localizations.login_Text_signupVerifyPostDescriptionFromEmail(email),
-      'login_Text_signupVerifyPreDescriptionEmail': (email) =>
-          localizations.login_Text_signupVerifyPreDescriptionEmail(email),
-      'logRecordsConsole_Text_recordsCountHint': (count) =>
-          localizations.logRecordsConsole_Text_recordsCountHint(count),
-      'main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError':
-          (actual, supportedConstraint) => localizations
-              .main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError(
-                actual,
-                supportedConstraint,
-              ),
-      'messaging_ConversationBuilders_contactExtension': (extension) =>
-          localizations.messaging_ConversationBuilders_contactExtension(
-            extension,
+        },
+      'messaging_ConversationBuilders_contactExtension' => switch (args) {
+        [final String extension] =>
+          messaging_ConversationBuilders_contactExtension(extension),
+        _ => throw ArgumentError(
+          'messaging_ConversationBuilders_contactExtension requires 1 arguments',
+        ),
+      },
+      'notifications_errorSnackBar_signalingDisconnectWithCodeName' =>
+        switch (args) {
+          [final String codeName] =>
+            notifications_errorSnackBar_signalingDisconnectWithCodeName(
+              codeName,
+            ),
+          _ => throw ArgumentError(
+            'notifications_errorSnackBar_signalingDisconnectWithCodeName requires 1 arguments',
           ),
-      'notifications_errorSnackBar_signalingDisconnectWithCodeName':
-          (codeName) => localizations
-              .notifications_errorSnackBar_signalingDisconnectWithCodeName(
-                codeName,
-              ),
-      'notifications_errorSnackBar_signalingDisconnectWithSystemReason':
-          (reason) => localizations
-              .notifications_errorSnackBar_signalingDisconnectWithSystemReason(
-                reason,
-              ),
-      'notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason':
-          (reason) => localizations
-              .notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason(
-                reason,
-              ),
-      'numberActions_callFrom': (number) =>
-          localizations.numberActions_callFrom(number),
-      'presence_infoView_source': (source) =>
-          localizations.presence_infoView_source(source),
-      'recents_BodyCenter_empty': (filter) =>
-          localizations.recents_BodyCenter_empty(filter),
-      'recents_snackBar_deleted': (name) =>
-          localizations.recents_snackBar_deleted(name),
-      'recentTimeAfterMidnight': (time) =>
-          localizations.recentTimeAfterMidnight(time),
-      'recentTimeBeforeMidnight': (time) =>
-          localizations.recentTimeBeforeMidnight(time),
-      'socketError_defaultDescription': (errorCode) =>
-          localizations.socketError_defaultDescription(errorCode),
-      'user_agreement_checkbox_text': (url) =>
-          localizations.user_agreement_checkbox_text(url),
-      'user_agreement_description': (appName) =>
-          localizations.user_agreement_description(appName),
-      'webview_defaultError_details': (description, code) =>
-          localizations.webview_defaultError_details(description, code),
+        },
+      'notifications_errorSnackBar_signalingDisconnectWithSystemReason' =>
+        switch (args) {
+          [final String reason] =>
+            notifications_errorSnackBar_signalingDisconnectWithSystemReason(
+              reason,
+            ),
+          _ => throw ArgumentError(
+            'notifications_errorSnackBar_signalingDisconnectWithSystemReason requires 1 arguments',
+          ),
+        },
+      'notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason' =>
+        switch (args) {
+          [final String reason] =>
+            notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason(
+              reason,
+            ),
+          _ => throw ArgumentError(
+            'notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason requires 1 arguments',
+          ),
+        },
+      'numberActions_callFrom' => switch (args) {
+        [final String number] => numberActions_callFrom(number),
+        _ => throw ArgumentError('numberActions_callFrom requires 1 arguments'),
+      },
+      'presence_infoView_source' => switch (args) {
+        [final Object source] => presence_infoView_source(source),
+        _ => throw ArgumentError(
+          'presence_infoView_source requires 1 arguments',
+        ),
+      },
+      'recents_BodyCenter_empty' => switch (args) {
+        [final Object filter] => recents_BodyCenter_empty(filter),
+        _ => throw ArgumentError(
+          'recents_BodyCenter_empty requires 1 arguments',
+        ),
+      },
+      'recents_snackBar_deleted' => switch (args) {
+        [final String name] => recents_snackBar_deleted(name),
+        _ => throw ArgumentError(
+          'recents_snackBar_deleted requires 1 arguments',
+        ),
+      },
+      'recentTimeAfterMidnight' => switch (args) {
+        [final DateTime time] => recentTimeAfterMidnight(time),
+        _ => throw ArgumentError(
+          'recentTimeAfterMidnight requires 1 arguments',
+        ),
+      },
+      'recentTimeBeforeMidnight' => switch (args) {
+        [final DateTime time] => recentTimeBeforeMidnight(time),
+        _ => throw ArgumentError(
+          'recentTimeBeforeMidnight requires 1 arguments',
+        ),
+      },
+      'socketError_defaultDescription' => switch (args) {
+        [final int? errorCode] => socketError_defaultDescription(errorCode),
+        _ => throw ArgumentError(
+          'socketError_defaultDescription requires 1 arguments',
+        ),
+      },
+      'user_agreement_checkbox_text' => switch (args) {
+        [final Object url] => user_agreement_checkbox_text(url),
+        _ => throw ArgumentError(
+          'user_agreement_checkbox_text requires 1 arguments',
+        ),
+      },
+      'user_agreement_description' => switch (args) {
+        [final Object appName] => user_agreement_description(appName),
+        _ => throw ArgumentError(
+          'user_agreement_description requires 1 arguments',
+        ),
+      },
+      'webview_defaultError_details' => switch (args) {
+        [final String description, final int code] =>
+          webview_defaultError_details(description, code),
+        _ => throw ArgumentError(
+          'webview_defaultError_details requires 2 arguments',
+        ),
+      },
+      _ => null,
     };
+  }
+
+  String? parseL10n(String translationKey, {List<Object>? arguments}) {
+    final result = lookupKey(translationKey, arguments);
+    if (result == null) {
+      return null;
+    }
+    return result as String;
   }
 }

--- a/lib/repositories/contacts/contacts_local_data_source.dart
+++ b/lib/repositories/contacts/contacts_local_data_source.dart
@@ -230,7 +230,7 @@ class ContactsLocalDataSourceImpl implements ContactsLocalDataSource {
     final externalContactEmail = externalContact.email;
 
     // Cleanup old emails
-    final externalContactEmails = [if (externalContactEmail != null) externalContactEmail];
+    final externalContactEmails = [?externalContactEmail];
     await _appDatabase.contactEmailsDao.deleteOtherContactEmailsOfContactId(contactId, externalContactEmails);
 
     if (externalContactEmail != null) {

--- a/lib/widgets/no_data_placeholder.dart
+++ b/lib/widgets/no_data_placeholder.dart
@@ -107,9 +107,9 @@ class NoDataPlaceholder extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (iconWidget != null) iconWidget,
-          if (contentWidget != null) contentWidget,
-          if (actionsWidget != null) actionsWidget,
+          ?iconWidget,
+          ?contentWidget,
+          ?actionsWidget,
         ],
       ),
     );

--- a/lib/widgets/plain_list_tile.dart
+++ b/lib/widgets/plain_list_tile.dart
@@ -75,10 +75,10 @@ class PlainListTile extends StatelessWidget {
                   ),
                 ),
               ),
-              if (trailing != null) trailing!,
+              ?trailing,
             ],
           ),
-          if (bottom != null) bottom!,
+          ?bottom,
         ],
       ),
     );

--- a/packages/_http_client/pubspec.yaml
+++ b/packages/_http_client/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
     path: ../ssl_certificates
 
 dev_dependencies:
-  lints: ^6.0.0
+  lints: ^6.1.0

--- a/packages/_tcp_proxy/pubspec.yaml
+++ b/packages/_tcp_proxy/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
   meta: any
 
 dev_dependencies:
-  lints: any
+  lints: ^6.1.0

--- a/packages/_web_socket_channel/pubspec.yaml
+++ b/packages/_web_socket_channel/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
     path: ../ssl_certificates
 
 dev_dependencies:
-  lints: ^6.0.0
+  lints: ^6.1.0

--- a/packages/data/app_database/lib/src/app_database.g.dart
+++ b/packages/data/app_database/lib/src/app_database.g.dart
@@ -3694,9 +3694,6 @@ class $ChatMembersTableTable extends ChatMembersTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
   @override
@@ -4034,9 +4031,6 @@ class $ChatMessagesTableTable extends ChatMessagesTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _replyToIdMeta = const VerificationMeta(
     'replyToId',
@@ -4737,9 +4731,6 @@ class $ChatMessageSyncCursorTableTable extends ChatMessageSyncCursorTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   @override
   late final GeneratedColumnWithTypeConverter<MessageSyncCursorTypeEnum, String>
@@ -5035,9 +5026,6 @@ class $ChatMessageReadCursorTableTable extends ChatMessageReadCursorTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
   @override
@@ -5324,9 +5312,6 @@ class $ChatOutboxMessageTableTable extends ChatOutboxMessageTable
     true,
     type: DriftSqlType.int,
     requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _participantIdMeta = const VerificationMeta(
     'participantId',
@@ -5874,9 +5859,6 @@ class $ChatOutboxMessageEditTableTable extends ChatOutboxMessageEditTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _newContentMeta = const VerificationMeta(
     'newContent',
@@ -6237,9 +6219,6 @@ class $ChatOutboxMessageDeleteTableTable extends ChatOutboxMessageDeleteTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _sendAttemptsMeta = const VerificationMeta(
     'sendAttempts',
@@ -6524,9 +6503,6 @@ class $ChatOutboxReadCursorsTableTable extends ChatOutboxReadCursorsTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES chats (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _timestampUsecMeta = const VerificationMeta(
     'timestampUsec',
@@ -7205,9 +7181,6 @@ class $SmsMessagesTableTable extends SmsMessagesTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES sms_conversations (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _fromPhoneNumberMeta = const VerificationMeta(
     'fromPhoneNumber',
@@ -7875,9 +7848,6 @@ class $SmsMessageSyncCursorTableTable extends SmsMessageSyncCursorTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES sms_conversations (id) ON DELETE CASCADE',
-    ),
   );
   @override
   late final GeneratedColumnWithTypeConverter<SmsSyncCursorTypeEnum, String>
@@ -8182,9 +8152,6 @@ class $SmsMessageReadCursorTableTable extends SmsMessageReadCursorTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES sms_conversations (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
   @override
@@ -8478,9 +8445,6 @@ class $SmsOutboxMessagesTableTable extends SmsOutboxMessagesTable
     true,
     type: DriftSqlType.int,
     requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES sms_conversations (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _fromPhoneNumberMeta = const VerificationMeta(
     'fromPhoneNumber',
@@ -8990,9 +8954,6 @@ class $SmsOutboxMessageDeleteTableTable extends SmsOutboxMessageDeleteTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES sms_conversations (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _sendAttemptsMeta = const VerificationMeta(
     'sendAttempts',
@@ -9289,9 +9250,6 @@ class $SmsOutboxReadCursorsTableTable extends SmsOutboxReadCursorsTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES sms_conversations (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _timestampUsecMeta = const VerificationMeta(
     'timestampUsec',
@@ -12027,9 +11985,6 @@ class $SystemNotificationsOutboxTableTable
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES system_notifications (id) ON DELETE CASCADE',
-    ),
   );
   @override
   late final GeneratedColumnWithTypeConverter<SnOutboxDataActionType, String>
@@ -14756,129 +14711,6 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       ),
       result: [TableUpdate('contact_phones', kind: UpdateKind.delete)],
     ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('chat_members', kind: UpdateKind.delete)],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('chat_messages', kind: UpdateKind.delete)],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('chat_message_sync_cursors', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('chat_message_read_cursors', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('chat_outbox_messages', kind: UpdateKind.delete)],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('chat_outbox_message_edits', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('chat_outbox_message_deletes', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'chats',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('chat_outbox_read_cursors', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'sms_conversations',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('sms_messages', kind: UpdateKind.delete)],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'sms_conversations',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('sms_message_sync_cursors', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'sms_conversations',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('sms_message_read_cursors', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'sms_conversations',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('sms_outbox_messages', kind: UpdateKind.delete)],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'sms_conversations',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('sms_outbox_message_deletes', kind: UpdateKind.delete),
-      ],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'sms_conversations',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('sms_outbox_read_cursors', kind: UpdateKind.delete)],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'system_notifications',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [
-        TableUpdate('system_notifications_outbox', kind: UpdateKind.delete),
-      ],
-    ),
   ]);
 }
 
@@ -16880,226 +16712,6 @@ typedef $$ChatsTableTableUpdateCompanionBuilder =
       Value<DateTime> updatedAtRemote,
     });
 
-final class $$ChatsTableTableReferences
-    extends BaseReferences<_$AppDatabase, $ChatsTableTable, ChatData> {
-  $$ChatsTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
-
-  static MultiTypedResultKey<$ChatMembersTableTable, List<ChatMemberData>>
-  _chatMembersTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
-    db.chatMembersTable,
-    aliasName: $_aliasNameGenerator(
-      db.chatsTable.id,
-      db.chatMembersTable.chatId,
-    ),
-  );
-
-  $$ChatMembersTableTableProcessedTableManager get chatMembersTableRefs {
-    final manager = $$ChatMembersTableTableTableManager(
-      $_db,
-      $_db.chatMembersTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatMembersTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<$ChatMessagesTableTable, List<ChatMessageData>>
-  _chatMessagesTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.chatMessagesTable,
-        aliasName: $_aliasNameGenerator(
-          db.chatsTable.id,
-          db.chatMessagesTable.chatId,
-        ),
-      );
-
-  $$ChatMessagesTableTableProcessedTableManager get chatMessagesTableRefs {
-    final manager = $$ChatMessagesTableTableTableManager(
-      $_db,
-      $_db.chatMessagesTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatMessagesTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $ChatMessageSyncCursorTableTable,
-    List<ChatMessageSyncCursorData>
-  >
-  _chatMessageSyncCursorTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.chatMessageSyncCursorTable,
-        aliasName: $_aliasNameGenerator(
-          db.chatsTable.id,
-          db.chatMessageSyncCursorTable.chatId,
-        ),
-      );
-
-  $$ChatMessageSyncCursorTableTableProcessedTableManager
-  get chatMessageSyncCursorTableRefs {
-    final manager = $$ChatMessageSyncCursorTableTableTableManager(
-      $_db,
-      $_db.chatMessageSyncCursorTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatMessageSyncCursorTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $ChatMessageReadCursorTableTable,
-    List<ChatMessageReadCursorData>
-  >
-  _chatMessageReadCursorTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.chatMessageReadCursorTable,
-        aliasName: $_aliasNameGenerator(
-          db.chatsTable.id,
-          db.chatMessageReadCursorTable.chatId,
-        ),
-      );
-
-  $$ChatMessageReadCursorTableTableProcessedTableManager
-  get chatMessageReadCursorTableRefs {
-    final manager = $$ChatMessageReadCursorTableTableTableManager(
-      $_db,
-      $_db.chatMessageReadCursorTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatMessageReadCursorTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $ChatOutboxMessageTableTable,
-    List<ChatOutboxMessageData>
-  >
-  _chatOutboxMessageTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.chatOutboxMessageTable,
-        aliasName: $_aliasNameGenerator(
-          db.chatsTable.id,
-          db.chatOutboxMessageTable.chatId,
-        ),
-      );
-
-  $$ChatOutboxMessageTableTableProcessedTableManager
-  get chatOutboxMessageTableRefs {
-    final manager = $$ChatOutboxMessageTableTableTableManager(
-      $_db,
-      $_db.chatOutboxMessageTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatOutboxMessageTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $ChatOutboxMessageEditTableTable,
-    List<ChatOutboxMessageEditData>
-  >
-  _chatOutboxMessageEditTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.chatOutboxMessageEditTable,
-        aliasName: $_aliasNameGenerator(
-          db.chatsTable.id,
-          db.chatOutboxMessageEditTable.chatId,
-        ),
-      );
-
-  $$ChatOutboxMessageEditTableTableProcessedTableManager
-  get chatOutboxMessageEditTableRefs {
-    final manager = $$ChatOutboxMessageEditTableTableTableManager(
-      $_db,
-      $_db.chatOutboxMessageEditTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatOutboxMessageEditTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $ChatOutboxMessageDeleteTableTable,
-    List<ChatOutboxMessageDeleteData>
-  >
-  _chatOutboxMessageDeleteTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.chatOutboxMessageDeleteTable,
-        aliasName: $_aliasNameGenerator(
-          db.chatsTable.id,
-          db.chatOutboxMessageDeleteTable.chatId,
-        ),
-      );
-
-  $$ChatOutboxMessageDeleteTableTableProcessedTableManager
-  get chatOutboxMessageDeleteTableRefs {
-    final manager = $$ChatOutboxMessageDeleteTableTableTableManager(
-      $_db,
-      $_db.chatOutboxMessageDeleteTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatOutboxMessageDeleteTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $ChatOutboxReadCursorsTableTable,
-    List<ChatOutboxReadCursorData>
-  >
-  _chatOutboxReadCursorsTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.chatOutboxReadCursorsTable,
-        aliasName: $_aliasNameGenerator(
-          db.chatsTable.id,
-          db.chatOutboxReadCursorsTable.chatId,
-        ),
-      );
-
-  $$ChatOutboxReadCursorsTableTableProcessedTableManager
-  get chatOutboxReadCursorsTableRefs {
-    final manager = $$ChatOutboxReadCursorsTableTableTableManager(
-      $_db,
-      $_db.chatOutboxReadCursorsTable,
-    ).filter((f) => f.chatId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _chatOutboxReadCursorsTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-}
-
 class $$ChatsTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatsTableTable> {
   $$ChatsTableTableFilterComposer({
@@ -17134,219 +16746,6 @@ class $$ChatsTableTableFilterComposer
     column: $table.updatedAtRemote,
     builder: (column) => ColumnFilters(column),
   );
-
-  Expression<bool> chatMembersTableRefs(
-    Expression<bool> Function($$ChatMembersTableTableFilterComposer f) f,
-  ) {
-    final $$ChatMembersTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.chatMembersTable,
-      getReferencedColumn: (t) => t.chatId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatMembersTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatMembersTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
-
-  Expression<bool> chatMessagesTableRefs(
-    Expression<bool> Function($$ChatMessagesTableTableFilterComposer f) f,
-  ) {
-    final $$ChatMessagesTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.chatMessagesTable,
-      getReferencedColumn: (t) => t.chatId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatMessagesTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatMessagesTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
-
-  Expression<bool> chatMessageSyncCursorTableRefs(
-    Expression<bool> Function($$ChatMessageSyncCursorTableTableFilterComposer f)
-    f,
-  ) {
-    final $$ChatMessageSyncCursorTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatMessageSyncCursorTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatMessageSyncCursorTableTableFilterComposer(
-                $db: $db,
-                $table: $db.chatMessageSyncCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> chatMessageReadCursorTableRefs(
-    Expression<bool> Function($$ChatMessageReadCursorTableTableFilterComposer f)
-    f,
-  ) {
-    final $$ChatMessageReadCursorTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatMessageReadCursorTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatMessageReadCursorTableTableFilterComposer(
-                $db: $db,
-                $table: $db.chatMessageReadCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> chatOutboxMessageTableRefs(
-    Expression<bool> Function($$ChatOutboxMessageTableTableFilterComposer f) f,
-  ) {
-    final $$ChatOutboxMessageTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxMessageTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxMessageTableTableFilterComposer(
-                $db: $db,
-                $table: $db.chatOutboxMessageTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> chatOutboxMessageEditTableRefs(
-    Expression<bool> Function($$ChatOutboxMessageEditTableTableFilterComposer f)
-    f,
-  ) {
-    final $$ChatOutboxMessageEditTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxMessageEditTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxMessageEditTableTableFilterComposer(
-                $db: $db,
-                $table: $db.chatOutboxMessageEditTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> chatOutboxMessageDeleteTableRefs(
-    Expression<bool> Function(
-      $$ChatOutboxMessageDeleteTableTableFilterComposer f,
-    )
-    f,
-  ) {
-    final $$ChatOutboxMessageDeleteTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxMessageDeleteTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxMessageDeleteTableTableFilterComposer(
-                $db: $db,
-                $table: $db.chatOutboxMessageDeleteTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> chatOutboxReadCursorsTableRefs(
-    Expression<bool> Function($$ChatOutboxReadCursorsTableTableFilterComposer f)
-    f,
-  ) {
-    final $$ChatOutboxReadCursorsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxReadCursorsTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxReadCursorsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.chatOutboxReadCursorsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
 }
 
 class $$ChatsTableTableOrderingComposer
@@ -17411,228 +16810,6 @@ class $$ChatsTableTableAnnotationComposer
     column: $table.updatedAtRemote,
     builder: (column) => column,
   );
-
-  Expression<T> chatMembersTableRefs<T extends Object>(
-    Expression<T> Function($$ChatMembersTableTableAnnotationComposer a) f,
-  ) {
-    final $$ChatMembersTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.chatMembersTable,
-      getReferencedColumn: (t) => t.chatId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatMembersTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatMembersTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
-
-  Expression<T> chatMessagesTableRefs<T extends Object>(
-    Expression<T> Function($$ChatMessagesTableTableAnnotationComposer a) f,
-  ) {
-    final $$ChatMessagesTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatMessagesTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatMessagesTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.chatMessagesTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> chatMessageSyncCursorTableRefs<T extends Object>(
-    Expression<T> Function(
-      $$ChatMessageSyncCursorTableTableAnnotationComposer a,
-    )
-    f,
-  ) {
-    final $$ChatMessageSyncCursorTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatMessageSyncCursorTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatMessageSyncCursorTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.chatMessageSyncCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> chatMessageReadCursorTableRefs<T extends Object>(
-    Expression<T> Function(
-      $$ChatMessageReadCursorTableTableAnnotationComposer a,
-    )
-    f,
-  ) {
-    final $$ChatMessageReadCursorTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatMessageReadCursorTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatMessageReadCursorTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.chatMessageReadCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> chatOutboxMessageTableRefs<T extends Object>(
-    Expression<T> Function($$ChatOutboxMessageTableTableAnnotationComposer a) f,
-  ) {
-    final $$ChatOutboxMessageTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxMessageTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxMessageTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.chatOutboxMessageTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> chatOutboxMessageEditTableRefs<T extends Object>(
-    Expression<T> Function(
-      $$ChatOutboxMessageEditTableTableAnnotationComposer a,
-    )
-    f,
-  ) {
-    final $$ChatOutboxMessageEditTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxMessageEditTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxMessageEditTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.chatOutboxMessageEditTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> chatOutboxMessageDeleteTableRefs<T extends Object>(
-    Expression<T> Function(
-      $$ChatOutboxMessageDeleteTableTableAnnotationComposer a,
-    )
-    f,
-  ) {
-    final $$ChatOutboxMessageDeleteTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxMessageDeleteTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxMessageDeleteTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.chatOutboxMessageDeleteTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> chatOutboxReadCursorsTableRefs<T extends Object>(
-    Expression<T> Function(
-      $$ChatOutboxReadCursorsTableTableAnnotationComposer a,
-    )
-    f,
-  ) {
-    final $$ChatOutboxReadCursorsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.chatOutboxReadCursorsTable,
-          getReferencedColumn: (t) => t.chatId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$ChatOutboxReadCursorsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.chatOutboxReadCursorsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
 }
 
 class $$ChatsTableTableTableManager
@@ -17646,18 +16823,9 @@ class $$ChatsTableTableTableManager
           $$ChatsTableTableAnnotationComposer,
           $$ChatsTableTableCreateCompanionBuilder,
           $$ChatsTableTableUpdateCompanionBuilder,
-          (ChatData, $$ChatsTableTableReferences),
+          (ChatData, BaseReferences<_$AppDatabase, $ChatsTableTable, ChatData>),
           ChatData,
-          PrefetchHooks Function({
-            bool chatMembersTableRefs,
-            bool chatMessagesTableRefs,
-            bool chatMessageSyncCursorTableRefs,
-            bool chatMessageReadCursorTableRefs,
-            bool chatOutboxMessageTableRefs,
-            bool chatOutboxMessageEditTableRefs,
-            bool chatOutboxMessageDeleteTableRefs,
-            bool chatOutboxReadCursorsTableRefs,
-          })
+          PrefetchHooks Function()
         > {
   $$ChatsTableTableTableManager(_$AppDatabase db, $ChatsTableTable table)
     : super(
@@ -17699,216 +16867,9 @@ class $$ChatsTableTableTableManager
                 updatedAtRemote: updatedAtRemote,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatsTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback:
-              ({
-                chatMembersTableRefs = false,
-                chatMessagesTableRefs = false,
-                chatMessageSyncCursorTableRefs = false,
-                chatMessageReadCursorTableRefs = false,
-                chatOutboxMessageTableRefs = false,
-                chatOutboxMessageEditTableRefs = false,
-                chatOutboxMessageDeleteTableRefs = false,
-                chatOutboxReadCursorsTableRefs = false,
-              }) {
-                return PrefetchHooks(
-                  db: db,
-                  explicitlyWatchedTables: [
-                    if (chatMembersTableRefs) db.chatMembersTable,
-                    if (chatMessagesTableRefs) db.chatMessagesTable,
-                    if (chatMessageSyncCursorTableRefs)
-                      db.chatMessageSyncCursorTable,
-                    if (chatMessageReadCursorTableRefs)
-                      db.chatMessageReadCursorTable,
-                    if (chatOutboxMessageTableRefs) db.chatOutboxMessageTable,
-                    if (chatOutboxMessageEditTableRefs)
-                      db.chatOutboxMessageEditTable,
-                    if (chatOutboxMessageDeleteTableRefs)
-                      db.chatOutboxMessageDeleteTable,
-                    if (chatOutboxReadCursorsTableRefs)
-                      db.chatOutboxReadCursorsTable,
-                  ],
-                  addJoins: null,
-                  getPrefetchedDataCallback: (items) async {
-                    return [
-                      if (chatMembersTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatMemberData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatMembersTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatMembersTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (chatMessagesTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatMessageData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatMessagesTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatMessagesTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (chatMessageSyncCursorTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatMessageSyncCursorData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatMessageSyncCursorTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatMessageSyncCursorTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (chatMessageReadCursorTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatMessageReadCursorData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatMessageReadCursorTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatMessageReadCursorTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (chatOutboxMessageTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatOutboxMessageData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatOutboxMessageTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatOutboxMessageTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (chatOutboxMessageEditTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatOutboxMessageEditData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatOutboxMessageEditTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatOutboxMessageEditTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (chatOutboxMessageDeleteTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatOutboxMessageDeleteData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatOutboxMessageDeleteTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatOutboxMessageDeleteTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (chatOutboxReadCursorsTableRefs)
-                        await $_getPrefetchedData<
-                          ChatData,
-                          $ChatsTableTable,
-                          ChatOutboxReadCursorData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$ChatsTableTableReferences
-                              ._chatOutboxReadCursorsTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$ChatsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).chatOutboxReadCursorsTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.chatId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                    ];
-                  },
-                );
-              },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -17923,18 +16884,9 @@ typedef $$ChatsTableTableProcessedTableManager =
       $$ChatsTableTableAnnotationComposer,
       $$ChatsTableTableCreateCompanionBuilder,
       $$ChatsTableTableUpdateCompanionBuilder,
-      (ChatData, $$ChatsTableTableReferences),
+      (ChatData, BaseReferences<_$AppDatabase, $ChatsTableTable, ChatData>),
       ChatData,
-      PrefetchHooks Function({
-        bool chatMembersTableRefs,
-        bool chatMessagesTableRefs,
-        bool chatMessageSyncCursorTableRefs,
-        bool chatMessageReadCursorTableRefs,
-        bool chatOutboxMessageTableRefs,
-        bool chatOutboxMessageEditTableRefs,
-        bool chatOutboxMessageDeleteTableRefs,
-        bool chatOutboxReadCursorsTableRefs,
-      })
+      PrefetchHooks Function()
     >;
 typedef $$ChatMembersTableTableCreateCompanionBuilder =
     ChatMemberDataCompanion Function({
@@ -17951,35 +16903,6 @@ typedef $$ChatMembersTableTableUpdateCompanionBuilder =
       Value<GroupAuthoritiesEnum?> groupAuthorities,
     });
 
-final class $$ChatMembersTableTableReferences
-    extends
-        BaseReferences<_$AppDatabase, $ChatMembersTableTable, ChatMemberData> {
-  $$ChatMembersTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(db.chatMembersTable.chatId, db.chatsTable.id),
-      );
-
-  $$ChatsTableTableProcessedTableManager get chatId {
-    final $_column = $_itemColumn<int>('chat_id')!;
-
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$ChatMembersTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatMembersTableTable> {
   $$ChatMembersTableTableFilterComposer({
@@ -17991,6 +16914,11 @@ class $$ChatMembersTableTableFilterComposer
   });
   ColumnFilters<int> get id => $composableBuilder(
     column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -18008,29 +16936,6 @@ class $$ChatMembersTableTableFilterComposer
     column: $table.groupAuthorities,
     builder: (column) => ColumnWithTypeConverterFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMembersTableTableOrderingComposer
@@ -18047,6 +16952,11 @@ class $$ChatMembersTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get userId => $composableBuilder(
     column: $table.userId,
     builder: (column) => ColumnOrderings(column),
@@ -18056,29 +16966,6 @@ class $$ChatMembersTableTableOrderingComposer
     column: $table.groupAuthorities,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMembersTableTableAnnotationComposer
@@ -18093,6 +16980,9 @@ class $$ChatMembersTableTableAnnotationComposer
   GeneratedColumn<int> get id =>
       $composableBuilder(column: $table.id, builder: (column) => column);
 
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
+
   GeneratedColumn<String> get userId =>
       $composableBuilder(column: $table.userId, builder: (column) => column);
 
@@ -18101,29 +16991,6 @@ class $$ChatMembersTableTableAnnotationComposer
     column: $table.groupAuthorities,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMembersTableTableTableManager
@@ -18137,9 +17004,16 @@ class $$ChatMembersTableTableTableManager
           $$ChatMembersTableTableAnnotationComposer,
           $$ChatMembersTableTableCreateCompanionBuilder,
           $$ChatMembersTableTableUpdateCompanionBuilder,
-          (ChatMemberData, $$ChatMembersTableTableReferences),
+          (
+            ChatMemberData,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatMembersTableTable,
+              ChatMemberData
+            >,
+          ),
           ChatMemberData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatMembersTableTableTableManager(
     _$AppDatabase db,
@@ -18181,56 +17055,9 @@ class $$ChatMembersTableTableTableManager
                 groupAuthorities: groupAuthorities,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatMembersTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatMembersTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatMembersTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -18245,9 +17072,12 @@ typedef $$ChatMembersTableTableProcessedTableManager =
       $$ChatMembersTableTableAnnotationComposer,
       $$ChatMembersTableTableCreateCompanionBuilder,
       $$ChatMembersTableTableUpdateCompanionBuilder,
-      (ChatMemberData, $$ChatMembersTableTableReferences),
+      (
+        ChatMemberData,
+        BaseReferences<_$AppDatabase, $ChatMembersTableTable, ChatMemberData>,
+      ),
       ChatMemberData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$ChatMessagesTableTableCreateCompanionBuilder =
     ChatMessageDataCompanion Function({
@@ -18280,39 +17110,6 @@ typedef $$ChatMessagesTableTableUpdateCompanionBuilder =
       Value<int?> deletedAtRemoteUsec,
     });
 
-final class $$ChatMessagesTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $ChatMessagesTableTable,
-          ChatMessageData
-        > {
-  $$ChatMessagesTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(db.chatMessagesTable.chatId, db.chatsTable.id),
-      );
-
-  $$ChatsTableTableProcessedTableManager get chatId {
-    final $_column = $_itemColumn<int>('chat_id')!;
-
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$ChatMessagesTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatMessagesTableTable> {
   $$ChatMessagesTableTableFilterComposer({
@@ -18334,6 +17131,11 @@ class $$ChatMessagesTableTableFilterComposer
 
   ColumnFilters<String> get senderId => $composableBuilder(
     column: $table.senderId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -18376,29 +17178,6 @@ class $$ChatMessagesTableTableFilterComposer
     column: $table.deletedAtRemoteUsec,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessagesTableTableOrderingComposer
@@ -18422,6 +17201,11 @@ class $$ChatMessagesTableTableOrderingComposer
 
   ColumnOrderings<String> get senderId => $composableBuilder(
     column: $table.senderId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -18464,29 +17248,6 @@ class $$ChatMessagesTableTableOrderingComposer
     column: $table.deletedAtRemoteUsec,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessagesTableTableAnnotationComposer
@@ -18506,6 +17267,9 @@ class $$ChatMessagesTableTableAnnotationComposer
 
   GeneratedColumn<String> get senderId =>
       $composableBuilder(column: $table.senderId, builder: (column) => column);
+
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
 
   GeneratedColumn<int> get replyToId =>
       $composableBuilder(column: $table.replyToId, builder: (column) => column);
@@ -18540,29 +17304,6 @@ class $$ChatMessagesTableTableAnnotationComposer
     column: $table.deletedAtRemoteUsec,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessagesTableTableTableManager
@@ -18576,9 +17317,16 @@ class $$ChatMessagesTableTableTableManager
           $$ChatMessagesTableTableAnnotationComposer,
           $$ChatMessagesTableTableCreateCompanionBuilder,
           $$ChatMessagesTableTableUpdateCompanionBuilder,
-          (ChatMessageData, $$ChatMessagesTableTableReferences),
+          (
+            ChatMessageData,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatMessagesTableTable,
+              ChatMessageData
+            >,
+          ),
           ChatMessageData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatMessagesTableTableTableManager(
     _$AppDatabase db,
@@ -18653,56 +17401,9 @@ class $$ChatMessagesTableTableTableManager
                 deletedAtRemoteUsec: deletedAtRemoteUsec,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatMessagesTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatMessagesTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatMessagesTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -18717,9 +17418,12 @@ typedef $$ChatMessagesTableTableProcessedTableManager =
       $$ChatMessagesTableTableAnnotationComposer,
       $$ChatMessagesTableTableCreateCompanionBuilder,
       $$ChatMessagesTableTableUpdateCompanionBuilder,
-      (ChatMessageData, $$ChatMessagesTableTableReferences),
+      (
+        ChatMessageData,
+        BaseReferences<_$AppDatabase, $ChatMessagesTableTable, ChatMessageData>,
+      ),
       ChatMessageData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$ChatMessageSyncCursorTableTableCreateCompanionBuilder =
     ChatMessageSyncCursorDataCompanion Function({
@@ -18736,42 +17440,6 @@ typedef $$ChatMessageSyncCursorTableTableUpdateCompanionBuilder =
       Value<int> rowid,
     });
 
-final class $$ChatMessageSyncCursorTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $ChatMessageSyncCursorTableTable,
-          ChatMessageSyncCursorData
-        > {
-  $$ChatMessageSyncCursorTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(
-          db.chatMessageSyncCursorTable.chatId,
-          db.chatsTable.id,
-        ),
-      );
-
-  $$ChatsTableTableProcessedTableManager get chatId {
-    final $_column = $_itemColumn<int>('chat_id')!;
-
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$ChatMessageSyncCursorTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatMessageSyncCursorTableTable> {
   $$ChatMessageSyncCursorTableTableFilterComposer({
@@ -18781,6 +17449,11 @@ class $$ChatMessageSyncCursorTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnWithTypeConverterFilters<
     MessageSyncCursorTypeEnum,
     MessageSyncCursorTypeEnum,
@@ -18795,29 +17468,6 @@ class $$ChatMessageSyncCursorTableTableFilterComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessageSyncCursorTableTableOrderingComposer
@@ -18829,6 +17479,11 @@ class $$ChatMessageSyncCursorTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get cursorType => $composableBuilder(
     column: $table.cursorType,
     builder: (column) => ColumnOrderings(column),
@@ -18838,29 +17493,6 @@ class $$ChatMessageSyncCursorTableTableOrderingComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessageSyncCursorTableTableAnnotationComposer
@@ -18872,6 +17504,9 @@ class $$ChatMessageSyncCursorTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
+
   GeneratedColumnWithTypeConverter<MessageSyncCursorTypeEnum, String>
   get cursorType => $composableBuilder(
     column: $table.cursorType,
@@ -18882,29 +17517,6 @@ class $$ChatMessageSyncCursorTableTableAnnotationComposer
     column: $table.timestampUsec,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessageSyncCursorTableTableTableManager
@@ -18920,10 +17532,14 @@ class $$ChatMessageSyncCursorTableTableTableManager
           $$ChatMessageSyncCursorTableTableUpdateCompanionBuilder,
           (
             ChatMessageSyncCursorData,
-            $$ChatMessageSyncCursorTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatMessageSyncCursorTableTable,
+              ChatMessageSyncCursorData
+            >,
           ),
           ChatMessageSyncCursorData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatMessageSyncCursorTableTableTableManager(
     _$AppDatabase db,
@@ -18973,56 +17589,9 @@ class $$ChatMessageSyncCursorTableTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatMessageSyncCursorTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatMessageSyncCursorTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatMessageSyncCursorTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -19037,9 +17606,16 @@ typedef $$ChatMessageSyncCursorTableTableProcessedTableManager =
       $$ChatMessageSyncCursorTableTableAnnotationComposer,
       $$ChatMessageSyncCursorTableTableCreateCompanionBuilder,
       $$ChatMessageSyncCursorTableTableUpdateCompanionBuilder,
-      (ChatMessageSyncCursorData, $$ChatMessageSyncCursorTableTableReferences),
+      (
+        ChatMessageSyncCursorData,
+        BaseReferences<
+          _$AppDatabase,
+          $ChatMessageSyncCursorTableTable,
+          ChatMessageSyncCursorData
+        >,
+      ),
       ChatMessageSyncCursorData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$ChatMessageReadCursorTableTableCreateCompanionBuilder =
     ChatMessageReadCursorDataCompanion Function({
@@ -19056,42 +17632,6 @@ typedef $$ChatMessageReadCursorTableTableUpdateCompanionBuilder =
       Value<int> rowid,
     });
 
-final class $$ChatMessageReadCursorTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $ChatMessageReadCursorTableTable,
-          ChatMessageReadCursorData
-        > {
-  $$ChatMessageReadCursorTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(
-          db.chatMessageReadCursorTable.chatId,
-          db.chatsTable.id,
-        ),
-      );
-
-  $$ChatsTableTableProcessedTableManager get chatId {
-    final $_column = $_itemColumn<int>('chat_id')!;
-
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$ChatMessageReadCursorTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatMessageReadCursorTableTable> {
   $$ChatMessageReadCursorTableTableFilterComposer({
@@ -19101,6 +17641,11 @@ class $$ChatMessageReadCursorTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get userId => $composableBuilder(
     column: $table.userId,
     builder: (column) => ColumnFilters(column),
@@ -19110,29 +17655,6 @@ class $$ChatMessageReadCursorTableTableFilterComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessageReadCursorTableTableOrderingComposer
@@ -19144,6 +17666,11 @@ class $$ChatMessageReadCursorTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get userId => $composableBuilder(
     column: $table.userId,
     builder: (column) => ColumnOrderings(column),
@@ -19153,29 +17680,6 @@ class $$ChatMessageReadCursorTableTableOrderingComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessageReadCursorTableTableAnnotationComposer
@@ -19187,6 +17691,9 @@ class $$ChatMessageReadCursorTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
+
   GeneratedColumn<String> get userId =>
       $composableBuilder(column: $table.userId, builder: (column) => column);
 
@@ -19194,29 +17701,6 @@ class $$ChatMessageReadCursorTableTableAnnotationComposer
     column: $table.timestampUsec,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatMessageReadCursorTableTableTableManager
@@ -19232,10 +17716,14 @@ class $$ChatMessageReadCursorTableTableTableManager
           $$ChatMessageReadCursorTableTableUpdateCompanionBuilder,
           (
             ChatMessageReadCursorData,
-            $$ChatMessageReadCursorTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatMessageReadCursorTableTable,
+              ChatMessageReadCursorData
+            >,
           ),
           ChatMessageReadCursorData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatMessageReadCursorTableTableTableManager(
     _$AppDatabase db,
@@ -19284,56 +17772,9 @@ class $$ChatMessageReadCursorTableTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatMessageReadCursorTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatMessageReadCursorTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatMessageReadCursorTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -19348,9 +17789,16 @@ typedef $$ChatMessageReadCursorTableTableProcessedTableManager =
       $$ChatMessageReadCursorTableTableAnnotationComposer,
       $$ChatMessageReadCursorTableTableCreateCompanionBuilder,
       $$ChatMessageReadCursorTableTableUpdateCompanionBuilder,
-      (ChatMessageReadCursorData, $$ChatMessageReadCursorTableTableReferences),
+      (
+        ChatMessageReadCursorData,
+        BaseReferences<
+          _$AppDatabase,
+          $ChatMessageReadCursorTableTable,
+          ChatMessageReadCursorData
+        >,
+      ),
       ChatMessageReadCursorData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$ChatOutboxMessageTableTableCreateCompanionBuilder =
     ChatOutboxMessageDataCompanion Function({
@@ -19377,42 +17825,6 @@ typedef $$ChatOutboxMessageTableTableUpdateCompanionBuilder =
       Value<int> rowid,
     });
 
-final class $$ChatOutboxMessageTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $ChatOutboxMessageTableTable,
-          ChatOutboxMessageData
-        > {
-  $$ChatOutboxMessageTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(
-          db.chatOutboxMessageTable.chatId,
-          db.chatsTable.id,
-        ),
-      );
-
-  $$ChatsTableTableProcessedTableManager? get chatId {
-    final $_column = $_itemColumn<int>('chat_id');
-    if ($_column == null) return null;
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$ChatOutboxMessageTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatOutboxMessageTableTable> {
   $$ChatOutboxMessageTableTableFilterComposer({
@@ -19424,6 +17836,11 @@ class $$ChatOutboxMessageTableTableFilterComposer
   });
   ColumnFilters<String> get idKey => $composableBuilder(
     column: $table.idKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -19456,29 +17873,6 @@ class $$ChatOutboxMessageTableTableFilterComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageTableTableOrderingComposer
@@ -19492,6 +17886,11 @@ class $$ChatOutboxMessageTableTableOrderingComposer
   });
   ColumnOrderings<String> get idKey => $composableBuilder(
     column: $table.idKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -19524,29 +17923,6 @@ class $$ChatOutboxMessageTableTableOrderingComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageTableTableAnnotationComposer
@@ -19560,6 +17936,9 @@ class $$ChatOutboxMessageTableTableAnnotationComposer
   });
   GeneratedColumn<String> get idKey =>
       $composableBuilder(column: $table.idKey, builder: (column) => column);
+
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
 
   GeneratedColumn<String> get participantId => $composableBuilder(
     column: $table.participantId,
@@ -19584,29 +17963,6 @@ class $$ChatOutboxMessageTableTableAnnotationComposer
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageTableTableTableManager
@@ -19620,9 +17976,16 @@ class $$ChatOutboxMessageTableTableTableManager
           $$ChatOutboxMessageTableTableAnnotationComposer,
           $$ChatOutboxMessageTableTableCreateCompanionBuilder,
           $$ChatOutboxMessageTableTableUpdateCompanionBuilder,
-          (ChatOutboxMessageData, $$ChatOutboxMessageTableTableReferences),
+          (
+            ChatOutboxMessageData,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatOutboxMessageTableTable,
+              ChatOutboxMessageData
+            >,
+          ),
           ChatOutboxMessageData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatOutboxMessageTableTableTableManager(
     _$AppDatabase db,
@@ -19691,56 +18054,9 @@ class $$ChatOutboxMessageTableTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatOutboxMessageTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatOutboxMessageTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatOutboxMessageTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -19755,9 +18071,16 @@ typedef $$ChatOutboxMessageTableTableProcessedTableManager =
       $$ChatOutboxMessageTableTableAnnotationComposer,
       $$ChatOutboxMessageTableTableCreateCompanionBuilder,
       $$ChatOutboxMessageTableTableUpdateCompanionBuilder,
-      (ChatOutboxMessageData, $$ChatOutboxMessageTableTableReferences),
+      (
+        ChatOutboxMessageData,
+        BaseReferences<
+          _$AppDatabase,
+          $ChatOutboxMessageTableTable,
+          ChatOutboxMessageData
+        >,
+      ),
       ChatOutboxMessageData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$ChatOutboxMessageEditTableTableCreateCompanionBuilder =
     ChatOutboxMessageEditDataCompanion Function({
@@ -19775,42 +18098,6 @@ typedef $$ChatOutboxMessageEditTableTableUpdateCompanionBuilder =
       Value<String> newContent,
       Value<int> sendAttempts,
     });
-
-final class $$ChatOutboxMessageEditTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $ChatOutboxMessageEditTableTable,
-          ChatOutboxMessageEditData
-        > {
-  $$ChatOutboxMessageEditTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(
-          db.chatOutboxMessageEditTable.chatId,
-          db.chatsTable.id,
-        ),
-      );
-
-  $$ChatsTableTableProcessedTableManager get chatId {
-    final $_column = $_itemColumn<int>('chat_id')!;
-
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
 
 class $$ChatOutboxMessageEditTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatOutboxMessageEditTableTable> {
@@ -19831,6 +18118,11 @@ class $$ChatOutboxMessageEditTableTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get newContent => $composableBuilder(
     column: $table.newContent,
     builder: (column) => ColumnFilters(column),
@@ -19840,29 +18132,6 @@ class $$ChatOutboxMessageEditTableTableFilterComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageEditTableTableOrderingComposer
@@ -19884,6 +18153,11 @@ class $$ChatOutboxMessageEditTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get newContent => $composableBuilder(
     column: $table.newContent,
     builder: (column) => ColumnOrderings(column),
@@ -19893,29 +18167,6 @@ class $$ChatOutboxMessageEditTableTableOrderingComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageEditTableTableAnnotationComposer
@@ -19933,6 +18184,9 @@ class $$ChatOutboxMessageEditTableTableAnnotationComposer
   GeneratedColumn<String> get idKey =>
       $composableBuilder(column: $table.idKey, builder: (column) => column);
 
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
+
   GeneratedColumn<String> get newContent => $composableBuilder(
     column: $table.newContent,
     builder: (column) => column,
@@ -19942,29 +18196,6 @@ class $$ChatOutboxMessageEditTableTableAnnotationComposer
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageEditTableTableTableManager
@@ -19980,10 +18211,14 @@ class $$ChatOutboxMessageEditTableTableTableManager
           $$ChatOutboxMessageEditTableTableUpdateCompanionBuilder,
           (
             ChatOutboxMessageEditData,
-            $$ChatOutboxMessageEditTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatOutboxMessageEditTableTable,
+              ChatOutboxMessageEditData
+            >,
           ),
           ChatOutboxMessageEditData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatOutboxMessageEditTableTableTableManager(
     _$AppDatabase db,
@@ -20036,56 +18271,9 @@ class $$ChatOutboxMessageEditTableTableTableManager
                 sendAttempts: sendAttempts,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatOutboxMessageEditTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatOutboxMessageEditTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatOutboxMessageEditTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -20100,9 +18288,16 @@ typedef $$ChatOutboxMessageEditTableTableProcessedTableManager =
       $$ChatOutboxMessageEditTableTableAnnotationComposer,
       $$ChatOutboxMessageEditTableTableCreateCompanionBuilder,
       $$ChatOutboxMessageEditTableTableUpdateCompanionBuilder,
-      (ChatOutboxMessageEditData, $$ChatOutboxMessageEditTableTableReferences),
+      (
+        ChatOutboxMessageEditData,
+        BaseReferences<
+          _$AppDatabase,
+          $ChatOutboxMessageEditTableTable,
+          ChatOutboxMessageEditData
+        >,
+      ),
       ChatOutboxMessageEditData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$ChatOutboxMessageDeleteTableTableCreateCompanionBuilder =
     ChatOutboxMessageDeleteDataCompanion Function({
@@ -20118,42 +18313,6 @@ typedef $$ChatOutboxMessageDeleteTableTableUpdateCompanionBuilder =
       Value<int> chatId,
       Value<int> sendAttempts,
     });
-
-final class $$ChatOutboxMessageDeleteTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $ChatOutboxMessageDeleteTableTable,
-          ChatOutboxMessageDeleteData
-        > {
-  $$ChatOutboxMessageDeleteTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(
-          db.chatOutboxMessageDeleteTable.chatId,
-          db.chatsTable.id,
-        ),
-      );
-
-  $$ChatsTableTableProcessedTableManager get chatId {
-    final $_column = $_itemColumn<int>('chat_id')!;
-
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
 
 class $$ChatOutboxMessageDeleteTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatOutboxMessageDeleteTableTable> {
@@ -20174,33 +18333,15 @@ class $$ChatOutboxMessageDeleteTableTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<int> get sendAttempts => $composableBuilder(
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageDeleteTableTableOrderingComposer
@@ -20222,33 +18363,15 @@ class $$ChatOutboxMessageDeleteTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get sendAttempts => $composableBuilder(
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageDeleteTableTableAnnotationComposer
@@ -20266,33 +18389,13 @@ class $$ChatOutboxMessageDeleteTableTableAnnotationComposer
   GeneratedColumn<String> get idKey =>
       $composableBuilder(column: $table.idKey, builder: (column) => column);
 
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
+
   GeneratedColumn<int> get sendAttempts => $composableBuilder(
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxMessageDeleteTableTableTableManager
@@ -20308,10 +18411,14 @@ class $$ChatOutboxMessageDeleteTableTableTableManager
           $$ChatOutboxMessageDeleteTableTableUpdateCompanionBuilder,
           (
             ChatOutboxMessageDeleteData,
-            $$ChatOutboxMessageDeleteTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatOutboxMessageDeleteTableTable,
+              ChatOutboxMessageDeleteData
+            >,
           ),
           ChatOutboxMessageDeleteData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatOutboxMessageDeleteTableTableTableManager(
     _$AppDatabase db,
@@ -20360,56 +18467,9 @@ class $$ChatOutboxMessageDeleteTableTableTableManager
                 sendAttempts: sendAttempts,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatOutboxMessageDeleteTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatOutboxMessageDeleteTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatOutboxMessageDeleteTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -20426,10 +18486,14 @@ typedef $$ChatOutboxMessageDeleteTableTableProcessedTableManager =
       $$ChatOutboxMessageDeleteTableTableUpdateCompanionBuilder,
       (
         ChatOutboxMessageDeleteData,
-        $$ChatOutboxMessageDeleteTableTableReferences,
+        BaseReferences<
+          _$AppDatabase,
+          $ChatOutboxMessageDeleteTableTable,
+          ChatOutboxMessageDeleteData
+        >,
       ),
       ChatOutboxMessageDeleteData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$ChatOutboxReadCursorsTableTableCreateCompanionBuilder =
     ChatOutboxReadCursorDataCompanion Function({
@@ -20444,42 +18508,6 @@ typedef $$ChatOutboxReadCursorsTableTableUpdateCompanionBuilder =
       Value<int> sendAttempts,
     });
 
-final class $$ChatOutboxReadCursorsTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $ChatOutboxReadCursorsTableTable,
-          ChatOutboxReadCursorData
-        > {
-  $$ChatOutboxReadCursorsTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $ChatsTableTable _chatIdTable(_$AppDatabase db) =>
-      db.chatsTable.createAlias(
-        $_aliasNameGenerator(
-          db.chatOutboxReadCursorsTable.chatId,
-          db.chatsTable.id,
-        ),
-      );
-
-  $$ChatsTableTableProcessedTableManager get chatId {
-    final $_column = $_itemColumn<int>('chat_id')!;
-
-    final manager = $$ChatsTableTableTableManager(
-      $_db,
-      $_db.chatsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_chatIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$ChatOutboxReadCursorsTableTableFilterComposer
     extends Composer<_$AppDatabase, $ChatOutboxReadCursorsTableTable> {
   $$ChatOutboxReadCursorsTableTableFilterComposer({
@@ -20489,6 +18517,11 @@ class $$ChatOutboxReadCursorsTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<int> get timestampUsec => $composableBuilder(
     column: $table.timestampUsec,
     builder: (column) => ColumnFilters(column),
@@ -20498,29 +18531,6 @@ class $$ChatOutboxReadCursorsTableTableFilterComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$ChatsTableTableFilterComposer get chatId {
-    final $$ChatsTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableFilterComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxReadCursorsTableTableOrderingComposer
@@ -20532,6 +18542,11 @@ class $$ChatOutboxReadCursorsTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get chatId => $composableBuilder(
+    column: $table.chatId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get timestampUsec => $composableBuilder(
     column: $table.timestampUsec,
     builder: (column) => ColumnOrderings(column),
@@ -20541,29 +18556,6 @@ class $$ChatOutboxReadCursorsTableTableOrderingComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$ChatsTableTableOrderingComposer get chatId {
-    final $$ChatsTableTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableOrderingComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxReadCursorsTableTableAnnotationComposer
@@ -20575,6 +18567,9 @@ class $$ChatOutboxReadCursorsTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
+
   GeneratedColumn<int> get timestampUsec => $composableBuilder(
     column: $table.timestampUsec,
     builder: (column) => column,
@@ -20584,29 +18579,6 @@ class $$ChatOutboxReadCursorsTableTableAnnotationComposer
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$ChatsTableTableAnnotationComposer get chatId {
-    final $$ChatsTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.chatId,
-      referencedTable: $db.chatsTable,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$ChatsTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.chatsTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$ChatOutboxReadCursorsTableTableTableManager
@@ -20622,10 +18594,14 @@ class $$ChatOutboxReadCursorsTableTableTableManager
           $$ChatOutboxReadCursorsTableTableUpdateCompanionBuilder,
           (
             ChatOutboxReadCursorData,
-            $$ChatOutboxReadCursorsTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $ChatOutboxReadCursorsTableTable,
+              ChatOutboxReadCursorData
+            >,
           ),
           ChatOutboxReadCursorData,
-          PrefetchHooks Function({bool chatId})
+          PrefetchHooks Function()
         > {
   $$ChatOutboxReadCursorsTableTableTableManager(
     _$AppDatabase db,
@@ -20670,56 +18646,9 @@ class $$ChatOutboxReadCursorsTableTableTableManager
                 sendAttempts: sendAttempts,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$ChatOutboxReadCursorsTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({chatId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (chatId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.chatId,
-                                referencedTable:
-                                    $$ChatOutboxReadCursorsTableTableReferences
-                                        ._chatIdTable(db),
-                                referencedColumn:
-                                    $$ChatOutboxReadCursorsTableTableReferences
-                                        ._chatIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -20734,9 +18663,16 @@ typedef $$ChatOutboxReadCursorsTableTableProcessedTableManager =
       $$ChatOutboxReadCursorsTableTableAnnotationComposer,
       $$ChatOutboxReadCursorsTableTableCreateCompanionBuilder,
       $$ChatOutboxReadCursorsTableTableUpdateCompanionBuilder,
-      (ChatOutboxReadCursorData, $$ChatOutboxReadCursorsTableTableReferences),
+      (
+        ChatOutboxReadCursorData,
+        BaseReferences<
+          _$AppDatabase,
+          $ChatOutboxReadCursorsTableTable,
+          ChatOutboxReadCursorData
+        >,
+      ),
       ChatOutboxReadCursorData,
-      PrefetchHooks Function({bool chatId})
+      PrefetchHooks Function()
     >;
 typedef $$SmsConversationsTableTableCreateCompanionBuilder =
     SmsConversationDataCompanion Function({
@@ -20754,183 +18690,6 @@ typedef $$SmsConversationsTableTableUpdateCompanionBuilder =
       Value<DateTime> createdAtRemote,
       Value<DateTime> updatedAtRemote,
     });
-
-final class $$SmsConversationsTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SmsConversationsTableTable,
-          SmsConversationData
-        > {
-  $$SmsConversationsTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static MultiTypedResultKey<$SmsMessagesTableTable, List<SmsMessageData>>
-  _smsMessagesTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
-    db.smsMessagesTable,
-    aliasName: $_aliasNameGenerator(
-      db.smsConversationsTable.id,
-      db.smsMessagesTable.conversationId,
-    ),
-  );
-
-  $$SmsMessagesTableTableProcessedTableManager get smsMessagesTableRefs {
-    final manager = $$SmsMessagesTableTableTableManager(
-      $_db,
-      $_db.smsMessagesTable,
-    ).filter((f) => f.conversationId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _smsMessagesTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $SmsMessageSyncCursorTableTable,
-    List<SmsMessageSyncCursorData>
-  >
-  _smsMessageSyncCursorTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.smsMessageSyncCursorTable,
-        aliasName: $_aliasNameGenerator(
-          db.smsConversationsTable.id,
-          db.smsMessageSyncCursorTable.conversationId,
-        ),
-      );
-
-  $$SmsMessageSyncCursorTableTableProcessedTableManager
-  get smsMessageSyncCursorTableRefs {
-    final manager = $$SmsMessageSyncCursorTableTableTableManager(
-      $_db,
-      $_db.smsMessageSyncCursorTable,
-    ).filter((f) => f.conversationId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _smsMessageSyncCursorTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $SmsMessageReadCursorTableTable,
-    List<SmsMessageReadCursorData>
-  >
-  _smsMessageReadCursorTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.smsMessageReadCursorTable,
-        aliasName: $_aliasNameGenerator(
-          db.smsConversationsTable.id,
-          db.smsMessageReadCursorTable.conversationId,
-        ),
-      );
-
-  $$SmsMessageReadCursorTableTableProcessedTableManager
-  get smsMessageReadCursorTableRefs {
-    final manager = $$SmsMessageReadCursorTableTableTableManager(
-      $_db,
-      $_db.smsMessageReadCursorTable,
-    ).filter((f) => f.conversationId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _smsMessageReadCursorTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $SmsOutboxMessagesTableTable,
-    List<SmsOutboxMessageData>
-  >
-  _smsOutboxMessagesTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.smsOutboxMessagesTable,
-        aliasName: $_aliasNameGenerator(
-          db.smsConversationsTable.id,
-          db.smsOutboxMessagesTable.conversationId,
-        ),
-      );
-
-  $$SmsOutboxMessagesTableTableProcessedTableManager
-  get smsOutboxMessagesTableRefs {
-    final manager = $$SmsOutboxMessagesTableTableTableManager(
-      $_db,
-      $_db.smsOutboxMessagesTable,
-    ).filter((f) => f.conversationId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _smsOutboxMessagesTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $SmsOutboxMessageDeleteTableTable,
-    List<SmsOutboxMessageDeleteData>
-  >
-  _smsOutboxMessageDeleteTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.smsOutboxMessageDeleteTable,
-        aliasName: $_aliasNameGenerator(
-          db.smsConversationsTable.id,
-          db.smsOutboxMessageDeleteTable.conversationId,
-        ),
-      );
-
-  $$SmsOutboxMessageDeleteTableTableProcessedTableManager
-  get smsOutboxMessageDeleteTableRefs {
-    final manager = $$SmsOutboxMessageDeleteTableTableTableManager(
-      $_db,
-      $_db.smsOutboxMessageDeleteTable,
-    ).filter((f) => f.conversationId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _smsOutboxMessageDeleteTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-
-  static MultiTypedResultKey<
-    $SmsOutboxReadCursorsTableTable,
-    List<SmsOutboxReadCursorData>
-  >
-  _smsOutboxReadCursorsTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.smsOutboxReadCursorsTable,
-        aliasName: $_aliasNameGenerator(
-          db.smsConversationsTable.id,
-          db.smsOutboxReadCursorsTable.conversationId,
-        ),
-      );
-
-  $$SmsOutboxReadCursorsTableTableProcessedTableManager
-  get smsOutboxReadCursorsTableRefs {
-    final manager = $$SmsOutboxReadCursorsTableTableTableManager(
-      $_db,
-      $_db.smsOutboxReadCursorsTable,
-    ).filter((f) => f.conversationId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _smsOutboxReadCursorsTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-}
 
 class $$SmsConversationsTableTableFilterComposer
     extends Composer<_$AppDatabase, $SmsConversationsTableTable> {
@@ -20965,167 +18724,6 @@ class $$SmsConversationsTableTableFilterComposer
     column: $table.updatedAtRemote,
     builder: (column) => ColumnFilters(column),
   );
-
-  Expression<bool> smsMessagesTableRefs(
-    Expression<bool> Function($$SmsMessagesTableTableFilterComposer f) f,
-  ) {
-    final $$SmsMessagesTableTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.smsMessagesTable,
-      getReferencedColumn: (t) => t.conversationId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$SmsMessagesTableTableFilterComposer(
-            $db: $db,
-            $table: $db.smsMessagesTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
-
-  Expression<bool> smsMessageSyncCursorTableRefs(
-    Expression<bool> Function($$SmsMessageSyncCursorTableTableFilterComposer f)
-    f,
-  ) {
-    final $$SmsMessageSyncCursorTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsMessageSyncCursorTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsMessageSyncCursorTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsMessageSyncCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> smsMessageReadCursorTableRefs(
-    Expression<bool> Function($$SmsMessageReadCursorTableTableFilterComposer f)
-    f,
-  ) {
-    final $$SmsMessageReadCursorTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsMessageReadCursorTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsMessageReadCursorTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsMessageReadCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> smsOutboxMessagesTableRefs(
-    Expression<bool> Function($$SmsOutboxMessagesTableTableFilterComposer f) f,
-  ) {
-    final $$SmsOutboxMessagesTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsOutboxMessagesTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsOutboxMessagesTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsOutboxMessagesTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> smsOutboxMessageDeleteTableRefs(
-    Expression<bool> Function(
-      $$SmsOutboxMessageDeleteTableTableFilterComposer f,
-    )
-    f,
-  ) {
-    final $$SmsOutboxMessageDeleteTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsOutboxMessageDeleteTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsOutboxMessageDeleteTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsOutboxMessageDeleteTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<bool> smsOutboxReadCursorsTableRefs(
-    Expression<bool> Function($$SmsOutboxReadCursorsTableTableFilterComposer f)
-    f,
-  ) {
-    final $$SmsOutboxReadCursorsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsOutboxReadCursorsTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsOutboxReadCursorsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsOutboxReadCursorsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
 }
 
 class $$SmsConversationsTableTableOrderingComposer
@@ -21194,167 +18792,6 @@ class $$SmsConversationsTableTableAnnotationComposer
     column: $table.updatedAtRemote,
     builder: (column) => column,
   );
-
-  Expression<T> smsMessagesTableRefs<T extends Object>(
-    Expression<T> Function($$SmsMessagesTableTableAnnotationComposer a) f,
-  ) {
-    final $$SmsMessagesTableTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.smsMessagesTable,
-      getReferencedColumn: (t) => t.conversationId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$SmsMessagesTableTableAnnotationComposer(
-            $db: $db,
-            $table: $db.smsMessagesTable,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
-
-  Expression<T> smsMessageSyncCursorTableRefs<T extends Object>(
-    Expression<T> Function($$SmsMessageSyncCursorTableTableAnnotationComposer a)
-    f,
-  ) {
-    final $$SmsMessageSyncCursorTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsMessageSyncCursorTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsMessageSyncCursorTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsMessageSyncCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> smsMessageReadCursorTableRefs<T extends Object>(
-    Expression<T> Function($$SmsMessageReadCursorTableTableAnnotationComposer a)
-    f,
-  ) {
-    final $$SmsMessageReadCursorTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsMessageReadCursorTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsMessageReadCursorTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsMessageReadCursorTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> smsOutboxMessagesTableRefs<T extends Object>(
-    Expression<T> Function($$SmsOutboxMessagesTableTableAnnotationComposer a) f,
-  ) {
-    final $$SmsOutboxMessagesTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsOutboxMessagesTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsOutboxMessagesTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsOutboxMessagesTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> smsOutboxMessageDeleteTableRefs<T extends Object>(
-    Expression<T> Function(
-      $$SmsOutboxMessageDeleteTableTableAnnotationComposer a,
-    )
-    f,
-  ) {
-    final $$SmsOutboxMessageDeleteTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsOutboxMessageDeleteTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsOutboxMessageDeleteTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsOutboxMessageDeleteTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
-
-  Expression<T> smsOutboxReadCursorsTableRefs<T extends Object>(
-    Expression<T> Function($$SmsOutboxReadCursorsTableTableAnnotationComposer a)
-    f,
-  ) {
-    final $$SmsOutboxReadCursorsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.smsOutboxReadCursorsTable,
-          getReferencedColumn: (t) => t.conversationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsOutboxReadCursorsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsOutboxReadCursorsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
 }
 
 class $$SmsConversationsTableTableTableManager
@@ -21368,16 +18805,16 @@ class $$SmsConversationsTableTableTableManager
           $$SmsConversationsTableTableAnnotationComposer,
           $$SmsConversationsTableTableCreateCompanionBuilder,
           $$SmsConversationsTableTableUpdateCompanionBuilder,
-          (SmsConversationData, $$SmsConversationsTableTableReferences),
+          (
+            SmsConversationData,
+            BaseReferences<
+              _$AppDatabase,
+              $SmsConversationsTableTable,
+              SmsConversationData
+            >,
+          ),
           SmsConversationData,
-          PrefetchHooks Function({
-            bool smsMessagesTableRefs,
-            bool smsMessageSyncCursorTableRefs,
-            bool smsMessageReadCursorTableRefs,
-            bool smsOutboxMessagesTableRefs,
-            bool smsOutboxMessageDeleteTableRefs,
-            bool smsOutboxReadCursorsTableRefs,
-          })
+          PrefetchHooks Function()
         > {
   $$SmsConversationsTableTableTableManager(
     _$AppDatabase db,
@@ -21430,175 +18867,9 @@ class $$SmsConversationsTableTableTableManager
                 updatedAtRemote: updatedAtRemote,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SmsConversationsTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback:
-              ({
-                smsMessagesTableRefs = false,
-                smsMessageSyncCursorTableRefs = false,
-                smsMessageReadCursorTableRefs = false,
-                smsOutboxMessagesTableRefs = false,
-                smsOutboxMessageDeleteTableRefs = false,
-                smsOutboxReadCursorsTableRefs = false,
-              }) {
-                return PrefetchHooks(
-                  db: db,
-                  explicitlyWatchedTables: [
-                    if (smsMessagesTableRefs) db.smsMessagesTable,
-                    if (smsMessageSyncCursorTableRefs)
-                      db.smsMessageSyncCursorTable,
-                    if (smsMessageReadCursorTableRefs)
-                      db.smsMessageReadCursorTable,
-                    if (smsOutboxMessagesTableRefs) db.smsOutboxMessagesTable,
-                    if (smsOutboxMessageDeleteTableRefs)
-                      db.smsOutboxMessageDeleteTable,
-                    if (smsOutboxReadCursorsTableRefs)
-                      db.smsOutboxReadCursorsTable,
-                  ],
-                  addJoins: null,
-                  getPrefetchedDataCallback: (items) async {
-                    return [
-                      if (smsMessagesTableRefs)
-                        await $_getPrefetchedData<
-                          SmsConversationData,
-                          $SmsConversationsTableTable,
-                          SmsMessageData
-                        >(
-                          currentTable: table,
-                          referencedTable:
-                              $$SmsConversationsTableTableReferences
-                                  ._smsMessagesTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$SmsConversationsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).smsMessagesTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.conversationId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (smsMessageSyncCursorTableRefs)
-                        await $_getPrefetchedData<
-                          SmsConversationData,
-                          $SmsConversationsTableTable,
-                          SmsMessageSyncCursorData
-                        >(
-                          currentTable: table,
-                          referencedTable:
-                              $$SmsConversationsTableTableReferences
-                                  ._smsMessageSyncCursorTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$SmsConversationsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).smsMessageSyncCursorTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.conversationId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (smsMessageReadCursorTableRefs)
-                        await $_getPrefetchedData<
-                          SmsConversationData,
-                          $SmsConversationsTableTable,
-                          SmsMessageReadCursorData
-                        >(
-                          currentTable: table,
-                          referencedTable:
-                              $$SmsConversationsTableTableReferences
-                                  ._smsMessageReadCursorTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$SmsConversationsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).smsMessageReadCursorTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.conversationId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (smsOutboxMessagesTableRefs)
-                        await $_getPrefetchedData<
-                          SmsConversationData,
-                          $SmsConversationsTableTable,
-                          SmsOutboxMessageData
-                        >(
-                          currentTable: table,
-                          referencedTable:
-                              $$SmsConversationsTableTableReferences
-                                  ._smsOutboxMessagesTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$SmsConversationsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).smsOutboxMessagesTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.conversationId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (smsOutboxMessageDeleteTableRefs)
-                        await $_getPrefetchedData<
-                          SmsConversationData,
-                          $SmsConversationsTableTable,
-                          SmsOutboxMessageDeleteData
-                        >(
-                          currentTable: table,
-                          referencedTable:
-                              $$SmsConversationsTableTableReferences
-                                  ._smsOutboxMessageDeleteTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$SmsConversationsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).smsOutboxMessageDeleteTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.conversationId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                      if (smsOutboxReadCursorsTableRefs)
-                        await $_getPrefetchedData<
-                          SmsConversationData,
-                          $SmsConversationsTableTable,
-                          SmsOutboxReadCursorData
-                        >(
-                          currentTable: table,
-                          referencedTable:
-                              $$SmsConversationsTableTableReferences
-                                  ._smsOutboxReadCursorsTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$SmsConversationsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).smsOutboxReadCursorsTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.conversationId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                    ];
-                  },
-                );
-              },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -21613,16 +18884,16 @@ typedef $$SmsConversationsTableTableProcessedTableManager =
       $$SmsConversationsTableTableAnnotationComposer,
       $$SmsConversationsTableTableCreateCompanionBuilder,
       $$SmsConversationsTableTableUpdateCompanionBuilder,
-      (SmsConversationData, $$SmsConversationsTableTableReferences),
+      (
+        SmsConversationData,
+        BaseReferences<
+          _$AppDatabase,
+          $SmsConversationsTableTable,
+          SmsConversationData
+        >,
+      ),
       SmsConversationData,
-      PrefetchHooks Function({
-        bool smsMessagesTableRefs,
-        bool smsMessageSyncCursorTableRefs,
-        bool smsMessageReadCursorTableRefs,
-        bool smsOutboxMessagesTableRefs,
-        bool smsOutboxMessageDeleteTableRefs,
-        bool smsOutboxReadCursorsTableRefs,
-      })
+      PrefetchHooks Function()
     >;
 typedef $$SmsMessagesTableTableCreateCompanionBuilder =
     SmsMessageDataCompanion Function({
@@ -21653,38 +18924,6 @@ typedef $$SmsMessagesTableTableUpdateCompanionBuilder =
       Value<int?> deletedAtRemoteUsec,
     });
 
-final class $$SmsMessagesTableTableReferences
-    extends
-        BaseReferences<_$AppDatabase, $SmsMessagesTableTable, SmsMessageData> {
-  $$SmsMessagesTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $SmsConversationsTableTable _conversationIdTable(_$AppDatabase db) =>
-      db.smsConversationsTable.createAlias(
-        $_aliasNameGenerator(
-          db.smsMessagesTable.conversationId,
-          db.smsConversationsTable.id,
-        ),
-      );
-
-  $$SmsConversationsTableTableProcessedTableManager get conversationId {
-    final $_column = $_itemColumn<int>('conversation_id')!;
-
-    final manager = $$SmsConversationsTableTableTableManager(
-      $_db,
-      $_db.smsConversationsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_conversationIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$SmsMessagesTableTableFilterComposer
     extends Composer<_$AppDatabase, $SmsMessagesTableTable> {
   $$SmsMessagesTableTableFilterComposer({
@@ -21706,6 +18945,11 @@ class $$SmsMessagesTableTableFilterComposer
 
   ColumnFilters<String> get externalId => $composableBuilder(
     column: $table.externalId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -21748,30 +18992,6 @@ class $$SmsMessagesTableTableFilterComposer
     column: $table.deletedAtRemoteUsec,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$SmsConversationsTableTableFilterComposer get conversationId {
-    final $$SmsConversationsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessagesTableTableOrderingComposer
@@ -21795,6 +19015,11 @@ class $$SmsMessagesTableTableOrderingComposer
 
   ColumnOrderings<String> get externalId => $composableBuilder(
     column: $table.externalId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -21832,30 +19057,6 @@ class $$SmsMessagesTableTableOrderingComposer
     column: $table.deletedAtRemoteUsec,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$SmsConversationsTableTableOrderingComposer get conversationId {
-    final $$SmsConversationsTableTableOrderingComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableOrderingComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessagesTableTableAnnotationComposer
@@ -21875,6 +19076,11 @@ class $$SmsMessagesTableTableAnnotationComposer
 
   GeneratedColumn<String> get externalId => $composableBuilder(
     column: $table.externalId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
     builder: (column) => column,
   );
 
@@ -21911,30 +19117,6 @@ class $$SmsMessagesTableTableAnnotationComposer
     column: $table.deletedAtRemoteUsec,
     builder: (column) => column,
   );
-
-  $$SmsConversationsTableTableAnnotationComposer get conversationId {
-    final $$SmsConversationsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessagesTableTableTableManager
@@ -21948,9 +19130,16 @@ class $$SmsMessagesTableTableTableManager
           $$SmsMessagesTableTableAnnotationComposer,
           $$SmsMessagesTableTableCreateCompanionBuilder,
           $$SmsMessagesTableTableUpdateCompanionBuilder,
-          (SmsMessageData, $$SmsMessagesTableTableReferences),
+          (
+            SmsMessageData,
+            BaseReferences<
+              _$AppDatabase,
+              $SmsMessagesTableTable,
+              SmsMessageData
+            >,
+          ),
           SmsMessageData,
-          PrefetchHooks Function({bool conversationId})
+          PrefetchHooks Function()
         > {
   $$SmsMessagesTableTableTableManager(
     _$AppDatabase db,
@@ -22019,56 +19208,9 @@ class $$SmsMessagesTableTableTableManager
                 deletedAtRemoteUsec: deletedAtRemoteUsec,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SmsMessagesTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({conversationId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (conversationId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.conversationId,
-                                referencedTable:
-                                    $$SmsMessagesTableTableReferences
-                                        ._conversationIdTable(db),
-                                referencedColumn:
-                                    $$SmsMessagesTableTableReferences
-                                        ._conversationIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -22083,9 +19225,12 @@ typedef $$SmsMessagesTableTableProcessedTableManager =
       $$SmsMessagesTableTableAnnotationComposer,
       $$SmsMessagesTableTableCreateCompanionBuilder,
       $$SmsMessagesTableTableUpdateCompanionBuilder,
-      (SmsMessageData, $$SmsMessagesTableTableReferences),
+      (
+        SmsMessageData,
+        BaseReferences<_$AppDatabase, $SmsMessagesTableTable, SmsMessageData>,
+      ),
       SmsMessageData,
-      PrefetchHooks Function({bool conversationId})
+      PrefetchHooks Function()
     >;
 typedef $$SmsMessageSyncCursorTableTableCreateCompanionBuilder =
     SmsMessageSyncCursorDataCompanion Function({
@@ -22102,42 +19247,6 @@ typedef $$SmsMessageSyncCursorTableTableUpdateCompanionBuilder =
       Value<int> rowid,
     });
 
-final class $$SmsMessageSyncCursorTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SmsMessageSyncCursorTableTable,
-          SmsMessageSyncCursorData
-        > {
-  $$SmsMessageSyncCursorTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $SmsConversationsTableTable _conversationIdTable(_$AppDatabase db) =>
-      db.smsConversationsTable.createAlias(
-        $_aliasNameGenerator(
-          db.smsMessageSyncCursorTable.conversationId,
-          db.smsConversationsTable.id,
-        ),
-      );
-
-  $$SmsConversationsTableTableProcessedTableManager get conversationId {
-    final $_column = $_itemColumn<int>('conversation_id')!;
-
-    final manager = $$SmsConversationsTableTableTableManager(
-      $_db,
-      $_db.smsConversationsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_conversationIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$SmsMessageSyncCursorTableTableFilterComposer
     extends Composer<_$AppDatabase, $SmsMessageSyncCursorTableTable> {
   $$SmsMessageSyncCursorTableTableFilterComposer({
@@ -22147,6 +19256,11 @@ class $$SmsMessageSyncCursorTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnWithTypeConverterFilters<
     SmsSyncCursorTypeEnum,
     SmsSyncCursorTypeEnum,
@@ -22161,30 +19275,6 @@ class $$SmsMessageSyncCursorTableTableFilterComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$SmsConversationsTableTableFilterComposer get conversationId {
-    final $$SmsConversationsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessageSyncCursorTableTableOrderingComposer
@@ -22196,6 +19286,11 @@ class $$SmsMessageSyncCursorTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get cursorType => $composableBuilder(
     column: $table.cursorType,
     builder: (column) => ColumnOrderings(column),
@@ -22205,30 +19300,6 @@ class $$SmsMessageSyncCursorTableTableOrderingComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$SmsConversationsTableTableOrderingComposer get conversationId {
-    final $$SmsConversationsTableTableOrderingComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableOrderingComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessageSyncCursorTableTableAnnotationComposer
@@ -22240,6 +19311,11 @@ class $$SmsMessageSyncCursorTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => column,
+  );
+
   GeneratedColumnWithTypeConverter<SmsSyncCursorTypeEnum, String>
   get cursorType => $composableBuilder(
     column: $table.cursorType,
@@ -22250,30 +19326,6 @@ class $$SmsMessageSyncCursorTableTableAnnotationComposer
     column: $table.timestampUsec,
     builder: (column) => column,
   );
-
-  $$SmsConversationsTableTableAnnotationComposer get conversationId {
-    final $$SmsConversationsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessageSyncCursorTableTableTableManager
@@ -22289,10 +19341,14 @@ class $$SmsMessageSyncCursorTableTableTableManager
           $$SmsMessageSyncCursorTableTableUpdateCompanionBuilder,
           (
             SmsMessageSyncCursorData,
-            $$SmsMessageSyncCursorTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $SmsMessageSyncCursorTableTable,
+              SmsMessageSyncCursorData
+            >,
           ),
           SmsMessageSyncCursorData,
-          PrefetchHooks Function({bool conversationId})
+          PrefetchHooks Function()
         > {
   $$SmsMessageSyncCursorTableTableTableManager(
     _$AppDatabase db,
@@ -22341,56 +19397,9 @@ class $$SmsMessageSyncCursorTableTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SmsMessageSyncCursorTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({conversationId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (conversationId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.conversationId,
-                                referencedTable:
-                                    $$SmsMessageSyncCursorTableTableReferences
-                                        ._conversationIdTable(db),
-                                referencedColumn:
-                                    $$SmsMessageSyncCursorTableTableReferences
-                                        ._conversationIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -22405,9 +19414,16 @@ typedef $$SmsMessageSyncCursorTableTableProcessedTableManager =
       $$SmsMessageSyncCursorTableTableAnnotationComposer,
       $$SmsMessageSyncCursorTableTableCreateCompanionBuilder,
       $$SmsMessageSyncCursorTableTableUpdateCompanionBuilder,
-      (SmsMessageSyncCursorData, $$SmsMessageSyncCursorTableTableReferences),
+      (
+        SmsMessageSyncCursorData,
+        BaseReferences<
+          _$AppDatabase,
+          $SmsMessageSyncCursorTableTable,
+          SmsMessageSyncCursorData
+        >,
+      ),
       SmsMessageSyncCursorData,
-      PrefetchHooks Function({bool conversationId})
+      PrefetchHooks Function()
     >;
 typedef $$SmsMessageReadCursorTableTableCreateCompanionBuilder =
     SmsMessageReadCursorDataCompanion Function({
@@ -22424,42 +19440,6 @@ typedef $$SmsMessageReadCursorTableTableUpdateCompanionBuilder =
       Value<int> rowid,
     });
 
-final class $$SmsMessageReadCursorTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SmsMessageReadCursorTableTable,
-          SmsMessageReadCursorData
-        > {
-  $$SmsMessageReadCursorTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $SmsConversationsTableTable _conversationIdTable(_$AppDatabase db) =>
-      db.smsConversationsTable.createAlias(
-        $_aliasNameGenerator(
-          db.smsMessageReadCursorTable.conversationId,
-          db.smsConversationsTable.id,
-        ),
-      );
-
-  $$SmsConversationsTableTableProcessedTableManager get conversationId {
-    final $_column = $_itemColumn<int>('conversation_id')!;
-
-    final manager = $$SmsConversationsTableTableTableManager(
-      $_db,
-      $_db.smsConversationsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_conversationIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$SmsMessageReadCursorTableTableFilterComposer
     extends Composer<_$AppDatabase, $SmsMessageReadCursorTableTable> {
   $$SmsMessageReadCursorTableTableFilterComposer({
@@ -22469,6 +19449,11 @@ class $$SmsMessageReadCursorTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get userId => $composableBuilder(
     column: $table.userId,
     builder: (column) => ColumnFilters(column),
@@ -22478,30 +19463,6 @@ class $$SmsMessageReadCursorTableTableFilterComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$SmsConversationsTableTableFilterComposer get conversationId {
-    final $$SmsConversationsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessageReadCursorTableTableOrderingComposer
@@ -22513,6 +19474,11 @@ class $$SmsMessageReadCursorTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get userId => $composableBuilder(
     column: $table.userId,
     builder: (column) => ColumnOrderings(column),
@@ -22522,30 +19488,6 @@ class $$SmsMessageReadCursorTableTableOrderingComposer
     column: $table.timestampUsec,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$SmsConversationsTableTableOrderingComposer get conversationId {
-    final $$SmsConversationsTableTableOrderingComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableOrderingComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessageReadCursorTableTableAnnotationComposer
@@ -22557,6 +19499,11 @@ class $$SmsMessageReadCursorTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get userId =>
       $composableBuilder(column: $table.userId, builder: (column) => column);
 
@@ -22564,30 +19511,6 @@ class $$SmsMessageReadCursorTableTableAnnotationComposer
     column: $table.timestampUsec,
     builder: (column) => column,
   );
-
-  $$SmsConversationsTableTableAnnotationComposer get conversationId {
-    final $$SmsConversationsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsMessageReadCursorTableTableTableManager
@@ -22603,10 +19526,14 @@ class $$SmsMessageReadCursorTableTableTableManager
           $$SmsMessageReadCursorTableTableUpdateCompanionBuilder,
           (
             SmsMessageReadCursorData,
-            $$SmsMessageReadCursorTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $SmsMessageReadCursorTableTable,
+              SmsMessageReadCursorData
+            >,
           ),
           SmsMessageReadCursorData,
-          PrefetchHooks Function({bool conversationId})
+          PrefetchHooks Function()
         > {
   $$SmsMessageReadCursorTableTableTableManager(
     _$AppDatabase db,
@@ -22655,56 +19582,9 @@ class $$SmsMessageReadCursorTableTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SmsMessageReadCursorTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({conversationId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (conversationId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.conversationId,
-                                referencedTable:
-                                    $$SmsMessageReadCursorTableTableReferences
-                                        ._conversationIdTable(db),
-                                referencedColumn:
-                                    $$SmsMessageReadCursorTableTableReferences
-                                        ._conversationIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -22719,9 +19599,16 @@ typedef $$SmsMessageReadCursorTableTableProcessedTableManager =
       $$SmsMessageReadCursorTableTableAnnotationComposer,
       $$SmsMessageReadCursorTableTableCreateCompanionBuilder,
       $$SmsMessageReadCursorTableTableUpdateCompanionBuilder,
-      (SmsMessageReadCursorData, $$SmsMessageReadCursorTableTableReferences),
+      (
+        SmsMessageReadCursorData,
+        BaseReferences<
+          _$AppDatabase,
+          $SmsMessageReadCursorTableTable,
+          SmsMessageReadCursorData
+        >,
+      ),
       SmsMessageReadCursorData,
-      PrefetchHooks Function({bool conversationId})
+      PrefetchHooks Function()
     >;
 typedef $$SmsOutboxMessagesTableTableCreateCompanionBuilder =
     SmsOutboxMessageDataCompanion Function({
@@ -22746,42 +19633,6 @@ typedef $$SmsOutboxMessagesTableTableUpdateCompanionBuilder =
       Value<int> rowid,
     });
 
-final class $$SmsOutboxMessagesTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SmsOutboxMessagesTableTable,
-          SmsOutboxMessageData
-        > {
-  $$SmsOutboxMessagesTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $SmsConversationsTableTable _conversationIdTable(_$AppDatabase db) =>
-      db.smsConversationsTable.createAlias(
-        $_aliasNameGenerator(
-          db.smsOutboxMessagesTable.conversationId,
-          db.smsConversationsTable.id,
-        ),
-      );
-
-  $$SmsConversationsTableTableProcessedTableManager? get conversationId {
-    final $_column = $_itemColumn<int>('conversation_id');
-    if ($_column == null) return null;
-    final manager = $$SmsConversationsTableTableTableManager(
-      $_db,
-      $_db.smsConversationsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_conversationIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$SmsOutboxMessagesTableTableFilterComposer
     extends Composer<_$AppDatabase, $SmsOutboxMessagesTableTable> {
   $$SmsOutboxMessagesTableTableFilterComposer({
@@ -22793,6 +19644,11 @@ class $$SmsOutboxMessagesTableTableFilterComposer
   });
   ColumnFilters<String> get idKey => $composableBuilder(
     column: $table.idKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -22820,30 +19676,6 @@ class $$SmsOutboxMessagesTableTableFilterComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$SmsConversationsTableTableFilterComposer get conversationId {
-    final $$SmsConversationsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxMessagesTableTableOrderingComposer
@@ -22857,6 +19689,11 @@ class $$SmsOutboxMessagesTableTableOrderingComposer
   });
   ColumnOrderings<String> get idKey => $composableBuilder(
     column: $table.idKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -22884,30 +19721,6 @@ class $$SmsOutboxMessagesTableTableOrderingComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$SmsConversationsTableTableOrderingComposer get conversationId {
-    final $$SmsConversationsTableTableOrderingComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableOrderingComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxMessagesTableTableAnnotationComposer
@@ -22921,6 +19734,11 @@ class $$SmsOutboxMessagesTableTableAnnotationComposer
   });
   GeneratedColumn<String> get idKey =>
       $composableBuilder(column: $table.idKey, builder: (column) => column);
+
+  GeneratedColumn<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<String> get fromPhoneNumber => $composableBuilder(
     column: $table.fromPhoneNumber,
@@ -22944,30 +19762,6 @@ class $$SmsOutboxMessagesTableTableAnnotationComposer
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$SmsConversationsTableTableAnnotationComposer get conversationId {
-    final $$SmsConversationsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxMessagesTableTableTableManager
@@ -22981,9 +19775,16 @@ class $$SmsOutboxMessagesTableTableTableManager
           $$SmsOutboxMessagesTableTableAnnotationComposer,
           $$SmsOutboxMessagesTableTableCreateCompanionBuilder,
           $$SmsOutboxMessagesTableTableUpdateCompanionBuilder,
-          (SmsOutboxMessageData, $$SmsOutboxMessagesTableTableReferences),
+          (
+            SmsOutboxMessageData,
+            BaseReferences<
+              _$AppDatabase,
+              $SmsOutboxMessagesTableTable,
+              SmsOutboxMessageData
+            >,
+          ),
           SmsOutboxMessageData,
-          PrefetchHooks Function({bool conversationId})
+          PrefetchHooks Function()
         > {
   $$SmsOutboxMessagesTableTableTableManager(
     _$AppDatabase db,
@@ -23048,56 +19849,9 @@ class $$SmsOutboxMessagesTableTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SmsOutboxMessagesTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({conversationId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (conversationId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.conversationId,
-                                referencedTable:
-                                    $$SmsOutboxMessagesTableTableReferences
-                                        ._conversationIdTable(db),
-                                referencedColumn:
-                                    $$SmsOutboxMessagesTableTableReferences
-                                        ._conversationIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -23112,9 +19866,16 @@ typedef $$SmsOutboxMessagesTableTableProcessedTableManager =
       $$SmsOutboxMessagesTableTableAnnotationComposer,
       $$SmsOutboxMessagesTableTableCreateCompanionBuilder,
       $$SmsOutboxMessagesTableTableUpdateCompanionBuilder,
-      (SmsOutboxMessageData, $$SmsOutboxMessagesTableTableReferences),
+      (
+        SmsOutboxMessageData,
+        BaseReferences<
+          _$AppDatabase,
+          $SmsOutboxMessagesTableTable,
+          SmsOutboxMessageData
+        >,
+      ),
       SmsOutboxMessageData,
-      PrefetchHooks Function({bool conversationId})
+      PrefetchHooks Function()
     >;
 typedef $$SmsOutboxMessageDeleteTableTableCreateCompanionBuilder =
     SmsOutboxMessageDeleteDataCompanion Function({
@@ -23130,42 +19891,6 @@ typedef $$SmsOutboxMessageDeleteTableTableUpdateCompanionBuilder =
       Value<int> conversationId,
       Value<int> sendAttempts,
     });
-
-final class $$SmsOutboxMessageDeleteTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SmsOutboxMessageDeleteTableTable,
-          SmsOutboxMessageDeleteData
-        > {
-  $$SmsOutboxMessageDeleteTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $SmsConversationsTableTable _conversationIdTable(_$AppDatabase db) =>
-      db.smsConversationsTable.createAlias(
-        $_aliasNameGenerator(
-          db.smsOutboxMessageDeleteTable.conversationId,
-          db.smsConversationsTable.id,
-        ),
-      );
-
-  $$SmsConversationsTableTableProcessedTableManager get conversationId {
-    final $_column = $_itemColumn<int>('conversation_id')!;
-
-    final manager = $$SmsConversationsTableTableTableManager(
-      $_db,
-      $_db.smsConversationsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_conversationIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
 
 class $$SmsOutboxMessageDeleteTableTableFilterComposer
     extends Composer<_$AppDatabase, $SmsOutboxMessageDeleteTableTable> {
@@ -23186,34 +19911,15 @@ class $$SmsOutboxMessageDeleteTableTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<int> get sendAttempts => $composableBuilder(
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$SmsConversationsTableTableFilterComposer get conversationId {
-    final $$SmsConversationsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxMessageDeleteTableTableOrderingComposer
@@ -23235,34 +19941,15 @@ class $$SmsOutboxMessageDeleteTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get sendAttempts => $composableBuilder(
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$SmsConversationsTableTableOrderingComposer get conversationId {
-    final $$SmsConversationsTableTableOrderingComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableOrderingComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxMessageDeleteTableTableAnnotationComposer
@@ -23280,34 +19967,15 @@ class $$SmsOutboxMessageDeleteTableTableAnnotationComposer
   GeneratedColumn<String> get idKey =>
       $composableBuilder(column: $table.idKey, builder: (column) => column);
 
+  GeneratedColumn<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<int> get sendAttempts => $composableBuilder(
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$SmsConversationsTableTableAnnotationComposer get conversationId {
-    final $$SmsConversationsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxMessageDeleteTableTableTableManager
@@ -23323,10 +19991,14 @@ class $$SmsOutboxMessageDeleteTableTableTableManager
           $$SmsOutboxMessageDeleteTableTableUpdateCompanionBuilder,
           (
             SmsOutboxMessageDeleteData,
-            $$SmsOutboxMessageDeleteTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $SmsOutboxMessageDeleteTableTable,
+              SmsOutboxMessageDeleteData
+            >,
           ),
           SmsOutboxMessageDeleteData,
-          PrefetchHooks Function({bool conversationId})
+          PrefetchHooks Function()
         > {
   $$SmsOutboxMessageDeleteTableTableTableManager(
     _$AppDatabase db,
@@ -23375,56 +20047,9 @@ class $$SmsOutboxMessageDeleteTableTableTableManager
                 sendAttempts: sendAttempts,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SmsOutboxMessageDeleteTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({conversationId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (conversationId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.conversationId,
-                                referencedTable:
-                                    $$SmsOutboxMessageDeleteTableTableReferences
-                                        ._conversationIdTable(db),
-                                referencedColumn:
-                                    $$SmsOutboxMessageDeleteTableTableReferences
-                                        ._conversationIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -23441,10 +20066,14 @@ typedef $$SmsOutboxMessageDeleteTableTableProcessedTableManager =
       $$SmsOutboxMessageDeleteTableTableUpdateCompanionBuilder,
       (
         SmsOutboxMessageDeleteData,
-        $$SmsOutboxMessageDeleteTableTableReferences,
+        BaseReferences<
+          _$AppDatabase,
+          $SmsOutboxMessageDeleteTableTable,
+          SmsOutboxMessageDeleteData
+        >,
       ),
       SmsOutboxMessageDeleteData,
-      PrefetchHooks Function({bool conversationId})
+      PrefetchHooks Function()
     >;
 typedef $$SmsOutboxReadCursorsTableTableCreateCompanionBuilder =
     SmsOutboxReadCursorDataCompanion Function({
@@ -23459,42 +20088,6 @@ typedef $$SmsOutboxReadCursorsTableTableUpdateCompanionBuilder =
       Value<int> sendAttempts,
     });
 
-final class $$SmsOutboxReadCursorsTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SmsOutboxReadCursorsTableTable,
-          SmsOutboxReadCursorData
-        > {
-  $$SmsOutboxReadCursorsTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $SmsConversationsTableTable _conversationIdTable(_$AppDatabase db) =>
-      db.smsConversationsTable.createAlias(
-        $_aliasNameGenerator(
-          db.smsOutboxReadCursorsTable.conversationId,
-          db.smsConversationsTable.id,
-        ),
-      );
-
-  $$SmsConversationsTableTableProcessedTableManager get conversationId {
-    final $_column = $_itemColumn<int>('conversation_id')!;
-
-    final manager = $$SmsConversationsTableTableTableManager(
-      $_db,
-      $_db.smsConversationsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_conversationIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$SmsOutboxReadCursorsTableTableFilterComposer
     extends Composer<_$AppDatabase, $SmsOutboxReadCursorsTableTable> {
   $$SmsOutboxReadCursorsTableTableFilterComposer({
@@ -23504,6 +20097,11 @@ class $$SmsOutboxReadCursorsTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<int> get timestampUsec => $composableBuilder(
     column: $table.timestampUsec,
     builder: (column) => ColumnFilters(column),
@@ -23513,30 +20111,6 @@ class $$SmsOutboxReadCursorsTableTableFilterComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$SmsConversationsTableTableFilterComposer get conversationId {
-    final $$SmsConversationsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxReadCursorsTableTableOrderingComposer
@@ -23548,6 +20122,11 @@ class $$SmsOutboxReadCursorsTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get timestampUsec => $composableBuilder(
     column: $table.timestampUsec,
     builder: (column) => ColumnOrderings(column),
@@ -23557,30 +20136,6 @@ class $$SmsOutboxReadCursorsTableTableOrderingComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$SmsConversationsTableTableOrderingComposer get conversationId {
-    final $$SmsConversationsTableTableOrderingComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableOrderingComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxReadCursorsTableTableAnnotationComposer
@@ -23592,6 +20147,11 @@ class $$SmsOutboxReadCursorsTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<int> get timestampUsec => $composableBuilder(
     column: $table.timestampUsec,
     builder: (column) => column,
@@ -23601,30 +20161,6 @@ class $$SmsOutboxReadCursorsTableTableAnnotationComposer
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$SmsConversationsTableTableAnnotationComposer get conversationId {
-    final $$SmsConversationsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.conversationId,
-          referencedTable: $db.smsConversationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SmsConversationsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.smsConversationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SmsOutboxReadCursorsTableTableTableManager
@@ -23638,9 +20174,16 @@ class $$SmsOutboxReadCursorsTableTableTableManager
           $$SmsOutboxReadCursorsTableTableAnnotationComposer,
           $$SmsOutboxReadCursorsTableTableCreateCompanionBuilder,
           $$SmsOutboxReadCursorsTableTableUpdateCompanionBuilder,
-          (SmsOutboxReadCursorData, $$SmsOutboxReadCursorsTableTableReferences),
+          (
+            SmsOutboxReadCursorData,
+            BaseReferences<
+              _$AppDatabase,
+              $SmsOutboxReadCursorsTableTable,
+              SmsOutboxReadCursorData
+            >,
+          ),
           SmsOutboxReadCursorData,
-          PrefetchHooks Function({bool conversationId})
+          PrefetchHooks Function()
         > {
   $$SmsOutboxReadCursorsTableTableTableManager(
     _$AppDatabase db,
@@ -23685,56 +20228,9 @@ class $$SmsOutboxReadCursorsTableTableTableManager
                 sendAttempts: sendAttempts,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SmsOutboxReadCursorsTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({conversationId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (conversationId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.conversationId,
-                                referencedTable:
-                                    $$SmsOutboxReadCursorsTableTableReferences
-                                        ._conversationIdTable(db),
-                                referencedColumn:
-                                    $$SmsOutboxReadCursorsTableTableReferences
-                                        ._conversationIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -23749,9 +20245,16 @@ typedef $$SmsOutboxReadCursorsTableTableProcessedTableManager =
       $$SmsOutboxReadCursorsTableTableAnnotationComposer,
       $$SmsOutboxReadCursorsTableTableCreateCompanionBuilder,
       $$SmsOutboxReadCursorsTableTableUpdateCompanionBuilder,
-      (SmsOutboxReadCursorData, $$SmsOutboxReadCursorsTableTableReferences),
+      (
+        SmsOutboxReadCursorData,
+        BaseReferences<
+          _$AppDatabase,
+          $SmsOutboxReadCursorsTableTable,
+          SmsOutboxReadCursorData
+        >,
+      ),
       SmsOutboxReadCursorData,
-      PrefetchHooks Function({bool conversationId})
+      PrefetchHooks Function()
     >;
 typedef $$SipSubscriptionsTableTableCreateCompanionBuilder =
     SipSubscriptionDataCompanion Function({
@@ -24903,48 +21406,6 @@ typedef $$SystemNotificationsTableTableUpdateCompanionBuilder =
       Value<int> updatedAtRemoteUsec,
     });
 
-final class $$SystemNotificationsTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SystemNotificationsTableTable,
-          SystemNotificationData
-        > {
-  $$SystemNotificationsTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static MultiTypedResultKey<
-    $SystemNotificationsOutboxTableTable,
-    List<SystemNotificationOutboxEntryData>
-  >
-  _systemNotificationsOutboxTableRefsTable(_$AppDatabase db) =>
-      MultiTypedResultKey.fromTable(
-        db.systemNotificationsOutboxTable,
-        aliasName: $_aliasNameGenerator(
-          db.systemNotificationsTable.id,
-          db.systemNotificationsOutboxTable.notificationId,
-        ),
-      );
-
-  $$SystemNotificationsOutboxTableTableProcessedTableManager
-  get systemNotificationsOutboxTableRefs {
-    final manager = $$SystemNotificationsOutboxTableTableTableManager(
-      $_db,
-      $_db.systemNotificationsOutboxTable,
-    ).filter((f) => f.notificationId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(
-      _systemNotificationsOutboxTableRefsTable($_db),
-    );
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-}
-
 class $$SystemNotificationsTableTableFilterComposer
     extends Composer<_$AppDatabase, $SystemNotificationsTableTable> {
   $$SystemNotificationsTableTableFilterComposer({
@@ -24993,35 +21454,6 @@ class $$SystemNotificationsTableTableFilterComposer
     column: $table.updatedAtRemoteUsec,
     builder: (column) => ColumnFilters(column),
   );
-
-  Expression<bool> systemNotificationsOutboxTableRefs(
-    Expression<bool> Function(
-      $$SystemNotificationsOutboxTableTableFilterComposer f,
-    )
-    f,
-  ) {
-    final $$SystemNotificationsOutboxTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.systemNotificationsOutboxTable,
-          getReferencedColumn: (t) => t.notificationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SystemNotificationsOutboxTableTableFilterComposer(
-                $db: $db,
-                $table: $db.systemNotificationsOutboxTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
 }
 
 class $$SystemNotificationsTableTableOrderingComposer
@@ -25102,35 +21534,6 @@ class $$SystemNotificationsTableTableAnnotationComposer
     column: $table.updatedAtRemoteUsec,
     builder: (column) => column,
   );
-
-  Expression<T> systemNotificationsOutboxTableRefs<T extends Object>(
-    Expression<T> Function(
-      $$SystemNotificationsOutboxTableTableAnnotationComposer a,
-    )
-    f,
-  ) {
-    final $$SystemNotificationsOutboxTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.id,
-          referencedTable: $db.systemNotificationsOutboxTable,
-          getReferencedColumn: (t) => t.notificationId,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SystemNotificationsOutboxTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.systemNotificationsOutboxTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return f(composer);
-  }
 }
 
 class $$SystemNotificationsTableTableTableManager
@@ -25144,9 +21547,16 @@ class $$SystemNotificationsTableTableTableManager
           $$SystemNotificationsTableTableAnnotationComposer,
           $$SystemNotificationsTableTableCreateCompanionBuilder,
           $$SystemNotificationsTableTableUpdateCompanionBuilder,
-          (SystemNotificationData, $$SystemNotificationsTableTableReferences),
+          (
+            SystemNotificationData,
+            BaseReferences<
+              _$AppDatabase,
+              $SystemNotificationsTableTable,
+              SystemNotificationData
+            >,
+          ),
           SystemNotificationData,
-          PrefetchHooks Function({bool systemNotificationsOutboxTableRefs})
+          PrefetchHooks Function()
         > {
   $$SystemNotificationsTableTableTableManager(
     _$AppDatabase db,
@@ -25207,50 +21617,9 @@ class $$SystemNotificationsTableTableTableManager
                 updatedAtRemoteUsec: updatedAtRemoteUsec,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SystemNotificationsTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback:
-              ({systemNotificationsOutboxTableRefs = false}) {
-                return PrefetchHooks(
-                  db: db,
-                  explicitlyWatchedTables: [
-                    if (systemNotificationsOutboxTableRefs)
-                      db.systemNotificationsOutboxTable,
-                  ],
-                  addJoins: null,
-                  getPrefetchedDataCallback: (items) async {
-                    return [
-                      if (systemNotificationsOutboxTableRefs)
-                        await $_getPrefetchedData<
-                          SystemNotificationData,
-                          $SystemNotificationsTableTable,
-                          SystemNotificationOutboxEntryData
-                        >(
-                          currentTable: table,
-                          referencedTable:
-                              $$SystemNotificationsTableTableReferences
-                                  ._systemNotificationsOutboxTableRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$SystemNotificationsTableTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).systemNotificationsOutboxTableRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.notificationId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                    ];
-                  },
-                );
-              },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -25265,9 +21634,16 @@ typedef $$SystemNotificationsTableTableProcessedTableManager =
       $$SystemNotificationsTableTableAnnotationComposer,
       $$SystemNotificationsTableTableCreateCompanionBuilder,
       $$SystemNotificationsTableTableUpdateCompanionBuilder,
-      (SystemNotificationData, $$SystemNotificationsTableTableReferences),
+      (
+        SystemNotificationData,
+        BaseReferences<
+          _$AppDatabase,
+          $SystemNotificationsTableTable,
+          SystemNotificationData
+        >,
+      ),
       SystemNotificationData,
-      PrefetchHooks Function({bool systemNotificationsOutboxTableRefs})
+      PrefetchHooks Function()
     >;
 typedef $$SystemNotificationsOutboxTableTableCreateCompanionBuilder =
     SystemNotificationOutboxEntryDataCompanion Function({
@@ -25286,43 +21662,6 @@ typedef $$SystemNotificationsOutboxTableTableUpdateCompanionBuilder =
       Value<int> rowid,
     });
 
-final class $$SystemNotificationsOutboxTableTableReferences
-    extends
-        BaseReferences<
-          _$AppDatabase,
-          $SystemNotificationsOutboxTableTable,
-          SystemNotificationOutboxEntryData
-        > {
-  $$SystemNotificationsOutboxTableTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $SystemNotificationsTableTable _notificationIdTable(
-    _$AppDatabase db,
-  ) => db.systemNotificationsTable.createAlias(
-    $_aliasNameGenerator(
-      db.systemNotificationsOutboxTable.notificationId,
-      db.systemNotificationsTable.id,
-    ),
-  );
-
-  $$SystemNotificationsTableTableProcessedTableManager get notificationId {
-    final $_column = $_itemColumn<int>('notification_id')!;
-
-    final manager = $$SystemNotificationsTableTableTableManager(
-      $_db,
-      $_db.systemNotificationsTable,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_notificationIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$SystemNotificationsOutboxTableTableFilterComposer
     extends Composer<_$AppDatabase, $SystemNotificationsOutboxTableTable> {
   $$SystemNotificationsOutboxTableTableFilterComposer({
@@ -25332,6 +21671,11 @@ class $$SystemNotificationsOutboxTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get notificationId => $composableBuilder(
+    column: $table.notificationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnWithTypeConverterFilters<
     SnOutboxDataActionType,
     SnOutboxDataActionType,
@@ -25352,30 +21696,6 @@ class $$SystemNotificationsOutboxTableTableFilterComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$SystemNotificationsTableTableFilterComposer get notificationId {
-    final $$SystemNotificationsTableTableFilterComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.notificationId,
-          referencedTable: $db.systemNotificationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SystemNotificationsTableTableFilterComposer(
-                $db: $db,
-                $table: $db.systemNotificationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SystemNotificationsOutboxTableTableOrderingComposer
@@ -25387,6 +21707,11 @@ class $$SystemNotificationsOutboxTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get notificationId => $composableBuilder(
+    column: $table.notificationId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get actionType => $composableBuilder(
     column: $table.actionType,
     builder: (column) => ColumnOrderings(column),
@@ -25401,30 +21726,6 @@ class $$SystemNotificationsOutboxTableTableOrderingComposer
     column: $table.sendAttempts,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$SystemNotificationsTableTableOrderingComposer get notificationId {
-    final $$SystemNotificationsTableTableOrderingComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.notificationId,
-          referencedTable: $db.systemNotificationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SystemNotificationsTableTableOrderingComposer(
-                $db: $db,
-                $table: $db.systemNotificationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SystemNotificationsOutboxTableTableAnnotationComposer
@@ -25436,6 +21737,11 @@ class $$SystemNotificationsOutboxTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get notificationId => $composableBuilder(
+    column: $table.notificationId,
+    builder: (column) => column,
+  );
+
   GeneratedColumnWithTypeConverter<SnOutboxDataActionType, String>
   get actionType => $composableBuilder(
     column: $table.actionType,
@@ -25449,30 +21755,6 @@ class $$SystemNotificationsOutboxTableTableAnnotationComposer
     column: $table.sendAttempts,
     builder: (column) => column,
   );
-
-  $$SystemNotificationsTableTableAnnotationComposer get notificationId {
-    final $$SystemNotificationsTableTableAnnotationComposer composer =
-        $composerBuilder(
-          composer: this,
-          getCurrentColumn: (t) => t.notificationId,
-          referencedTable: $db.systemNotificationsTable,
-          getReferencedColumn: (t) => t.id,
-          builder:
-              (
-                joinBuilder, {
-                $addJoinBuilderToRootComposer,
-                $removeJoinBuilderFromRootComposer,
-              }) => $$SystemNotificationsTableTableAnnotationComposer(
-                $db: $db,
-                $table: $db.systemNotificationsTable,
-                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-                joinBuilder: joinBuilder,
-                $removeJoinBuilderFromRootComposer:
-                    $removeJoinBuilderFromRootComposer,
-              ),
-        );
-    return composer;
-  }
 }
 
 class $$SystemNotificationsOutboxTableTableTableManager
@@ -25488,10 +21770,14 @@ class $$SystemNotificationsOutboxTableTableTableManager
           $$SystemNotificationsOutboxTableTableUpdateCompanionBuilder,
           (
             SystemNotificationOutboxEntryData,
-            $$SystemNotificationsOutboxTableTableReferences,
+            BaseReferences<
+              _$AppDatabase,
+              $SystemNotificationsOutboxTableTable,
+              SystemNotificationOutboxEntryData
+            >,
           ),
           SystemNotificationOutboxEntryData,
-          PrefetchHooks Function({bool notificationId})
+          PrefetchHooks Function()
         > {
   $$SystemNotificationsOutboxTableTableTableManager(
     _$AppDatabase db,
@@ -25544,56 +21830,9 @@ class $$SystemNotificationsOutboxTableTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$SystemNotificationsOutboxTableTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({notificationId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (notificationId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.notificationId,
-                                referencedTable:
-                                    $$SystemNotificationsOutboxTableTableReferences
-                                        ._notificationIdTable(db),
-                                referencedColumn:
-                                    $$SystemNotificationsOutboxTableTableReferences
-                                        ._notificationIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -25610,10 +21849,14 @@ typedef $$SystemNotificationsOutboxTableTableProcessedTableManager =
       $$SystemNotificationsOutboxTableTableUpdateCompanionBuilder,
       (
         SystemNotificationOutboxEntryData,
-        $$SystemNotificationsOutboxTableTableReferences,
+        BaseReferences<
+          _$AppDatabase,
+          $SystemNotificationsOutboxTableTable,
+          SystemNotificationOutboxEntryData
+        >,
       ),
       SystemNotificationOutboxEntryData,
-      PrefetchHooks Function({bool notificationId})
+      PrefetchHooks Function()
     >;
 typedef $$PresenceInfoTableTableCreateCompanionBuilder =
     PresenceInfoDataCompanion Function({

--- a/packages/device_auto_rotate/example/pubspec.lock
+++ b/packages/device_auto_rotate/example/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -242,10 +242,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:

--- a/packages/pjsua_companion/pubspec.yaml
+++ b/packages/pjsua_companion/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
   logging: ^1.3.0
 
 dev_dependencies:
-  lints: ^6.0.0
+  lints: ^6.1.0

--- a/packages/ssl_certificates/pubspec.yaml
+++ b/packages/ssl_certificates/pubspec.yaml
@@ -9,4 +9,4 @@ environment:
   sdk: ^3.8.0
 
 dev_dependencies:
-  lints: ^6.0.0
+  lints: ^6.1.0

--- a/packages/store_info_extractor/pubspec.yaml
+++ b/packages/store_info_extractor/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
   pub_semver: ^2.2.0
 
 dev_dependencies:
-  lints: ^6.0.0
-  test: ^1.26.3
+  lints: ^6.1.0
+  test: ^1.31.0

--- a/packages/webtrit_api/lib/src/webtrit_http_request_executor.dart
+++ b/packages/webtrit_api/lib/src/webtrit_http_request_executor.dart
@@ -30,7 +30,7 @@ class HttpRequestExecutor {
     final request = http.Request(method.toUpperCase(), uri);
 
     final xRequestId = requestId ?? RequestUtil.generate();
-    final finalHeaders = {'x-request-id': xRequestId, if (headers != null) ...headers};
+    final finalHeaders = {'x-request-id': xRequestId, ...?headers};
 
     request.headers.addAll(finalHeaders);
 

--- a/packages/webtrit_api/pubspec.yaml
+++ b/packages/webtrit_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   freezed_annotation: ^3.1.0
   http: ^1.6.0
-  json_annotation: ^4.9.0
+  json_annotation: ^4.12.0
   meta: any
   pub_semver: ^2.2.0
   logging: ^1.3.0
@@ -19,10 +19,10 @@ dependencies:
     path: ../_http_client
 
 dev_dependencies:
-  build_runner: ^2.10.1
-  freezed: ^3.2.3
-  json_serializable: ^6.11.1
-  lints: ^6.0.0
-  test: ^1.26.3
-  mocktail: ^1.0.4
+  build_runner: ^2.15.0
+  freezed: ^3.2.5
+  json_serializable: ^6.14.0
+  lints: ^6.1.0
+  test: ^1.31.0
+  mocktail: ^1.0.5
 

--- a/packages/webtrit_appearance_theme/pubspec.yaml
+++ b/packages/webtrit_appearance_theme/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 
 dependencies:
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.9.0
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0
-  freezed: ^3.2.3
-  build_runner: ^2.10.1
-  json_serializable: ^6.11.1
+  freezed: ^3.2.5
+  build_runner: ^2.15.0
+  json_serializable: ^6.14.0
   webtrit_analysis:
     git: https://github.com/WebTrit/webtrit_analysis.git
-  test: ^1.26.3
+  test: ^1.31.0

--- a/packages/webtrit_phone_number/pubspec.yaml
+++ b/packages/webtrit_phone_number/pubspec.yaml
@@ -14,4 +14,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  lints: ^6.0.0
+  lints: ^6.1.0

--- a/packages/webtrit_signaling/pubspec.yaml
+++ b/packages/webtrit_signaling/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   equatable: ^2.0.8
   logging: ^1.3.0
-  logging_appenders: ^1.4.0+1
+  logging_appenders: ^2.0.0+1
   meta: any
   web_socket_channel: ^3.0.3
 

--- a/packages/webtrit_signaling/pubspec.yaml
+++ b/packages/webtrit_signaling/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
     path: ../_web_socket_channel
 
 dev_dependencies:
-  lints: ^6.0.0
-  test: ^1.26.3
-  mocktail: ^1.0.4
-  fake_async: ^1.3.1
+  lints: ^6.1.0
+  test: ^1.31.0
+  mocktail: ^1.0.5
+  fake_async: ^1.3.3
   _tcp_proxy:
     path: ../_tcp_proxy

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/pubspec.yaml
@@ -34,6 +34,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  fake_async: ^1.3.1
+  fake_async: ^1.3.3
   flutter_lints: ^6.0.0
   plugin_platform_interface: ^2.1.8

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   logging: ^1.3.0
-  logging_appenders: ^1.4.0+1
+  logging_appenders: ^2.0.0+1
   connectivity_plus: ^7.1.1
   webtrit_signaling:
     path: ../../webtrit_signaling

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/pubspec.yaml
@@ -32,5 +32,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pigeon: ^26.0.3
+  pigeon: ^26.3.4
   flutter_lints: ^6.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: cli_launcher
-      sha256: "17d2744fb9a254c49ec8eda582536abe714ea0131533e24389843a4256f82eac"
+      sha256: "35cf15a3ffaeb9c11849eaa0afba761bb76dceb42d050532bfd3e1299c9748cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2+1"
+    version: "0.3.3+1"
   cli_util:
     dependency: transitive
     description:
@@ -373,18 +373,18 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c"
+      sha256: "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65"
       url: "https://pub.dev"
     source: hosted
-    version: "12.3.0"
+    version: "13.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      sha256: "04b173a92e2d9161dfead145667037c8d834db725ce2e7b942bfe18fd2f45a46"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.3"
+    version: "8.1.0"
   device_region:
     dependency: "direct main"
     description:
@@ -409,22 +409,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.1"
-  dio:
-    dependency: transitive
-    description:
-      name: dio
-      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.9.0"
-  dio_web_adapter:
-    dependency: transitive
-    description:
-      name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
   dispose_scope:
     dependency: transitive
     description:
@@ -485,10 +469,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: d07d37192dbf97461359c1518788f203b0c9102cfd2c35a716b823741219542c
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -797,10 +789,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.2"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -1074,10 +1066,10 @@ packages:
     dependency: "direct dev"
     description:
       name: l10n_mapper_generator
-      sha256: "2c74194f476ffc6a37b16b2851fe73cbe35b6eec936cb485afa85fc0d974eb8d"
+      sha256: "557fd17562cb9f071a28fc760cb8dcd27addc340ead43b1972f9310153b9385e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "3.0.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -1146,10 +1138,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging_appenders
-      sha256: "7fefa09636824f312432721c0bf77967ab19003116650729bd202bdf98142d70"
+      sha256: "3fa9192d4b6018b23c9effd3c87c738847fa0fb68e647dd2630c16207476817d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0+1"
+    version: "2.0.0+1"
   mask_text_input_formatter:
     dependency: "direct main"
     description:
@@ -1178,10 +1170,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "7dcc4444d79b538ab8353bb38308f97e90b032984f75e8fd516fedfe8160b35e"
+      sha256: "9dcac9ca25da86540d1e843f85fffb29967cc5c79d76ca1aacddb57590cee84e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.0"
+    version: "7.8.0"
   meta:
     dependency: "direct main"
     description:
@@ -1202,10 +1194,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   mustache_template:
     dependency: transitive
     description:
@@ -1266,18 +1258,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1554,18 +1546,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "14c8860d4de93d3a7e53af51bff479598c4e999605290756bbbe45cf65b37840"
+      sha256: a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "13.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -2148,18 +2140,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.3.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      sha256: "73b1d78920a9d6e03f8b4e43e612b87bf3152a0e5c5e5150267762b7c4116904"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.3"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "96.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
+      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.1"
+    version: "10.2.0"
   ansi_styles:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      sha256: "04300eaf5821962aae8b5cd94f67013fd2fd326dc3be212d3ec1ae7470f09834"
+      sha256: "7aa0e90874928e78709f0a21a69fb5bc2ae1aa932dec862930d2af85c40adb01"
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.0"
+    version: "10.5.0"
   bloc:
     dependency: "direct main"
     description:
@@ -341,10 +341,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.7"
   dart_webrtc:
     dependency: transitive
     description:
@@ -832,10 +832,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
+      sha256: f23ea33b3863f119b58ed1b586e881a46bd28715ddcc4dbc33104524e3434131
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.5"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -1034,10 +1034,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
+      sha256: "5b89c1e32ae3840bb20a1b3434e3a590173ad3cb605896fb0f60487ce2f8104e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.2"
+    version: "6.11.4"
   just_audio:
     dependency: "direct main"
     description:
@@ -1065,10 +1065,11 @@ packages:
   l10n_mapper_generator:
     dependency: "direct dev"
     description:
-      name: l10n_mapper_generator
-      sha256: "557fd17562cb9f071a28fc760cb8dcd27addc340ead43b1972f9310153b9385e"
-      url: "https://pub.dev"
-    source: hosted
+      path: l10n_mapper_generator
+      ref: "8a90364"
+      resolved-ref: "8a90364fe8509688435d3a9f7ad35f7072679d50"
+      url: "https://github.com/SERDUN/l10n_mapper.git"
+    source: git
     version: "3.0.0"
   leak_tracker:
     dependency: transitive
@@ -1098,10 +1099,10 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: "4f3d70c34c52cc5034e8cc6f53d35aa3a32fb373b78fb4c29cf45cd1dcf06942"
+      sha256: c16e95ddf7b2d49dd551357b7212fe2ce9f13ec7ad1b1e660c157184031e96c0
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.10"
   linkify:
     dependency: "direct main"
     description:
@@ -1663,10 +1664,10 @@ packages:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1687,10 +1688,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   sqlite3:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1115,10 +1115,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   build_daemon:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "39ad4ca8a2876779737c60e4228b4bcd35d4352ef7e14e47514093edc012c734"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -664,18 +664,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: b6bafbbd981da2f964eb45bcb8b8a7676a281084f8922c0c75de4cfbaa849311
+      sha256: "1413fbd0b67f76ac17800989013438caec3b64564c9ffd1eea6cd7e170d9b0e5"
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.0"
+    version: "5.14.1"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      sha256: c99b10af9d404e3f46fd1927e7d90099779e935e86022674c4c2a9e6c2a93b29
+      sha256: db00922dd5f4c1aa33aeab7f74117f1cd224e7a1e8bea1e312b8d09b8101a909
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.0"
+    version: "5.14.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -1026,18 +1026,18 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "5b89c1e32ae3840bb20a1b3434e3a590173ad3cb605896fb0f60487ce2f8104e"
+      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.4"
+    version: "6.14.0"
   just_audio:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,7 +77,7 @@ dependencies:
   google_fonts: ^8.1.0
   google_api_availability: ^5.0.1
   intl: any
-  json_annotation: ^4.9.0
+  json_annotation: ^4.12.0
   just_audio: ^0.10.5
   linkify: ^5.0.0
   logging: ^1.3.0
@@ -159,13 +159,13 @@ dev_dependencies:
       url: https://github.com/SERDUN/l10n_mapper.git
       ref: 8a90364
       path: l10n_mapper_generator
-  build_runner: ^2.7.1
-  flutter_gen_runner: ^5.12.0
+  build_runner: ^2.15.0
+  flutter_gen_runner: ^5.14.1
   flutter_launcher_icons: ^0.14.4
   flutter_lints: ^6.0.0
   flutter_native_splash: ^2.4.7
-  freezed: ^3.2.3
-  json_serializable: ^6.11.1
+  freezed: ^3.2.5
+  json_serializable: ^6.14.0
   patrol: ^4.6.1
   mocktail: ^1.0.5
   fake_async: ^1.3.3
@@ -243,14 +243,14 @@ melos:
 
     generate:
       description: Run build_runner for packages that use code generation.
-      exec: dart run build_runner build --delete-conflicting-outputs
+      exec: dart run build_runner build --workspace
       packageFilters:
         dependsOn:
           - build_runner
 
     generate:watch:
       description: Watch and rebuild generated files on change.
-      exec: dart run build_runner watch --delete-conflicting-outputs
+      exec: dart run build_runner watch --workspace
       packageFilters:
         dependsOn:
           - build_runner

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   clock: ^1.1.2
   connectivity_plus: ^7.1.1
   cross_file: ^0.3.5+2
-  device_info_plus: ^12.2.0
+  device_info_plus: ^13.1.0
   drift: ^2.29.0
   equatable: ^2.0.8
   firebase_analytics: ^12.4.1
@@ -81,10 +81,10 @@ dependencies:
   just_audio: ^0.10.5
   linkify: ^5.0.0
   logging: ^1.3.0
-  logging_appenders: ^1.4.0+1
+  logging_appenders: ^2.0.0+1
   material_color_utilities: any
   meta: any
-  package_info_plus: ^9.0.0
+  package_info_plus: ^10.1.0
   path: ^1.9.1
   path_provider: ^2.1.5
   permission_handler: ^12.0.1
@@ -92,7 +92,7 @@ dependencies:
   provider: ^6.1.5+1
   pub_semver: ^2.2.0
   sdp_transform: ^0.3.2
-  share_plus: ^12.0.1
+  share_plus: ^13.1.0
   shared_preferences: ^2.5.5
   stream_transform: ^2.1.1
   url_launcher: ^6.3.2
@@ -151,7 +151,7 @@ dev_dependencies:
     sdk: flutter
 
   auto_route_generator: ^10.2.5
-  l10n_mapper_generator: ^2.2.0
+  l10n_mapper_generator: ^3.0.0
   build_runner: ^2.7.1
   flutter_gen_runner: ^5.12.0
   flutter_launcher_icons: ^0.14.4
@@ -160,9 +160,9 @@ dev_dependencies:
   freezed: ^3.2.3
   json_serializable: ^6.11.1
   patrol: ^4.6.1
-  mocktail: ^1.0.4
+  mocktail: ^1.0.5
   fake_async: ^1.3.3
-  melos: ^7.0.0
+  melos: ^7.8.0
 
 flutter:
   generate: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,8 +150,15 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  auto_route_generator: ^10.2.5
-  l10n_mapper_generator: ^3.0.0
+  auto_route_generator: ^10.5.0
+  # TODO: temporary fork pin. Switch back to a pub.dev version constraint once
+  # analyzer ^13.0.0 support lands upstream
+  # (SERDUN/l10n_mapper -> kwado-tech/l10n_mapper).
+  l10n_mapper_generator:
+    git:
+      url: https://github.com/SERDUN/l10n_mapper.git
+      ref: 8a90364
+      path: l10n_mapper_generator
   build_runner: ^2.7.1
   flutter_gen_runner: ^5.12.0
   flutter_launcher_icons: ^0.14.4


### PR DESCRIPTION
## Summary

- Bump direct/dev deps: `device_info_plus 13`, `logging_appenders 2.0.0+1`, `package_info_plus 10`, `share_plus 13`, `auto_route_generator 10.5`, `build_runner 2.15`, `freezed 3.2.5`, `json_serializable 6.14`, `json_annotation 4.12`, `flutter_gen_runner 5.14.1`, `mocktail 1.0.5`, `melos 7.8`, plus aligned dev deps across `packages/*` (lints, test, build_runner, freezed, json_serializable, pigeon, fake_async)
- Migrate `FilteredLogzIoAppender` to the new `http`-based API in `logging_appenders 2.x` (replaces Dio/`sendLogEventsWithDio` with `sendLogEventsWithHttp`, switches `DioException` filtering to `http.ClientException`/`SocketException`/`TimeoutException`)
- Pin `l10n_mapper_generator` to a personal fork — upstream caps `analyzer` at `^8.3.0`, which blocks `auto_route_generator ^10.5.0` and the rest of the codegen ecosystem. Fork widens to `>=10.0.0 <14.0.0` (SERDUN/l10n_mapper@`chore/upgrade-analyzer-13`). Drop the pin once upstream releases analyzer 10+ support.
- Switch melos `generate` / `generate:watch` scripts to `--workspace` — `flutter_gen_runner 5.14.0+` moved to a workspace-aware build pipeline; without `--workspace` the build picks an arbitrary workspace member and emits empty `Assets` there instead of generating `lib/app/assets.gen.dart`. Also drops `--delete-conflicting-outputs`, removed in `build_runner 2.15`.

## Null-aware collection migration (`dart fix --apply` after `lints 6.1.0`)

`lints 6.1.0` enables the `use_null_aware_elements` rule. `dart fix --apply` rewrites the `if (x != null) ...` collection-if patterns into the new Dart 3.10+ null-aware forms. Semantics are identical — the runtime result is the same; the rewrite is purely syntactic.

| Form | Context | Behavior when `null` |
|---|---|---|
| `[..., ?x]` | list/set element | element is skipped |
| `[..., ...?x]` | list/set spread | spread is skipped |
| `{..., 'k': ?v}` | map entry value | the **entire entry** (key + value) is skipped — `'k'` does NOT appear with a null value, the key is simply absent |
| `{..., ...?m}` | map spread | spread is skipped |

Example:
```dart
// before
if (coreUrl != null) 'coreUrl': coreUrl,
if (tenantId != null) 'tenantId': tenantId,

// after
'coreUrl': ?coreUrl,
'tenantId': ?tenantId,
```
Both produce a map without `coreUrl`/`tenantId` keys when the corresponding values are null.

Applied as auto-fix to 13 sites across 9 files (list elements + map spread). `packages/webtrit_signaling/lib/src/requests/call/transfer_request.dart` was left as an explicit `if (...)` — `dart fix` mishandles the null-aware **map-entry** rewrite for that file and produces broken output. Safe to leave; will follow up manually.
