### PR TITLE
fix(call): stabilize renegotiation guards (WT-1540)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -527,11 +527,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       add(_ConnectivityResultChanged(currentConnectivityResult));
     });
 
-    if (connectivityState == ConnectivityResult.none) {
-      _reconnectController.notifyNetworkUnavailable();
-    } else {
-      _reconnectController.notifyNetworkAvailable();
-    }
+    // Initial WS connect is initiated by MainShell `..connect()`; runtime
+    // connectivity changes flow through the subscription above. No bootstrap
+    // call to the reconnect controller is needed - calling notifyNetworkAvailable
+    // here would proactively disconnect a healthy WS that just delivered the
+    // handshake (the disconnect path inside notifyNetworkAvailable assumes a
+    // real interface change, which a bootstrap snapshot is not).
 
     WebRTC.initialize(options: webRtcOptionsBuilder?.build());
   }
@@ -2958,8 +2959,14 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       return;
     }
 
-    final sigState = pc.signalingState;
-    if (sigState != null && sigState != RTCSignalingState.RTCSignalingStateStable) {
+    // pc.signalingState is a Dart-side cache populated only after the first
+    // native state event. On a freshly created PC the event may not have
+    // arrived yet; force a platform round-trip in that case so the guard
+    // gets the real native state instead of guessing what null means.
+    final cachedSigState = pc.signalingState;
+    final sigState = cachedSigState ?? await pc.getSignalingState();
+    _logger.info('__onMutationRenegotiate: sigState=$sigState (cache=$cachedSigState)');
+    if (sigState != RTCSignalingState.RTCSignalingStateStable) {
       _logger.fine(() => '__onMutationRenegotiate: pc signalingState is $sigState, skipping renegotiation');
       return;
     }
@@ -2997,6 +3004,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // Dont forget to invoke __onMutationRenegotiate manualy when signaling reconnected to make sure the new offer will be sended
     //
     final signalingConnected = state.isSignalingEstablished;
+    _logger.info(
+      '__onMutationRenegotiate: signaling check'
+      ' signalingConnected=$signalingConnected'
+      ' signalingClientStatus=${state.callServiceState.signalingClientStatus}'
+      ' isHandshakeEstablished=${state.isHandshakeEstablished}'
+      ' registration=${state.callServiceState.registration?.status}'
+      ' networkStatus=${state.callServiceState.networkStatus}'
+      ' linesCount=${state.linesCount}'
+      ' appLifecycle=${state.currentAppLifecycleState}',
+    );
     if (!signalingConnected) {
       _logger.info('__onMutationRenegotiate: signaling not connected, skipping renegotiation');
       return;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -3004,16 +3004,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // Dont forget to invoke __onMutationRenegotiate manualy when signaling reconnected to make sure the new offer will be sended
     //
     final signalingConnected = state.isSignalingEstablished;
-    _logger.info(
-      '__onMutationRenegotiate: signaling check'
-      ' signalingConnected=$signalingConnected'
-      ' signalingClientStatus=${state.callServiceState.signalingClientStatus}'
-      ' isHandshakeEstablished=${state.isHandshakeEstablished}'
-      ' registration=${state.callServiceState.registration?.status}'
-      ' networkStatus=${state.callServiceState.networkStatus}'
-      ' linesCount=${state.linesCount}'
-      ' appLifecycle=${state.currentAppLifecycleState}',
-    );
     if (!signalingConnected) {
       _logger.info('__onMutationRenegotiate: signaling not connected, skipping renegotiation');
       return;

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2958,8 +2958,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       return;
     }
 
-    if (pc.signalingState != RTCSignalingState.RTCSignalingStateStable) {
-      _logger.fine(() => '__onMutationRenegotiate: pc signalingState is ${pc.signalingState}, skipping renegotiation');
+    final sigState = pc.signalingState;
+    if (sigState != null && sigState != RTCSignalingState.RTCSignalingStateStable) {
+      _logger.fine(() => '__onMutationRenegotiate: pc signalingState is $sigState, skipping renegotiation');
       return;
     }
 


### PR DESCRIPTION
## Scope

Small hygiene cleanup. Does not on its own fix WT-1540 (audio loss after force-stop or after wifi flap on dtls_recreate_on_ice_restart=true); it removes one of several contributors to the redundant renegotiate / reconnect chatter that surfaced while investigating WT-1540.

## Changes
- Treat null pc.signalingState as stable in __onMutationRenegotiate. A freshly created PC returns null before the first native state callback fires; the guard previously interpreted that as non-stable and silently dropped the first renegotiate event.
- When the Dart-side signalingState cache is null, do a getSignalingState() round-trip so the guard decides on the real native state instead of guessing.
- Drop the bootstrap notifyNetworkAvailable call. The initial WS connect is already initiated by MainShell..connect(); runtime connectivity changes flow through onConnectivityChanged. The bootstrap call was tearing down the freshly-handshaken WS, producing a cold-start connect-disconnect-connect cycle.

## What this does not cover
- Audio not restored after process force-stop and reopen
- Janus DTLS recreate behaviour on ICE restart (only matters when dtls_recreate_on_ice_restart=true; default and prod = false, so no-op there).

Follow-up to #1310: continues trimming the unnecessary reconnect chatter on cold start and after network changes.
