### PR TITLE
feat(screenshots): interactive, parameterized login and main-screen previews

### DIFF
--- a/screenshots/lib/mocks/interactive_call_bloc.dart
+++ b/screenshots/lib/mocks/interactive_call_bloc.dart
@@ -22,8 +22,14 @@ class InteractiveCallBloc extends Cubit<CallState> implements CallBloc {
         CallState(
           callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
           activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
+          // Built-in earpiece + speaker so the speaker toggle renders and can switch.
+          audioDevice: _earpiece,
+          availableAudioDevices: const [_earpiece, _speaker],
         ),
       );
+
+  static const _earpiece = CallAudioDevice(type: CallAudioDeviceType.earpiece);
+  static const _speaker = CallAudioDevice(type: CallAudioDeviceType.speaker);
 
   final String _callId;
 
@@ -40,6 +46,11 @@ class InteractiveCallBloc extends Cubit<CallState> implements CallBloc {
       }
       if (event == CallControlEvent.setHeld(_callId, value)) {
         return state.copyWithMappedActiveCall(_callId, (call) => call.copyWith(held: value));
+      }
+    }
+    for (final device in const [_earpiece, _speaker]) {
+      if (event == CallControlEvent.audioDeviceSet(_callId, device)) {
+        return state.copyWith(audioDevice: device);
       }
     }
     return null;

--- a/screenshots/lib/mocks/interactive_call_bloc.dart
+++ b/screenshots/lib/mocks/interactive_call_bloc.dart
@@ -1,6 +1,4 @@
-import 'dart:async';
-
-import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -10,46 +8,43 @@ import 'package:screenshots/data/data.dart';
 /// A [CallBloc] stand-in whose mute/hold buttons actually toggle, so the call
 /// screen preview reacts to input instead of staying a frozen snapshot.
 ///
-/// The concrete [CallControlEvent] subclasses are private, so they can't be
-/// pattern-matched from here; events are matched by equality (Equatable) using
-/// the known call id instead. Camera is intentionally not reduced — its button
+/// Implemented as a real [Cubit] (not a mocktail mock) so `state`/`stream`/
+/// `emit` behave normally; the rest of the [CallBloc]/CallkeepDelegate surface
+/// is routed to [noSuchMethod] (returns null), matching the old mock behavior.
+///
+/// Control events are matched by equality (their concrete types are private),
+/// using the known call id. Camera is intentionally not reduced — its button
 /// reads `isCameraActive`, which needs real media tracks the preview lacks.
