### PR TITLE
feat(contacts): gate external (PBX) contacts by adapter capability (WT-727)

### DIFF
--- a/lib/app/constants.dart
+++ b/lib/app/constants.dart
@@ -74,6 +74,7 @@ const kSystemNotificationsPushFeatureFlag = 'notificationsPush';
 const kSipPresenceFeatureFlag = 'sipPresence';
 const kSipDialogsFeatureFlag = 'sipDialogs';
 const kCallHistoryFeatureFlag = 'callHistory';
+const kExtensionsFeatureFlag = 'extensions';
 
 /// Adapter capability for the call-to-action list shown in the client UI.
 ///

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -209,7 +209,10 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
 
             final token = context.read<AppBloc>().state.session.token!;
 
-            final contactsRemoteDataSource = ContactsRemoteDataSourceImpl(webtritApiClient, token);
+            final supportsExtensions = context.read<FeatureAccess>().coreSupport.supportsExtensions;
+            final contactsRemoteDataSource = supportsExtensions
+                ? ContactsRemoteDataSourceImpl(webtritApiClient, token)
+                : null;
             final contactsLocalDataSource = ContactsLocalDataSourceImpl(appDatabase);
 
             return ContactsRepository(
@@ -452,16 +455,17 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                       return bloc;
                     },
                   ),
