### PR TITLE
fix(theme): settings group-header background hidden when a page background is set

### DIFF
--- a/lib/widgets/themed_scaffold.dart
+++ b/lib/widgets/themed_scaffold.dart
@@ -111,7 +111,10 @@ class ThemedScaffold extends StatelessWidget {
         width: double.infinity,
         height: double.infinity,
         decoration: boxDecoration,
-        child: currentBody,
+        // A transparent Material above the background so descendants that paint as Ink on the
+        // nearest Material (ListTile.tileColor, Ink) render over the gradient/image instead of
+        // under it — otherwise this decoration Container hides those colors.
+        child: Material(type: MaterialType.transparency, child: currentBody),
       );
     }
 


### PR DESCRIPTION
Settings section headers ("SETTINGS", "TOOLBOX") ignored their configured Group Headers background whenever the settings page also had a `background` set. Reproduces on a theme whose `pages.settings.background` is a gradient/image; works when that background is null. Confirmed by diffing two themes via the API — the failing one had `settings.background = gradient` plus a real `groupTitleListTile.backgroundColor`, the working one had both null.

Root cause: a page background makes `ThemedScaffold` wrap the body in a `Container(decoration: gradient/image)`. That Container sits between the body's `Material` and its content, so anything painted as Ink on the nearest Material — `ListTile.tileColor`, `Ink` — is drawn underneath and the Container paints over it.

Fix: wrap the body in a transparent `Material` above the background decoration, so Ink/tileColor render over the gradient/image. Systemic — covers any such widget on a page with a background. Login is unaffected (it uses `LoginScaffold`, not `ThemedScaffold`).

`dart analyze` clean.