### PR TITLE
feat(cdrs): make server capability the sole source of truth for call history (WT-727)

### DIFF
--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -55,8 +55,7 @@
           "initial": false,
           "type": "recents",
           "titleL10n": "main_BottomNavigationBarItemLabel_recents",
-          "icon": "0xe03a",
-          "useCdrs": false
+          "icon": "0xe03a"
         },
         {
           "enabled": true,

--- a/docs/application_config.md
+++ b/docs/application_config.md
@@ -6,16 +6,16 @@ navigation structure, and screen-specific behaviors.
 ## Table of Contents
 
 - [Login Configuration](#login-configuration)
-    - [Login Common](#login-common)
-    - [Login Mode Select](#login-mode-select)
+  - [Login Common](#login-common)
+  - [Login Mode Select](#login-mode-select)
 - [Main Configuration](#main-configuration)
-    - [Bottom Menu Configuration](#bottom-menu-configuration)
-    - [Tab Variants](#tab-variants)
+  - [Bottom Menu Configuration](#bottom-menu-configuration)
+  - [Tab Variants](#tab-variants)
 - [Call Configuration](#call-configuration)
-    - [Transfer Configuration](#transfer-configuration)
+  - [Transfer Configuration](#transfer-configuration)
 - [Settings Configuration](#settings-configuration)
-    - [Settings Sections](#settings-sections)
-    - [Settings Items](#settings-items)
+  - [Settings Sections](#settings-sections)
+  - [Settings Items](#settings-items)
 - [Embedded Pages](#embedded-pages)
 
 ---
@@ -99,8 +99,7 @@ the application.
           "initial": false,
           "type": "recents",
           "titleL10n": "main_BottomNavigationBarItemLabel_recents",
-          "icon": "0xe03a",
-          "useCdrs": false
+          "icon": "0xe03a"
         },
         {
           "enabled": true,
@@ -183,12 +182,13 @@ Recent calls or history screen.
   "type": "recents",
   "enabled": true,
   "titleL10n": "main_BottomNavigationBarItemLabel_recents",
-  "icon": "0xe03a",
-  "useCdrs": false
+  "icon": "0xe03a"
 }
 ```
 
-- `useCdrs`: *(optional)* whether to fetch recent data from remote CDR history.
+Remote call history (CDRs) is no longer configured here. It is enabled automatically when the
+server advertises the `callHistory` adapter capability in system-info; otherwise the recents tab
+falls back to the local device call log.
 
 ### **ContactsTabScheme**
 

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -164,7 +164,7 @@ class AppRouter extends RootStackRouter {
                   ],
                 ),
 
-                if (_bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.useCdrs == false)
+                if (_bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory == false)
                   AutoRoute(
                     page: RecentsRouterPageRoute.page,
                     path: MainFlavor.recents.name,
@@ -175,7 +175,7 @@ class AppRouter extends RootStackRouter {
                       AutoRoute(page: NumberCdrsScreenPageRoute.page, path: 'number_cdrs'),
                     ],
                   ),
-                if (_bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.useCdrs == true)
+                if (_bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory == true)
                   AutoRoute(
                     page: RecentCdrsRouterPageRoute.page,
                     path: MainFlavor.recents.name,
@@ -391,7 +391,7 @@ class AppRouter extends RootStackRouter {
           children: [
             switch (_mainInitialTab) {
               // Recents tab can be either with CDRs or standard
-              RecentsBottomMenuTab(useCdrs: true) => const RecentCdrsRouterPageRoute(),
+              RecentsBottomMenuTab(supportsCallHistory: true) => const RecentCdrsRouterPageRoute(),
               RecentsBottomMenuTab() => const RecentsRouterPageRoute(),
               // Contacts tab
               ContactsBottomMenuTab() => const ContactsRouterPageRoute(),

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -365,7 +365,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
               dispose: (context, service) => service.dispose(),
               lazy: false,
             ),
-            if (featureAccess.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>()?.useCdrs == true)
+            if (featureAccess.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory == true)
               Provider<CdrsSyncWorker>(
                 create: (context) =>
                     CdrsSyncWorker(context.read<CdrsLocalRepository>(), context.read<CdrsRemoteRepository>())..init(),

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -234,8 +234,8 @@ abstract final class BottomMenuMapper {
         titleL10n: tab.titleL10n,
         icon: tab.icon.toIconData(),
       ),
-      recents: (enabled, initial, titleL10n, icon, useCdrs) => RecentsBottomMenuTab(
-        useCdrs: useCdrs && coreSupport.supportsCallHistory,
+      recents: (enabled, initial, titleL10n, icon) => RecentsBottomMenuTab(
+        supportsCallHistory: coreSupport.supportsCallHistory,
         enabled: tab.enabled,
         initial: tab.initial,
         titleL10n: tab.titleL10n,

--- a/lib/features/contact/view/contact_screen_page.dart
+++ b/lib/features/contact/view/contact_screen_page.dart
@@ -29,7 +29,7 @@ class ContactScreenPage extends StatelessWidget {
     final canVideoCall = callConfig.isVideoCallEnabled;
     final canTransfer = callConfig.isBlindTransferEnabled;
     final favoritesEnabled = bottomMenuFeature.getTabEnabled<FavoritesBottomMenuTab>() != null;
-    final useCdrsForHistory = bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.useCdrs ?? false;
+    final useCdrsForHistory = bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory ?? false;
 
     bool isTileEnabled(ContactAction action, [bool capability = true]) {
       return contactsConfig.phoneTileActions.contains(action) && capability;

--- a/lib/features/favorites/view/favorites_screen_page.dart
+++ b/lib/features/favorites/view/favorites_screen_page.dart
@@ -18,7 +18,7 @@ class FavoritesScreenPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final featureAccess = context.read<FeatureAccess>();
 
-    final cdrsEnabled = featureAccess.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>()?.useCdrs;
+    final cdrsEnabled = featureAccess.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory;
 
     final widget = FavoritesScreen(
       title: const Text(EnvironmentConfig.APP_NAME),

--- a/lib/features/main/view/main_screen_page.dart
+++ b/lib/features/main/view/main_screen_page.dart
@@ -119,7 +119,7 @@ class MainScreenPage extends StatelessWidget {
         case MessagingBottomMenuTab():
           return const ConversationsScreenPageRoute();
         case RecentsBottomMenuTab():
-          return tab.useCdrs ? const RecentCdrsScreenPageRoute() : const RecentsRouterPageRoute();
+          return tab.supportsCallHistory ? const RecentCdrsScreenPageRoute() : const RecentsRouterPageRoute();
         case ContactsBottomMenuTab():
           return ContactsRouterPageRoute(children: [ContactsScreenPageRoute(sourceTypes: tab.contactSourceTypes)]);
         case EmbeddedBottomMenuTab():

--- a/lib/models/feature_access/bottom_menu_feature.dart
+++ b/lib/models/feature_access/bottom_menu_feature.dart
@@ -77,7 +77,7 @@ final class RecentsBottomMenuTab extends BottomMenuTab {
   static const cdrsSegment = 'cdrs';
 
   const RecentsBottomMenuTab({
-    required this.useCdrs,
+    required this.supportsCallHistory,
     required super.enabled,
     required super.initial,
     required super.titleL10n,
@@ -85,16 +85,18 @@ final class RecentsBottomMenuTab extends BottomMenuTab {
     super.data,
   });
 
-  final bool useCdrs;
+  // Formerly `useCdrs`. Resolved from the adapter `callHistory` capability
+  // (CoreSupport.supportsCallHistory); when true the recents tab uses remote CDRs.
+  final bool supportsCallHistory;
 
   @override
   MainFlavor get flavor => MainFlavor.recents;
 
   @override
-  String get routePath => '${super.routePath}${useCdrs ? '/$cdrsSegment' : ''}';
+  String get routePath => '${super.routePath}${supportsCallHistory ? '/$cdrsSegment' : ''}';
 
   @override
-  List<Object?> get props => [...super.props, useCdrs];
+  List<Object?> get props => [...super.props, supportsCallHistory];
 }
 
 final class ContactsBottomMenuTab extends BottomMenuTab {

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -147,7 +147,6 @@ class AppConfigMain with _$AppConfigMain {
           initial: false,
           titleL10n: 'main_BottomNavigationBarItemLabel_recents',
           icon: '0xe03a',
-          useCdrs: false,
         ),
         ContactsTabScheme(
           enabled: true,
@@ -372,7 +371,6 @@ sealed class BottomMenuTabScheme with _$BottomMenuTabScheme {
     @Default(false) bool initial,
     required String titleL10n,
     required String icon,
-    @Default(false) bool useCdrs,
   }) = RecentsTabScheme;
 
   @JsonSerializable(explicitToJson: true)

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
@@ -2655,11 +2655,11 @@ return embedded(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  bool useCdrs)?  recents,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  recents,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case FavoritesTabScheme() when favorites != null:
 return favorites(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case RecentsTabScheme() when recents != null:
-return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.useCdrs);case ContactsTabScheme() when contacts != null:
+return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case ContactsTabScheme() when contacts != null:
 return contacts(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.contactSourceTypes);case KeypadTabScheme() when keypad != null:
 return keypad(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case MessagingTabScheme() when messaging != null:
 return messaging(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case EmbeddedTabScheme() when embedded != null:
@@ -2681,11 +2681,11 @@ return embedded(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.emb
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  favorites,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  bool useCdrs)  recents,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)  contacts,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  keypad,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  messaging,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)  embedded,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  favorites,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  recents,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)  contacts,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  keypad,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  messaging,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)  embedded,}) {final _that = this;
 switch (_that) {
 case FavoritesTabScheme():
 return favorites(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case RecentsTabScheme():
-return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.useCdrs);case ContactsTabScheme():
+return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case ContactsTabScheme():
 return contacts(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.contactSourceTypes);case KeypadTabScheme():
 return keypad(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case MessagingTabScheme():
 return messaging(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case EmbeddedTabScheme():
@@ -2703,11 +2703,11 @@ return embedded(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.emb
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon,  bool useCdrs)?  recents,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  recents,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,}) {final _that = this;
 switch (_that) {
 case FavoritesTabScheme() when favorites != null:
 return favorites(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case RecentsTabScheme() when recents != null:
-return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.useCdrs);case ContactsTabScheme() when contacts != null:
+return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case ContactsTabScheme() when contacts != null:
 return contacts(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.contactSourceTypes);case KeypadTabScheme() when keypad != null:
 return keypad(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case MessagingTabScheme() when messaging != null:
 return messaging(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case EmbeddedTabScheme() when embedded != null:
@@ -2802,14 +2802,13 @@ as String,
 
 @JsonSerializable(explicitToJson: true)
 class RecentsTabScheme extends BottomMenuTabScheme {
-  const RecentsTabScheme({this.enabled = true, this.initial = false, required this.titleL10n, required this.icon, this.useCdrs = false, final  String? $type}): $type = $type ?? 'recents',super._();
+  const RecentsTabScheme({this.enabled = true, this.initial = false, required this.titleL10n, required this.icon, final  String? $type}): $type = $type ?? 'recents',super._();
   factory RecentsTabScheme.fromJson(Map<String, dynamic> json) => _$RecentsTabSchemeFromJson(json);
 
 @override@JsonKey() final  bool enabled;
 @override@JsonKey() final  bool initial;
 @override final  String titleL10n;
 @override final  String icon;
-@JsonKey() final  bool useCdrs;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -2828,16 +2827,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsTabScheme&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.initial, initial) || other.initial == initial)&&(identical(other.titleL10n, titleL10n) || other.titleL10n == titleL10n)&&(identical(other.icon, icon) || other.icon == icon)&&(identical(other.useCdrs, useCdrs) || other.useCdrs == useCdrs));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsTabScheme&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.initial, initial) || other.initial == initial)&&(identical(other.titleL10n, titleL10n) || other.titleL10n == titleL10n)&&(identical(other.icon, icon) || other.icon == icon));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enabled,initial,titleL10n,icon,useCdrs);
+int get hashCode => Object.hash(runtimeType,enabled,initial,titleL10n,icon);
 
 @override
 String toString() {
-  return 'BottomMenuTabScheme.recents(enabled: $enabled, initial: $initial, titleL10n: $titleL10n, icon: $icon, useCdrs: $useCdrs)';
+  return 'BottomMenuTabScheme.recents(enabled: $enabled, initial: $initial, titleL10n: $titleL10n, icon: $icon)';
 }
 
 
@@ -2848,7 +2847,7 @@ abstract mixin class $RecentsTabSchemeCopyWith<$Res> implements $BottomMenuTabSc
   factory $RecentsTabSchemeCopyWith(RecentsTabScheme value, $Res Function(RecentsTabScheme) _then) = _$RecentsTabSchemeCopyWithImpl;
 @override @useResult
 $Res call({
- bool enabled, bool initial, String titleL10n, String icon, bool useCdrs
+ bool enabled, bool initial, String titleL10n, String icon
 });
 
 
@@ -2865,14 +2864,13 @@ class _$RecentsTabSchemeCopyWithImpl<$Res>
 
 /// Create a copy of BottomMenuTabScheme
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? initial = null,Object? titleL10n = null,Object? icon = null,Object? useCdrs = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? initial = null,Object? titleL10n = null,Object? icon = null,}) {
   return _then(RecentsTabScheme(
 enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool,initial: null == initial ? _self.initial : initial // ignore: cast_nullable_to_non_nullable
 as bool,titleL10n: null == titleL10n ? _self.titleL10n : titleL10n // ignore: cast_nullable_to_non_nullable
 as String,icon: null == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
-as String,useCdrs: null == useCdrs ? _self.useCdrs : useCdrs // ignore: cast_nullable_to_non_nullable
-as bool,
+as String,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
@@ -140,7 +140,6 @@ AppConfigMain _$AppConfigMainFromJson(Map<String, dynamic> json) =>
                   initial: false,
                   titleL10n: 'main_BottomNavigationBarItemLabel_recents',
                   icon: '0xe03a',
-                  useCdrs: false,
                 ),
                 ContactsTabScheme(
                   enabled: true,
@@ -563,7 +562,6 @@ RecentsTabScheme _$RecentsTabSchemeFromJson(Map<String, dynamic> json) =>
       initial: json['initial'] as bool? ?? false,
       titleL10n: json['titleL10n'] as String,
       icon: json['icon'] as String,
-      useCdrs: json['useCdrs'] as bool? ?? false,
       $type: json['type'] as String?,
     );
 
@@ -573,7 +571,6 @@ Map<String, dynamic> _$RecentsTabSchemeToJson(RecentsTabScheme instance) =>
       'initial': instance.initial,
       'titleL10n': instance.titleL10n,
       'icon': instance.icon,
-      'useCdrs': instance.useCdrs,
       'type': instance.$type,
     };
 

--- a/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
+++ b/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
@@ -51,12 +51,11 @@ void main() {
       // Recents
       tabs[1].when(
         favorites: unexpectedFavorites,
-        recents: (enabled, initial, titleL10n, icon, useCdrs) {
+        recents: (enabled, initial, titleL10n, icon) {
           expect(enabled, isFalse);
           expect(initial, isFalse);
           expect(titleL10n, 'main_BottomNavigationBarItemLabel_recents');
           expect(icon, '0xe03a');
-          expect(useCdrs, isFalse); // default
         },
         contacts: unexpectedContacts,
         keypad: unexpectedKeypad,

--- a/packages/webtrit_appearance_theme/test/helpers/freezed_unexpected.dart
+++ b/packages/webtrit_appearance_theme/test/helpers/freezed_unexpected.dart
@@ -6,8 +6,7 @@ Never unexpectedKeypad(bool a, bool b, String c, String d) => throw TestFailure(
 
 Never unexpectedMessaging(bool a, bool b, String c, String d) => throw TestFailure('Unexpected messaging variant hit');
 
-Never unexpectedRecents(bool a, bool b, String c, String d, bool e) =>
-    throw TestFailure('Unexpected recents variant hit');
+Never unexpectedRecents(bool a, bool b, String c, String d) => throw TestFailure('Unexpected recents variant hit');
 
 Never unexpectedContacts(bool a, bool b, String c, String d, List<String> e) =>
     throw TestFailure('Unexpected contacts variant hit');

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -76,7 +76,7 @@ class MainScreenScreenshot extends StatelessWidget {
         initial: false,
         titleL10n: 'main_BottomNavigationBarItemLabel_recents',
         icon: Icons.history,
-        useCdrs: false,
+        supportsCallHistory: false,
       ),
       ContactsBottomMenuTab(
         enabled: true,

--- a/test/data/bottom_menu_mapper_test.dart
+++ b/test/data/bottom_menu_mapper_test.dart
@@ -9,12 +9,12 @@ import 'package:webtrit_phone/utils/core_support.dart';
 
 void main() {
   group('BottomMenuMapper recents useCdrs gating by the callHistory capability', () {
-    AppConfig appConfigWithRecents({required bool useCdrs}) {
+    AppConfig appConfigWithRecents() {
       return AppConfig(
         mainConfig: AppConfigMain(
           bottomMenu: AppConfigBottomMenu(
             tabs: [
-              BottomMenuTabScheme.recents(enabled: true, titleL10n: 'recents', icon: '0xe03a', useCdrs: useCdrs),
+              const BottomMenuTabScheme.recents(enabled: true, titleL10n: 'recents', icon: '0xe03a'),
               const BottomMenuTabScheme.keypad(enabled: true, titleL10n: 'keypad', icon: '0xe1ce'),
             ],
           ),
@@ -26,19 +26,15 @@ void main() {
 
     bool? recentsUseCdrs(AppConfig appConfig, List<String> flags) {
       final config = BottomMenuMapper.map(appConfig, emptyEmbedded, CoreSupportImpl(flags));
-      return config.getTabEnabled<RecentsBottomMenuTab>()?.useCdrs;
+      return config.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory;
     }
 
-    test('useCdrs configured AND callHistory advertised -> true', () {
-      expect(recentsUseCdrs(appConfigWithRecents(useCdrs: true), [kCallHistoryFeatureFlag]), isTrue);
+    test('callHistory advertised -> true', () {
+      expect(recentsUseCdrs(appConfigWithRecents(), [kCallHistoryFeatureFlag]), isTrue);
     });
 
-    test('useCdrs configured but callHistory NOT advertised -> false (local fallback)', () {
-      expect(recentsUseCdrs(appConfigWithRecents(useCdrs: true), const []), isFalse);
-    });
-
-    test('callHistory advertised but useCdrs not configured -> false', () {
-      expect(recentsUseCdrs(appConfigWithRecents(useCdrs: false), [kCallHistoryFeatureFlag]), isFalse);
+    test('callHistory NOT advertised -> false (local call log fallback)', () {
+      expect(recentsUseCdrs(appConfigWithRecents(), const []), isFalse);
     });
   });
 }


### PR DESCRIPTION
Follow-up to #1324. CDR (call-history) usage was gated by two signals - the local AppConfig `useCdrs` flag and the adapter `callHistory` capability from system-info. This made the local flag a redundant, easy-to-misconfigure second switch.

This PR makes the server capability the single source of truth: CDR is enabled only when the adapter advertises `callHistory`.

## How

- webtrit_appearance_theme: drop `useCdrs` from `RecentsTabScheme` (factory + default), regenerate freezed/json.
- lib/data/feature_access.dart: recents tab now `supportsCallHistory: coreSupport.supportsCallHistory` (was `useCdrs && supportsCallHistory`).
- assets/themes/app.config.json: drop `useCdrs` from the recents tab.
- Tests: gate purely by the `callHistory` capability.

## Rename for core consistency

The runtime field `RecentsBottomMenuTab.useCdrs` is renamed to `supportsCallHistory` to stay consistent with the core capability naming (`CoreSupport.supportsCallHistory` / adapter `callHistory`). A comment above the field keeps the former `useCdrs` name for traceability. All consumers were updated (router, main shell, main/contact/favorites screens). The field is kept as the resolved value, so every CDR consumer keeps working unchanged.

## Backward compatibility

Existing theme JSON that still carries `useCdrs` deserializes fine - json_serializable ignores the now-unknown key. No migration needed.

## Follow-up (separate)

- Configurator: remove the Use CDRs toggle from the recents tab. Once it bumps the webtrit_appearance_theme dependency, RecentsTabScheme no longer accepts `useCdrs` and it will not compile.