### PR TITLE
chore: sort and group pubspec dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ workspace:
   - packages/_tcp_proxy
   - packages/pjsua_companion
   - screenshots
+
 # Version format: <Major>.<Minor>.<Patch>[-<Pre-release>]+<Build>
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
@@ -42,15 +43,23 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+  async: ^2.13.1
+  audio_session: ^0.2.3
   auto_route: ^11.1.0
   bloc: ^9.2.1
   bloc_concurrency: ^0.3.0
+  bloc_test: ^10.0.0
   characters: ^1.4.1
   clock: ^1.1.2
+  collection: ^1.19.1
   connectivity_plus: ^7.1.1
+  country_code_picker: ^3.4.1
   cross_file: ^0.3.5+2
   device_info_plus: ^13.1.0
+  device_region: ^1.4.0
+  dlibphonenumber: ^1.1.64
   drift: ^2.29.0
+  emoji_picker_flutter: ^4.4.0
   equatable: ^2.0.8
   firebase_analytics: ^12.4.1
   firebase_app_installations: ^0.4.2+2
@@ -59,29 +68,25 @@ dependencies:
   firebase_messaging: ^16.2.2
   firebase_remote_config: ^6.5.1
   flutter_bloc: ^9.1.1
-  # TODO: temporary fork pin. Switch back to a pub.dev version constraint once
-  # RawContact.dataMimetypes lands upstream
-  # (SERDUN/flutter_contacts#2 -> QuisApp/flutter_contacts).
-  flutter_contacts:
-    git:
-      url: https://github.com/SERDUN/flutter_contacts.git
-      ref: main
+  flutter_local_notifications: ^21.0.0
+  flutter_parsed_text: ^2.2.1
   flutter_secure_storage: ^10.3.1
   flutter_svg: ^2.3.0
-  flutter_webrtc:
-    git:
-      url: https://github.com/WebTrit/flutter-webrtc.git
-      ref: main_ext_rebase_06.05.26
   formz: ^0.8.0
   freezed_annotation: ^3.1.0
-  google_fonts: ^8.1.0
   google_api_availability: ^5.0.1
+  google_fonts: ^8.1.0
+  gravatar_utils: ^1.0.0
+  html: ^0.15.6
+  http: ^1.6.0
+  icon_decoration: ^2.1.0
   intl: any
   json_annotation: ^4.12.0
   just_audio: ^0.10.5
   linkify: ^5.0.0
   logging: ^1.3.0
   logging_appenders: ^2.0.0+1
+  mask_text_input_formatter: ^2.9.0
   material_color_utilities: any
   meta: any
   package_info_plus: ^10.1.0
@@ -91,6 +96,8 @@ dependencies:
   phoenix_socket: ^0.8.0
   provider: ^6.1.5+1
   pub_semver: ^2.2.0
+  quiver: ^3.2.2
+  rxdart: ^0.28.0
   sdp_transform: ^0.3.2
   share_plus: ^13.1.0
   shared_preferences: ^2.5.5
@@ -100,50 +107,47 @@ dependencies:
   validators: ^3.0.0
   webview_flutter: ^4.13.1
   webview_flutter_web: ^0.2.3+4
-  collection: ^1.19.1
-  quiver: ^3.2.2
-  flutter_parsed_text: ^2.2.1
-  flutter_local_notifications: ^21.0.0
-  gravatar_utils: ^1.0.0
-  dlibphonenumber: ^1.1.64
-  device_region: ^1.4.0
-  html: ^0.15.6
-  http: ^1.6.0
-  audio_session: ^0.2.3
-  bloc_test: ^10.0.0
   workmanager: ^0.9.0+3
-  country_code_picker: ^3.4.1
-  icon_decoration: ^2.1.0
-  emoji_picker_flutter: ^4.4.0
-  mask_text_input_formatter: ^2.9.0
-  async: ^2.13.1
-  rxdart: ^0.28.0
 
+  # Local path/workspace packages, sorted by name.
+  app_database:
+    path: ./packages/data/app_database
+  device_auto_rotate:
+    path: ./packages/device_auto_rotate
+  pjsua_companion:
+    path: ./packages/pjsua_companion
+  ssl_certificates:
+    path: ./packages/ssl_certificates
+  store_info_extractor:
+    path: ./packages/store_info_extractor
   webtrit_api:
     path: ./packages/webtrit_api
