### PR TITLE
fix(call): centralize OS connectivity behind ConnectivityService (WT-1540)

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -556,6 +556,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         ),
                         signalingModule: _signalingModule,
                         peerConnectionManager: peerConnectionManager,
+                        connectivityService: context.read<ConnectivityService>(),
                         onSessionInvalidated: () =>
                             appBloc.add(const AppLogoutRequested(reason: AppLogoutReason.sessionMissed)),
                         foregroundCallPushSignal: RemotePushBroker.pendingCallForegroundPushs,

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -151,6 +151,15 @@ Future<InstanceRegistry> bootstrap() async {
 
   final appLifecycle = await AppLifecycle.initMaster();
 
+  // ConnectivityService - single owner of `Connectivity()` plugin subscription.
+  // Built here (not in RootApp) so the deduplication cache can be seeded via an
+  // awaited `checkConnectivity()` read before any consumer subscribes. This
+  // prevents the listener's first replayed event from being misinterpreted as a
+  // real interface change downstream.
+  final connectivityService = await ConnectivityServiceImpl.create(
+    connectivityChecker: _createConnectivityChecker(apiClientFactory),
+  );
+
   // Register instances into the Registry
 
   // Configuration & Info
@@ -188,12 +197,28 @@ Future<InstanceRegistry> bootstrap() async {
   // Network clients
   registry.register<WebtritApiClientFactory>(apiClientFactory);
   registry.register<RemoteConfigService>(cachedRemoteConfigService);
+  registry.register<ConnectivityService>(connectivityService);
 
   // Final side-effect initializations that rely on registered components
   await _initCallkeep(featureAccess);
   await _initWorkManager();
 
   return registry;
+}
+
+/// Creates the platform [ConnectivityChecker] used by [ConnectivityService]
+/// for HTTP liveness probes. Picks the custom-URL implementation if a
+/// dedicated check endpoint is provided via [EnvironmentConfig], otherwise
+/// falls back to the default API-client-based check.
+ConnectivityChecker _createConnectivityChecker(WebtritApiClientFactory apiClientFactory) {
+  final customUrl = EnvironmentConfig.CONNECTIVITY_CHECK_URL;
+  return switch (customUrl) {
+    String url => CustomConnectivityChecker(
+      connectivityCheckUrl: url,
+      createHttpRequestExecutor: apiClientFactory.createHttpRequestExecutor(),
+    ),
+    null => DefaultConnectivityChecker(apiClient: apiClientFactory.createWebtritApiClient()),
+  };
 }
 
 /// Initializes [AppPermissions] with an exclusion callback.

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -151,7 +151,8 @@ Future<InstanceRegistry> bootstrap() async {
 
   final appLifecycle = await AppLifecycle.initMaster();
 
-  // ConnectivityService - single owner of `Connectivity()` plugin subscription.
+  // ConnectivityService - owns the `Connectivity()` plugin subscription used by
+  // the call subsystem (other features still keep their own direct subscriptions).
   // Built here (not in RootApp) so the deduplication cache can be seeded via an
   // awaited `checkConnectivity()` read before any consumer subscribes. This
   // prevents the listener's first replayed event from being misinterpreted as a

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -25,6 +25,7 @@ import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/push_notification/push_notifications.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/services/services.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
@@ -102,7 +103,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final VoidCallback? onCallEnded;
   final OnDiagnosticReportRequested onDiagnosticReportRequested;
 
-  StreamSubscription<List<ConnectivityResult>>? _connectivityChangedSubscription;
+  StreamSubscription<ConnectivityResult>? _connectivityChangedSubscription;
   StreamSubscription<void>? _foregroundCallPushSubscription;
   final _iceRestartDebounce = DebounceMap<String>(const Duration(seconds: 2));
 
@@ -113,6 +114,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   late final PeerConnectionManager _peerConnectionManager;
   late final HandshakeProcessor _handshakeProcessor;
+  final ConnectivityService _connectivityService;
 
   final _callkeepSound = WebtritCallkeepSound();
 
@@ -142,9 +144,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     this.peerConnectionPolicyApplier,
     required SignalingModule signalingModule,
     required PeerConnectionManager peerConnectionManager,
+    required ConnectivityService connectivityService,
     this.onCallEnded,
     Stream<void>? foregroundCallPushSignal,
-  }) : super(const CallState()) {
+  }) : _connectivityService = connectivityService,
+       super(const CallState()) {
     _mediaManager = CallMediaManager(callkeep: callkeep);
     _signalingModule = signalingModule;
     _peerConnectionManager = peerConnectionManager;
@@ -512,8 +516,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     emit(state.copyWith(currentAppLifecycleState: lifecycleState));
     _logger.fine('_onCallStarted initial lifecycle state: $lifecycleState');
 
-    // Initialize connectivity state
-    final connectivityState = (await Connectivity().checkConnectivity()).first;
+    // Initialize connectivity state from the centralized service. The service
+    // owns the single subscription to `Connectivity().onConnectivityChanged`
+    // and exposes a deduplicated stream of changes, so the bloc no longer
+    // talks to the plugin directly.
+    final connectivityState = _connectivityService.currentConnectivityResult;
     emit(
       state.copyWith(
         callServiceState: state.callServiceState.copyWith(networkStatus: connectivityState.toNetworkStatus()),
@@ -521,10 +528,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
     _logger.finer('_onCallStarted initial connectivity state: $connectivityState');
 
-    // Subscribe to future connectivity changes
-    _connectivityChangedSubscription = Connectivity().onConnectivityChanged.listen((result) {
-      final currentConnectivityResult = result.first;
-      add(_ConnectivityResultChanged(currentConnectivityResult));
+    // Subscribe to deduplicated future connectivity changes. The first replay
+    // event from `Connectivity().onConnectivityChanged` is already filtered by
+    // the service when it matches the cached initial value, so no bootstrap
+    // call to the reconnect controller is needed here - the initial WS connect
+    // is initiated by MainShell `..connect()` and runtime changes flow through
+    // this subscription.
+    _connectivityChangedSubscription = _connectivityService.connectivityResultStream.listen((result) {
+      add(_ConnectivityResultChanged(result));
     });
 
     // Initial WS connect is initiated by MainShell `..connect()`; runtime

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -534,9 +534,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // call to the reconnect controller is needed here - the initial WS connect
     // is initiated by MainShell `..connect()` and runtime changes flow through
     // this subscription.
-    _connectivityChangedSubscription = _connectivityService.connectivityResultStream.listen((result) {
-      add(_ConnectivityResultChanged(result));
-    });
+    _connectivityChangedSubscription = _connectivityService.connectivityResultStream.listen(
+      (result) => add(_ConnectivityResultChanged(result)),
+    );
 
     // Initial WS connect is initiated by MainShell `..connect()`; runtime
     // connectivity changes flow through the subscription above. No bootstrap

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -517,7 +517,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _logger.fine('_onCallStarted initial lifecycle state: $lifecycleState');
 
     // Initialize connectivity state from the centralized service. The service
-    // owns the single subscription to `Connectivity().onConnectivityChanged`
+    // owns the call subsystem's subscription to `Connectivity().onConnectivityChanged`
     // and exposes a deduplicated stream of changes, so the bloc no longer
     // talks to the plugin directly.
     final connectivityState = _connectivityService.currentConnectivityResult;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -102,7 +102,7 @@ class RootApp extends StatelessWidget {
         // Provides `AppDatabase` by reading it from `AppDatabaseLifecycleHolder`.
         // When this provider is read, it triggers creation of the holder first (provider is lazy).
         Provider<AppDatabase>(create: (context) => context.read<AppDatabaseLifecycleHolder>().db),
-        Provider<ConnectivityService>(create: _createConnectivityService, dispose: _disposeConnectivityService),
+        Provider<ConnectivityService>(create: (_) => instanceRegistry.get(), dispose: _disposeConnectivityService),
       ],
       child: Builder(
         builder: (context) {
@@ -186,21 +186,6 @@ class RootApp extends StatelessWidget {
 
   Future<void> _disposeAppDatabaseLifecycleHolder(BuildContext _, AppDatabaseLifecycleHolder holder) async {
     await holder.dispose();
-  }
-
-  ConnectivityService _createConnectivityService(BuildContext context) {
-    final customUrl = EnvironmentConfig.CONNECTIVITY_CHECK_URL;
-    final apiFactory = context.read<WebtritApiClientFactory>();
-
-    final connectivityChecker = switch (customUrl) {
-      String url => CustomConnectivityChecker(
-        connectivityCheckUrl: url,
-        createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
-      ),
-      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
-    };
-
-    return ConnectivityServiceImpl(connectivityChecker: connectivityChecker);
   }
 
   void _disposeConnectivityService(BuildContext _, ConnectivityService value) {

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 
 import 'package:webtrit_phone/utils/utils.dart';
@@ -42,7 +43,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
   /// subscribes. Must be awaited so the listener's first replayed event is
   /// recognized as a duplicate and filtered.
   static Future<ConnectivityServiceImpl> create({required ConnectivityChecker connectivityChecker}) async {
-    final initialResult = (await Connectivity().checkConnectivity()).first;
+    final initialResult = (await Connectivity().checkConnectivity()).firstOrNull ?? ConnectivityResult.none;
     return ConnectivityServiceImpl._(connectivityChecker: connectivityChecker, initialResult: initialResult);
   }
 
@@ -67,13 +68,15 @@ class ConnectivityServiceImpl implements ConnectivityService {
   Future<bool> checkConnection() => _checkConnection(_lastResult);
 
   Future<void> _handleConnectivityChange(List<ConnectivityResult> result) async {
-    final next = result.first;
+    final next = result.firstOrNull ?? ConnectivityResult.none;
     if (next != _lastResult) {
       _lastResult = next;
       _resultController.add(next);
     }
     final connected = await _checkConnection(next);
-    _onlineController.add(connected);
+    if (next == _lastResult) {
+      _onlineController.add(connected);
+    }
   }
 
   Future<bool> _checkConnection(ConnectivityResult current) async {

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -42,6 +42,13 @@ class ConnectivityServiceImpl implements ConnectivityService {
   /// state via `checkConnectivity()` to seed the cache before any consumer
   /// subscribes. Must be awaited so the listener's first replayed event is
   /// recognized as a duplicate and filtered.
+  ///
+  /// The awaited read is a cheap local platform-channel query of the OS
+  /// transport state - it performs no network I/O (the HTTP liveness probe runs
+  /// later, on change events), so its cost on the bootstrap/splash path is
+  /// negligible next to heavier inits such as the DB isolate spawn. An empty
+  /// platform result is treated as `ConnectivityResult.none` rather than
+  /// throwing, so startup is never blocked by a missing entry.
   static Future<ConnectivityServiceImpl> create({required ConnectivityChecker connectivityChecker}) async {
     final initialResult = (await Connectivity().checkConnectivity()).firstOrNull ?? ConnectivityResult.none;
     return ConnectivityServiceImpl._(connectivityChecker: connectivityChecker, initialResult: initialResult);

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -5,46 +5,87 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 abstract class ConnectivityService {
+  /// Last seen `ConnectivityResult` from any source (initial platform read or
+  /// subsequent change event). Always non-null after the service is created.
+  ConnectivityResult get currentConnectivityResult;
+
+  /// Stream of raw `ConnectivityResult` values, deduplicated against the cached
+  /// current value. Emits only when the OS reports a value different from the
+  /// last accepted one. The first event after subscribe that mirrors the cached
+  /// initial value is filtered out here - this is the bridge that the plugin's
+  /// own `Stream.distinct()` does not cover (plugin compares within stream only;
+  /// it does not know about `checkConnectivity()` snapshot reads).
+  Stream<ConnectivityResult> get connectivityResultStream;
+
+  /// Boolean online-state stream that combines OS connectivity with an HTTP
+  /// liveness probe via [ConnectivityChecker]. Emits on every change event,
+  /// after the probe completes.
   Stream<bool> get connectionStream;
 
+  /// One-shot online check: OS state + HTTP probe.
   Future<bool> checkConnection();
 
   void dispose();
 }
 
 class ConnectivityServiceImpl implements ConnectivityService {
-  ConnectivityServiceImpl({required ConnectivityChecker connectivityChecker})
-    : _connectivityChecker = connectivityChecker {
+  ConnectivityServiceImpl._({
+    required ConnectivityChecker connectivityChecker,
+    required ConnectivityResult initialResult,
+  }) : _connectivityChecker = connectivityChecker,
+       _lastResult = initialResult {
     _connectivitySubscription = _connectivity.onConnectivityChanged.listen(_handleConnectivityChange);
   }
 
-  final Connectivity _connectivity = Connectivity();
-  final StreamController<bool> _controller = StreamController<bool>.broadcast();
-  final ConnectivityChecker _connectivityChecker;
-  late final StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
-
-  @override
-  Stream<bool> get connectionStream => _controller.stream;
-
-  @override
-  Future<bool> checkConnection() async {
-    final result = await _connectivity.checkConnectivity();
-    if (result.contains(ConnectivityResult.none) || result.isEmpty) {
-      return false;
-    }
-
-    return _connectivityChecker.checkConnection();
+  /// Creates a fully-initialised service. Reads the current OS connectivity
+  /// state via `checkConnectivity()` to seed the cache before any consumer
+  /// subscribes. Must be awaited so the listener's first replayed event is
+  /// recognized as a duplicate and filtered.
+  static Future<ConnectivityServiceImpl> create({required ConnectivityChecker connectivityChecker}) async {
+    final initialResult = (await Connectivity().checkConnectivity()).first;
+    return ConnectivityServiceImpl._(connectivityChecker: connectivityChecker, initialResult: initialResult);
   }
 
+  final Connectivity _connectivity = Connectivity();
+  final ConnectivityChecker _connectivityChecker;
+  final StreamController<bool> _onlineController = StreamController<bool>.broadcast();
+  final StreamController<ConnectivityResult> _resultController = StreamController<ConnectivityResult>.broadcast();
+  late final StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
+
+  ConnectivityResult _lastResult;
+
+  @override
+  ConnectivityResult get currentConnectivityResult => _lastResult;
+
+  @override
+  Stream<ConnectivityResult> get connectivityResultStream => _resultController.stream;
+
+  @override
+  Stream<bool> get connectionStream => _onlineController.stream;
+
+  @override
+  Future<bool> checkConnection() => _checkConnection(_lastResult);
+
   Future<void> _handleConnectivityChange(List<ConnectivityResult> result) async {
-    final connected = await checkConnection();
-    _controller.add(connected);
+    final next = result.first;
+    if (next != _lastResult) {
+      _lastResult = next;
+      _resultController.add(next);
+    }
+    final connected = await _checkConnection(next);
+    _onlineController.add(connected);
+  }
+
+  Future<bool> _checkConnection(ConnectivityResult current) async {
+    if (current == ConnectivityResult.none) return false;
+    return _connectivityChecker.checkConnection();
   }
 
   @override
   void dispose() {
     _connectivityChecker.dispose();
     _connectivitySubscription.cancel();
-    _controller.close();
+    _resultController.close();
+    _onlineController.close();
   }
 }

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -61,6 +61,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
   late final StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
 
   ConnectivityResult _lastResult;
+  bool _disposed = false;
 
   @override
   ConnectivityResult get currentConnectivityResult => _lastResult;
@@ -81,7 +82,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
       _resultController.add(next);
     }
     final connected = await _checkConnection(next);
-    if (next == _lastResult) {
+    if (!_disposed && next == _lastResult) {
       _onlineController.add(connected);
     }
   }
@@ -93,6 +94,7 @@ class ConnectivityServiceImpl implements ConnectivityService {
 
   @override
   void dispose() {
+    _disposed = true;
     _connectivityChecker.dispose();
     _connectivitySubscription.cancel();
     _resultController.close();

--- a/test/mocks/fake_connectivity_service.dart
+++ b/test/mocks/fake_connectivity_service.dart
@@ -1,18 +1,30 @@
 import 'dart:async';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
+
 import 'package:webtrit_phone/services/services.dart';
 
-/// Lightweight fake ConnectivityService with controllable stream and checkConnection().
+/// Lightweight fake ConnectivityService with controllable streams and checkConnection().
 class FakeConnectivityService implements ConnectivityService {
-  FakeConnectivityService({bool initialConnected = false}) : _connected = initialConnected;
+  FakeConnectivityService({bool initialConnected = false, ConnectivityResult initialResult = ConnectivityResult.none})
+    : _connected = initialConnected,
+      _currentResult = initialResult;
 
   final _controller = StreamController<bool>.broadcast();
+  final _resultController = StreamController<ConnectivityResult>.broadcast();
   bool _connected;
+  ConnectivityResult _currentResult;
 
   int checkCalls = 0;
 
   @override
   Stream<bool> get connectionStream => _controller.stream;
+
+  @override
+  ConnectivityResult get currentConnectivityResult => _currentResult;
+
+  @override
+  Stream<ConnectivityResult> get connectivityResultStream => _resultController.stream;
 
   @override
   Future<bool> checkConnection() async {
@@ -29,8 +41,17 @@ class FakeConnectivityService implements ConnectivityService {
   /// Alias for [setConnected] to keep backward compatibility.
   void push(bool connected) => setConnected(connected);
 
+  /// Set current ConnectivityResult and emit on the deduped stream if different.
+  void setConnectivityResult(ConnectivityResult result) {
+    if (result != _currentResult) {
+      _currentResult = result;
+      _resultController.add(result);
+    }
+  }
+
   @override
   void dispose() {
     _controller.close();
+    _resultController.close();
   }
 }


### PR DESCRIPTION
## Summary
- `ConnectivityServiceImpl` is now the single owner of the `connectivity_plus` subscription.
- `ConnectivityServiceImpl.create()` seeds the cached `currentConnectivityResult` from an awaited `checkConnectivity()` during bootstrap.
- New `connectivityResultStream` exposes a deduplicated raw-result broadcast; the existing `connectionStream` and `checkConnection()` bool API are unchanged.
- `CallBloc` takes `ConnectivityService` via constructor, drops its direct `Connectivity()` subscription, and reads initial network state from the service cache. The bootstrap `notifyNetworkAvailable/Unavailable` call in `_onCallStarted` is removed - the centralized service is the single source of truth.
- `bootstrap.dart` constructs and registers the service; `RootApp` reads it from `InstanceRegistry` instead of constructing it inline.

## WT-1540
`CallBloc` used to subscribe to `Connectivity().onConnectivityChanged` directly and also issue a separate `Connectivity().checkConnectivity()` for the initial state. These two plugin APIs do not share state: `checkConnectivity()` is a stateless one-shot and the stream's `Stream.distinct()` only dedupes within a single subscription. The first listener event after subscribe is therefore never filtered, even when it mirrors the bootstrap snapshot value, and was misinterpreted downstream as a real interface change. With the WT-1508 fix in place this surfaced as a forced disconnect-reconnect of a healthy WebSocket shortly after restore.

The fix moves the dedup into `ConnectivityServiceImpl._handleConnectivityChange`: the next value is compared against the cache and emitted to `connectivityResultStream` only on a real change. The very first listener event that matches the bootstrap value is filtered at the source, so no downstream consumer ever sees the spurious replay.

WT-1508 behavior is preserved: a genuine `wifi -> mobile` interface change still passes through the deduped stream and the existing `notifyNetworkAvailable` path in the reconnect controller is taken.

## Test plan
- [x] Existing test suite remains green
- [ ] Cold start on Android with wifi already on, active call on server: WebSocket connects once and stays; no `disconnecting stale connection` log
- [ ] iOS WiFi-to-LTE switch mid-call: WT-1508 recovery path still triggers, audio recovers within ~1s