### PR TITLE
fix(settings): list separators invisible on themes whose surface matches the background

### DIFF
--- a/lib/features/settings/widgets/list_tile_separator.dart
+++ b/lib/features/settings/widgets/list_tile_separator.dart
@@ -6,8 +6,10 @@ class ListTileSeparator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // TODO(Serdun): move color to style
+    // Use outlineVariant (the Material 3 divider role), not surface: surface equals the list
+    // background, so the separator was invisible on themes whose surface matches the page.
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Divider(height: 1, indent: 15, endIndent: 15, color: colorScheme.surface);
+    return Divider(height: 1, indent: 15, endIndent: 15, color: colorScheme.outlineVariant);
   }
 }


### PR DESCRIPTION
The "Show List Separators" divider lines in the settings list were invisible on some themes (e.g. one whose color scheme surface is #FFFFFF on a white settings background).

Cause: `ListTileSeparator` colored the `Divider` with `colorScheme.surface`, which is the same color as the list background, so the line blended in.

Fix: use `colorScheme.outlineVariant` — the Material 3 divider role — so the separator is a visible, theme-derived hairline regardless of the surface color.

`dart analyze` clean.