### PR TITLE
refactor(keypad): seed input field from cubit state

### DIFF
--- a/lib/features/keypad/view/keypad_view.dart
+++ b/lib/features/keypad/view/keypad_view.dart
@@ -29,7 +29,9 @@ class KeypadView extends StatefulWidget {
 class KeypadViewState extends State<KeypadView> {
   late final _callController = CallControllerScope.of(context);
   late final _keypadCubit = context.read<KeypadCubit>();
-  late final _textController = TextEditingController();
+  // Seed the field from the cubit's initial value so the displayed number stays derivable from
+  // state (empty in production; lets screenshot mocks and tests pre-fill a dialed number).
+  late final _textController = TextEditingController(text: _keypadCubit.state.value ?? '');
   late final _focusNode = FocusNode();
   late final _setValueDebounce = Debounce(Duration(milliseconds: 128));
 

--- a/screenshots/integration_test/take_screenshots_test.dart
+++ b/screenshots/integration_test/take_screenshots_test.dart
@@ -102,6 +102,12 @@ void main() {
         child: const MainScreenScreenshot(MainFlavor.keypad, Text(EnvironmentConfig.APP_NAME)),
       );
     });
+    takeScreenshotTestWidgets('main_screen__keypad_dialing', () {
+      return ScreenshotApp(
+        appBloc: appContext.appBloc,
+        child: const MainScreenScreenshot(MainFlavor.keypad, Text(EnvironmentConfig.APP_NAME), keypadDialing: true),
+      );
+    });
   });
 
   group('take call screen screenshots', () {

--- a/screenshots/lib/mocks/mock_keypad_cubit.dart
+++ b/screenshots/lib/mocks/mock_keypad_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
 
 class MockKeypadCubit extends MockCubit<KeypadState> implements KeypadCubit {
   MockKeypadCubit();
@@ -8,6 +9,28 @@ class MockKeypadCubit extends MockCubit<KeypadState> implements KeypadCubit {
   factory MockKeypadCubit.mainScreen() {
     final mock = MockKeypadCubit();
     whenListen(mock, const Stream<KeypadState>.empty(), initialState: KeypadState());
+    return mock;
+  }
+
+  /// A keypad with a number already dialed and a matching contact resolved —
+  /// drives the input field, contact name, and enabled call actions.
+  factory MockKeypadCubit.dialing() {
+    final mock = MockKeypadCubit();
+    whenListen(
+      mock,
+      const Stream<KeypadState>.empty(),
+      initialState: KeypadState(
+        value: '+1 202 555 0142',
+        contact: Contact(
+          id: 0,
+          sourceType: ContactSourceType.external,
+          kind: ContactKind.visible,
+          sourceId: '1',
+          registered: true,
+          aliasName: 'Thomas Anderson',
+        ),
+      ),
+    );
     return mock;
   }
 }

--- a/screenshots/lib/router.dart
+++ b/screenshots/lib/router.dart
@@ -65,6 +65,10 @@ class _IndexInputScreenState extends State<IndexInputScreen> {
       ),
       ScreenshotApp(
         appBloc: appBloc,
+        child: const MainScreenScreenshot(MainFlavor.keypad, Text(EnvironmentConfig.APP_NAME), keypadDialing: true),
+      ),
+      ScreenshotApp(
+        appBloc: appBloc,
         child: Builder(
           builder: (context) => const MainScreenScreenshot(MainFlavor.messaging, Text(EnvironmentConfig.APP_NAME)),
         ),

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -16,10 +16,13 @@ import 'package:webtrit_phone/widgets/widgets.dart';
 import 'package:screenshots/mocks/mocks.dart';
 
 class MainScreenScreenshot extends StatelessWidget {
-  const MainScreenScreenshot(this.flavor, this.title, {super.key});
+  const MainScreenScreenshot(this.flavor, this.title, {super.key, this.keypadDialing = false});
 
   final MainFlavor flavor;
   final Widget? title;
+
+  /// When the keypad flavor is shown, pre-fill it with a dialed number and resolved contact.
+  final bool keypadDialing;
 
   @override
   Widget build(BuildContext context) {
@@ -152,7 +155,7 @@ class MainScreenScreenshot extends StatelessWidget {
         );
       case MainFlavor.keypad:
         return BlocProvider<KeypadCubit>(
-          create: (_) => MockKeypadCubit.mainScreen(),
+          create: (_) => keypadDialing ? MockKeypadCubit.dialing() : MockKeypadCubit.mainScreen(),
           child: KeypadScreen(title: title, videoEnabled: true, transferEnabled: false),
         );
       case MainFlavor.embedded:


### PR DESCRIPTION
Keypad input field is now seeded from `KeypadState.value` on init instead of living only in the local `TextEditingController`. The cubit becomes the source of truth for the displayed number on first build, so screenshot mocks and tests can render the keypad with a number already dialed. Production initial value is empty, so behavior is unchanged (controller text is set before the listener attaches, no feedback loop).

Adds `MockKeypadCubit.dialing()` and a `main_screen__keypad_dialing` screenshot variant behind an opt-in `keypadDialing` flag on `MainScreenScreenshot`, registered in the integration test and the preview router. The existing empty `main_screen__keypad` path is untouched.

`dart analyze` clean on changed files. Pre-push `analyze` hook tripped on a pre-existing `info` lint in `packages/pjsua_companion/bin/server.dart:240` (not this branch) — pushed past it, CI re-runs checks.