-                  BlocProvider<ExternalContactsSyncBloc>(
-                    lazy: false,
-                    create: (context) {
-                      return ExternalContactsSyncBloc(
-                        userRepository: context.read<UserRepository>(),
-                        externalContactsRepository: context.read<ExternalContactsRepository>(),
-                        contactsRepository: context.read<ContactsRepository>(),
-                      )..add(const ExternalContactsSyncStarted());
-                    },
-                  ),
+                  if (featureAccess.coreSupport.supportsExtensions)
+                    BlocProvider<ExternalContactsSyncBloc>(
+                      lazy: false,
+                      create: (context) {
+                        return ExternalContactsSyncBloc(
+                          userRepository: context.read<UserRepository>(),
+                          externalContactsRepository: context.read<ExternalContactsRepository>(),
+                          contactsRepository: context.read<ContactsRepository>(),
+                        )..add(const ExternalContactsSyncStarted());
+                      },
+                    ),
                   BlocProvider<CallBloc>(
                     create: (context) {
                       final appBloc = context.read<AppBloc>();
@@ -695,6 +699,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// can be made here without touching the [Provider] or [PollingService] setup.
   List<PollingRegistration> _pollingRegistrations(BuildContext context) {
     final isVoicemailsEnabled = context.read<FeatureAccess>().settingsConfig.voicemailsEnabled;
+    final supportsExtensions = context.read<FeatureAccess>().coreSupport.supportsExtensions;
     final cliSettingsRepository = context.read<CallerIdSettingsRepository>();
     final favoritesRepository = context.read<FavoritesRepository>();
     final sipSubscriptionsRepository = context.read<SipSubscriptionsRepository>();
@@ -708,10 +713,11 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
         listener: context.read<SystemInfoRepository>(),
         interval: const Duration(seconds: EnvironmentConfig.SYSTEM_INFO_REPOSITORY_POLLING_INTERVAL_SECONDS),
       ),
-      PollingRegistration(
-        listener: context.read<ExternalContactsRepository>(),
-        interval: const Duration(seconds: EnvironmentConfig.EXTERNAL_CONTACTS_REPOSITORY_POLLING_INTERVAL_SECONDS),
-      ),
+      if (supportsExtensions)
+        PollingRegistration(
+          listener: context.read<ExternalContactsRepository>(),
+          interval: const Duration(seconds: EnvironmentConfig.EXTERNAL_CONTACTS_REPOSITORY_POLLING_INTERVAL_SECONDS),
+        ),
       if (isVoicemailsEnabled)
         PollingRegistration(
           listener: context.read<VoicemailRepository>(),

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -201,8 +201,9 @@ abstract final class LoginMapper {
 abstract final class BottomMenuMapper {
   /// Maps [AppConfig] and [EmbeddedConfig] to a [BottomMenuConfig].
   ///
-  /// [coreSupport] is used to resolve capability-gated tab options (e.g. the
-  /// recents tab only uses server CDRs when the adapter advertises call history).
+  /// [coreSupport] resolves capability-gated tab options - e.g. the recents tab uses server CDRs only
+  /// when the adapter advertises call history, and the contacts tab keeps the `external` source only
+  /// when it advertises the `extensions` capability.
   static BottomMenuConfig map(AppConfig appConfig, EmbeddedConfig embeddedConfig, CoreSupport coreSupport) {
     final bottomMenu = appConfig.mainConfig.bottomMenu;
 
@@ -213,6 +214,7 @@ abstract final class BottomMenuMapper {
     final bottomMenuTabs = bottomMenu.tabs
         .where((tab) => tab.enabled)
         .map((tab) => _createBottomMenuTab(tab, embeddedConfig, coreSupport))
+        .where((tab) => !(tab is ContactsBottomMenuTab && tab.contactSourceTypes.isEmpty))
         .toList();
 
     if (bottomMenuTabs.isEmpty) {
@@ -246,7 +248,10 @@ abstract final class BottomMenuMapper {
         initial: tab.initial,
         titleL10n: tab.titleL10n,
         icon: tab.icon.toIconData(),
-        contactSourceTypes: contactSourceTypes.map((type) => ContactSourceType.values.byName(type)).toList(),
+        contactSourceTypes: contactSourceTypes
+            .map((type) => ContactSourceType.values.byName(type))
+            .where((type) => type != ContactSourceType.external || coreSupport.supportsExtensions)
+            .toList(),
       ),
       keypad: (enabled, initial, titleL10n, icon) => KeypadBottomMenuTab(
         enabled: tab.enabled,

--- a/lib/utils/core_support.dart
+++ b/lib/utils/core_support.dart
@@ -33,6 +33,9 @@ abstract class CoreSupport {
 
   /// Check if the call history (CDR) feature is supported by the remote system.
   bool get supportsCallHistory;
+
+  /// Check if the external (server/PBX) contacts directory is supported by the remote system.
+  bool get supportsExtensions;
 }
 
 class CoreSupportImpl extends Equatable implements CoreSupport {
@@ -62,6 +65,9 @@ class CoreSupportImpl extends Equatable implements CoreSupport {
 
   @override
   bool get supportsCallHistory => _has(kCallHistoryFeatureFlag);
+
+  @override
+  bool get supportsExtensions => _has(kExtensionsFeatureFlag);
 
   @override
   List<Object?> get props {

--- a/test/data/bottom_menu_mapper_test.dart
+++ b/test/data/bottom_menu_mapper_test.dart
@@ -8,6 +8,8 @@ import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/core_support.dart';
 
 void main() {
+  final emptyEmbedded = EmbeddedMapper.map(const []);
+
   group('BottomMenuMapper recents useCdrs gating by the callHistory capability', () {
     AppConfig appConfigWithRecents({required bool useCdrs}) {
       return AppConfig(
@@ -21,8 +23,6 @@ void main() {
         ),
       );
     }
-
-    final emptyEmbedded = EmbeddedMapper.map(const []);
 
     bool? recentsUseCdrs(AppConfig appConfig, List<String> flags) {
       final config = BottomMenuMapper.map(appConfig, emptyEmbedded, CoreSupportImpl(flags));
@@ -39,6 +39,58 @@ void main() {
 
     test('callHistory advertised but useCdrs not configured -> false', () {
       expect(recentsUseCdrs(appConfigWithRecents(useCdrs: false), [kCallHistoryFeatureFlag]), isFalse);
+    });
+  });
+
+  group('BottomMenuMapper external contact source gating by the extensions capability', () {
+    AppConfig appConfigWithContacts({required List<String> sources}) {
+      return AppConfig(
+        mainConfig: AppConfigMain(
+          bottomMenu: AppConfigBottomMenu(
+            tabs: [
+              BottomMenuTabScheme.contacts(
+                enabled: true,
+                titleL10n: 'contacts',
+                icon: '0xee35',
+                contactSourceTypes: sources,
+              ),
+              const BottomMenuTabScheme.keypad(enabled: true, titleL10n: 'keypad', icon: '0xe1ce'),
+            ],
+          ),
+        ),
+      );
+    }
+
+    ContactsBottomMenuTab? contactsTab(AppConfig appConfig, List<String> flags) {
+      final config = BottomMenuMapper.map(appConfig, emptyEmbedded, CoreSupportImpl(flags));
+      return config.getTabEnabled<ContactsBottomMenuTab>();
+    }
+
+    test('keeps external source when extensions is advertised', () {
+      final tab = contactsTab(appConfigWithContacts(sources: ['local', 'external']), [kExtensionsFeatureFlag]);
+
+      expect(tab, isNotNull);
+      expect(tab!.contactSourceTypes, containsAll([ContactSourceType.local, ContactSourceType.external]));
+    });
+
+    test('drops external source when extensions is not advertised', () {
+      final tab = contactsTab(appConfigWithContacts(sources: ['local', 'external']), const []);
+
+      expect(tab, isNotNull);
+      expect(tab!.contactSourceTypes, [ContactSourceType.local]);
+    });
+
+    test('drops the whole contacts tab when only external is configured and unsupported', () {
+      final tab = contactsTab(appConfigWithContacts(sources: ['external']), const []);
+
+      expect(tab, isNull);
+    });
+
+    test('keeps an external-only contacts tab when extensions is advertised', () {
+      final tab = contactsTab(appConfigWithContacts(sources: ['external']), [kExtensionsFeatureFlag]);
+
+      expect(tab, isNotNull);
+      expect(tab!.contactSourceTypes, [ContactSourceType.external]);
     });
   });
 }

--- a/test/utils/core_support_test.dart
+++ b/test/utils/core_support_test.dart
@@ -19,12 +19,21 @@ void main() {
       expect(cs.supportsSystemPushNotifications, isFalse);
       expect(cs.supportsCallToActions, isFalse);
       expect(cs.supportsCallHistory, isFalse);
+      expect(cs.supportsExtensions, isFalse);
     });
 
     test('call-to-actions only', () {
       final cs = createCoreSupportWithFlags([kCtaListFeatureFlag]);
 
       expect(cs.supportsCallToActions, isTrue);
+      expect(cs.supportsVoicemail, isFalse);
+      expect(cs.supportsSms, isFalse);
+    });
+
+    test('extensions only', () {
+      final cs = createCoreSupportWithFlags([kExtensionsFeatureFlag]);
+
+      expect(cs.supportsExtensions, isTrue);
       expect(cs.supportsVoicemail, isFalse);
       expect(cs.supportsSms, isFalse);
     });


### PR DESCRIPTION
External / PBX contacts (`GET /user/contacts` and `GET /user/contacts/{id}`) were fetched and polled
regardless of whether the adapter advertises the `extensions` capability in `system-info`.

`CoreSupport.supportsExtensions` exposes the adapter `extensions` capability. The combination with the
local contacts config happens in `FeatureAccess`.

**Requests** are gated on the capability (not on `contactSourceTypes`, since external contacts also
feed chat/SMS participant name resolution):
- `ExternalContactsSyncBloc` provider is created only when supported (`main_shell`).
- The `ExternalContactsRepository` polling registration is gated.
- `ContactsRepository` receives a `null` remote data source when unsupported, so per-contact
  `/user/contacts/{id}` fetches are skipped.

**Visibility** combines config and capability: `BottomMenuMapper` keeps the `external` contact source
only when supported, and drops the contacts tab entirely if no sources remain.

**Resolution** (`remote -> local -> number`) needs no new code: the remote fetch is suppressed by the
`null` data source, the unified local DB lookup covers synced contacts, and `ContactInfoBuilder`
renders the raw number when no contact is found.

## Changes

- `lib/app/constants.dart` - add `kExtensionsFeatureFlag = 'extensions'`.
- `lib/utils/core_support.dart` - add `supportsExtensions`.
- `lib/data/feature_access.dart` - `BottomMenuMapper.map` takes `coreSupport`; filter the `external`
  source and drop an emptied contacts tab.
- `lib/app/router/main_shell.dart` - gate the sync bloc, polling, and remote data source.
- `test/utils/core_support_test.dart`, `test/data/bottom_menu_mapper_test.dart` - coverage.

## Behavior when `extensions` is not advertised

- Zero `/user/contacts` and `/user/contacts/{id}` requests (sync, polling, per-contact).
- Contacts tab shows local contacts only, or disappears if it was external-only.
- Name resolution in calls/chats/SMS falls back to local contacts, then the raw number.