### PR TITLE
feat(login): pre-populate core URL autocomplete from env

### DIFF
--- a/dart_define.json
+++ b/dart_define.json
@@ -4,6 +4,8 @@
   "WEBTRIT_APP_PERIODIC_POLLING": true,
   "_WEBTRIT_APP_CORE_URL": "",
   "WEBTRIT_APP_DEMO_CORE_URL": "http://192.168.10.100:4000",
+  "_WEBTRIT_APP_PREDEFINED_CORE_URLS": "",
+  "__WEBTRIT_APP_PREDEFINED_CORE_URLS_DESCRIPTION": "Semicolon-separated list of Core URLs to pre-populate the core URL autocomplete dropdown on the login screen. Example: 'https://core1.example.com;https://core2.example.com'. Suggestions are always shown; user-typed entries appear above presets and case-insensitive duplicates are merged.",
   "_WEBTRIT_APP_CORE_VERSION_CONSTRAINT": "",
   "WEBTRIT_APP_LINK_DOMAIN": "app.webtrit.com",
   "__WEBTRIT_APP_LINK_DOMAIN_DESCRIPTION": "If provided, enables Android App Links integration via intent-filter. Must match assetlinks.json configuration on the target domain. This functionality is configured via Android flavors — if the value is non-empty, the 'deeplinks' flavor is selected automatically.",

--- a/lib/environment_config.dart
+++ b/lib/environment_config.dart
@@ -32,6 +32,14 @@ class EnvironmentConfig {
   static const DEMO_CORE_URL__NAME = 'WEBTRIT_APP_DEMO_CORE_URL';
   static const DEMO_CORE_URL = String.fromEnvironment(DEMO_CORE_URL__NAME, defaultValue: 'http://localhost:4000');
 
+  static const PREDEFINED_CORE_URLS__NAME = 'WEBTRIT_APP_PREDEFINED_CORE_URLS';
+  static const _PREDEFINED_CORE_URLS_RAW = String.fromEnvironment(PREDEFINED_CORE_URLS__NAME);
+  static final List<String> PREDEFINED_CORE_URLS = _PREDEFINED_CORE_URLS_RAW
+      .split(';')
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .toList(growable: false);
+
   static const CORE_VERSION_CONSTRAINT__NAME = 'WEBTRIT_APP_CORE_VERSION_CONSTRAINT';
   static const CORE_VERSION_CONSTRAINT = String.fromEnvironment(
     CORE_VERSION_CONSTRAINT__NAME,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -126,7 +126,10 @@ class RootApp extends StatelessWidget {
           final encodingSettingsRepository = EncodingSettingsRepositoryPrefsImpl(prefs);
           final localeRepository = LocaleRepositoryPrefsImpl(prefs);
           final themeModeRepository = ThemeModeRepositoryPrefsImpl(prefs);
-          final autocompleteHistoryRepository = AutocompleteHistoryRepositoryPrefsImpl(prefs);
+          final autocompleteHistoryRepository = AutocompleteHistoryRepositoryPrefsImpl(
+            prefs,
+            presets: {'recent_core_urls': EnvironmentConfig.PREDEFINED_CORE_URLS},
+          );
 
           return MultiRepositoryProvider(
             providers: [

--- a/lib/repositories/autocomplete_history/autocomplete_history_repository.dart
+++ b/lib/repositories/autocomplete_history/autocomplete_history_repository.dart
@@ -6,14 +6,24 @@ abstract interface class AutocompleteHistoryRepository {
 }
 
 class AutocompleteHistoryRepositoryPrefsImpl implements AutocompleteHistoryRepository {
-  AutocompleteHistoryRepositoryPrefsImpl(this._appPreferences);
+  AutocompleteHistoryRepositoryPrefsImpl(this._appPreferences, {this.presets = const {}});
   final AppPreferences _appPreferences;
+  final Map<String, List<String>> presets;
   final _prefsKeyPrefix = 'autocomplete_history_';
 
   @override
   List<String> getHistory(String key) {
     final valueKey = _prefsKeyPrefix + key;
-    return _appPreferences.getStringList(valueKey) ?? [];
+    final stored = _appPreferences.getStringList(valueKey) ?? const [];
+    final preset = presets[key] ?? const [];
+    if (preset.isEmpty) return stored;
+
+    final seen = <String>{};
+    final merged = <String>[];
+    for (final v in [...stored, ...preset]) {
+      if (seen.add(v.toLowerCase())) merged.add(v);
+    }
+    return merged;
   }
 
   @override


### PR DESCRIPTION
## Summary
- Adds `WEBTRIT_APP_PREDEFINED_CORE_URLS` env (semicolon-separated) so build configs can seed the login core URL autocomplete dropdown without writing to SharedPreferences.
- `AutocompleteHistoryRepository.getHistory()` now merges stored entries with per-key presets via case-insensitive dedup; user-typed entries stay on top, presets follow.

## How to enable on a build
In `dart_define.json`, drop the leading `_` and set the value:
```json
"WEBTRIT_APP_PREDEFINED_CORE_URLS": "https://core1.example.com;https://core2.example.com"
```

## Design notes
- Presets are **not persisted** — they only appear at read time. User deletion of a preset is a non-issue (they were never written). Updating the env on a new build immediately reflects in suggestions without migrations.
- `addToHistory()` is unchanged; only user-submitted URLs land in prefs.
- `maxItems` (8) caps stored history only — presets always show in full.

## Dependency
Currently includes the drive-by lint fix from #1315 because pre-push analyze flags it across the whole tree and this branch can't push without it.
**After #1315 merges to `develop`**, rebase this branch onto `develop` and force-push to drop the duplicated lint commit.