### PR TITLE
feat(settings): themeable separator style (visibility + color)

### DIFF
--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -74,7 +74,7 @@ class SettingsScreen extends StatelessWidget {
                       builder: (context, sessionState) =>
                           SessionStatusListTile(status: sessionState.status, onTap: () => _onDiagnosticTap(context)),
                     ),
-                    if (showSeparators) const ListTileSeparator(),
+                    if (showSeparators) ListTileSeparator(color: effectiveStyle?.separatorColor),
                     BlocBuilder<RegisterStatusCubit, RegisterStatus>(
                       builder: (context, registerState) => SwitchListTile(
                         title: Text(
@@ -93,7 +93,7 @@ class SettingsScreen extends StatelessWidget {
                               ),
                       ),
                     ),
-                    if (showSeparators) const ListTileSeparator(),
+                    if (showSeparators) ListTileSeparator(color: effectiveStyle?.separatorColor),
                     SettingsTile(
                       key: settingsLogoutButtonKey,
                       title: context.l10n.settings_ListViewTileTitle_logout,
@@ -101,6 +101,7 @@ class SettingsScreen extends StatelessWidget {
                       iconColor: effectiveStyle?.logoutIconColor ?? effectiveStyle?.leadingIconsColor,
                       textStyle: effectiveStyle?.itemTextStyle,
                       showSeparator: showSeparators,
+                      separatorColor: effectiveStyle?.separatorColor,
                       onTap: () => _onLogoutTap(context),
                     ),
                     for (final section in sections) ...[
@@ -121,6 +122,7 @@ class SettingsScreen extends StatelessWidget {
                                 iconColor: item.iconColor ?? effectiveStyle?.leadingIconsColor,
                                 textStyle: effectiveStyle?.itemTextStyle,
                                 showSeparator: showSeparators,
+                                separatorColor: effectiveStyle?.separatorColor,
                                 onTap: () => _onItemTap(context, item),
                               );
                             },
@@ -133,6 +135,7 @@ class SettingsScreen extends StatelessWidget {
                               iconColor: item.iconColor ?? effectiveStyle?.leadingIconsColor,
                               textStyle: effectiveStyle?.itemTextStyle,
                               showSeparator: showSeparators,
+                              separatorColor: effectiveStyle?.separatorColor,
                               onTap: () => _onItemTap(context, item),
                             ),
                         ] else if (item.flavor == SettingsFlavor.voicemail) ...[
@@ -143,6 +146,7 @@ class SettingsScreen extends StatelessWidget {
                             trailing: UnreadBadge(count: state.unreadVoicemailCount),
                             textStyle: effectiveStyle?.itemTextStyle,
                             showSeparator: showSeparators,
+                            separatorColor: effectiveStyle?.separatorColor,
                             onTap: () => _onItemTap(context, item),
                           ),
                         ] else
@@ -152,6 +156,7 @@ class SettingsScreen extends StatelessWidget {
                             iconColor: item.iconColor ?? effectiveStyle?.leadingIconsColor,
                             textStyle: effectiveStyle?.itemTextStyle,
                             showSeparator: showSeparators,
+                            separatorColor: effectiveStyle?.separatorColor,
                             onTap: () => _onItemTap(context, item),
                           ),
                       ],

--- a/lib/features/settings/view/settings_screen_style.dart
+++ b/lib/features/settings/view/settings_screen_style.dart
@@ -23,6 +23,7 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
     this.groupTitleListStyle,
     this.listViewPadding,
     this.showSeparators,
+    this.separatorColor,
     this.itemTextStyle,
   });
 
@@ -47,6 +48,9 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
   /// Whether to show separators between settings list items.
   final bool? showSeparators;
 
+  /// Color of the separators between settings list items. `null` → theme default.
+  final Color? separatorColor;
+
   /// Text style for list items
   final TextStyle? itemTextStyle;
 