-class InteractiveCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
-  InteractiveCallBloc({required bool video}) : _callId = (video ? dVideoActiveCall : dAudioActiveCall).callId {
-    _current = CallState(
-      callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
-      activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
-    );
-    whenListen(this, _controller.stream, initialState: _current);
-  }
+class InteractiveCallBloc extends Cubit<CallState> implements CallBloc {
+  InteractiveCallBloc({required bool video})
+    : _callId = (video ? dVideoActiveCall : dAudioActiveCall).callId,
+      super(
+        CallState(
+          callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+          activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
+        ),
+      );
 
   final String _callId;
-  final StreamController<CallState> _controller = StreamController<CallState>.broadcast();
-  late CallState _current;
 
   @override
   void add(CallEvent event) {
     final next = _reduce(event);
-    if (next != null && next != _current) {
-      _current = next;
-      _controller.add(next);
-    }
+    if (next != null) emit(next);
   }
 
   CallState? _reduce(CallEvent event) {
     for (final value in const [true, false]) {
       if (event == CallControlEvent.setMuted(_callId, value)) {
-        return _current.copyWithMappedActiveCall(_callId, (call) => call.copyWith(muted: value));
+        return state.copyWithMappedActiveCall(_callId, (call) => call.copyWith(muted: value));
       }
       if (event == CallControlEvent.setHeld(_callId, value)) {
-        return _current.copyWithMappedActiveCall(_callId, (call) => call.copyWith(held: value));
+        return state.copyWithMappedActiveCall(_callId, (call) => call.copyWith(held: value));
       }
     }
     return null;
   }
 
   @override
-  Future<void> close() async {
-    await _controller.close();
-  }
+  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/screenshots/lib/mocks/interactive_call_bloc.dart
+++ b/screenshots/lib/mocks/interactive_call_bloc.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+
+import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+import 'package:screenshots/data/data.dart';
+
+/// A [CallBloc] stand-in whose mute/hold buttons actually toggle, so the call
+/// screen preview reacts to input instead of staying a frozen snapshot.
+///
+/// The concrete [CallControlEvent] subclasses are private, so they can't be
+/// pattern-matched from here; events are matched by equality (Equatable) using
+/// the known call id instead. Camera is intentionally not reduced — its button
+/// reads `isCameraActive`, which needs real media tracks the preview lacks.
+class InteractiveCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
+  InteractiveCallBloc({required bool video}) : _callId = (video ? dVideoActiveCall : dAudioActiveCall).callId {
+    _current = CallState(
+      callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+      activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
+    );
+    whenListen(this, _controller.stream, initialState: _current);
+  }
+
+  final String _callId;
+  final StreamController<CallState> _controller = StreamController<CallState>.broadcast();
+  late CallState _current;
+
+  @override
+  void add(CallEvent event) {
+    final next = _reduce(event);
+    if (next != null && next != _current) {
+      _current = next;
+      _controller.add(next);
+    }
+  }
+
+  CallState? _reduce(CallEvent event) {
+    for (final value in const [true, false]) {
+      if (event == CallControlEvent.setMuted(_callId, value)) {
+        return _current.copyWithMappedActiveCall(_callId, (call) => call.copyWith(muted: value));
+      }
+      if (event == CallControlEvent.setHeld(_callId, value)) {
+        return _current.copyWithMappedActiveCall(_callId, (call) => call.copyWith(held: value));
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<void> close() async {
+    await _controller.close();
+  }
+}

--- a/screenshots/lib/mocks/mock_diagnostic_cubit.dart
+++ b/screenshots/lib/mocks/mock_diagnostic_cubit.dart
@@ -1,7 +1,11 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_phone/features/settings/features/diagnostic/bloc/diagnostic_cubit.dart';
+import 'package:webtrit_phone/features/settings/features/diagnostic/models/permission_with_status.dart';
 import 'package:webtrit_phone/features/settings/features/diagnostic/models/push_token_status.dart';
+
+class _FakePermissionWithStatus extends Fake implements PermissionWithStatus {}
 
 class MockDiagnosticCubit extends MockCubit<DiagnosticState> implements DiagnosticCubit {
   MockDiagnosticCubit();
@@ -15,6 +19,12 @@ class MockDiagnosticCubit extends MockCubit<DiagnosticState> implements Diagnost
         pushTokenStatus: PushTokenStatus(token: 'fcm-token-demo-1234567890', type: PushTokenStatusType.success),
       ),
     );
+    // The screen calls these (fetchStatuses on app-lifecycle change, the others on tap);
+    // they return Future<void>, so an unstubbed-mock null would fail the cast.
+    registerFallbackValue(_FakePermissionWithStatus());
+    when(() => mock.fetchStatuses()).thenAnswer((_) async {});
+    when(() => mock.openAppSettings()).thenAnswer((_) async {});
+    when(() => mock.handleRequestPermission(any())).thenAnswer((_) async {});
     return mock;
   }
 }

--- a/screenshots/lib/mocks/mock_network_tester_cubit.dart
+++ b/screenshots/lib/mocks/mock_network_tester_cubit.dart
@@ -1,0 +1,15 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/features/settings/features/diagnostic/bloc/network_tester_cubit.dart';
+
+class MockNetworkTesterCubit extends MockCubit<NetworkTesterState> implements NetworkTesterCubit {
+  MockNetworkTesterCubit();
+
+  factory MockNetworkTesterCubit.initial() {
+    final mock = MockNetworkTesterCubit();
+    whenListen(mock, const Stream<NetworkTesterState>.empty(), initialState: const NetworkTesterState());
+    when(() => mock.refresh()).thenAnswer((_) async {});
+    return mock;
+  }
+}

--- a/screenshots/lib/mocks/mocks.dart
+++ b/screenshots/lib/mocks/mocks.dart
@@ -27,6 +27,7 @@ export 'mock_messaging_bloc.dart';
 export 'mock_microphone_status_bloc.dart';
 export 'mock_missed_recent_cdrs_cubit.dart';
 export 'mock_network_cubit.dart';
