### PR TITLE
fix: prefer backend contact over local phonebook on number collision

### DIFF
--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -174,6 +174,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Future<FullContactData?> getContactByPhoneNumber(String number) async {
     final query = _joinFullData(select(contactsTable))
       ..where(contactPhonesTable.number.equals(number))
+      ..orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)])
       ..limit(1);
 
     return query.get().then(_gatherSingleContact);
@@ -198,6 +199,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Stream<FullContactData?> watchContactByPhoneNumber(String number) {
     final query = _joinFullData(select(contactsTable))
       ..where(contactPhonesTable.number.equals(number))
+      ..orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)])
       ..limit(1);
 
     return query.watch().map(_gatherSingleContact);
@@ -206,6 +208,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Future<FullContactData?> getContactByPhoneMatchedEnding(String number) {
     final query = _joinFullData(select(contactsTable));
     query.where(contactPhonesTable.number.regexp('.*$number', caseSensitive: false));
+    query.orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)]);
     query.limit(1);
 
     return query.get().then(_gatherSingleContact);
@@ -214,6 +217,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Stream<FullContactData?> watchContactByPhoneMatchedEnding(String number) {
     final query = _joinFullData(select(contactsTable));
     query.where(contactPhonesTable.number.regexp('.*$number', caseSensitive: false));
+    query.orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)]);
     query.limit(1);
 
     return query.watch().map((data) => _gatherMultipleContacts(data).firstOrNull);

--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -606,6 +606,104 @@ void main() {
     });
   });
 
+  group('getContactByPhoneNumber - local vs external number collision', () {
+    // A local phonebook contact and an external/PBX contact share the SAME phone
+    // number. Without an explicit ORDER BY the winner is left to SQLite's
+    // unspecified row order (platform/data dependent). Ordering by sourceType DESC
+    // makes the external (PBX) entry win deterministically, regardless of
+    // insertion order.
+    Future<void> setupCollision({required bool localFirst}) async {
+      final dao = database.contactsDao;
+      final phonesDao = database.contactPhonesDao;
+
+      Future<void> addLocal() async {
+        final c = await dao.insertOnUniqueConflictUpdateContact(
+          ContactDataCompanion(
+            sourceType: Value(ContactSourceTypeEnum.local),
+            sourceId: Value('local-4'),
+            firstName: Value('Loca Contact 4'),
+            aliasName: Value('Loca Contact 4'),
+          ),
+        );
+        await phonesDao.insertOnUniqueConflictUpdateContactPhone(
+          ContactPhoneDataCompanion(contactId: Value(c.id), number: Value('4'), label: Value('mobile')),
+        );
+      }
+
+      Future<void> addExternal() async {
+        final c = await dao.insertOnUniqueConflictUpdateContact(
+          ContactDataCompanion(
+            sourceType: Value(ContactSourceTypeEnum.external),
+            sourceId: Value('ext-4'),
+            aliasName: Value('Dima4'),
+          ),
+        );
+        await phonesDao.insertOnUniqueConflictUpdateContactPhone(
+          ContactPhoneDataCompanion(contactId: Value(c.id), number: Value('4'), label: Value('ext')),
+        );
+      }
+
+      if (localFirst) {
+        await addLocal();
+        await addExternal();
+      } else {
+        await addExternal();
+        await addLocal();
+      }
+    }
+
+    // Sanity: prove a REAL collision exists (both a local and an external
+    // contact carry number "4") so a passing winner-assertion is not a false
+    // negative caused by one side failing to insert.
+    Future<void> assertRealCollision() async {
+      final all = await database.contactsDao.getAllContacts(null);
+      final withNumber4 = all.where((c) => c.phones.any((p) => p.number == '4')).toList();
+      expect(withNumber4.length, 2, reason: 'both local + external must carry number 4');
+      expect(
+        withNumber4.any(
+          (c) => c.contact.sourceType == ContactSourceTypeEnum.local && c.contact.aliasName == 'Loca Contact 4',
+        ),
+        isTrue,
+      );
+      expect(
+        withNumber4.any(
+          (c) => c.contact.sourceType == ContactSourceTypeEnum.external && c.contact.aliasName == 'Dima4',
+        ),
+        isTrue,
+      );
+    }
+
+    test('local inserted FIRST then external -> PBX alias wins', () async {
+      await setupCollision(localFirst: true);
+      await assertRealCollision();
+
+      final contact = await database.contactsDao.getContactByPhoneNumber('4');
+
+      expect(contact, isNotNull);
+      expect(
+        contact!.contact.sourceType,
+        ContactSourceTypeEnum.external,
+        reason: 'external (PBX) should win on collision',
+      );
+      expect(contact.contact.aliasName, 'Dima4');
+    });
+
+    test('external inserted FIRST then local -> PBX alias wins', () async {
+      await setupCollision(localFirst: false);
+      await assertRealCollision();
+
+      final contact = await database.contactsDao.getContactByPhoneNumber('4');
+
+      expect(contact, isNotNull);
+      expect(
+        contact!.contact.sourceType,
+        ContactSourceTypeEnum.external,
+        reason: 'external (PBX) should win on collision',
+      );
+      expect(contact.contact.aliasName, 'Dima4');
+    });
+  });
+
   group('ContactPhonesDao', () {
     late int contactId;
 

--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -606,12 +606,12 @@ void main() {
     });
   });
 
