### PR TITLE
build: pin webtrit_callkeep to tag 0.0.2

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1822,58 +1822,74 @@ packages:
   webtrit_callkeep:
     dependency: "direct main"
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep"
-      relative: true
-    source: path
-    version: "0.3.5+0"
+      path: webtrit_callkeep
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
+    version: "0.0.2+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_android"
-      relative: true
-    source: path
+      path: webtrit_callkeep_android
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_ios:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_ios"
-      relative: true
-    source: path
+      path: webtrit_callkeep_ios
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_linux:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_linux"
-      relative: true
-    source: path
+      path: webtrit_callkeep_linux
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_macos:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_macos"
-      relative: true
-    source: path
+      path: webtrit_callkeep_macos
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_platform_interface:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_platform_interface"
-      relative: true
-    source: path
+      path: webtrit_callkeep_platform_interface
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.3.5+0"
   webtrit_callkeep_web:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_web"
-      relative: true
-    source: path
+      path: webtrit_callkeep_web
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_windows:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_windows"
-      relative: true
-    source: path
+      path: webtrit_callkeep_windows
+      ref: "0.0.2"
+      resolved-ref: "6ae789f6f1ae65cb99f79da73ebbcb17f59f8a86"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_phone_number:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,7 +96,11 @@ dependencies:
   webtrit_signaling:
     path: ./packages/webtrit_signaling
   webtrit_callkeep:
-    path: ../webtrit_callkeep/webtrit_callkeep
+    # Release branches pin callkeep to a published tag (see docs/release_versioning.md).
+    git:
+      url: https://github.com/WebTrit/webtrit_callkeep.git
+      ref: 0.0.2
+      path: webtrit_callkeep
   store_info_extractor:
     path: ./packages/store_info_extractor
   ssl_certificates:


### PR DESCRIPTION
Pins `webtrit_callkeep` to the published tag `0.0.2` (resolved commit `6ae789f`, version 0.0.2+0) so this release builds deterministically against the exact compatible callkeep instead of a build-time path dependency.

- `pubspec.yaml`: `path:` -> `git: { url, ref: 0.0.2, path: webtrit_callkeep }`
- `pubspec.lock`: callkeep packages resolve from git at `6ae789f` (only callkeep entries change)

Note: tag `0.0.2` was corrected (it previously pointed at a pre-bump commit reading `0.3.5+0`); it now resolves to the real 0.0.2 release. Regenerated with Flutter 3.29.3 (this branch's SDK). See docs/release_versioning.md.