### PR TITLE
fix(call): run signaling and call-state guards before createOffer (WT-1540)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2963,13 +2963,26 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       return;
     }
 
-    final offerCandidate = await pc.createOffer();
-
-    // Note: prepare all asychronous info before checking synchrounous state below
-    // to avoid races as possible,
-    // for example:
-    // - while [await _peerConnectionManager.retrieve, await pc.createOffer], activeCall.updating or signalingConnected can be changed
-
+    // All synchronous state guards run BEFORE createOffer.
+    //
+    // createOffer is not a read-only "snapshot the SDP" call: with the default
+    // OfferToReceiveAudio/Video constraints flutter-webrtc instructs the native
+    // PC to add recvonly transceivers if matching ones do not already exist,
+    // which advances the internal mid counter. If we bail after createOffer
+    // (e.g. because signaling is not connected), those transceivers leak onto
+    // the PC. The next renegotiate cycle calls createOffer again and adds
+    // ANOTHER set, eventually emitting an offer whose m-line mids no longer
+    // match what Janus answers with (mid:0 from Asterisk pass-through), so
+    // setRemoteDescription rejects the answer and the PC is stuck in
+    // have-local-offer forever.
+    //
+    // Guard order trade-off: the original author placed createOffer first to
+    // capture "fresh" SDP before checking state, on the assumption that state
+    // could shift during an async wait. That race window still exists between
+    // createOffer and setLocalDescription/execute below, but the cost of
+    // proceeding with stale state there (offer sent to a freshly-closed
+    // signaling channel -> SignalingTransactionTerminateByDisconnect, caught
+    // by the catch block) is far cheaper than the PC corruption above.
     final activeCall = state.retrieveActiveCall(e.callId);
     if (activeCall == null) {
       _logger.info('__onMutationRenegotiate: activeCall disposed, skipping renegotiation');
@@ -3000,6 +3013,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _logger.info('__onMutationRenegotiate: signaling not connected, skipping renegotiation');
       return;
     }
+
+    final offerCandidate = await pc.createOffer();
 
     // If call already in updating state, mostly by remote renegetiation, hold, transfer etc..
     // skip it but schedule another renegotiation in 1 second later to ensure the pending one is finished


### PR DESCRIPTION
## Summary
- Move `activeCall`, `line`, `processingStatus.hasPeerConnectionReady`, and `signalingConnected` checks ABOVE `pc.createOffer()` in `__onMutationRenegotiate`.
- On a bail-path the PC is no longer mutated by `createOffer`'s side effects.

## WT-1540
`createOffer()` is not read-only. With the default `OfferToReceiveAudio/Video: true` constraints flutter-webrtc tells the native PC to add recvonly transceivers if matching ones do not already exist, advancing the internal mid counter. Leaving `createOffer` before the guards meant any renegotiate dispatched while signaling was mid-disconnect (bad wifi, cellular handover, server-forced WS close, ICE restart from real connectivity change) would mutate the PC and then bail at the guard, leaking the transceivers. The next renegotiate ran `createOffer` again and added another set, eventually emitting an offer whose m-line mids (2, 3, ...) no longer matched what Janus answers with (mid:0 from the Asterisk pass-through). `setRemoteDescription` rejected the answer with "order of m-lines in answer does not match order in offer", the PC got stuck in `have-local-offer`, audio never resumed.

The race window the original author warned about (state changing during an async wait) still exists between `createOffer` and `setLocalDescription`/`execute` below. But the cost of proceeding with stale state at that point - offer sent to a freshly-closed signaling channel, caught by the existing try/catch as `SignalingTransactionTerminateByDisconnect` - is far cheaper than the PC corruption above.

## Test plan
- [ ] Existing test suite remains green
- [ ] Active call -> toggle wifi off -> wifi on: audio recovers and stays (previously: audio briefly resumed then died with `setRemoteDescription failed: order of m-lines in answer doesn't match order in offer`)
- [ ] Cellular handover mid-call: audio recovers without `setRemoteDescription failed` warnings
- [ ] Force-stop + reopen mid-call (the original WT-1540 scenario): audio restores correctly

## Related
- Companion refactor PR [#1310](https://github.com/WebTrit/webtrit_phone/pull/1310) centralizes OS connectivity state and closes the spurious-event class of triggers. This PR closes the remaining bad-network class by fixing the PC mutation leak. Both PRs target WT-1540 and are independent of each other (can land in either order).