### PR TITLE
fix: point flutter_contacts ref to main after upstream merge

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -650,8 +650,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: e4486d7
-      resolved-ref: e4486d7fc60a78fac6b7b3884ef6a1ff41b0c05f
+      ref: main
+      resolved-ref: ca26b8ebc7ba56de4652a4656ff183353b7e847b
       url: "https://github.com/SERDUN/flutter_contacts.git"
     source: git
     version: "2.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   flutter_contacts:
     git:
       url: https://github.com/SERDUN/flutter_contacts.git
-      ref: e4486d7
+      ref: main
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
   flutter_webrtc:


### PR DESCRIPTION
## Summary

- `pubspec.yaml` pinned `flutter_contacts` to commit `e4486d7` of the `SERDUN/flutter_contacts` fork, but that commit no longer exists in the fork history after PR [SERDUN/flutter_contacts#2](https://github.com/SERDUN/flutter_contacts/pull/2) was merged. `flutter pub get` fails with `unknown revision`.
- Switch the `ref` to `main` so it tracks the merged state of the fork until we can move back to a pub.dev version.

## Test plan

- [ ] `melos bootstrap`
- [ ] `flutter pub get` resolves without errors
- [ ] App builds and contacts feature works (verifies `RawContact.dataMimetypes` still present)