### PR TITLE
feat: gate call-to-actions by adapter capability (WT-727)

### DIFF
--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -74,6 +74,12 @@ const kSystemNotificationsPushFeatureFlag = 'notificationsPush';
 const kSipPresenceFeatureFlag = 'sipPresence';
 const kSipDialogsFeatureFlag = 'sipDialogs';
 
+/// Adapter capability for the call-to-action list shown in the client UI.
+///
+/// Note: the wire value is snake_case (`cta_list`), unlike the other camelCase
+/// capability flags. See webtrit_bss_adapter_python `app/bss/models.py` `SupportedEnum`.
+const kCtaListFeatureFlag = 'cta_list';
+
 /// Key under `system-info` `adapter.custom` listing the identifier types the
 /// backend adapter accepts for OTP sign-in (e.g. `phone_number`, `email`).
 ///

--- a/lib/features/main/view/main_screen_page.dart
+++ b/lib/features/main/view/main_screen_page.dart
@@ -30,7 +30,10 @@ class MainScreenPage extends StatelessWidget {
     final bottomMenuManager = featureAccess.bottomMenuConfig;
     final tabs = bottomMenuManager.tabs;
 
-    final callToActionsEnabled = featureAccess.coreSupport.supportsCallToActions;
+    // Reactive: rebuilds when the adapter capability becomes available (e.g. system-info loads async).
+    final callToActionsEnabled = context.select<FeatureAccess, bool>(
+      (features) => features.coreSupport.supportsCallToActions,
+    );
 
     final systemNotificationsFeature = featureAccess.systemNotificationsConfig;
     final systemNotificationsEnabled = systemNotificationsFeature.systemNotificationsSupport;
@@ -43,7 +46,6 @@ class MainScreenPage extends StatelessWidget {
 
         if (callToActionsEnabled) {
           final isRouteActive = context.router.isRouteActive(MainScreenPageRoute.name);
-          final tabsRouter = AutoTabsRouter.of(context);
           final flavor = MainFlavor.values[tabsRouter.activeIndex];
 
           context.read<CallToActionsCubit>()

--- a/lib/features/main/view/main_screen_page.dart
+++ b/lib/features/main/view/main_screen_page.dart
@@ -25,12 +25,12 @@ class MainScreenPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final mainScreenRouteStateRepository = context.read<MainScreenRouteStateRepository>();
-    // TODO(Serdun): Move this to the environment configuration not to use the CORE_URL.
-    const appDemoFlow = EnvironmentConfig.CORE_URL == null;
 
     final featureAccess = context.read<FeatureAccess>();
     final bottomMenuManager = featureAccess.bottomMenuConfig;
     final tabs = bottomMenuManager.tabs;
+
+    final callToActionsEnabled = featureAccess.coreSupport.supportsCallToActions;
 
     final systemNotificationsFeature = featureAccess.systemNotificationsConfig;
     final systemNotificationsEnabled = systemNotificationsFeature.systemNotificationsSupport;
@@ -41,7 +41,7 @@ class MainScreenPage extends StatelessWidget {
       builder: (context, child) {
         final tabsRouter = AutoTabsRouter.of(context);
 
-        if (appDemoFlow) {
+        if (callToActionsEnabled) {
           final isRouteActive = context.router.isRouteActive(MainScreenPageRoute.name);
           final tabsRouter = AutoTabsRouter.of(context);
           final flavor = MainFlavor.values[tabsRouter.activeIndex];
@@ -84,7 +84,7 @@ class MainScreenPage extends StatelessWidget {
           storeInfoExtractor: StoreInfoExtractor(),
         )..add(const MainBlocInit());
       },
-      child: appDemoFlow
+      child: callToActionsEnabled
           ? BlocProvider<CallToActionsCubit>(
               create: (context) => CallToActionsCubit(
                 callToActionsRepository: context.read<CallToActionsRepository>(),

--- a/lib/utils/core_support.dart
+++ b/lib/utils/core_support.dart
@@ -27,6 +27,9 @@ abstract class CoreSupport {
 
   /// Check if the system push notifications feature is supported by remote system.
   bool get supportsSystemPushNotifications;
+
+  /// Check if the call-to-action list feature is supported by the remote system.
+  bool get supportsCallToActions;
 }
 
 class CoreSupportImpl extends Equatable implements CoreSupport {
@@ -50,6 +53,9 @@ class CoreSupportImpl extends Equatable implements CoreSupport {
 
   @override
   bool get supportsSystemPushNotifications => _has(kSystemNotificationsPushFeatureFlag);
+
+  @override
+  bool get supportsCallToActions => _has(kCtaListFeatureFlag);
 
   @override
   List<Object?> get props {

--- a/test/utils/core_support_test.dart
+++ b/test/utils/core_support_test.dart
@@ -17,6 +17,15 @@ void main() {
       expect(cs.supportsChats, isFalse);
       expect(cs.supportsSystemNotifications, isFalse);
       expect(cs.supportsSystemPushNotifications, isFalse);
+      expect(cs.supportsCallToActions, isFalse);
+    });
+
+    test('call-to-actions only', () {
+      final cs = createCoreSupportWithFlags([kCtaListFeatureFlag]);
+
+      expect(cs.supportsCallToActions, isTrue);
+      expect(cs.supportsVoicemail, isFalse);
+      expect(cs.supportsSms, isFalse);
     });
 
     test('voicemail only', () {


### PR DESCRIPTION
The `call_to_actions` feature was previously mounted and fetched only in the demo build
(`EnvironmentConfig.CORE_URL == null`). This drives it by the adapter capability **`cta_list`**
advertised in `system-info` instead, so call-to-actions are requested only when the adapter
supports them — the build environment no longer decides it.

## Changes

- `lib/app/constants.dart` — add `kCtaListFeatureFlag = 'cta_list'`.
  Note: the wire value is **snake_case** (`cta_list`), unlike the other camelCase capability
  flags (confirmed in `webtrit_bss_adapter_python` `SupportedEnum`).
- `lib/utils/core_support.dart` — add `CoreSupport.supportsCallToActions`.
- `lib/features/main/view/main_screen_page.dart` — replace the `appDemoFlow` gate (mount +
  `getActions`) with `featureAccess.coreSupport.supportsCallToActions`.
- `test/utils/core_support_test.dart` — cover the new getter.