+  webtrit_appearance_theme:
+    path: ./packages/webtrit_appearance_theme
+  webtrit_callkeep:
+    # develop tracks the local working copy of callkeep for co-development.
+    # On release branches this is pinned to a callkeep tag (see docs/release_versioning.md).
+    # Never back-merge a git ref onto develop - keep this a path here (enforced by callkeep-path-guard).
+    path: ../webtrit_callkeep/webtrit_callkeep
   webtrit_phone_number:
     path: ./packages/webtrit_phone_number
   webtrit_signaling:
     path: ./packages/webtrit_signaling
   webtrit_signaling_service:
     path: ./packages/webtrit_signaling_service/webtrit_signaling_service
-  webtrit_callkeep:
-    # develop tracks the local working copy of callkeep for co-development.
-    # On release branches this is pinned to a callkeep tag (see docs/release_versioning.md).
-    # Never back-merge a git ref onto develop - keep this a path here (enforced by callkeep-path-guard).
-    path: ../webtrit_callkeep/webtrit_callkeep
-  store_info_extractor:
-    path: ./packages/store_info_extractor
-  ssl_certificates:
-    path: ./packages/ssl_certificates
-  app_database:
-    path: ./packages/data/app_database
-  webtrit_appearance_theme:
-    path: ./packages/webtrit_appearance_theme
-  device_auto_rotate:
-    path: ./packages/device_auto_rotate
-  pjsua_companion:
-    path: ./packages/pjsua_companion
+
+  # Git forks, sorted by name.
+  # TODO: temporary fork pin. Switch back to a pub.dev version constraint once
+  # RawContact.dataMimetypes lands upstream
+  # (SERDUN/flutter_contacts#2 -> QuisApp/flutter_contacts).
+  flutter_contacts:
+    git:
+      url: https://github.com/SERDUN/flutter_contacts.git
+      ref: main
+  flutter_webrtc:
+    git:
+      url: https://github.com/WebTrit/flutter-webrtc.git
+      ref: main_ext_rebase_06.05.26
 
 dev_dependencies:
   integration_test:
@@ -154,6 +158,14 @@ dev_dependencies:
     sdk: flutter
 
   auto_route_generator: ^10.5.0
+  build_runner: ^2.15.0
+  fake_async: ^1.3.3
+  flutter_gen_runner: ^5.14.1
+  flutter_launcher_icons: ^0.14.4
+  flutter_lints: ^6.0.0
+  flutter_native_splash: ^2.4.7
+  freezed: ^3.2.5
+  json_serializable: ^6.14.0
   # TODO: temporary fork pin. Switch back to a pub.dev version constraint once
   # analyzer ^13.0.0 support lands upstream
   # (SERDUN/l10n_mapper -> kwado-tech/l10n_mapper).
@@ -162,17 +174,9 @@ dev_dependencies:
       url: https://github.com/SERDUN/l10n_mapper.git
       ref: 8a90364
       path: l10n_mapper_generator
-  build_runner: ^2.15.0
-  flutter_gen_runner: ^5.14.1
-  flutter_launcher_icons: ^0.14.4
-  flutter_lints: ^6.0.0
-  flutter_native_splash: ^2.4.7
-  freezed: ^3.2.5
-  json_serializable: ^6.14.0
-  patrol: ^4.6.1
-  mocktail: ^1.0.5
-  fake_async: ^1.3.3
   melos: ^7.8.0
+  mocktail: ^1.0.5
+  patrol: ^4.6.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary

Reorganizes `pubspec.yaml` dependencies for easier scanning and maintenance:

- Sorts `dependencies` and `dev_dependencies` alphabetically.
- Groups local path/workspace packages together under a labeled comment.
- Groups git forks (`flutter_contacts`, `flutter_webrtc`) together under a labeled comment.

No version changes — purely a reordering/grouping of existing entries.

## Test plan

- [x] `melos run test` passes (pre-push hook)
- [x] `melos run analyze` clean
- [x] `melos bootstrap` resolves without changes