### PR TITLE
build: pin webtrit_callkeep to tag 1.1.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1161,10 +1161,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: "direct main"
     description:
@@ -1782,26 +1782,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   time:
     dependency: transitive
     description:
@@ -2022,58 +2022,74 @@ packages:
   webtrit_callkeep:
     dependency: "direct main"
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep"
-      relative: true
-    source: path
-    version: "0.0.0+0"
+      path: webtrit_callkeep
+      ref: "1.1.0"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
+    version: "1.1.0+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_android"
-      relative: true
-    source: path
+      path: webtrit_callkeep_android
+      ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_ios:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_ios"
-      relative: true
-    source: path
+      path: webtrit_callkeep_ios
+      ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_linux:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_linux"
-      relative: true
-    source: path
+      path: webtrit_callkeep_linux
+      ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_macos:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_macos"
-      relative: true
-    source: path
+      path: webtrit_callkeep_macos
+      ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_platform_interface:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_platform_interface"
-      relative: true
-    source: path
+      path: webtrit_callkeep_platform_interface
+      ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_web:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_web"
-      relative: true
-    source: path
+      path: webtrit_callkeep_web
+      ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_windows:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_windows"
-      relative: true
-    source: path
+      path: webtrit_callkeep_windows
+      ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      resolved-ref: "5c9b54ed0209e4dc3d1b8c3e039418755e9b91db"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_signaling_service:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -121,7 +121,11 @@ dependencies:
   webtrit_signaling_service:
     path: ./packages/webtrit_signaling_service/webtrit_signaling_service
   webtrit_callkeep:
-    path: ../webtrit_callkeep/webtrit_callkeep
+    # Release branches pin callkeep to a published tag (see docs/release_versioning.md).
+    git:
+      url: https://github.com/WebTrit/webtrit_callkeep.git
+      ref: 1.1.0
+      path: webtrit_callkeep
   store_info_extractor:
     path: ./packages/store_info_extractor
   ssl_certificates:


### PR DESCRIPTION
Pins `webtrit_callkeep` to tag `1.1.0` (resolved `5c9b54e`) so this release builds deterministically against the exact compatible callkeep instead of a build-time path dependency.

- `pubspec.yaml`: `path:` -> `git: { url, ref: 1.1.0, path: webtrit_callkeep }`
- `pubspec.lock`: callkeep packages resolve from git at `5c9b54e` (only callkeep entries change)

Regenerated with Flutter 3.41.2 (this branch's SDK). See docs/release_versioning.md.