### PR TITLE
ci: guard callkeep dependency type (path on develop, pinned on release)

### DIFF
--- a/.github/workflows/callkeep-path-guard.yaml
+++ b/.github/workflows/callkeep-path-guard.yaml
@@ -1,0 +1,29 @@
+name: callkeep-path-guard
+
+# On develop, webtrit_callkeep must stay a path dependency (see docs/release_versioning.md).
+# This catches a release `git:` ref accidentally back-merged onto develop.
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure webtrit_callkeep is a path dependency
+        run: |
+          HAS_PATH=$(yq '.dependencies.webtrit_callkeep | has("path")' pubspec.yaml)
+          HAS_GIT=$(yq '.dependencies.webtrit_callkeep | has("git")' pubspec.yaml)
+          echo "webtrit_callkeep: has(path)=$HAS_PATH has(git)=$HAS_GIT"
+          if [ "$HAS_PATH" != "true" ] || [ "$HAS_GIT" = "true" ]; then
+            echo "::error::On develop, webtrit_callkeep must use 'path:', not a git ref. A release pin was likely back-merged. See docs/release_versioning.md."
+            exit 1
+          fi
+          echo "OK: webtrit_callkeep is a path dependency."

--- a/.github/workflows/callkeep-path-guard.yaml
+++ b/.github/workflows/callkeep-path-guard.yaml
@@ -17,13 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Uses Ruby's built-in YAML (psych) - always available on GitHub runners, no extra install.
       - name: Ensure webtrit_callkeep is a path dependency
         run: |
-          HAS_PATH=$(yq '.dependencies.webtrit_callkeep | has("path")' pubspec.yaml)
-          HAS_GIT=$(yq '.dependencies.webtrit_callkeep | has("git")' pubspec.yaml)
-          echo "webtrit_callkeep: has(path)=$HAS_PATH has(git)=$HAS_GIT"
-          if [ "$HAS_PATH" != "true" ] || [ "$HAS_GIT" = "true" ]; then
-            echo "::error::On develop, webtrit_callkeep must use 'path:', not a git ref. A release pin was likely back-merged. See docs/release_versioning.md."
-            exit 1
-          fi
-          echo "OK: webtrit_callkeep is a path dependency."
+          ruby -ryaml -e '
+            dep = (YAML.load_file("pubspec.yaml")["dependencies"] || {})["webtrit_callkeep"]
+            ok = dep.is_a?(Hash) && dep.key?("path") && !dep.key?("git")
+            unless ok
+              warn "::error::On develop, webtrit_callkeep must use a path dependency, not a git ref. A release pin was likely back-merged. See docs/release_versioning.md."
+              exit 1
+            end
+            puts "OK: webtrit_callkeep is a path dependency."
+          '

--- a/.github/workflows/callkeep-pin-guard.yaml
+++ b/.github/workflows/callkeep-pin-guard.yaml
@@ -20,13 +20,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Uses Ruby's built-in YAML (psych) - always available on GitHub runners, no extra install.
       - name: Ensure webtrit_callkeep is pinned to a git ref
         run: |
-          HAS_GIT=$(yq '.dependencies.webtrit_callkeep | has("git")' pubspec.yaml)
-          REF=$(yq -r '.dependencies.webtrit_callkeep.git.ref // ""' pubspec.yaml)
-          echo "webtrit_callkeep: has(git)=$HAS_GIT ref=$REF"
-          if [ "$HAS_GIT" != "true" ] || [ -z "$REF" ]; then
-            echo "::error::On release branches and tags, webtrit_callkeep must be pinned to a git ref (got path/none). See docs/release_versioning.md."
-            exit 1
-          fi
-          echo "OK: webtrit_callkeep is pinned to ref '$REF'."
+          ruby -ryaml -e '
+            dep = (YAML.load_file("pubspec.yaml")["dependencies"] || {})["webtrit_callkeep"]
+            git = dep.is_a?(Hash) ? dep["git"] : nil
+            ref = git.is_a?(Hash) ? git["ref"].to_s : ""
+            if ref.empty?
+              warn "::error::On release branches and tags, webtrit_callkeep must be pinned to a git ref (got path/none). See docs/release_versioning.md."
+              exit 1
+            end
+            puts "OK: webtrit_callkeep is pinned to ref #{ref}."
+          '