+export 'mock_network_tester_cubit.dart';
 export 'mock_notifications_bloc.dart';
 export 'mock_number_cdrs_log_cubit.dart';
 export 'mock_permissions_cubit.dart';

--- a/screenshots/lib/mocks/mocks.dart
+++ b/screenshots/lib/mocks/mocks.dart
@@ -1,4 +1,5 @@
 export 'datasources/datasources.dart';
+export 'interactive_call_bloc.dart';
 export 'mock_about_bloc.dart';
 export 'mock_app_bloc.dart';
 export 'mock_call_bloc.dart';

--- a/screenshots/lib/mocks/repository/mock_contacts_repository.dart
+++ b/screenshots/lib/mocks/repository/mock_contacts_repository.dart
@@ -35,4 +35,8 @@ class MockContactsRepository extends Mock implements ContactsRepository {
       (contact) => contact.sourceType == sourceType && contact.sourceId == sourceId,
     );
   }
+
+  // Used by the real KeypadCubit during interactive keypad previews; no live lookup needed.
+  @override
+  Future<Contact?> getContactByPhoneNumber(String number) async => null;
 }

--- a/screenshots/lib/screenshots/call_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/call_screen_screenshot.dart
@@ -11,11 +11,15 @@ class CallScreenScreenshot extends StatefulWidget {
   const CallScreenScreenshot(
     this.video, {
     super.key,
+    this.interactive = false,
     this.localePlaceholderImageUrl = 'https://dummyimage.com/600x800/00e326/fff.jpg&text=locale',
     this.remotePlaceholderImageUrl = 'https://dummyimage.com/600x800/0048e3/fff.jpg&text=remote',
   });
 
   final bool video;
+
+  /// Use a reactive call bloc so the mute/hold buttons toggle instead of staying frozen.
+  final bool interactive;
   final String localePlaceholderImageUrl;
   final String remotePlaceholderImageUrl;
 
@@ -38,7 +42,13 @@ class _CallScreenScreenshotState extends State<CallScreenScreenshot> {
         PageRouteBuilder(
           pageBuilder: (context, _, _) {
             return MultiBlocProvider(
-              providers: [BlocProvider<CallBloc>(create: (context) => MockCallBloc.callScreen(widget.video))],
+              providers: [
+                BlocProvider<CallBloc>(
+                  create: (context) => widget.interactive
+                      ? InteractiveCallBloc(video: widget.video)
+                      : MockCallBloc.callScreen(widget.video),
+                ),
+              ],
               child: CallScreen(
                 localePlaceholderBuilder: (context) =>
                     Image.network(widget.localePlaceholderImageUrl, fit: BoxFit.fitHeight),

--- a/screenshots/lib/screenshots/diagnostic_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/diagnostic_screen_screenshot.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 
 import 'package:webtrit_phone/features/settings/features/diagnostic/bloc/diagnostic_cubit.dart';
+import 'package:webtrit_phone/features/settings/features/diagnostic/bloc/network_tester_cubit.dart';
 import 'package:webtrit_phone/features/settings/features/diagnostic/models/diagnostic_context.dart';
 import 'package:webtrit_phone/features/settings/features/diagnostic/view/diagnostic_screen.dart';
 
@@ -35,8 +36,11 @@ class _DiagnosticScreenScreenshotState extends State<DiagnosticScreenScreenshot>
                   create: (_) => DiagnosticScreenContext(isLocalContactsFeatureEnabled: true),
                 ),
               ],
-              child: BlocProvider<DiagnosticCubit>(
-                create: (_) => MockDiagnosticCubit.initial(),
+              child: MultiBlocProvider(
+                providers: [
+                  BlocProvider<DiagnosticCubit>(create: (_) => MockDiagnosticCubit.initial()),
+                  BlocProvider<NetworkTesterCubit>(create: (_) => MockNetworkTesterCubit.initial()),
+                ],
                 child: const DiagnosticScreen(),
               ),
             );

--- a/screenshots/lib/screenshots/login_otp_signin_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_otp_signin_screen_screenshot.dart
@@ -1,37 +1,14 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:webtrit_phone/features/features.dart';
-import 'package:webtrit_phone/widgets/widgets.dart';
-import 'package:webtrit_phone/app/constants.dart';
 
-import 'package:screenshots/mocks/mocks.dart';
+import 'login_screenshot.dart';
 
 class LoginOtpSignInScreenshot extends StatelessWidget {
   const LoginOtpSignInScreenshot({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final themeData = Theme.of(context);
-
-    final LoginSwitchScreenStyles? loginPageStyles = themeData.extension<LoginSwitchScreenStyles>();
-    final LoginSwitchScreenStyle? localStyle = loginPageStyles?.primary;
-
-    return BlocProvider<LoginCubit>(
-      create: (context) => MockLoginCubit.loginSwitchScreen(),
-      child: LoginSwitchScreen(
-        appBar: AppBar(leading: const ExtBackButton(disabled: false), backgroundColor: Colors.transparent),
-        header: Column(
-          children: [
-            ConfigurableThemeImage(style: localStyle?.pictureLogoStyle),
-            const SizedBox(height: kInset),
-          ],
-        ),
-        body: const LoginOtpSigninRequestScreen(),
-        currentLoginType: LoginType.otpSignin,
-        supportedLoginTypes: const [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup],
-      ),
-    );
+    return const LoginScreenshot(initialLoginType: LoginType.otpSignin);
   }
 }

--- a/screenshots/lib/screenshots/login_password_signin_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_password_signin_screen_screenshot.dart
@@ -1,37 +1,14 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:webtrit_phone/features/features.dart';
-import 'package:webtrit_phone/widgets/widgets.dart';
-import 'package:webtrit_phone/app/constants.dart';
 
-import 'package:screenshots/mocks/mocks.dart';
+import 'login_screenshot.dart';
 
 class LoginPasswordSignInScreenshot extends StatelessWidget {
   const LoginPasswordSignInScreenshot({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final themeData = Theme.of(context);
-
-    final LoginSwitchScreenStyles? loginPageStyles = themeData.extension<LoginSwitchScreenStyles>();
-    final LoginSwitchScreenStyle? localStyle = loginPageStyles?.primary;
-
-    return BlocProvider<LoginCubit>(
-      create: (context) => MockLoginCubit.loginSwitchScreen(),
-      child: LoginSwitchScreen(
-        appBar: AppBar(leading: const ExtBackButton(disabled: false), backgroundColor: Colors.transparent),
-        header: Column(
-          children: [
-            ConfigurableThemeImage(style: localStyle?.pictureLogoStyle),
-            const SizedBox(height: kInset),
-          ],
-        ),
-        body: const LoginPasswordSigninScreen(),
-        currentLoginType: LoginType.passwordSignin,
-        supportedLoginTypes: const [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup],
-      ),
-    );
+    return const LoginScreenshot(initialLoginType: LoginType.passwordSignin);
   }
 }

--- a/screenshots/lib/screenshots/login_screenshot.dart
+++ b/screenshots/lib/screenshots/login_screenshot.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/extensions/iterable.dart';
+import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
+
+import 'package:screenshots/mocks/mocks.dart';
+
+/// Single, parameterized and interactive login screenshot.
+///
+/// Replaces the former one-screenshot-per-tab duplication: [initialLoginType]
+/// selects which tab is shown first, and tapping a tab actually switches the
+/// body when pointer interaction is enabled (snapshot mode just renders the
+/// initial tab).
+class LoginScreenshot extends StatefulWidget {
+  const LoginScreenshot({
+    super.key,
+    this.initialLoginType = LoginType.otpSignin,
+    this.supportedLoginTypes = const [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup],
+  });
+
+  final LoginType initialLoginType;
+  final List<LoginType> supportedLoginTypes;
+
+  @override
+  State<LoginScreenshot> createState() => _LoginScreenshotState();
+}
+
+class _LoginScreenshotState extends State<LoginScreenshot> {
+  late LoginType _type = widget.initialLoginType;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final localStyle = themeData.extension<LoginSwitchScreenStyles>()?.primary;
+
+    final embedded =
+        context.watch<FeatureAccess?>()?.loginConfig.actions.firstWhereOrNull(
+              (element) => element.flavor == LoginFlavor.embedded,
+            )
+            as LoginEmbeddedModeButton?;
+
+    return BlocProvider<LoginCubit>(
+      create: (context) => MockLoginCubit.loginSwitchScreen(embedded: embedded?.customLoginFeature),
+      child: LoginSwitchScreen(
+        appBar: AppBar(leading: const ExtBackButton(disabled: false), backgroundColor: Colors.transparent),
+        header: Column(
+          children: [
+            ConfigurableThemeImage(style: localStyle?.pictureLogoStyle),
+            const SizedBox(height: kInset),
+          ],
+        ),
+        body: _bodyFor(context, _type, embedded),
+        currentLoginType: _type,
+        supportedLoginTypes: widget.supportedLoginTypes,
+        onLoginTypeChanged: (type) => setState(() => _type = type),
+      ),
+    );
+  }
+
+  Widget _bodyFor(BuildContext context, LoginType type, LoginEmbeddedModeButton? embedded) {
+    switch (type) {
+      case LoginType.otpSignin:
+        return const LoginOtpSigninRequestScreen();
+      case LoginType.passwordSignin:
+        return const LoginPasswordSigninScreen();
+      case LoginType.signup:
+        return _signupBody(context, embedded);
+    }
+  }
+
+  Widget _signupBody(BuildContext context, LoginEmbeddedModeButton? embedded) {
+    if (embedded == null) {
+      return const Center(child: Text('Embedded page not set up'));
+    }
+
+    final appMetadataProvider = context.read<AppMetadataProvider>();
+    return LoginSignupEmbeddedRequestScreen(
+      initialUrl: embedded.customLoginFeature.uri,
+      userAgent: appMetadataProvider.userAgent,
+      mediaQueryMetricsData: null,
+      deviceInfoData: null,
+      pageInjectionStrategyBuilder: () => DefaultPayloadInjectionStrategy(),
+      connectivityRecoveryStrategyBuilder: () => NoneConnectivityRecoveryStrategy(),
+    );
+  }
+}

--- a/screenshots/lib/screenshots/login_screenshot.dart
+++ b/screenshots/lib/screenshots/login_screenshot.dart
@@ -75,8 +75,9 @@ class _LoginScreenshotState extends State<LoginScreenshot> {
   }
 
   Widget _signupBody(BuildContext context, LoginEmbeddedModeButton? embedded) {
+    // No embedded resource configured → the app falls back to the native sign-up screen.
     if (embedded == null) {
-      return const Center(child: Text('Embedded page not set up'));
+      return const LoginSignupRequestScreen();
     }
 
     final appMetadataProvider = context.read<AppMetadataProvider>();

--- a/screenshots/lib/screenshots/login_signup_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_signup_screen_screenshot.dart
@@ -1,15 +1,8 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:webtrit_phone/data/data.dart';
-import 'package:webtrit_phone/extensions/iterable.dart';
 import 'package:webtrit_phone/features/features.dart';
-import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/widgets/widgets.dart';
-import 'package:webtrit_phone/app/constants.dart';
 
-import 'package:screenshots/mocks/mocks.dart';
+import 'login_screenshot.dart';
 
 class LoginSignUpScreenshot extends StatelessWidget {
   const LoginSignUpScreenshot({
@@ -21,47 +14,6 @@ class LoginSignUpScreenshot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final themeData = Theme.of(context);
-    final appMetadataProvider = context.read<AppMetadataProvider>();
-
-    final LoginSwitchScreenStyles? loginPageStyles = themeData.extension<LoginSwitchScreenStyles>();
-    final LoginSwitchScreenStyle? localStyle = loginPageStyles?.primary;
-
-    final sections = context.watch<FeatureAccess?>()?.loginConfig.actions.firstWhereOrNull(
-      (element) => element.flavor == LoginFlavor.embedded,
-    );
-
-    final embedded = sections as LoginEmbeddedModeButton?;
-
-    if (embedded == null) {
-      return const Center(child: Text('Embedded page not set up'));
-    }
-
-    return BlocProvider<LoginCubit>(
-      create: (context) => MockLoginCubit.loginSwitchScreen(embedded: embedded.customLoginFeature),
-      child: LoginSwitchScreen(
-        appBar: AppBar(leading: const ExtBackButton(disabled: false), backgroundColor: Colors.transparent),
-        header: Column(
-          children: [
-            ConfigurableThemeImage(style: localStyle?.pictureLogoStyle),
-            const SizedBox(height: kInset),
-          ],
-        ),
-        body: LoginSignupEmbeddedRequestScreen(
-          initialUrl: embedded.customLoginFeature.uri,
-          userAgent: appMetadataProvider.userAgent,
-          mediaQueryMetricsData: null,
-          deviceInfoData: null,
-          pageInjectionStrategyBuilder: () {
-            return DefaultPayloadInjectionStrategy();
-          },
-          connectivityRecoveryStrategyBuilder: () {
-            return NoneConnectivityRecoveryStrategy();
-          },
-        ),
-        currentLoginType: LoginType.signup,
-        supportedLoginTypes: supportedLoginTypes,
-      ),
-    );
+    return LoginScreenshot(initialLoginType: LoginType.signup, supportedLoginTypes: supportedLoginTypes);
   }
 }

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -214,9 +214,13 @@ class _MainScreenScreenshotState extends State<MainScreenScreenshot> {
             BlocProvider<SmsConversationsCubit>(create: (_) => MockSmsConversationsCubit.withConversations()),
             BlocProvider<UnreadCountCubit>(create: (_) => MockUnreadCountCubit.withUnreadMessages()),
           ],
-          child: const ConversationsScreen(
-            title: Text(EnvironmentConfig.APP_NAME),
-            initialTabsState: SingleTabState(TabType.chat, true),
+          child: ConversationsScreen(
+            title: const Text(EnvironmentConfig.APP_NAME),
+            // Dual tabs expose the chat/sms tab bar (its TabController is local, so switching
+            // works) for the interactive preview; the snapshot stays chat-only.
+            initialTabsState: widget.interactive
+                ? const DualTabState(TabType.chat, true)
+                : const SingleTabState(TabType.chat, true),
           ),
         );
     }

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -15,14 +15,32 @@ import 'package:webtrit_phone/widgets/widgets.dart';
 
 import 'package:screenshots/mocks/mocks.dart';
 
-class MainScreenScreenshot extends StatelessWidget {
-  const MainScreenScreenshot(this.flavor, this.title, {super.key, this.keypadDialing = false});
+class MainScreenScreenshot extends StatefulWidget {
+  const MainScreenScreenshot(
+    this.flavor,
+    this.title, {
+    super.key,
+    this.keypadDialing = false,
+    this.interactive = false,
+  });
 
   final MainFlavor flavor;
   final Widget? title;
 
   /// When the keypad flavor is shown, pre-fill it with a dialed number and resolved contact.
+  /// Ignored when [interactive] is true (the live keypad starts empty and reacts to input).
   final bool keypadDialing;
+
+  /// Enables bottom-menu tab switching and wires a live keypad cubit, so the
+  /// preview behaves like the app instead of a single static snapshot.
+  final bool interactive;
+
+  @override
+  State<MainScreenScreenshot> createState() => _MainScreenScreenshotState();
+}
+
+class _MainScreenScreenshotState extends State<MainScreenScreenshot> {
+  late MainFlavor _flavor = widget.flavor;
 
   @override
   Widget build(BuildContext context) {
@@ -45,7 +63,7 @@ class MainScreenScreenshot extends StatelessWidget {
             body: AppBarParams(
               systemNotificationsEnabled: true,
               pullableCallDialogs: const [],
-              child: _buildFlavorWidget(context, flavor, featureAccess),
+              child: _buildFlavorWidget(context, _flavor, featureAccess),
             ),
             bottomNavigationBar: _buildBottomNavigationBar(context, tabs),
           ),
@@ -106,15 +124,23 @@ class MainScreenScreenshot extends StatelessWidget {
   BottomNavigationBar _buildBottomNavigationBar(BuildContext context, List<BottomMenuTab> tabs) {
     final textTheme = Theme.of(context).textTheme;
 
+    final selectedIndex = tabs.indexWhere((tab) => tab.flavor == _flavor);
+
     return BottomNavigationBar(
-      currentIndex: tabs.indexWhere((tab) => tab.flavor == flavor),
+      currentIndex: selectedIndex < 0 ? 0 : selectedIndex,
       type: BottomNavigationBarType.fixed,
       selectedLabelStyle: textTheme.bodySmall,
       unselectedLabelStyle: textTheme.bodySmall,
+      onTap: widget.interactive ? (index) => _selectTab(tabs[index].flavor) : null,
       items: tabs
           .map((tab) => BottomNavigationBarItem(icon: Icon(tab.icon), label: context.parseL10n(tab.titleL10n)))
           .toList(),
     );
+  }
+
+  void _selectTab(MainFlavor flavor) {
+    if (flavor == _flavor) return;
+    setState(() => _flavor = flavor);
   }
 
   Widget _buildFlavorWidget(BuildContext context, MainFlavor flavor, FeatureAccess? featureAccess) {
@@ -125,7 +151,7 @@ class MainScreenScreenshot extends StatelessWidget {
         return BlocProvider<FavoritesBloc>(
           create: (_) => MockFavoritesBloc.mainScreen(),
           child: FavoritesScreen(
-            title: title,
+            title: widget.title,
             transferEnabled: false,
             videoEnabled: true,
             chatsEnabled: false,
@@ -137,7 +163,7 @@ class MainScreenScreenshot extends StatelessWidget {
         return BlocProvider<RecentsBloc>(
           create: (_) => MockRecentsBloc.mainScreen(),
           child: RecentsScreen(
-            title: title,
+            title: widget.title,
             transferEnabled: false,
             videoEnabled: true,
             chatsEnabled: false,
@@ -150,13 +176,22 @@ class MainScreenScreenshot extends StatelessWidget {
           child: ContactsScreen(
             sourceTypes: const [ContactSourceType.local, ContactSourceType.external],
             sourceTypeWidgetBuilder: _buildContactSourceTypeWidget,
-            title: title,
+            title: widget.title,
           ),
         );
       case MainFlavor.keypad:
         return BlocProvider<KeypadCubit>(
-          create: (_) => keypadDialing ? MockKeypadCubit.dialing() : MockKeypadCubit.mainScreen(),
-          child: KeypadScreen(title: title, videoEnabled: true, transferEnabled: false),
+          create: (context) => widget.interactive
+              ? KeypadCubit(context.read<ContactsRepository>())
+              : (widget.keypadDialing ? MockKeypadCubit.dialing() : MockKeypadCubit.mainScreen()),
+          child: Builder(
+            // CallControllerScope is only read when a call action is tapped; provide it so the
+            // interactive keypad's call buttons dispatch to the (mock) CallBloc instead of asserting.
+            builder: (context) => CallControllerScope(
+              controller: CallController(callBloc: context.read<CallBloc>()),
+              child: KeypadScreen(title: widget.title, videoEnabled: true, transferEnabled: false),
+            ),
+          ),
         );
       case MainFlavor.embedded:
         return BlocProvider<EmbeddedCubit>(

--- a/screenshots/lib/screenshots/screenshots.dart
+++ b/screenshots/lib/screenshots/screenshots.dart
@@ -14,6 +14,7 @@ export 'login_mode_select_screen_screenshot.dart';
 export 'login_otp_signin_screen_screenshot.dart';
 export 'login_otp_verify_screen_screenshot.dart';
 export 'login_password_signin_screen_screenshot.dart';
+export 'login_screenshot.dart';
 export 'login_signup_screen_screenshot.dart';
 export 'login_signup_verify_screen_screenshot.dart';
 export 'login_switch_screen_screenshot.dart';


### PR DESCRIPTION
Reworks the screenshot widgets so a single parameterized widget can act both as a static snapshot and as a live, interactive preview — removing the need for one screenshot per state.

Login: the otp/password/signup request tabs were three near-duplicate screenshots that hardcoded the selected tab and never wired `onLoginTypeChanged`, so tapping a tab did nothing. They now delegate to one `LoginScreenshot(initialLoginType:)` that holds the selected type in state and switches the body on tap. The three public classes are kept as thin wrappers so existing snapshot names and call sites are unchanged.

Main screen: `MainScreenScreenshot` is now stateful. A new `interactive` flag enables bottom-menu tab switching (the `BottomNavigationBar` gained an `onTap`), and the keypad flavor swaps the frozen `MockKeypadCubit` for a real `KeypadCubit(MockContactsRepository)` so the call buttons enable/disable as the field changes. `CallControllerScope` is wired to the mock `CallBloc` so tapping a call action dispatches instead of asserting. `MockContactsRepository.getContactByPhoneNumber` is stubbed for the live cubit.

All new params (`interactive`, existing `keypadDialing`) are optional and default to the previous static behavior, so CI snapshot generation and the current configurator are unaffected. The configurator will opt into `interactive` and collapse the duplicate variants in a follow-up.

`dart analyze` clean across the screenshots package.