### PR TITLE
feat(about): show webtrit_callkeep version on the About screen

### DIFF
--- a/lib/data/app_info.dart
+++ b/lib/data/app_info.dart
@@ -12,8 +12,9 @@ class AppInfo {
     final id = await appIdProvider.getId();
 
     String? appVersion = await getAppVersion();
+    String callkeepVersion = await getCallkeepVersion();
 
-    return AppInfo._(appIdProvider, id, appVersion);
+    return AppInfo._(appIdProvider, id, appVersion, callkeepVersion);
   }
 
   static Future<String?> getAppVersion() async {
@@ -27,7 +28,32 @@ class AppInfo {
     }
   }
 
-  AppInfo._(this.appInfo, this._identifier, this._appVersion) {
+  /// Reads the webtrit_callkeep version from the bundled pubspec.yaml.
+  ///
+  /// On release branches the dependency is pinned to a git ref (the published
+  /// callkeep tag), which is returned as-is. On develop it is a local path
+  /// dependency with no ref, so [_localCallkeepVersion] is returned.
+  static Future<String> getCallkeepVersion() async {
+    try {
+      final pubspecString = await services.rootBundle.loadString(Assets.pubspec);
+      // Capture only the webtrit_callkeep block: its sub-lines are indented deeper
+      // than the 2-space dependency key, so a sibling git ref (e.g. flutter_webrtc)
+      // is not matched.
+      final block = RegExp(
+        r'^  webtrit_callkeep:\n((?:    .*\n?)*)',
+        multiLine: true,
+      ).firstMatch(pubspecString)?.group(1);
+      if (block == null) return _localCallkeepVersion;
+      return RegExp(r'ref:\s*(\S+)').firstMatch(block)?.group(1) ?? _localCallkeepVersion;
+    } catch (e) {
+      _logger.warning(e);
+      return _localCallkeepVersion;
+    }
+  }
+
+  static const String _localCallkeepVersion = 'local';
+
+  AppInfo._(this.appInfo, this._identifier, this._appVersion, this._callkeepVersion) {
     appInfo.onIdChange.listen((String id) {
       _identifier = id;
     });
@@ -39,7 +65,11 @@ class AppInfo {
 
   final String? _appVersion;
 
+  final String _callkeepVersion;
+
   String get identifier => _identifier;
 
   String get version => _appVersion ?? '';
+
+  String get callkeepVersion => _callkeepVersion;
 }

--- a/lib/data/app_info.dart
+++ b/lib/data/app_info.dart
@@ -12,7 +12,7 @@ class AppInfo {
     final id = await appIdProvider.getId();
 
     String? appVersion = await getAppVersion();
-    String callkeepVersion = await getCallkeepVersion();
+    final callkeepVersion = await getCallkeepVersion();
 
     return AppInfo._(appIdProvider, id, appVersion, callkeepVersion);
   }

--- a/lib/features/settings/features/about/bloc/about_bloc.dart
+++ b/lib/features/settings/features/about/bloc/about_bloc.dart
@@ -37,6 +37,7 @@ class AboutBloc extends Bloc<AboutEvent, AboutState> {
            userAgent: appMetadataProvider.userAgent,
            appInfo: appMetadataProvider.appInfo,
            deviceInfo: appMetadataProvider.deviceInfo,
+           callkeepVersion: appInfo.callkeepVersion,
          ),
        ) {
     on<AboutStarted>(_onStarted, transformer: restartable());

--- a/lib/features/settings/features/about/bloc/about_bloc.freezed.dart
+++ b/lib/features/settings/features/about/bloc/about_bloc.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AboutState {
 
- bool get progress; List<String> get embeddedLinks; String get packageName; String get appIdentifier; Uri get coreUrl; String get userAgent; String get appInfo; String get deviceInfo; String? get fcmPushToken; Version? get coreVersion;
+ bool get progress; List<String> get embeddedLinks; String get packageName; String get appIdentifier; Uri get coreUrl; String get userAgent; String get appInfo; String get deviceInfo; String get callkeepVersion; String? get fcmPushToken; Version? get coreVersion;
 /// Create a copy of AboutState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $AboutStateCopyWith<AboutState> get copyWith => _$AboutStateCopyWithImpl<AboutSt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutState&&(identical(other.progress, progress) || other.progress == progress)&&const DeepCollectionEquality().equals(other.embeddedLinks, embeddedLinks)&&(identical(other.packageName, packageName) || other.packageName == packageName)&&(identical(other.appIdentifier, appIdentifier) || other.appIdentifier == appIdentifier)&&(identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.appInfo, appInfo) || other.appInfo == appInfo)&&(identical(other.deviceInfo, deviceInfo) || other.deviceInfo == deviceInfo)&&(identical(other.fcmPushToken, fcmPushToken) || other.fcmPushToken == fcmPushToken)&&(identical(other.coreVersion, coreVersion) || other.coreVersion == coreVersion));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutState&&(identical(other.progress, progress) || other.progress == progress)&&const DeepCollectionEquality().equals(other.embeddedLinks, embeddedLinks)&&(identical(other.packageName, packageName) || other.packageName == packageName)&&(identical(other.appIdentifier, appIdentifier) || other.appIdentifier == appIdentifier)&&(identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.appInfo, appInfo) || other.appInfo == appInfo)&&(identical(other.deviceInfo, deviceInfo) || other.deviceInfo == deviceInfo)&&(identical(other.callkeepVersion, callkeepVersion) || other.callkeepVersion == callkeepVersion)&&(identical(other.fcmPushToken, fcmPushToken) || other.fcmPushToken == fcmPushToken)&&(identical(other.coreVersion, coreVersion) || other.coreVersion == coreVersion));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,progress,const DeepCollectionEquality().hash(embeddedLinks),packageName,appIdentifier,coreUrl,userAgent,appInfo,deviceInfo,fcmPushToken,coreVersion);
+int get hashCode => Object.hash(runtimeType,progress,const DeepCollectionEquality().hash(embeddedLinks),packageName,appIdentifier,coreUrl,userAgent,appInfo,deviceInfo,callkeepVersion,fcmPushToken,coreVersion);
 
 @override
 String toString() {
-  return 'AboutState(progress: $progress, embeddedLinks: $embeddedLinks, packageName: $packageName, appIdentifier: $appIdentifier, coreUrl: $coreUrl, userAgent: $userAgent, appInfo: $appInfo, deviceInfo: $deviceInfo, fcmPushToken: $fcmPushToken, coreVersion: $coreVersion)';
+  return 'AboutState(progress: $progress, embeddedLinks: $embeddedLinks, packageName: $packageName, appIdentifier: $appIdentifier, coreUrl: $coreUrl, userAgent: $userAgent, appInfo: $appInfo, deviceInfo: $deviceInfo, callkeepVersion: $callkeepVersion, fcmPushToken: $fcmPushToken, coreVersion: $coreVersion)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $AboutStateCopyWith<$Res>  {
   factory $AboutStateCopyWith(AboutState value, $Res Function(AboutState) _then) = _$AboutStateCopyWithImpl;
 @useResult
 $Res call({
- bool progress, List<String> embeddedLinks, String packageName, String appIdentifier, Uri coreUrl, String userAgent, String appInfo, String deviceInfo, String? fcmPushToken, Version? coreVersion
+ bool progress, List<String> embeddedLinks, String packageName, String appIdentifier, Uri coreUrl, String userAgent, String appInfo, String deviceInfo, String callkeepVersion, String? fcmPushToken, Version? coreVersion
 });
 
 
@@ -62,7 +62,7 @@ class _$AboutStateCopyWithImpl<$Res>
 
 /// Create a copy of AboutState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? progress = null,Object? embeddedLinks = null,Object? packageName = null,Object? appIdentifier = null,Object? coreUrl = null,Object? userAgent = null,Object? appInfo = null,Object? deviceInfo = null,Object? fcmPushToken = freezed,Object? coreVersion = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? progress = null,Object? embeddedLinks = null,Object? packageName = null,Object? appIdentifier = null,Object? coreUrl = null,Object? userAgent = null,Object? appInfo = null,Object? deviceInfo = null,Object? callkeepVersion = null,Object? fcmPushToken = freezed,Object? coreVersion = freezed,}) {
   return _then(AboutState(
 progress: null == progress ? _self.progress : progress // ignore: cast_nullable_to_non_nullable
 as bool,embeddedLinks: null == embeddedLinks ? _self.embeddedLinks : embeddedLinks // ignore: cast_nullable_to_non_nullable
@@ -72,6 +72,7 @@ as String,coreUrl: null == coreUrl ? _self.coreUrl : coreUrl // ignore: cast_nul
 as Uri,userAgent: null == userAgent ? _self.userAgent : userAgent // ignore: cast_nullable_to_non_nullable
 as String,appInfo: null == appInfo ? _self.appInfo : appInfo // ignore: cast_nullable_to_non_nullable
 as String,deviceInfo: null == deviceInfo ? _self.deviceInfo : deviceInfo // ignore: cast_nullable_to_non_nullable
+as String,callkeepVersion: null == callkeepVersion ? _self.callkeepVersion : callkeepVersion // ignore: cast_nullable_to_non_nullable
 as String,fcmPushToken: freezed == fcmPushToken ? _self.fcmPushToken : fcmPushToken // ignore: cast_nullable_to_non_nullable
 as String?,coreVersion: freezed == coreVersion ? _self.coreVersion : coreVersion // ignore: cast_nullable_to_non_nullable
 as Version?,

--- a/lib/features/settings/features/about/bloc/about_state.dart
+++ b/lib/features/settings/features/about/bloc/about_state.dart
@@ -11,6 +11,7 @@ class AboutState with _$AboutState {
     required this.userAgent,
     required this.appInfo,
     required this.deviceInfo,
+    required this.callkeepVersion,
     this.fcmPushToken,
     this.coreVersion,
   });
@@ -38,6 +39,9 @@ class AboutState with _$AboutState {
 
   @override
   final String deviceInfo;
+
+  @override
+  final String callkeepVersion;
 
   @override
   final String? fcmPushToken;

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -107,6 +107,11 @@ class _AboutScreenState extends State<AboutScreen> {
                                     value: state.fcmPushToken,
                                   ),
                                   SizedBox(height: delimiterHeight / 2),
+                                  InfoTile(
+                                    label: context.l10n.settings_AboutText_CallkeepVersion,
+                                    value: state.callkeepVersion,
+                                  ),
+                                  SizedBox(height: delimiterHeight / 2),
                                   CoreInfoTile(
                                     coreUrl: state.coreUrl,
                                     coreVersion: state.coreVersion,

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -98,6 +98,11 @@ class _AboutScreenState extends State<AboutScreen> {
                                   ),
                                   SizedBox(height: delimiterHeight / 2),
                                   InfoTile(
+                                    label: context.l10n.settings_AboutText_CallkeepVersion,
+                                    value: state.callkeepVersion,
+                                  ),
+                                  SizedBox(height: delimiterHeight / 2),
+                                  InfoTile(
                                     label: context.l10n.settings_AboutText_AppSessionIdentifier,
                                     value: state.appIdentifier,
                                   ),
@@ -105,11 +110,6 @@ class _AboutScreenState extends State<AboutScreen> {
                                   InfoTile(
                                     label: context.l10n.settings_AboutText_FCMPushNotificationToken,
                                     value: state.fcmPushToken,
-                                  ),
-                                  SizedBox(height: delimiterHeight / 2),
-                                  InfoTile(
-                                    label: context.l10n.settings_AboutText_CallkeepVersion,
-                                    value: state.callkeepVersion,
                                   ),
                                   SizedBox(height: delimiterHeight / 2),
                                   CoreInfoTile(

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -3294,6 +3294,12 @@ abstract class AppLocalizations {
   /// **'App Version'**
   String get settings_AboutText_AppVersion;
 
+  /// No description provided for @settings_AboutText_CallkeepVersion.
+  ///
+  /// In en, this message translates to:
+  /// **'CallKeep version'**
+  String get settings_AboutText_CallkeepVersion;
+
   /// No description provided for @settings_AboutText_CoreVersion.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -822,6 +822,8 @@ extension AppLocalizationsExtension on AppLocalizations {
       'settings_AboutText_AppSessionIdentifier' =>
         settings_AboutText_AppSessionIdentifier,
       'settings_AboutText_AppVersion' => settings_AboutText_AppVersion,
+      'settings_AboutText_CallkeepVersion' =>
+        settings_AboutText_CallkeepVersion,
       'settings_AboutText_CoreVersion' => settings_AboutText_CoreVersion,
       'settings_AboutText_CoreVersionUndefined' =>
         settings_AboutText_CoreVersionUndefined,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1772,6 +1772,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_AboutText_AppVersion => 'App Version';
 
   @override
+  String get settings_AboutText_CallkeepVersion => 'CallKeep version';
+
+  @override
   String get settings_AboutText_CoreVersion => 'WebTrit Cloud Backend version';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1794,6 +1794,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_AboutText_AppVersion => 'Versione dell\'app';
 
   @override
+  String get settings_AboutText_CallkeepVersion => 'Versione di CallKeep';
+
+  @override
   String get settings_AboutText_CoreVersion => 'Versione WebTrit Cloud Backend';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1794,6 +1794,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settings_AboutText_AppVersion => 'Версія застосунку';
 
   @override
+  String get settings_AboutText_CallkeepVersion => 'Версія CallKeep';
+
+  @override
   String get settings_AboutText_CoreVersion => 'Версія WebTrit Cloud Backend';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1480,6 +1480,8 @@
   "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AboutText_AppVersion": "App Version",
   "@settings_AboutText_AppVersion": {},
+  "settings_AboutText_CallkeepVersion": "CallKeep version",
+  "@settings_AboutText_CallkeepVersion": {},
   "settings_AboutText_CoreVersion": "WebTrit Cloud Backend version",
   "@settings_AboutText_CoreVersion": {},
   "settings_AboutText_CoreVersionUndefined": "?.?.?",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1480,6 +1480,8 @@
   "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AboutText_AppVersion": "Versione dell'app",
   "@settings_AboutText_AppVersion": {},
+  "settings_AboutText_CallkeepVersion": "Versione di CallKeep",
+  "@settings_AboutText_CallkeepVersion": {},
   "settings_AboutText_CoreVersion": "Versione WebTrit Cloud Backend",
   "@settings_AboutText_CoreVersion": {},
   "settings_AboutText_CoreVersionUndefined": "?.?.?",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1480,6 +1480,8 @@
   "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AboutText_AppVersion": "Версія застосунку",
   "@settings_AboutText_AppVersion": {},
+  "settings_AboutText_CallkeepVersion": "Версія CallKeep",
+  "@settings_AboutText_CallkeepVersion": {},
   "settings_AboutText_CoreVersion": "Версія WebTrit Cloud Backend",
   "@settings_AboutText_CoreVersion": {},
   "settings_AboutText_CoreVersionUndefined": "?.?.?",

--- a/screenshots/lib/mocks/mock_about_bloc.dart
+++ b/screenshots/lib/mocks/mock_about_bloc.dart
@@ -17,6 +17,7 @@ class MockAboutBloc extends MockBloc<AboutEvent, AboutState> implements AboutBlo
     appIdentifier: 'com.webtrit.phone',
     coreUrl: Uri.parse('https://core.example.com'),
     fcmPushToken: 'fcm-token-demo',
+    callkeepVersion: '1.2.0',
     coreVersion: coreVersion,
   );
 


### PR DESCRIPTION
Adds a "CallKeep version" row to the About screen.

## How
- `AppInfo.getCallkeepVersion()` reads the pinned `webtrit_callkeep` git ref from the bundled `pubspec.yaml` (same asset `AppInfo` already parses for `app_version`). A scoped regex captures only the `webtrit_callkeep` block so sibling git refs (flutter_contacts/flutter_webrtc) are not matched.
- Plumbed through `AppMetadataProvider`-adjacent path: `AboutBloc` -> new `AboutState.callkeepVersion` -> new `InfoTile` in `about_screen.dart`.
- l10n key `settings_AboutText_CallkeepVersion` added to en/uk/it ARB and regenerated.
- Screenshots mock updated so the workspace keeps compiling.

## Behaviour
- Release builds: shows the pinned callkeep tag (e.g. `1.2.0`).
- Develop builds: callkeep is a path dependency with no ref -> shows `local`.

Verified the parser against both real pubspecs: develop -> `local`, release/1.15.4 -> `1.2.0`. Lefthook (analyze + full test suite) green locally.