### PR TITLE
feat(ios): migrate to UIScene lifecycle

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,7 +3,7 @@ import Flutter
 import flutter_local_notifications
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -16,11 +16,14 @@ import flutter_local_notifications
       UNUserNotificationCenter
         .current().delegate = self as UNUserNotificationCenterDelegate
     }
-    GeneratedPluginRegistrant.register(with: self)
 
     return super.application(
       application,
       didFinishLaunchingWithOptions: launchOptions
     )
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -79,6 +79,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIStatusBarHidden</key>
 	<false/>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
## Summary

Adopts the **UIScene lifecycle** required by Flutter 3.41+ (default-enabled on the 3.44 we're on) and mandatory on a future iOS SDK, per the [official migration guide](https://flutter.dev/to/uiscene-migration). Our customized `AppDelegate` blocks Flutter's auto-migration, so this is the manual equivalent.

This is the **app-side** half of the migration (`webtrit_phone` only), as agreed — see the known follow-up below.

## Changes
- **`ios/Runner/AppDelegate.swift`** — conform to `FlutterImplicitEngineDelegate`; move `GeneratedPluginRegistrant.register()` out of `didFinishLaunching` into `didInitializeImplicitFlutterEngine(_:)` using `engineBridge.pluginRegistry`. The `flutter_local_notifications` registrant callback and the `UNUserNotificationCenter` delegate assignment stay in `didFinishLaunching` (notification handling isn't scene-scoped).
- **`ios/Runner/Info.plist`** — add `UIApplicationSceneManifest` → `FlutterSceneDelegate` with the `Main` storyboard (identical to what the Flutter migrator injects).

## Plugin compatibility (verified)
| Plugin | Status |
|---|---|
| webtrit_callkeep (VoIP/CallKit) | Incoming push **unaffected** — owns its own `PKPushRegistry`, independent of UIScene |
| firebase_messaging 16.2.2 | Already adopts `addSceneDelegate:` |
| flutter_local_notifications | Taps go through `UNUserNotificationCenterDelegate` (global, not scene-scoped) |

## Known follow-up (separate PR, webtrit_callkeep repo)
`webtrit_callkeep_ios` only implements the app-delegate `application:continueUserActivity:`, which handles `INStartCallIntent` — i.e. **starting a call from the iOS system Recents list / Siri / Handoff**. Under UIScene this routes to `scene:continueUserActivity:`, so until the plugin adopts `addSceneDelegate:` + `scene:continueUserActivity:`, that specific flow will not fire. Incoming calls and normal outgoing calls are not affected.