### PR TITLE
fix(call): suppress recvonly video transceiver in audio-only renegotiate offer (WT-1540)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2963,7 +2963,22 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       return;
     }
 
-    final offerCandidate = await pc.createOffer();
+    // Look up the active call up-front so we can gate the createOffer constraints
+    // on the actual media policy (audio-only vs video). The existing null/state
+    // guards below still run after the offer to preserve the original race semantics.
+    final renegotiateCall = state.retrieveActiveCall(e.callId);
+    final renegotiateHasVideo = renegotiateCall?.video ?? false;
+
+    // Pass explicit OfferToReceive* constraints so the underlying flutter-webrtc
+    // layer does not silently add a recvonly video transceiver as a side-effect
+    // of createOffer({}) for an audio-only call. Without this, an audio-only
+    // restoration produces a BUNDLE 0 1 offer (m=audio + m=video recvonly), and
+    // the next renegotiate cycle drifts the mids to 2/3 — which Janus then
+    // answers with mid:0 and libwebrtc rejects on mid mismatch, killing audio.
+    final offerCandidate = await pc.createOffer(<String, dynamic>{
+      'mandatory': <String, dynamic>{'OfferToReceiveAudio': true, 'OfferToReceiveVideo': renegotiateHasVideo},
+      'optional': <dynamic>[],
+    });
 
     // Note: prepare all asychronous info before checking synchrounous state below
     // to avoid races as possible,


### PR DESCRIPTION
## Summary

`pc.createOffer()` called without explicit constraints in `__onMutationRenegotiate` lets `flutter-webrtc` fall back to its `defaultSdpConstraints`, which silently sets `OfferToReceiveVideo: true`. On a freshly created `PeerConnection` that only has an audio sender attached (e.g. an audio-only restoration after force-stop + reopen), the native libwebrtc side interprets that constraint as an instruction to **add a recvonly video transceiver**, and the resulting offer carries an extra `m=video` line - `BUNDLE 0 1` instead of `BUNDLE 0`.

The next renegotiate cycle (signaling reconnect, ICE restart, anything that triggers it) regenerates mids for both transceivers, so the audio m-line ends up with `mid:2` and the auto-added video m-line with `mid:3`. Janus and Asterisk both keep `mid:0` from the original SIP dialog in their answer; libwebrtc on the app side then rejects `setRemoteDescription` on mid mismatch, the PC stays in `have-local-offer`, and audio never returns.

## Where

- Bug call site: `lib/features/call/bloc/call_bloc.dart:2966` (`pc.createOffer()` inside `__onMutationRenegotiate`).
- Entry point for the restoration scenario that surfaces it: `__onMutationRestoreCall` at `:3179` explicitly fires `add(_PeerConnectionEvent.renegotiationNeeded(...))` at `:3259`, which routes through `__onPeerConnectionEventRenegotiationNeeded` at `:3295` into `__onMutationRenegotiate` at `:2954`. The bad `m=video` is born inside that single `createOffer` call - not in `__onMutationRestoreCall` itself.

## Why this is hard to spot

The default that drives the side-effect lives outside our codebase, in `WebTrit/flutter-webrtc/lib/src/native/rtc_peerconnection_impl.dart:38-44`:

```dart
final Map<String, dynamic> defaultSdpConstraints = {
  'mandatory': {
    'OfferToReceiveAudio': true,
    'OfferToReceiveVideo': true,   // forced ON when caller passes nothing
  },
  'optional': [],
};
```

and line 330: `'constraints': constraints ?? defaultSdpConstraints`.

So `pc.createOffer()` and `pc.createOffer({})` look identical in the app code, but the first one inherits `OfferToReceiveVideo: true` from the fork's default. Without `git grep defaultSdpConstraints` across the fork, the chain "no constraints in app -> recvonly video transceiver auto-added by libwebrtc -> mid drift" is invisible.

## Change

Pass explicit `OfferToReceive*` constraints based on the current call's media policy:

```dart
final renegotiateCall = state.retrieveActiveCall(e.callId);
final renegotiateHasVideo = renegotiateCall?.video ?? false;

final offerCandidate = await pc.createOffer(<String, dynamic>{
  'mandatory': <String, dynamic>{
    'OfferToReceiveAudio': true,
    'OfferToReceiveVideo': renegotiateHasVideo,
  },
  'optional': <dynamic>[],
});
```

- **Audio-only call:** the side-effect-added `m=video` no longer appears; offer is `BUNDLE 0` with a single `m=audio mid:0`, stable across renegotiates.
- **Video call:** `renegotiateHasVideo == true` -> behaviour is unchanged.

The `activeCall` lookup is moved a few lines earlier to read the `video` flag. The original null / state guards below the `createOffer` still run afterwards, so the existing race semantics around `activeCall.updating` / `signalingConnected` are preserved.

Net: +16 / -1 in `lib/features/call/bloc/call_bloc.dart`, no behaviour change for video calls, no regression on any other `createOffer` site in this PR's scope.

## Related work

- [WebTrit/janus-gateway#12](https://github.com/WebTrit/janus-gateway/pull/12) - sibling fix for the other half of WT-1540: stops Janus from recreating the DTLS stack on every ICE restart when the peer's fingerprint has not changed. Independent of this PR; together they close both CASE A (`dtls_recreate=true` no longer breaks plain Wi-Fi handover) and CASE B (this PR).
- Long-term consideration: update `WebTrit/flutter-webrtc` `defaultSdpConstraints` so consumers do not silently get `OfferToReceiveVideo: true`. Out of scope here.

## Background

- WT-1540 - root issue: audio fails to restore after one of (force-stop + reopen, Wi-Fi handover, brief signaling reconnect).