--- a/.github/workflows/callkeep-pin-guard.yaml
+++ b/.github/workflows/callkeep-pin-guard.yaml
@@ -1,12 +1,15 @@
 name: callkeep-pin-guard
 
-# A release tag must pin webtrit_callkeep to a git ref (see docs/release_versioning.md).
-# Mirror of callkeep-path-guard (which keeps develop on a path dependency).
+# On release branches and release tags, webtrit_callkeep must be pinned to a git ref
+# (see docs/release_versioning.md). Mirror of callkeep-path-guard (which keeps develop on path).
 
 on:
   push:
     tags:
       - "*.*.*"
+  pull_request:
+    branches:
+      - "release/**"
 
 permissions:
   contents: read
@@ -23,7 +26,7 @@ jobs:
           REF=$(yq -r '.dependencies.webtrit_callkeep.git.ref // ""' pubspec.yaml)
           echo "webtrit_callkeep: has(git)=$HAS_GIT ref=$REF"
           if [ "$HAS_GIT" != "true" ] || [ -z "$REF" ]; then
-            echo "::error::Release tag '${GITHUB_REF_NAME}' requires webtrit_callkeep pinned to a git ref (got path/none). See docs/release_versioning.md."
+            echo "::error::On release branches and tags, webtrit_callkeep must be pinned to a git ref (got path/none). See docs/release_versioning.md."
             exit 1
           fi
           echo "OK: webtrit_callkeep is pinned to ref '$REF'."

--- a/.github/workflows/callkeep-pin-guard.yaml
+++ b/.github/workflows/callkeep-pin-guard.yaml
@@ -1,0 +1,29 @@
+name: callkeep-pin-guard
+
+# A release tag must pin webtrit_callkeep to a git ref (see docs/release_versioning.md).
+# Mirror of callkeep-path-guard (which keeps develop on a path dependency).
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure webtrit_callkeep is pinned to a git ref
+        run: |
+          HAS_GIT=$(yq '.dependencies.webtrit_callkeep | has("git")' pubspec.yaml)
+          REF=$(yq -r '.dependencies.webtrit_callkeep.git.ref // ""' pubspec.yaml)
+          echo "webtrit_callkeep: has(git)=$HAS_GIT ref=$REF"
+          if [ "$HAS_GIT" != "true" ] || [ -z "$REF" ]; then
+            echo "::error::Release tag '${GITHUB_REF_NAME}' requires webtrit_callkeep pinned to a git ref (got path/none). See docs/release_versioning.md."
+            exit 1
+          fi
+          echo "OK: webtrit_callkeep is pinned to ref '$REF'."

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -128,6 +128,9 @@ dependencies:
   webtrit_signaling_service:
     path: ./packages/webtrit_signaling_service/webtrit_signaling_service
   webtrit_callkeep:
+    # develop tracks the local working copy of callkeep for co-development.
+    # On release branches this is pinned to a callkeep tag (see docs/release_versioning.md).
+    # Never back-merge a git ref onto develop - keep this a path here (enforced by callkeep-path-guard).
     path: ../webtrit_callkeep/webtrit_callkeep
   store_info_extractor:
     path: ./packages/store_info_extractor


### PR DESCRIPTION
Adds symmetric CI guards so the callkeep dependency type is always correct for the branch, plus a clarifying comment next to the dependency in pubspec.yaml.

Two workflows:
- `callkeep-path-guard.yaml` - on PRs targeting `develop`, fails if `webtrit_callkeep` is not a `path:` dependency. Catches a release `git:` ref accidentally back-merged onto develop.
- `callkeep-pin-guard.yaml` - on PRs targeting `release/**` and on release tag pushes (`*.*.*`), fails if `webtrit_callkeep` is not pinned to a `git: { ref }`. Catches a release/tag that was cut without pinning callkeep.

Together: develop stays on `path:`, releases are always pinned. Implements the enforcement described in `docs/release_versioning.md`.