@@ -61,6 +65,7 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
     GroupTitleListStyle? groupTitleListStyle,
     EdgeInsetsGeometry? listViewPadding,
     bool? showSeparators,
+    Color? separatorColor,
     TextStyle? itemTextStyle,
   }) {
     return SettingScreenStyle(
@@ -74,6 +79,7 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
       groupTitleListStyle: groupTitleListStyle ?? this.groupTitleListStyle,
       listViewPadding: listViewPadding ?? this.listViewPadding,
       showSeparators: showSeparators ?? this.showSeparators,
+      separatorColor: separatorColor ?? this.separatorColor,
       itemTextStyle: itemTextStyle ?? this.itemTextStyle,
     );
   }
@@ -93,6 +99,7 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
       groupTitleListStyle: GroupTitleListStyle.merge(a.groupTitleListStyle, b.groupTitleListStyle),
       listViewPadding: b.listViewPadding ?? a.listViewPadding,
       showSeparators: b.showSeparators ?? a.showSeparators,
+      separatorColor: b.separatorColor ?? a.separatorColor,
       itemTextStyle: a.itemTextStyle?.merge(b.itemTextStyle) ?? b.itemTextStyle,
     );
   }
@@ -109,6 +116,7 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
       groupTitleListStyle: GroupTitleListStyle.lerp(a?.groupTitleListStyle, b?.groupTitleListStyle, t),
       listViewPadding: EdgeInsetsGeometry.lerp(a?.listViewPadding, b?.listViewPadding, t),
       showSeparators: t < 0.5 ? a?.showSeparators : b?.showSeparators,
+      separatorColor: Color.lerp(a?.separatorColor, b?.separatorColor, t),
       itemTextStyle: TextStyle.lerp(a?.itemTextStyle, b?.itemTextStyle, t),
     );
   }
@@ -126,6 +134,7 @@ class SettingScreenStyle extends BaseScreenStyle with Diagnosticable {
       ..add(DiagnosticsProperty<GroupTitleListStyle?>('groupTitleListStyle', groupTitleListStyle))
       ..add(DiagnosticsProperty<EdgeInsetsGeometry?>('listViewPadding', listViewPadding))
       ..add(DiagnosticsProperty<bool?>('showSeparators', showSeparators))
+      ..add(ColorProperty('separatorColor', separatorColor))
       ..add(DiagnosticsProperty<TextStyle?>('itemTextStyle', itemTextStyle));
   }
 }

--- a/lib/features/settings/widgets/list_tile_separator.dart
+++ b/lib/features/settings/widgets/list_tile_separator.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 
 class ListTileSeparator extends StatelessWidget {
-  const ListTileSeparator({super.key});
+  const ListTileSeparator({super.key, this.color});
+
+  /// Override color for the separator. `null` → theme default (outlineVariant).
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
-    // TODO(Serdun): move color to style
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Divider(height: 1, indent: 15, endIndent: 15, color: colorScheme.surface);
+    return Divider(height: 1, indent: 15, endIndent: 15, color: color ?? colorScheme.outlineVariant);
   }
 }

--- a/lib/features/settings/widgets/settings_tile.dart
+++ b/lib/features/settings/widgets/settings_tile.dart
@@ -16,6 +16,7 @@ class SettingsTile extends StatelessWidget {
     this.trailing,
     this.textStyle,
     this.showSeparator = true,
+    this.separatorColor,
     this.enabled = true,
     this.opacity = 1.0,
     super.key,
@@ -27,6 +28,7 @@ class SettingsTile extends StatelessWidget {
   final Widget? trailing;
   final TextStyle? textStyle;
   final bool showSeparator;
+  final Color? separatorColor;
   final VoidCallback onTap;
   final bool enabled;
   final double opacity;
@@ -46,6 +48,12 @@ class SettingsTile extends StatelessWidget {
 
     if (!showSeparator) return tile;
 
-    return Column(mainAxisSize: MainAxisSize.min, children: [tile, const ListTileSeparator()]);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        tile,
+        ListTileSeparator(color: separatorColor),
+      ],
+    );
   }
 }

