### PR TITLE
fix(settings): restore previous default separator color when none is configured

### DIFF
--- a/lib/features/settings/widgets/list_tile_separator.dart
+++ b/lib/features/settings/widgets/list_tile_separator.dart
@@ -3,13 +3,14 @@ import 'package:flutter/material.dart';
 class ListTileSeparator extends StatelessWidget {
   const ListTileSeparator({super.key, this.color});
 
-  /// Override color for the separator. `null` → theme default (outlineVariant).
+  /// Override color for the separator. `null` → the previous default (`colorScheme.surface`),
+  /// so a visible separator is opt-in via a configured color rather than forced on every theme.
   final Color? color;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Divider(height: 1, indent: 15, endIndent: 15, color: color ?? colorScheme.outlineVariant);
+    return Divider(height: 1, indent: 15, endIndent: 15, color: color ?? colorScheme.surface);
   }
 }


### PR DESCRIPTION
The themeable separator work (#1348) changed `ListTileSeparator`'s default color from `colorScheme.surface` to `colorScheme.outlineVariant`. That made separators visible on every theme that does not explicitly set a separator color — a behavior change for all existing themes.

Restore the previous default (`colorScheme.surface`) so the look is unchanged when nothing is configured; a visible separator is opt-in via the configured `separator.color`. The override param stays, so themes that set a color still get it.

`dart analyze` clean.