### PR TITLE
style(signaling): apply use_null_aware_elements in TransferRequest

### DIFF
--- a/packages/webtrit_signaling/lib/src/requests/call/transfer_request.dart
+++ b/packages/webtrit_signaling/lib/src/requests/call/transfer_request.dart
@@ -34,14 +34,13 @@ class TransferRequest extends CallRequest {
 
   @override
   Map<String, dynamic> toJson() {
-    final replaceCallId = this.replaceCallId;
     return {
       Request.typeKey: typeValue,
       'transaction': transaction,
       'line': line,
       'call_id': callId,
       'number': number,
-      if (replaceCallId != null) 'replace_call_id': replaceCallId,
+      'replace_call_id': ?replaceCallId,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the `if (replaceCallId != null) 'replace_call_id': replaceCallId` map entry in `TransferRequest.toJson()` with the null-aware element form (`'replace_call_id': ?replaceCallId`).
- Clears the only outstanding analyzer info (`use_null_aware_elements`) so pre-push analyze stays clean across the repo.
- Pure refactor — output JSON shape is identical.

## Why split out
Surfaced while preparing #1314 (predefined core URLs). The lint isn't related to that feature, so it gets its own PR for clean history.

## Test plan
- [x] `dart analyze` on `packages/webtrit_signaling` — no issues.
- [x] `dart test` on `packages/webtrit_signaling` — all green (hook ran 715 tests on push).