### PR TITLE
docs: relax comment standard to allow why-comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ dart run bin/create_new_schema_dump_and_test_migration.dart   # after Drift tabl
 ## Code Standards
 
 - No Cyrillic anywhere (source, comments, strings, logs, keys).
-- No inline comments — DartDoc only for public APIs.
+- Comments: no redundant *what* comments that restate the code; comments explain non-obvious *why* (rationale, gotchas, workarounds, links to issues). DartDoc for public APIs.
 - No DI frameworks (`get_it`, `injectable`, Service Locator — forbidden).
 - Single quotes; 120-char line width.
 - Never edit `*.g.dart` / `*.freezed.dart` / `*.gr.dart` — regenerate via `build_runner`.


### PR DESCRIPTION
Replaces the blanket **"No inline comments — DartDoc only for public APIs"** standard in `AGENTS.md` with a more useful formulation:

> Comments: no redundant *what* comments that restate the code; comments explain non-obvious *why* (rationale, gotchas, workarounds, links to issues). DartDoc for public APIs.

A flat ban on inline comments discourages exactly the comments that prevent regressions — e.g. documenting a subtle framework constraint right at the call site. The actual smell is *what*-comments that restate the code and rot; *why*-comments are valuable. This reframes the rule around that distinction while keeping DartDoc for public APIs.

Split out from the WT-727 recents-route crash fix (#1332), where this convention came up, so the convention change is reviewed on its own.