--- a/lib/theme/factory/styles/settings_screen_style_factory.dart
+++ b/lib/theme/factory/styles/settings_screen_style_factory.dart
@@ -29,11 +29,15 @@ class SettingsScreenStyleFactory implements ThemeStyleFactory<SettingsScreenStyl
       defaultFontFamily,
     ).create().primary;
 
-    // Separator: prefer the new `separator` style; fall back to the deprecated `showSeparators`
-    // boolean for any in-memory config not produced via fromJson (JSON loads are migrated).
+    // Separator: when a `separator` style is present it fully wins — `enabled == null` means
+    // "default (shown)" downstream, so the legacy boolean must NOT override it. Only fall back
+    // to the deprecated `showSeparators` when there is no `separator` config at all (e.g. an
+    // in-memory config not produced via fromJson; JSON loads are migrated into `separator`).
     final separator = config?.separator;
-    // ignore: deprecated_member_use
-    final showSeparators = separator?.enabled ?? config?.showSeparators;
+    final showSeparators = separator != null
+        ? separator.enabled
+        // ignore: deprecated_member_use
+        : config?.showSeparators;
     final separatorColor = separator?.color?.toColor();
 
     // Resolve theme override values safely

--- a/lib/theme/factory/styles/settings_screen_style_factory.dart
+++ b/lib/theme/factory/styles/settings_screen_style_factory.dart
@@ -29,6 +29,13 @@ class SettingsScreenStyleFactory implements ThemeStyleFactory<SettingsScreenStyl
       defaultFontFamily,
     ).create().primary;
 
+    // Separator: prefer the new `separator` style; fall back to the deprecated `showSeparators`
+    // boolean for any in-memory config not produced via fromJson (JSON loads are migrated).
+    final separator = config?.separator;
+    // ignore: deprecated_member_use
+    final showSeparators = separator?.enabled ?? config?.showSeparators;
+    final separatorColor = separator?.color?.toColor();
+
     // Resolve theme override values safely
     final contentThemeOverride = config?.themeOverride.mode.toThemeMode();
     final applyToAppBar = config?.themeOverride.applyToAppBar;
@@ -44,7 +51,8 @@ class SettingsScreenStyleFactory implements ThemeStyleFactory<SettingsScreenStyl
         logoutIconColor: logoutIconColor,
         groupTitleListStyle: groupTitleListStyle,
         listViewPadding: null,
-        showSeparators: config?.showSeparators,
+        showSeparators: showSeparators,
+        separatorColor: separatorColor,
         itemTextStyle: itemTextStyle,
       ),
     );

--- a/packages/webtrit_appearance_theme/lib/models/common/common.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/common.dart
@@ -9,6 +9,7 @@ export 'keypad_style_config.dart';
 export 'leading_avatar_style_config.dart';
 export 'overlay_style_model.dart';
 export 'padding_config.dart';
+export 'separator_style_config.dart';
 export 'style_types.dart';
 export 'text_field_config.dart';
 export 'text_field_mask_config.dart';

--- a/packages/webtrit_appearance_theme/lib/models/common/separator_style_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/separator_style_config.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'separator_style_config.freezed.dart';
+
+part 'separator_style_config.g.dart';
+
+/// Declarative configuration for a list separator (divider line between items).
+///
+/// `null` for the whole config means "use the default" (separator shown with the
+/// theme's default color); it does NOT mean hidden — set [enabled] to `false` for that.
+@freezed
+abstract class SeparatorStyleConfig with _$SeparatorStyleConfig {
+  const factory SeparatorStyleConfig({
+    /// Whether to render the separator. `null` → shown (default).
+    bool? enabled,
+
+    /// Separator color (hex string, e.g. `#CAC7D1`). `null` → theme default.
+    String? color,
+  }) = _SeparatorStyleConfig;
+
+  factory SeparatorStyleConfig.fromJson(Map<String, dynamic> json) => _$SeparatorStyleConfigFromJson(json);
+}

