### PR TITLE
ci: auto-tag main with app_version on release merge

### DIFF
--- a/.github/workflows/auto-tag-version.yaml
+++ b/.github/workflows/auto-tag-version.yaml
@@ -1,0 +1,45 @@
+name: auto-tag-version
+
+# After a release PR lands on main, publish the version tag automatically.
+# Reads the app_version field from the root pubspec.yaml and creates an annotated
+# tag X.Y.Z on the merged main commit if it does not already exist.
+# Idempotent: pushes that do not change app_version (or where the tag already
+# exists, e.g. a hotfix X.Y.Z+N reusing the same base) are no-ops.
+# Note: app_version (not the standard version: field) is the release version.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - pubspec.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create version tag if missing
+        run: |
+          set -euo pipefail
+          VERSION_FIELD=$(grep -m1 '^app_version:' pubspec.yaml | awk '{print $2}')
+          VERSION="${VERSION_FIELD%%+*}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read app_version from pubspec.yaml"
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Tag '$VERSION' already exists - nothing to do."
+            exit 0
+          fi
+          echo "Creating tag '$VERSION' on $GITHUB_SHA"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "release $VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/auto-tag-version.yaml
+++ b/.github/workflows/auto-tag-version.yaml
@@ -28,7 +28,10 @@ jobs:
       - name: Create version tag if missing
         run: |
           set -euo pipefail
-          VERSION_FIELD=$(grep -m1 '^app_version:' pubspec.yaml | awk '{print $2}')
+          # awk (not grep|awk): returns 0 even with no match, so a missing
+          # app_version yields an empty VERSION and reaches the error below
+          # instead of aborting on pipefail.
+          VERSION_FIELD=$(awk '/^app_version:/{print $2; exit}' pubspec.yaml)
           VERSION="${VERSION_FIELD%%+*}"
           if [ -z "$VERSION" ]; then
             echo "::error::Could not read app_version from pubspec.yaml"


### PR DESCRIPTION
Adds `.github/workflows/auto-tag-version.yaml`: on push to `main` that touches `pubspec.yaml`, reads `app_version` and creates annotated tag `X.Y.Z` if it does not already exist.

## Why
Mirrors the callkeep auto-tag flow - unifies release into one flow with no manual `git tag` step. Tags are created at the only safe point (the merged `main` commit), avoiding orphaned tags from squash-merge / rebased release branches.

## Notes
- Reads `app_version:` (the release version), not the standard `version:` field.
- Idempotent: no-op if the tag already exists (e.g. a hotfix `X.Y.Z+N` reusing the base) or app_version did not change.
- Tag naming matches the existing convention (`1.15.0`..`1.15.3`): bare `X.Y.Z`, no `v`, no `+N`.
- Activates for releases landing on `main` after this workflow is present there.