### PR TITLE
chore(ios): bump permission_handler_apple to 9.4.9 for SPM support

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1379,10 +1379,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.7"
+    version: "9.4.9"
   permission_handler_html:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Bumps `permission_handler_apple` `9.4.7 → 9.4.9` (lockfile only).

## Why

`permission_handler_apple` 9.4.8 added Swift Package Manager support (`Package.swift` under `ios/permission_handler_apple/`). After this bump the plugin drops off Flutter's *"do not support Swift Package Manager"* warning. Allowed by the existing `permission_handler: ^12.0.1` constraint (requires `permission_handler_apple: ^9.4.6`), so only `pubspec.lock` changes.

## Still warned (not in this PR)

| Plugin | Status |
|---|---|
| `workmanager_apple` | Has `Package.swift` but at `ios/Package.swift` instead of `ios/workmanager_apple/` — Flutter doesn't detect it. Needs upstream fix ([#665](https://github.com/fluttercommunity/flutter_workmanager/issues/665) open). |
| `flutter_webrtc` | Upstream has no SPM ([#2027](https://github.com/flutter-webrtc/flutter-webrtc/issues/2027), [#2045](https://github.com/flutter-webrtc/flutter-webrtc/issues/2045)). Could add `Package.swift` to our fork. |
| `device_region` | Unmaintained (last release 1.4.0, 2 years ago). Needs replacement/fork. |
| `patrol` | Test-only dependency. Low priority. |

## Testing

- `flutter pub upgrade permission_handler_apple` → `9.4.9`
- Pre-push hooks: analyze clean, full test suite passed (715 tests).