--- a/packages/webtrit_appearance_theme/lib/models/common/separator_style_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/separator_style_config.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'separator_style_config.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SeparatorStyleConfig {
+
+/// Whether to render the separator. `null` → shown (default).
+ bool? get enabled;/// Separator color (hex string, e.g. `#CAC7D1`). `null` → theme default.
+ String? get color;
+/// Create a copy of SeparatorStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SeparatorStyleConfigCopyWith<SeparatorStyleConfig> get copyWith => _$SeparatorStyleConfigCopyWithImpl<SeparatorStyleConfig>(this as SeparatorStyleConfig, _$identity);
+
+  /// Serializes this SeparatorStyleConfig to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SeparatorStyleConfig&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.color, color) || other.color == color));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,enabled,color);
+
+@override
+String toString() {
+  return 'SeparatorStyleConfig(enabled: $enabled, color: $color)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SeparatorStyleConfigCopyWith<$Res>  {
+  factory $SeparatorStyleConfigCopyWith(SeparatorStyleConfig value, $Res Function(SeparatorStyleConfig) _then) = _$SeparatorStyleConfigCopyWithImpl;
+@useResult
+$Res call({
+ bool? enabled, String? color
+});
+
+
+
+
+}
+/// @nodoc
+class _$SeparatorStyleConfigCopyWithImpl<$Res>
+    implements $SeparatorStyleConfigCopyWith<$Res> {
+  _$SeparatorStyleConfigCopyWithImpl(this._self, this._then);
+
+  final SeparatorStyleConfig _self;
+  final $Res Function(SeparatorStyleConfig) _then;
+
+/// Create a copy of SeparatorStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = freezed,Object? color = freezed,}) {
+  return _then(_self.copyWith(
+enabled: freezed == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool?,color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SeparatorStyleConfig].
+extension SeparatorStyleConfigPatterns on SeparatorStyleConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SeparatorStyleConfig value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SeparatorStyleConfig() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SeparatorStyleConfig value)  $default,){
+final _that = this;
+switch (_that) {
+case _SeparatorStyleConfig():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SeparatorStyleConfig value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SeparatorStyleConfig() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool? enabled,  String? color)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SeparatorStyleConfig() when $default != null:
+return $default(_that.enabled,_that.color);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool? enabled,  String? color)  $default,) {final _that = this;
+switch (_that) {
+case _SeparatorStyleConfig():
+return $default(_that.enabled,_that.color);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool? enabled,  String? color)?  $default,) {final _that = this;
+switch (_that) {
+case _SeparatorStyleConfig() when $default != null:
+return $default(_that.enabled,_that.color);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SeparatorStyleConfig implements SeparatorStyleConfig {
+  const _SeparatorStyleConfig({this.enabled, this.color});
+  factory _SeparatorStyleConfig.fromJson(Map<String, dynamic> json) => _$SeparatorStyleConfigFromJson(json);
+
+/// Whether to render the separator. `null` → shown (default).
+@override final  bool? enabled;
+/// Separator color (hex string, e.g. `#CAC7D1`). `null` → theme default.
+@override final  String? color;
+
+/// Create a copy of SeparatorStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SeparatorStyleConfigCopyWith<_SeparatorStyleConfig> get copyWith => __$SeparatorStyleConfigCopyWithImpl<_SeparatorStyleConfig>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SeparatorStyleConfigToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SeparatorStyleConfig&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.color, color) || other.color == color));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,enabled,color);
+
+@override
+String toString() {
+  return 'SeparatorStyleConfig(enabled: $enabled, color: $color)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SeparatorStyleConfigCopyWith<$Res> implements $SeparatorStyleConfigCopyWith<$Res> {
+  factory _$SeparatorStyleConfigCopyWith(_SeparatorStyleConfig value, $Res Function(_SeparatorStyleConfig) _then) = __$SeparatorStyleConfigCopyWithImpl;
+@override @useResult
+$Res call({
+ bool? enabled, String? color
+});
+
+
+
+
+}
+/// @nodoc
+class __$SeparatorStyleConfigCopyWithImpl<$Res>
+    implements _$SeparatorStyleConfigCopyWith<$Res> {
+  __$SeparatorStyleConfigCopyWithImpl(this._self, this._then);
+
+  final _SeparatorStyleConfig _self;
+  final $Res Function(_SeparatorStyleConfig) _then;
+
+/// Create a copy of SeparatorStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = freezed,Object? color = freezed,}) {
+  return _then(_SeparatorStyleConfig(
+enabled: freezed == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool?,color: freezed == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/webtrit_appearance_theme/lib/models/common/separator_style_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/separator_style_config.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'separator_style_config.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SeparatorStyleConfig _$SeparatorStyleConfigFromJson(
+  Map<String, dynamic> json,
+) => _SeparatorStyleConfig(
+  enabled: json['enabled'] as bool?,
+  color: json['color'] as String?,
+);
+
+Map<String, dynamic> _$SeparatorStyleConfigToJson(
+  _SeparatorStyleConfig instance,
+) => <String, dynamic>{'enabled': instance.enabled, 'color': instance.color};

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -475,6 +475,7 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
     this.logoutIconColor,
     this.groupTitleListTile,
     this.showSeparators = true,
+    this.separator,
     this.background,
     this.itemTextStyle,
     this.appBarBlurredSurface,
@@ -496,8 +497,15 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
   @override
   final GroupTitleListTileWidgetConfig? groupTitleListTile;
 
+  /// Deprecated: visibility now lives in [separator] (`separator.enabled`).
+  /// Kept for backward compatibility with themes saved before [separator] existed.
+  @Deprecated('Use separator.enabled instead')
   @override
   final bool showSeparators;
+
+  /// Style of the divider lines between setting items (visibility + color).
+  @override
+  final SeparatorStyleConfig? separator;
 
   @override
   final PageBackground? background;
@@ -508,7 +516,20 @@ class SettingsPageConfig with _$SettingsPageConfig implements BasePageConfig {
   @override
   final BlurredSurfaceConfig? appBarBlurredSurface;
 
-  factory SettingsPageConfig.fromJson(Map<String, Object?> json) => _$SettingsPageConfigFromJson(json);
+  factory SettingsPageConfig.fromJson(Map<String, Object?> json) {
+    // TODO: Migration workaround — themes saved before `separator` existed expressed separator
+    // visibility through the boolean `showSeparators`. Fold it into the new `separator` style
+    // (visibility kept, default color) when `separator` is absent, so those themes keep working.
+    // Remove this block and the deprecated `showSeparators` field in a future major release once
+    // all stored themes carry `separator`.
+    if (json['separator'] == null && json['showSeparators'] != null) {
+      json = {
+        ...json,
+        'separator': <String, Object?>{'enabled': json['showSeparators']},
+      };
+    }
+    return _$SettingsPageConfigFromJson(json);
+  }
 
   Map<String, Object?> toJson() => _$SettingsPageConfigToJson(this);
 }

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -2860,7 +2860,7 @@ case _:
 /// @nodoc
 mixin _$SettingsPageConfig {
 
- ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; PageBackground? get background; TextStyleConfig? get itemTextStyle; BlurredSurfaceConfig? get appBarBlurredSurface;
+ ThemeOverrideConfig get themeOverride; String? get leadingIconsColor; String? get userIconColor; String? get logoutIconColor; GroupTitleListTileWidgetConfig? get groupTitleListTile; bool get showSeparators; SeparatorStyleConfig? get separator; PageBackground? get background; TextStyleConfig? get itemTextStyle; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2871,16 +2871,16 @@ $SettingsPageConfigCopyWith<SettingsPageConfig> get copyWith => _$SettingsPageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.separator, separator) || other.separator == separator)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,background,itemTextStyle,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,separator,background,itemTextStyle,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, background: $background, itemTextStyle: $itemTextStyle, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'SettingsPageConfig(themeOverride: $themeOverride, leadingIconsColor: $leadingIconsColor, userIconColor: $userIconColor, logoutIconColor: $logoutIconColor, groupTitleListTile: $groupTitleListTile, showSeparators: $showSeparators, separator: $separator, background: $background, itemTextStyle: $itemTextStyle, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -2891,7 +2891,7 @@ abstract mixin class $SettingsPageConfigCopyWith<$Res>  {
   factory $SettingsPageConfigCopyWith(SettingsPageConfig value, $Res Function(SettingsPageConfig) _then) = _$SettingsPageConfigCopyWithImpl;
 @useResult
 $Res call({
- ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, PageBackground? background, TextStyleConfig? itemTextStyle, BlurredSurfaceConfig? appBarBlurredSurface
+ ThemeOverrideConfig themeOverride, String? leadingIconsColor, String? userIconColor, String? logoutIconColor, GroupTitleListTileWidgetConfig? groupTitleListTile, bool showSeparators, SeparatorStyleConfig? separator, PageBackground? background, TextStyleConfig? itemTextStyle, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -2908,7 +2908,7 @@ class _$SettingsPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of SettingsPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? background = freezed,Object? itemTextStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeOverride = null,Object? leadingIconsColor = freezed,Object? userIconColor = freezed,Object? logoutIconColor = freezed,Object? groupTitleListTile = freezed,Object? showSeparators = null,Object? separator = freezed,Object? background = freezed,Object? itemTextStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(SettingsPageConfig(
 themeOverride: null == themeOverride ? _self.themeOverride : themeOverride // ignore: cast_nullable_to_non_nullable
 as ThemeOverrideConfig,leadingIconsColor: freezed == leadingIconsColor ? _self.leadingIconsColor : leadingIconsColor // ignore: cast_nullable_to_non_nullable
@@ -2916,7 +2916,8 @@ as String?,userIconColor: freezed == userIconColor ? _self.userIconColor : userI
 as String?,logoutIconColor: freezed == logoutIconColor ? _self.logoutIconColor : logoutIconColor // ignore: cast_nullable_to_non_nullable
 as String?,groupTitleListTile: freezed == groupTitleListTile ? _self.groupTitleListTile : groupTitleListTile // ignore: cast_nullable_to_non_nullable
 as GroupTitleListTileWidgetConfig?,showSeparators: null == showSeparators ? _self.showSeparators : showSeparators // ignore: cast_nullable_to_non_nullable
-as bool,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
+as bool,separator: freezed == separator ? _self.separator : separator // ignore: cast_nullable_to_non_nullable
+as SeparatorStyleConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,itemTextStyle: freezed == itemTextStyle ? _self.itemTextStyle : itemTextStyle // ignore: cast_nullable_to_non_nullable
 as TextStyleConfig?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
 as BlurredSurfaceConfig?,

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -532,6 +532,11 @@ SettingsPageConfig _$SettingsPageConfigFromJson(Map<String, dynamic> json) =>
               json['groupTitleListTile'] as Map<String, dynamic>,
             ),
       showSeparators: json['showSeparators'] as bool? ?? true,
+      separator: json['separator'] == null
+          ? null
+          : SeparatorStyleConfig.fromJson(
+              json['separator'] as Map<String, dynamic>,
+            ),
       background: json['background'] == null
           ? null
           : PageBackground.fromJson(json['background'] as Map<String, dynamic>),
@@ -555,6 +560,7 @@ Map<String, dynamic> _$SettingsPageConfigToJson(SettingsPageConfig instance) =>
       'logoutIconColor': instance.logoutIconColor,
       'groupTitleListTile': instance.groupTitleListTile?.toJson(),
       'showSeparators': instance.showSeparators,
+      'separator': instance.separator?.toJson(),
       'background': instance.background?.toJson(),
       'itemTextStyle': instance.itemTextStyle?.toJson(),
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),

--- a/packages/webtrit_appearance_theme/test/settings_page_config_separator_test.dart
+++ b/packages/webtrit_appearance_theme/test/settings_page_config_separator_test.dart
@@ -1,0 +1,66 @@
+import 'package:test/test.dart';
+
+import 'package:webtrit_appearance_theme/webtrit_appearance_theme.dart';
+
+void main() {
+  group('SettingsPageConfig.separator', () {
+    group('legacy showSeparators migration', () {
+      test('legacy showSeparators=false folds into separator.enabled=false (default color)', () {
+        final config = SettingsPageConfig.fromJson({'showSeparators': false});
+
+        expect(config.separator, isNotNull);
+        expect(config.separator?.enabled, isFalse);
+        expect(config.separator?.color, isNull);
+      });
+
+      test('legacy showSeparators=true folds into separator.enabled=true', () {
+        final config = SettingsPageConfig.fromJson({'showSeparators': true});
+
+        expect(config.separator?.enabled, isTrue);
+      });
+
+      test('explicit separator wins over legacy showSeparators (no migration)', () {
+        final config = SettingsPageConfig.fromJson({
+          'showSeparators': true,
+          'separator': {'enabled': false, 'color': '#FF0000'},
+        });
+
+        expect(config.separator?.enabled, isFalse);
+        expect(config.separator?.color, '#FF0000');
+      });
+
+      test('migration does not mutate the caller json', () {
+        final json = <String, Object?>{'showSeparators': false};
+        SettingsPageConfig.fromJson(json);
+
+        expect(json.containsKey('separator'), isFalse);
+      });
+    });
+
+    group('new separator field', () {
+      test('absent separator and no legacy flag → null (inherit default)', () {
+        final config = SettingsPageConfig.fromJson(<String, Object?>{});
+
+        expect(config.separator, isNull);
+      });
+
+      test('parses enabled + color', () {
+        final config = SettingsPageConfig.fromJson({
+          'separator': {'enabled': true, 'color': '#CAC7D1'},
+        });
+
+        expect(config.separator?.enabled, isTrue);
+        expect(config.separator?.color, '#CAC7D1');
+      });
+
+      test('round-trips through toJson/fromJson', () {
+        const original = SettingsPageConfig(separator: SeparatorStyleConfig(enabled: false, color: '#123456'));
+
+        final restored = SettingsPageConfig.fromJson(original.toJson());
+
+        expect(restored.separator?.enabled, isFalse);
+        expect(restored.separator?.color, '#123456');
+      });
+    });
+  });
+}


### PR DESCRIPTION
Lets a theme override the settings-list separators — both whether they show and their color — instead of only a `showSeparators` boolean with a hardcoded color.

Architecture (chosen as B2 over a flat color field or null-as-visibility): extract a reusable `SeparatorStyleConfig` DTO (`enabled` + `color`) and add `SettingsPageConfig.separator`. `null` config = inherit default (shown, theme color); `enabled: false` = hidden — keeping the codebase's "null = inherit" convention.

Backward compatibility: `showSeparators` stays `@Deprecated`, and `SettingsPageConfig.fromJson` folds the legacy boolean into `separator.enabled` (default color) when `separator` is absent, so themes saved before this keep working. The migration block and the deprecated field are commented for removal in a future major release.

App side: the style factory derives visibility/color from `separator` (falling back to the legacy boolean for in-memory configs), `SettingScreenStyle` gains `separatorColor`, and `ListTileSeparator` paints it — defaulting to `outlineVariant` instead of `surface`, which also fixes separators being invisible on themes whose surface matches the list background.

Migration tests added in `packages/webtrit_appearance_theme`. `dart analyze` clean; appearance-theme separator tests pass.

Configurator UI to set the color is a follow-up PR (depends on this).