### PR TITLE
feat(cdrs): gate call history by adapter capability (WT-727)

### DIFF
--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -73,6 +73,7 @@ const kSystemNotificationsFeatureFlag = 'notifications';
 const kSystemNotificationsPushFeatureFlag = 'notificationsPush';
 const kSipPresenceFeatureFlag = 'sipPresence';
 const kSipDialogsFeatureFlag = 'sipDialogs';
+const kCallHistoryFeatureFlag = 'callHistory';
 
 /// Adapter capability for the call-to-action list shown in the client UI.
 ///

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -108,7 +108,7 @@ class FeatureAccess extends Equatable {
       final termsConfig = TermsMapper.map(embeddedResources);
 
       final loginConfig = LoginMapper.map(appConfig, embeddedConfig.embeddedResources);
-      final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig);
+      final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig, coreSupport);
       final settingsConfig = SettingsMapper.map(appConfig, embeddedResources, coreSupport, termsConfig);
       final callConfig = CallMapper.map(appConfig, featureOverrides);
       final messagingConfig = MessagingMapper.map(appConfig, coreSupport);
@@ -200,7 +200,10 @@ abstract final class LoginMapper {
 /// Mapper responsible for transforming [AppConfig] into [BottomMenuConfig].
 abstract final class BottomMenuMapper {
   /// Maps [AppConfig] and [EmbeddedConfig] to a [BottomMenuConfig].
-  static BottomMenuConfig map(AppConfig appConfig, EmbeddedConfig embeddedConfig) {
+  ///
+  /// [coreSupport] is used to resolve capability-gated tab options (e.g. the
+  /// recents tab only uses server CDRs when the adapter advertises call history).
+  static BottomMenuConfig map(AppConfig appConfig, EmbeddedConfig embeddedConfig, CoreSupport coreSupport) {
     final bottomMenu = appConfig.mainConfig.bottomMenu;
 
     if (bottomMenu.tabs.isEmpty) {
@@ -209,7 +212,7 @@ abstract final class BottomMenuMapper {
 
     final bottomMenuTabs = bottomMenu.tabs
         .where((tab) => tab.enabled)
-        .map((tab) => _createBottomMenuTab(tab, embeddedConfig))
+        .map((tab) => _createBottomMenuTab(tab, embeddedConfig, coreSupport))
         .toList();
 
     if (bottomMenuTabs.isEmpty) {
@@ -219,7 +222,11 @@ abstract final class BottomMenuMapper {
     return BottomMenuConfig(tabs: List.unmodifiable(bottomMenuTabs));
   }
 
-  static BottomMenuTab _createBottomMenuTab(BottomMenuTabScheme tab, EmbeddedConfig embeddedConfig) {
+  static BottomMenuTab _createBottomMenuTab(
+    BottomMenuTabScheme tab,
+    EmbeddedConfig embeddedConfig,
+    CoreSupport coreSupport,
+  ) {
     return tab.when(
       favorites: (enabled, initial, titleL10n, icon) => FavoritesBottomMenuTab(
         enabled: tab.enabled,
@@ -228,7 +235,7 @@ abstract final class BottomMenuMapper {
         icon: tab.icon.toIconData(),
       ),
       recents: (enabled, initial, titleL10n, icon, useCdrs) => RecentsBottomMenuTab(
-        useCdrs: useCdrs,
+        useCdrs: useCdrs && coreSupport.supportsCallHistory,
         enabled: tab.enabled,
         initial: tab.initial,
         titleL10n: tab.titleL10n,

--- a/lib/utils/core_support.dart
+++ b/lib/utils/core_support.dart
@@ -30,6 +30,9 @@ abstract class CoreSupport {
 
   /// Check if the call-to-action list feature is supported by the remote system.
   bool get supportsCallToActions;
+
+  /// Check if the call history (CDR) feature is supported by the remote system.
+  bool get supportsCallHistory;
 }
 
 class CoreSupportImpl extends Equatable implements CoreSupport {
@@ -56,6 +59,9 @@ class CoreSupportImpl extends Equatable implements CoreSupport {
 
   @override
   bool get supportsCallToActions => _has(kCtaListFeatureFlag);
+
+  @override
+  bool get supportsCallHistory => _has(kCallHistoryFeatureFlag);
 
   @override
   List<Object?> get props {

--- a/test/data/bottom_menu_mapper_test.dart
+++ b/test/data/bottom_menu_mapper_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_appearance_theme/webtrit_appearance_theme.dart';
+
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/utils/core_support.dart';
+
+void main() {
+  group('BottomMenuMapper recents useCdrs gating by the callHistory capability', () {
+    AppConfig appConfigWithRecents({required bool useCdrs}) {
+      return AppConfig(
+        mainConfig: AppConfigMain(
+          bottomMenu: AppConfigBottomMenu(
+            tabs: [
+              BottomMenuTabScheme.recents(enabled: true, titleL10n: 'recents', icon: '0xe03a', useCdrs: useCdrs),
+              const BottomMenuTabScheme.keypad(enabled: true, titleL10n: 'keypad', icon: '0xe1ce'),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final emptyEmbedded = EmbeddedMapper.map(const []);
+
+    bool? recentsUseCdrs(AppConfig appConfig, List<String> flags) {
+      final config = BottomMenuMapper.map(appConfig, emptyEmbedded, CoreSupportImpl(flags));
+      return config.getTabEnabled<RecentsBottomMenuTab>()?.useCdrs;
+    }
+
+    test('useCdrs configured AND callHistory advertised -> true', () {
+      expect(recentsUseCdrs(appConfigWithRecents(useCdrs: true), [kCallHistoryFeatureFlag]), isTrue);
+    });
+
+    test('useCdrs configured but callHistory NOT advertised -> false (local fallback)', () {
+      expect(recentsUseCdrs(appConfigWithRecents(useCdrs: true), const []), isFalse);
+    });
+
+    test('callHistory advertised but useCdrs not configured -> false', () {
+      expect(recentsUseCdrs(appConfigWithRecents(useCdrs: false), [kCallHistoryFeatureFlag]), isFalse);
+    });
+  });
+}

--- a/test/utils/core_support_test.dart
+++ b/test/utils/core_support_test.dart
@@ -18,6 +18,7 @@ void main() {
       expect(cs.supportsSystemNotifications, isFalse);
       expect(cs.supportsSystemPushNotifications, isFalse);
       expect(cs.supportsCallToActions, isFalse);
+      expect(cs.supportsCallHistory, isFalse);
     });
 
     test('call-to-actions only', () {
@@ -55,6 +56,14 @@ void main() {
     test('system notifications only', () {
       final cs = createCoreSupportWithFlags([kSystemNotificationsFeatureFlag]);
       expect(cs.supportsSystemNotifications, isTrue);
+    });
+
+    test('call history only', () {
+      final cs = createCoreSupportWithFlags([kCallHistoryFeatureFlag]);
+
+      expect(cs.supportsCallHistory, isTrue);
+      expect(cs.supportsVoicemail, isFalse);
+      expect(cs.supportsSms, isFalse);
     });
 
     test('all flags -> all getters true', () {


### PR DESCRIPTION
Recents CDRs (`GET /user/history`) were enabled solely by the local AppConfig `useCdrs` flag, without
checking whether the adapter advertises the `callHistory` capability in `system-info`. This gates CDR
usage on both signals.

## How

- `CoreSupport.supportsCallHistory` exposes the adapter `callHistory` capability (`adapter.supported`).
- `BottomMenuMapper` builds the recents tab with `useCdrs: useCdrs && coreSupport.supportsCallHistory`.

Every CDR consumer reads `RecentsBottomMenuTab.useCdrs`, so the gating applies to the sync worker, the
router, and the per-contact / favorites history buttons without further changes.

## Changes

- `lib/app/constants.dart` - add `kCallHistoryFeatureFlag = 'callHistory'`.
- `lib/utils/core_support.dart` - add `supportsCallHistory`.
- `lib/data/feature_access.dart` - `BottomMenuMapper.map` takes `coreSupport`; recents tab
  `useCdrs: useCdrs && coreSupport.supportsCallHistory`.
- `test/utils/core_support_test.dart` - cover `supportsCallHistory`.
- `test/data/bottom_menu_mapper_test.dart` - cover the recents `useCdrs` gating.

## Behavior when `callHistory` is not advertised

- No `CdrsSyncWorker`, zero `/user/history` requests.
- Recents tab remains, backed by the local device call log; contact/favorites history buttons open the
  local call log. No CDR-based screens are reached.

## Testing

- `flutter analyze` on changed files - no issues.
- `flutter test test/utils/core_support_test.dart test/data/bottom_menu_mapper_test.dart` - 11 passing.