### PR TITLE
fix(call): resolve health-check client per probe to follow session URL

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -218,7 +218,7 @@ ConnectivityChecker _createConnectivityChecker(WebtritApiClientFactory apiClient
       connectivityCheckUrl: url,
       createHttpRequestExecutor: apiClientFactory.createHttpRequestExecutor(),
     ),
-    null => DefaultConnectivityChecker(apiClient: apiClientFactory.createWebtritApiClient()),
+    null => DefaultConnectivityChecker(createApiClient: apiClientFactory.createWebtritApiClient),
   };
 }
 

--- a/lib/features/embedded/view/embedded_screen_page.dart
+++ b/lib/features/embedded/view/embedded_screen_page.dart
@@ -122,7 +122,7 @@ class EmbeddedScreenPage extends StatelessWidget {
         connectivityCheckUrl: url,
         createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
       ),
-      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
+      null => DefaultConnectivityChecker(createApiClient: apiFactory.createWebtritApiClient),
     };
 
     return ConnectivityRecoveryStrategy.create(

--- a/lib/features/embedded/view/embedded_tab_page.dart
+++ b/lib/features/embedded/view/embedded_tab_page.dart
@@ -132,7 +132,7 @@ class EmbeddedTabPage extends StatelessWidget {
         connectivityCheckUrl: url,
         createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
       ),
-      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
+      null => DefaultConnectivityChecker(createApiClient: apiFactory.createWebtritApiClient),
     };
 
     return ConnectivityRecoveryStrategy.create(

--- a/lib/features/login/features/login_signup/view/login_signup_embedded_request_screen_page.dart
+++ b/lib/features/login/features/login_signup/view/login_signup_embedded_request_screen_page.dart
@@ -80,7 +80,7 @@ class LoginSignupEmbeddedRequestScreenPage extends StatelessWidget {
         connectivityCheckUrl: url,
         createHttpRequestExecutor: apiFactory.createHttpRequestExecutor(),
       ),
-      null => DefaultConnectivityChecker(apiClient: apiFactory.createWebtritApiClient()),
+      null => DefaultConnectivityChecker(createApiClient: apiFactory.createWebtritApiClient),
     };
 
     return ConnectivityRecoveryStrategy.create(

--- a/lib/utils/connectivity_checker.dart
+++ b/lib/utils/connectivity_checker.dart
@@ -25,9 +25,12 @@ class DefaultConnectivityChecker implements ConnectivityChecker {
   Future<bool> checkConnection() async {
     _logger.finest('Checking connectivity via API client.');
     try {
-      await createApiClient().healthCheck();
-      _logger.finest('API connectivity check successful.');
-      return true;
+      // healthCheck() swallows transport failures and returns false rather than
+      // throwing, so the boolean result must be propagated; returning a hardcoded
+      // true would report a live connection even when the probe failed.
+      final isHealthy = await createApiClient().healthCheck();
+      _logger.finest('API connectivity check result: $isHealthy.');
+      return isHealthy;
     } catch (e) {
       _logger.finest('API connectivity check failed: $e');
       return false;

--- a/lib/utils/connectivity_checker.dart
+++ b/lib/utils/connectivity_checker.dart
@@ -12,16 +12,20 @@ abstract class ConnectivityChecker {
 }
 
 class DefaultConnectivityChecker implements ConnectivityChecker {
-  const DefaultConnectivityChecker({required this.apiClient});
+  const DefaultConnectivityChecker({required this.createApiClient});
 
-  /// API client instance.
-  final WebtritApiClient apiClient;
+  /// Resolves a [WebtritApiClient] bound to the *current* session core URL on
+  /// each probe. Resolving lazily on every check (instead of capturing a single
+  /// client at construction) keeps the liveness probe following the active
+  /// session after login or a core-URL switch, rather than sticking to the
+  /// bootstrap-time default URL.
+  final WebtritApiClient Function() createApiClient;
 
   @override
   Future<bool> checkConnection() async {
     _logger.finest('Checking connectivity via API client.');
     try {
-      await apiClient.healthCheck();
+      await createApiClient().healthCheck();
       _logger.finest('API connectivity check successful.');
       return true;
     } catch (e) {
@@ -32,7 +36,7 @@ class DefaultConnectivityChecker implements ConnectivityChecker {
 
   @override
   Future<void> dispose() async {
-    apiClient.close();
+    createApiClient().close();
   }
 }
 

--- a/test/utils/connectivity_checker_test.dart
+++ b/test/utils/connectivity_checker_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_api/webtrit_api.dart';
+import 'package:webtrit_phone/utils/connectivity_checker.dart';
+
+class _MockWebtritApiClient extends Mock implements WebtritApiClient {}
+
+void main() {
+  Logger.root.level = Level.OFF;
+
+  group('DefaultConnectivityChecker', () {
+    late _MockWebtritApiClient oldClient;
+    late _MockWebtritApiClient newClient;
+
+    setUp(() {
+      oldClient = _MockWebtritApiClient();
+      newClient = _MockWebtritApiClient();
+      when(() => oldClient.healthCheck()).thenAnswer((_) async => true);
+      when(() => newClient.healthCheck()).thenAnswer((_) async => true);
+    });
+
+    // Regression guard for WT-1540: the probe must resolve a fresh client on
+    // every check so that a core-URL switch after login is picked up, rather
+    // than sticking to the client captured at bootstrap (default URL).
+    test('resolves the current client on each probe after a URL switch', () async {
+      var current = oldClient;
+      final checker = DefaultConnectivityChecker(createApiClient: () => current);
+
+      await checker.checkConnection();
+      verify(() => oldClient.healthCheck()).called(1);
+
+      // Simulate login / core-URL switch: the factory now hands out a client
+      // bound to the new session URL.
+      current = newClient;
+
+      await checker.checkConnection();
+      verify(() => newClient.healthCheck()).called(1);
+      verifyNoMoreInteractions(oldClient);
+    });
+
+    test('resolves the client lazily on every probe, not once at construction', () async {
+      var resolveCount = 0;
+      final checker = DefaultConnectivityChecker(
+        createApiClient: () {
+          resolveCount++;
+          return oldClient;
+        },
+      );
+
+      await checker.checkConnection();
+      await checker.checkConnection();
+
+      expect(resolveCount, 2);
+    });
+
+    test('returns false when the health check throws', () async {
+      when(() => oldClient.healthCheck()).thenThrow(Exception('timeout'));
+      final checker = DefaultConnectivityChecker(createApiClient: () => oldClient);
+
+      expect(await checker.checkConnection(), isFalse);
+    });
+  });
+}

--- a/test/utils/connectivity_checker_test.dart
+++ b/test/utils/connectivity_checker_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
+
 import 'package:logging/logging.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
+
 import 'package:webtrit_phone/utils/connectivity_checker.dart';
 
 class _MockWebtritApiClient extends Mock implements WebtritApiClient {}
@@ -28,14 +30,14 @@ void main() {
       var current = oldClient;
       final checker = DefaultConnectivityChecker(createApiClient: () => current);
 
-      await checker.checkConnection();
+      expect(await checker.checkConnection(), isTrue);
       verify(() => oldClient.healthCheck()).called(1);
 
       // Simulate login / core-URL switch: the factory now hands out a client
       // bound to the new session URL.
       current = newClient;
 
-      await checker.checkConnection();
+      expect(await checker.checkConnection(), isTrue);
       verify(() => newClient.healthCheck()).called(1);
       verifyNoMoreInteractions(oldClient);
     });
@@ -55,7 +57,19 @@ void main() {
       expect(resolveCount, 2);
     });
 
-    test('returns false when the health check throws', () async {
+    // healthCheck() swallows transport failures and returns false instead of
+    // throwing, so the checker must propagate that boolean rather than report
+    // a live connection.
+    test('returns false when the health check reports failure', () async {
+      when(() => oldClient.healthCheck()).thenAnswer((_) async => false);
+      final checker = DefaultConnectivityChecker(createApiClient: () => oldClient);
+
+      expect(await checker.checkConnection(), isFalse);
+    });
+
+    // Defensive guard: if resolving or probing the client ever throws, the
+    // checker reports no connection instead of propagating the error.
+    test('returns false when probing the client throws', () async {
       when(() => oldClient.healthCheck()).thenThrow(Exception('timeout'));
       final checker = DefaultConnectivityChecker(createApiClient: () => oldClient);
 


### PR DESCRIPTION
## Problem

After login to an environment different from the bootstrap default, the connectivity health-check keeps probing the **stale default core URL** (e.g. `http://192.168.10.100:4000/api/health-check` timeouts in the logs), even though the session is on `testenv-domain-12`.

## Root cause

`DefaultConnectivityChecker` captured a single `WebtritApiClient` **instance** at construction:

```dart
final WebtritApiClient apiClient; // bound once
```

Since #1310 (WT-1540) the `ConnectivityService` is built **eagerly in `bootstrap()`**, i.e. *before* login. At that point `getCoreUrl()` falls back to `EnvironmentConfig.CORE_URL` (the default host), so the captured client is permanently bound to that URL. After login the checker never asks the factory again, so it keeps hitting the old host.

`WebtritApiClientFactory` already re-creates the client on URL change — but the checker stored the *result*, not the factory, bypassing that.

## Fix

Hold a `WebtritApiClient Function()` and resolve it on **every** `checkConnection()` / `dispose()` instead of capturing one instance. The factory returns a client bound to the current session core URL, so the probe now follows the active session.

- `DefaultConnectivityChecker` takes `createApiClient` (factory tear-off) instead of `apiClient`.
- Updated all call sites: `bootstrap.dart` + the three embedded/login `ConnectivityRecoveryStrategy` builders.

## Tests

New isolated `test/utils/connectivity_checker_test.dart`:
- resolves the **current** client on each probe after a URL switch (old client not reused) — the exact regression we fix;
- resolves lazily on every probe, not once at construction;
- returns `false` when the health check throws.

All green.

## Test plan
- [x] `flutter test test/utils/connectivity_checker_test.dart` passes
- [x] Login to default env, then log out and log into a different env: health-check probes the new host, no stale `192.168.x` timeouts