### PR TITLE
fix(cdrs): always register both recents route variants (WT-727)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,11 @@ packages/   → shared libs (must NOT import from lib/)
 - Theme: never raw `Colors.xxx` or `TextStyle` in widgets; `Theme.of(context).extension<T>()`.
 - Widgets: `StatelessWidget` always (not helper methods); dumb widgets in `features/*/view/widgets/`.
 - Tests: `MockClient`/`mocktail` — no real network calls; DB migrations via `SchemaVerifier`.
+- Routing (`auto_route`): the `AppRouter.routes` tree must ALWAYS be complete — never gate route
+  *declarations* on async/runtime values (server capability, login state, feature flags).
+  `routeCollection` is `late final`, built once at router construction (before server `system-info`
+  loads), so any `if (capability) AutoRoute(...)` is frozen with whatever the value was at startup;
+  later navigation to a route omitted then throws `Failed to navigate to <Route>`. Register every
+  variant unconditionally and decide which one to *show* at navigation/build time (e.g.
+  `AutoTabsRouter.routes`, guards, initial-tab resolver). Sibling routes may share a `path`
+  (`recents`) — `RouteCollection` only requires unique route *names*, and tab matching is name-based.

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -164,28 +164,31 @@ class AppRouter extends RootStackRouter {
                   ],
                 ),
 
-                if (_bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory == false)
-                  AutoRoute(
-                    page: RecentsRouterPageRoute.page,
-                    path: MainFlavor.recents.name,
-                    children: [
-                      AutoRoute(page: RecentsScreenPageRoute.page, path: ''),
-                      AutoRoute(page: ContactScreenPageRoute.page, path: 'contact'),
-                      AutoRoute(page: CallLogScreenPageRoute.page, path: 'call_log'),
-                      AutoRoute(page: NumberCdrsScreenPageRoute.page, path: 'number_cdrs'),
-                    ],
-                  ),
-                if (_bottomMenuFeature.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory == true)
-                  AutoRoute(
-                    page: RecentCdrsRouterPageRoute.page,
-                    path: MainFlavor.recents.name,
-                    children: [
-                      AutoRoute(page: RecentCdrsScreenPageRoute.page, path: ''),
-                      AutoRoute(page: ContactScreenPageRoute.page, path: 'contact'),
-                      AutoRoute(page: CallLogScreenPageRoute.page, path: 'call_log'),
-                      AutoRoute(page: NumberCdrsScreenPageRoute.page, path: 'number_cdrs'),
-                    ],
-                  ),
+                // Both recents tab variants are registered unconditionally so the frozen
+                // routeCollection (built once, before the server call-history capability is
+                // known) always remains a superset of any tab selection. Which variant is
+                // shown is decided at navigation/build time by _buildRoutePages and the
+                // initial-tab resolver based on the live supportsCallHistory capability.
+                AutoRoute(
+                  page: RecentsRouterPageRoute.page,
+                  path: MainFlavor.recents.name,
+                  children: [
+                    AutoRoute(page: RecentsScreenPageRoute.page, path: ''),
+                    AutoRoute(page: ContactScreenPageRoute.page, path: 'contact'),
+                    AutoRoute(page: CallLogScreenPageRoute.page, path: 'call_log'),
+                    AutoRoute(page: NumberCdrsScreenPageRoute.page, path: 'number_cdrs'),
+                  ],
+                ),
+                AutoRoute(
+                  page: RecentCdrsRouterPageRoute.page,
+                  path: MainFlavor.recents.name,
+                  children: [
+                    AutoRoute(page: RecentCdrsScreenPageRoute.page, path: ''),
+                    AutoRoute(page: ContactScreenPageRoute.page, path: 'contact'),
+                    AutoRoute(page: CallLogScreenPageRoute.page, path: 'call_log'),
+                    AutoRoute(page: NumberCdrsScreenPageRoute.page, path: 'number_cdrs'),
+                  ],
+                ),
 
                 AutoRoute(
                   page: ContactsRouterPageRoute.page,

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -164,11 +164,6 @@ class AppRouter extends RootStackRouter {
                   ],
                 ),
 
-                // Both recents tab variants are registered unconditionally so the frozen
-                // routeCollection (built once, before the server call-history capability is
-                // known) always remains a superset of any tab selection. Which variant is
-                // shown is decided at navigation/build time by _buildRoutePages and the
-                // initial-tab resolver based on the live supportsCallHistory capability.
                 AutoRoute(
                   page: RecentsRouterPageRoute.page,
                   path: MainFlavor.recents.name,

--- a/lib/features/main/view/main_screen_page.dart
+++ b/lib/features/main/view/main_screen_page.dart
@@ -119,7 +119,7 @@ class MainScreenPage extends StatelessWidget {
         case MessagingBottomMenuTab():
           return const ConversationsScreenPageRoute();
         case RecentsBottomMenuTab():
-          return tab.supportsCallHistory ? const RecentCdrsScreenPageRoute() : const RecentsRouterPageRoute();
+          return tab.supportsCallHistory ? const RecentCdrsRouterPageRoute() : const RecentsRouterPageRoute();
         case ContactsBottomMenuTab():
           return ContactsRouterPageRoute(children: [ContactsScreenPageRoute(sourceTypes: tab.contactSourceTypes)]);
         case EmbeddedBottomMenuTab():


### PR DESCRIPTION
## Problem

Logging in on a call-history-capable adapter (e.g. PortaSwitch) crashed the app on entering the main screen:

```
FlutterError: Failed to navigate to RecentCdrsRouterPageRoute
  at TabsRouter._resolveRoutes
```

The recents tab route was gated on the server call-history capability (`supportsCallHistory`), which loads asynchronously after login. But auto_route's `routeCollection` is `late final` — built **once** at router construction, before `system-info` resolves — so the gated `AutoRoute` froze with `supportsCallHistory == false`, registering only `RecentsRouterPageRoute`. After login the live capability flips to `true`, `_buildRoutePages` returns the CDRs variant, and `AutoTabsRouter` fails to match it.

Surfaced by WT-727 (#1327), which made the server capability the sole source of truth for call history (previously the gate was a static app-config value available at construction time).

## Fix

- Register **both** `RecentsRouterPageRoute` and `RecentCdrsRouterPageRoute` unconditionally, so the route tree is always a complete superset. The live capability still decides which variant is *shown* at navigation/build time (`_buildRoutePages`, guards, initial-tab resolver). Sibling routes may share the `recents` path — `RouteCollection` only requires unique route names, and tab matching is name-based.
- Fix `_buildRoutePages` to return the `RecentCdrsRouterPageRoute` tab wrapper instead of its `RecentCdrsScreenPageRoute` child, matching the pattern of every other tab.
- Document the "route tree must always be complete" rule in `AGENTS.md`.

## Testing

- `flutter analyze` on changed files: no issues.
- Manually verified: app no longer crashes on the recents tab after login on PortaSwitch (CDRs) and on the demo adapter (standard recents).