### PR TITLE
fix: do not resolve a local contact for your own number (self-call)

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -504,6 +504,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                       // Used to resolve the contact (and its display name) of the caller
                       final contactResolver = DefaultContactResolver(
                         contactsRepository: context.read<ContactsRepository>(),
+                        userRepository: context.read<UserRepository>(),
                       );
 
                       // Try to get CDRs sync worker to trigger immediate sync after call ends

--- a/lib/features/call/utils/contact_resolver.dart
+++ b/lib/features/call/utils/contact_resolver.dart
@@ -6,17 +6,31 @@ abstract class ContactResolver {
 }
 
 class DefaultContactResolver implements ContactResolver {
-  const DefaultContactResolver({required this.contactsRepository});
+  const DefaultContactResolver({required this.contactsRepository, required this.userRepository});
 
   final ContactsRepository contactsRepository;
+  final UserRepository userRepository;
 
   @override
   Future<Contact?> resolve(String? number) async {
     if (number == null || number.isEmpty) return null;
+
+    // Self-call: the current user is excluded from the synced PBX contacts, so for
+    // our own number only a stale local phonebook entry could match and it would
+    // override our identity on the call screen. Skip resolution and let the caller
+    // fall back to the signaling-provided name.
+    if (_isOwnNumber(number)) return null;
+
     try {
       return await contactsRepository.getContactByPhoneNumber(number);
     } catch (_) {
       return null;
     }
+  }
+
+  bool _isOwnNumber(String number) {
+    final numbers = userRepository.getLocalInfo()?.numbers;
+    if (numbers == null) return false;
+    return number == numbers.ext || number == numbers.main || (numbers.additional?.contains(number) ?? false);
   }
 }

--- a/lib/features/call/view/call_shell.dart
+++ b/lib/features/call/view/call_shell.dart
@@ -9,6 +9,7 @@ import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/features/orientations/orientations.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/repositories/contacts/contacts_repository.dart';
+import 'package:webtrit_phone/repositories/user_info/user_repository.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/app/constants.dart';
 
@@ -156,7 +157,10 @@ class _CallShellState extends State<CallShell> {
     final blfViaSipSupport = PresenceViewParams.of(context).blfViaSipSupport;
     final presenceViaSipSupport = PresenceViewParams.of(context).presenceViaSipSupport;
     final callBloc = context.read<CallBloc>();
-    final contactResolver = DefaultContactResolver(contactsRepository: context.read<ContactsRepository>());
+    final contactResolver = DefaultContactResolver(
+      contactsRepository: context.read<ContactsRepository>(),
+      userRepository: context.read<UserRepository>(),
+    );
 
     _thumbnailManager.show(
       context,

--- a/test/features/call/utils/contact_resolver_test.dart
+++ b/test/features/call/utils/contact_resolver_test.dart
@@ -4,19 +4,34 @@ import 'package:mocktail/mocktail.dart';
 import 'package:webtrit_phone/features/call/utils/contact_resolver.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/contacts/contacts_repository.dart';
+import 'package:webtrit_phone/repositories/user_info/user_repository.dart';
 
 class _MockContactsRepository extends Mock implements ContactsRepository {}
+
+class _MockUserRepository extends Mock implements UserRepository {}
 
 Contact _contact(String alias) =>
     Contact(id: 1, sourceType: ContactSourceType.external, kind: ContactKind.visible, aliasName: alias);
 
+UserInfo _userInfo({String? ext, String? main, List<String>? additional, String? alias, String? first, String? last}) =>
+    UserInfo(
+      numbers: Numbers(ext: ext, main: main, additional: additional),
+      aliasName: alias,
+      firstName: first,
+      lastName: last,
+    );
+
 void main() {
   late _MockContactsRepository contactsRepository;
+  late _MockUserRepository userRepository;
   late DefaultContactResolver resolver;
 
   setUp(() {
     contactsRepository = _MockContactsRepository();
-    resolver = DefaultContactResolver(contactsRepository: contactsRepository);
+    userRepository = _MockUserRepository();
+    // Default: no cached user info, so resolve() always falls through to the repository.
+    when(() => userRepository.getLocalInfo()).thenReturn(null);
+    resolver = DefaultContactResolver(contactsRepository: contactsRepository, userRepository: userRepository);
   });
 
   group('DefaultContactResolver.resolve', () {
@@ -49,6 +64,38 @@ void main() {
       when(() => contactsRepository.getContactByPhoneNumber('4')).thenThrow(Exception('db failure'));
 
       expect(await resolver.resolve('4'), isNull);
+    });
+  });
+
+  group('DefaultContactResolver.resolve - self-call (own number)', () {
+    test('own EXT returns null and does NOT resolve the local phonebook contact', () async {
+      when(() => userRepository.getLocalInfo()).thenReturn(_userInfo(ext: '3', main: '111000333', alias: 'Dima3'));
+      // A local phonebook contact also exists for the own number - it must NOT win.
+      when(() => contactsRepository.getContactByPhoneNumber('3')).thenAnswer((_) async => _contact('Local Contact'));
+
+      expect(await resolver.resolve('3'), isNull);
+      verifyNever(() => contactsRepository.getContactByPhoneNumber(any()));
+    });
+
+    test('own MAIN number returns null', () async {
+      when(() => userRepository.getLocalInfo()).thenReturn(_userInfo(ext: '3', main: '111000333', alias: 'Dima3'));
+
+      expect(await resolver.resolve('111000333'), isNull);
+    });
+
+    test('own ADDITIONAL number returns null', () async {
+      when(
+        () => userRepository.getLocalInfo(),
+      ).thenReturn(_userInfo(ext: '3', additional: ['777', '888'], alias: 'Dima3'));
+
+      expect(await resolver.resolve('888'), isNull);
+    });
+
+    test('non-own number falls through to the repository', () async {
+      when(() => userRepository.getLocalInfo()).thenReturn(_userInfo(ext: '3', main: '111000333', alias: 'Dima3'));
+      when(() => contactsRepository.getContactByPhoneNumber('4')).thenAnswer((_) async => _contact('Dima4'));
+
+      expect((await resolver.resolve('4'))?.maybeName, 'Dima4');
     });
   });
 }


### PR DESCRIPTION
## Overview

When dialing one of your own numbers (ext/main/additional), the call screen showed
a LOCAL phonebook contact name instead of your own identity. The current user is
excluded from the synced PBX contacts, so only a stale local phonebook entry could
match by number, and it overrode the name.

## Fix

`DefaultContactResolver` now returns `null` for the current user's own numbers
(checked via `UserRepository`), instead of resolving a contact. The call screen
then falls back to the signaling-provided name (the account's own alias) rather
than the local contact. Kept deliberately simple - no synthesized contact. Wired
through `main_shell.dart` and `call_shell.dart` so `CallBloc` and the call
thumbnail behave consistently.

## Tests

`contact_resolver_test.dart`: own ext/main/additional -> `null` (and the local
contact is NOT queried); non-own numbers still resolve via the repository.

## Verification

- [x] `dart analyze` clean
- [x] full `flutter test` suite green (pre-push hook)
- [ ] Manual: logged in as ext N, call N -> own name shown (not a local contact)

Ref: WT-1037
Note: rebased onto develop after #1357 (resolver consolidation) merged.