-  group('getContactByPhoneNumber - local vs external number collision', () {
+  group('phone-number lookups - local vs external number collision', () {
     // A local phonebook contact and an external/PBX contact share the SAME phone
     // number. Without an explicit ORDER BY the winner is left to SQLite's
     // unspecified row order (platform/data dependent). Ordering by sourceType DESC
-    // makes the external (PBX) entry win deterministically, regardless of
-    // insertion order.
+    // makes the external (PBX) entry win deterministically across every lookup
+    // method, regardless of insertion order.
     Future<void> setupCollision({required bool localFirst}) async {
       final dao = database.contactsDao;
       final phonesDao = database.contactPhonesDao;
@@ -621,8 +621,8 @@ void main() {
           ContactDataCompanion(
             sourceType: Value(ContactSourceTypeEnum.local),
             sourceId: Value('local-4'),
-            firstName: Value('Loca Contact 4'),
-            aliasName: Value('Loca Contact 4'),
+            firstName: Value('Local Contact 4'),
+            aliasName: Value('Local Contact 4'),
           ),
         );
         await phonesDao.insertOnUniqueConflictUpdateContactPhone(
@@ -661,7 +661,7 @@ void main() {
       expect(withNumber4.length, 2, reason: 'both local + external must carry number 4');
       expect(
         withNumber4.any(
-          (c) => c.contact.sourceType == ContactSourceTypeEnum.local && c.contact.aliasName == 'Loca Contact 4',
+          (c) => c.contact.sourceType == ContactSourceTypeEnum.local && c.contact.aliasName == 'Local Contact 4',
         ),
         isTrue,
       );
@@ -673,35 +673,33 @@ void main() {
       );
     }
 
-    test('local inserted FIRST then external -> PBX alias wins', () async {
-      await setupCollision(localFirst: true);
-      await assertRealCollision();
+    // Every lookup path touched by the ORDER BY fix must prefer the external
+    // (PBX) contact on a collision - exact-number and matched-ending, get + watch.
+    final lookups = <String, Future<FullContactData?> Function()>{
+      'getContactByPhoneNumber': () => database.contactsDao.getContactByPhoneNumber('4'),
+      'watchContactByPhoneNumber': () => database.contactsDao.watchContactByPhoneNumber('4').first,
+      'getContactByPhoneMatchedEnding': () => database.contactsDao.getContactByPhoneMatchedEnding('4'),
+      'watchContactByPhoneMatchedEnding': () => database.contactsDao.watchContactByPhoneMatchedEnding('4').first,
+    };
 
-      final contact = await database.contactsDao.getContactByPhoneNumber('4');
+    for (final entry in lookups.entries) {
+      for (final localFirst in [true, false]) {
+        test('${entry.key} prefers external (local-first=$localFirst)', () async {
+          await setupCollision(localFirst: localFirst);
+          await assertRealCollision();
 
-      expect(contact, isNotNull);
-      expect(
-        contact!.contact.sourceType,
-        ContactSourceTypeEnum.external,
-        reason: 'external (PBX) should win on collision',
-      );
-      expect(contact.contact.aliasName, 'Dima4');
-    });
+          final contact = await entry.value();
 
-    test('external inserted FIRST then local -> PBX alias wins', () async {
-      await setupCollision(localFirst: false);
-      await assertRealCollision();
-
-      final contact = await database.contactsDao.getContactByPhoneNumber('4');
-
-      expect(contact, isNotNull);
-      expect(
-        contact!.contact.sourceType,
-        ContactSourceTypeEnum.external,
-        reason: 'external (PBX) should win on collision',
-      );
-      expect(contact.contact.aliasName, 'Dima4');
-    });
+          expect(contact, isNotNull);
+          expect(
+            contact!.contact.sourceType,
+            ContactSourceTypeEnum.external,
+            reason: 'external (PBX) should win on collision',
+          );
+          expect(contact.contact.aliasName, 'Dima4');
+        });
+      }
+    }
   });
 
   group('ContactPhonesDao', () {


### PR DESCRIPTION
## Problem

When a number exists both as a local phonebook contact and as an external/PBX
extension, the call screen could show the local name instead of the PBX alias.
The lookup `getContactByPhoneNumber` used `LIMIT 1` with no `ORDER BY`, so the
winner was decided by SQLite's unspecified row order (platform/data dependent) -
latent and non-deterministic (it surfaced on 1.13.1; does not reproduce on host).

## Fix

Order the phone-number lookups by `sourceType` DESC so the external (PBX) entry
(`sourceType` index 1) wins deterministically over local (index 0). Applied to
`getContactByPhoneNumber`, `watchContactByPhoneNumber` and both
`PhoneMatchedEnding` variants.

## Tests

`contacts_dao_test.dart`: local-vs-external number collision in BOTH insertion
orders -> external/PBX wins (locks the ordering contract).

## Verification

- [x] `dart format` + `dart analyze` clean
- [x] full `flutter test` suite green (pre-push hook)
- [ ] Manual: number collision -> PBX alias shown

Ref: WT-1037
Related: #1356 (own alias on self-call)