### PR TITLE
fix: do not show a local contact for your own number on the keypad

### DIFF
--- a/lib/features/keypad/cubit/keypad_cubit.dart
+++ b/lib/features/keypad/cubit/keypad_cubit.dart
@@ -1,8 +1,8 @@
 import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'package:webtrit_phone/features/call/utils/contact_resolver.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/utils/debounce.dart';
 
 part 'keypad_state.dart';
@@ -10,9 +10,9 @@ part 'keypad_state.dart';
 part 'keypad_cubit.freezed.dart';
 
 class KeypadCubit extends Cubit<KeypadState> {
-  KeypadCubit(this._contactsRepository) : super(KeypadState());
+  KeypadCubit(this._contactResolver) : super(KeypadState());
 
-  final ContactsRepository _contactsRepository;
+  final ContactResolver _contactResolver;
   final _contactDebounce = Debounce();
 
   /// Sets current value and attempts to retrieve and update the contact matching the provided [number].
@@ -27,12 +27,13 @@ class KeypadCubit extends Cubit<KeypadState> {
     if (cleanedNumber.isNotEmpty) _contactDebounce.schedule(() => _fetchContact(cleanedNumber));
   }
 
-  /// Asynchronously fetches the contact from the repository.
+  /// Asynchronously resolves the contact for the typed [number].
   ///
-  /// - On success: updates the state with the retrieved contact.
-  /// - On error: resets the contact state to `null`.
+  /// Goes through [ContactResolver], which returns `null` for the current user's
+  /// own numbers (self-call), so the keypad does not surface a local phonebook
+  /// contact for your own number.
   Future<void> _fetchContact(String number) async {
-    final contact = await _contactsRepository.getContactByPhoneNumber(number);
+    final contact = await _contactResolver.resolve(number);
     if (isClosed) return;
 
     emit(state.copyWith(contact: contact));

--- a/lib/features/keypad/view/keypad_screen_page.dart
+++ b/lib/features/keypad/view/keypad_screen_page.dart
@@ -22,7 +22,15 @@ class KeypadScreenPage extends StatelessWidget {
       videoEnabled: featureAccess.callConfig.capabilities.isVideoCallEnabled,
       transferEnabled: featureAccess.callConfig.capabilities.isBlindTransferEnabled,
     );
-    final provider = BlocProvider(create: (context) => KeypadCubit(context.read<ContactsRepository>()), child: widget);
+    final provider = BlocProvider(
+      create: (context) => KeypadCubit(
+        DefaultContactResolver(
+          contactsRepository: context.read<ContactsRepository>(),
+          userRepository: context.read<UserRepository>(),
+        ),
+      ),
+      child: widget,
+    );
     return provider;
   }
 }

--- a/test/features/keypad/cubit/keypad_cubit_test.dart
+++ b/test/features/keypad/cubit/keypad_cubit_test.dart
@@ -1,0 +1,61 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/features/call/utils/contact_resolver.dart';
+import 'package:webtrit_phone/features/keypad/keypad.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+class _MockContactResolver extends Mock implements ContactResolver {}
+
+Contact _contact(String alias) =>
+    Contact(id: 1, sourceType: ContactSourceType.external, kind: ContactKind.visible, aliasName: alias);
+
+void main() {
+  late _MockContactResolver resolver;
+
+  setUp(() {
+    resolver = _MockContactResolver();
+  });
+
+  // Past the 300ms keypad debounce window.
+  const debounceWait = Duration(milliseconds: 400);
+
+  blocTest<KeypadCubit, KeypadState>(
+    'resolves the typed number through ContactResolver and emits the contact',
+    build: () {
+      when(() => resolver.resolve('4')).thenAnswer((_) async => _contact('Dima4'));
+      return KeypadCubit(resolver);
+    },
+    act: (cubit) => cubit.setValue('4'),
+    wait: debounceWait,
+    verify: (cubit) {
+      verify(() => resolver.resolve('4')).called(1);
+      expect(cubit.state.contact?.maybeName, 'Dima4');
+    },
+  );
+
+  blocTest<KeypadCubit, KeypadState>(
+    'keeps the contact null when the resolver returns null (e.g. own number)',
+    build: () {
+      when(() => resolver.resolve('3')).thenAnswer((_) async => null);
+      return KeypadCubit(resolver);
+    },
+    act: (cubit) => cubit.setValue('3'),
+    wait: debounceWait,
+    verify: (cubit) {
+      verify(() => resolver.resolve('3')).called(1);
+      expect(cubit.state.contact, isNull);
+    },
+  );
+
+  blocTest<KeypadCubit, KeypadState>(
+    'does not resolve when the value is cleared',
+    build: () => KeypadCubit(resolver),
+    act: (cubit) => cubit.setValue('   '),
+    wait: debounceWait,
+    verify: (_) {
+      verifyNever(() => resolver.resolve(any()));
+    },
+  );
+}


### PR DESCRIPTION
## Overview

On the keypad, typing your own number showed a local phonebook contact name under
the digits (e.g. "3" -> "Local Contact"). The live-name lookup called
`ContactsRepository.getContactByPhoneNumber` directly, bypassing the self-number
skip that the call screen already has (#1356), so a stale local contact for your
own number leaked through.

## Fix

Route `KeypadCubit` through `ContactResolver` (which returns `null` for the current
user's own ext/main/additional numbers) instead of the raw repository. Wire the
resolver in `keypad_screen_page` with `UserRepository`. The keypad now shows no
local contact for your own number, consistent with the call screen.

## Tests

`keypad_cubit_test.dart`: resolve delegation + emitted contact, the null
(own-number) case, and the cleared-value case (no lookup).

## Verification

- [x] `dart analyze` clean
- [x] full `flutter test` suite green (pre-push hook)
- [ ] Manual: on the keypad, type your own number -> no local contact name shown

Ref: WT-1037
Builds on #1356 (self-call skip in DefaultContactResolver, already merged).