### PR TITLE
fix: restore native dialer fallback for emergency numbers (WT-1600)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -13,7 +13,6 @@ import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 import 'package:async/async.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
@@ -2305,9 +2304,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     if (callkeepError != null) {
       if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
-        // Self-managed phone accounts cannot place emergency calls; hand the
-        // number off to the system dialer so the user can still dial it.
-        launchUrl(Uri(scheme: 'tel', path: e.handle.value));
+        // Self-managed phone accounts cannot place emergency calls. Explain why
+        // and offer to hand the number off to the system dialer, instead of
+        // silently switching to it.
+        submitNotification(EmergencyNumberNotification(e.handle.value));
       } else if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
         CrashlyticsUtils.recordError(
           'CallBloc - __onMutationControlStart selfManagedPhoneAccountNotRegistered',

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -13,6 +13,7 @@ import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 import 'package:async/async.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
@@ -2303,7 +2304,19 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
 
     if (callkeepError != null) {
-      _logger.warning('__onMutationControlStart error: $callkeepError');
+      if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
+        // Self-managed phone accounts cannot place emergency calls; hand the
+        // number off to the system dialer so the user can still dial it.
+        launchUrl(Uri(scheme: 'tel', path: e.handle.value));
+      } else if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
+        CrashlyticsUtils.recordError(
+          'CallBloc - __onMutationControlStart selfManagedPhoneAccountNotRegistered',
+          information: ['callId: $callId', 'handle: ${e.handle.value}'],
+        );
+      } else {
+        _logger.warning('__onMutationControlStart error: $callkeepError');
+        onDiagnosticReportRequested(callId, callkeepError);
+      }
       emit(state.copyWithPopActiveCall(callId));
     }
   }

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import 'package:permission_handler/permission_handler.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_signaling/webtrit_signaling.dart';
@@ -176,7 +176,10 @@ final class EmergencyNumberNotification extends MessageNotification {
   SnackBarAction? action(BuildContext context) {
     return SnackBarAction(
       label: context.l10n.notifications_errorSnackBarAction_emergencyNumber,
-      onPressed: () => launchUrl(Uri(scheme: 'tel', path: number)),
+      onPressed: () async {
+        final telUri = Uri(scheme: 'tel', path: number);
+        if (await canLaunchUrl(telUri)) launchUrl(telUri);
+      },
     );
   }
 }

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:permission_handler/permission_handler.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
@@ -154,6 +155,29 @@ final class GeneralUnableToCallNotification extends MessageNotification {
   @override
   String l10n(BuildContext context) {
     return context.l10n.notifications_errorSnackBar_generalUnableToCall;
+  }
+}
+
+/// Shown when callkeep rejects an outgoing call because the number is an
+/// emergency number. A self-managed phone account cannot place emergency
+/// calls, so we explain why and offer to hand the number off to the system
+/// dialer instead of silently switching apps.
+final class EmergencyNumberNotification extends MessageNotification {
+  const EmergencyNumberNotification(this.number);
+
+  final String number;
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.notifications_errorSnackBar_emergencyNumber(number);
+  }
+
+  @override
+  SnackBarAction? action(BuildContext context) {
+    return SnackBarAction(
+      label: context.l10n.notifications_errorSnackBarAction_emergencyNumber,
+      onPressed: () => launchUrl(Uri(scheme: 'tel', path: number)),
+    );
   }
 }
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2514,6 +2514,18 @@ abstract class AppLocalizations {
   /// **'Disconnected from the core due to the following reason: {reason}'**
   String notifications_errorSnackBar_signalingDisconnectWithSystemReason(String reason);
 
+  /// Shown in a snackbar when the user tries to call a number the device recognizes as an emergency number (e.g. 999, 112, 911). The app cannot place emergency calls itself, so it offers to open the system phone dialer instead. The action button label is notifications_errorSnackBarAction_emergencyNumber.
+  ///
+  /// In en, this message translates to:
+  /// **'{number} is an emergency number and cannot be dialed from the app'**
+  String notifications_errorSnackBar_emergencyNumber(String number);
+
+  /// Action button on the emergency-number snackbar. Tapping it opens the system phone dialer pre-filled with the emergency number so the user can place the call there.
+  ///
+  /// In en, this message translates to:
+  /// **'Open dialer'**
+  String get notifications_errorSnackBarAction_emergencyNumber;
+
   /// Shown in a notification or snackbar when the app's signaling session for the signed-in user is lost or rejected and re-authentication is required. Typical causes: expired or revoked access/refresh tokens, failed token refresh, authentication rejected by the core (e.g. SIP/WebTrit 401 Unauthorized), or the signaling server closing the session. Advise the user to sign in again to restore full functionality.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -658,6 +658,8 @@ extension AppLocalizationsExtension on AppLocalizations {
         notifications_errorSnackBar_sessionExpired,
       'notifications_errorSnackBar_SignalingConnectFailed' =>
         notifications_errorSnackBar_SignalingConnectFailed,
+      'notifications_errorSnackBarAction_emergencyNumber' =>
+        notifications_errorSnackBarAction_emergencyNumber,
       'notifications_errorSnackBar_SignalingSessionMissed' =>
         notifications_errorSnackBar_SignalingSessionMissed,
       'notifications_errorSnackBar_sipRegistrationFailed_Unavailable' =>
@@ -1617,6 +1619,14 @@ extension AppLocalizationsExtension on AppLocalizations {
             'notifications_errorSnackBar_signalingDisconnectWithSystemReason requires 1 arguments',
           ),
         },
+      'notifications_errorSnackBar_emergencyNumber' => switch (args) {
+        [final String number] => notifications_errorSnackBar_emergencyNumber(
+          number,
+        ),
+        _ => throw ArgumentError(
+          'notifications_errorSnackBar_emergencyNumber requires 1 arguments',
+        ),
+      },
       'notifications_errorSnackBar_sipRegistrationFailed_WithSystemReason' =>
         switch (args) {
           [final String reason] =>

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1348,6 +1348,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String notifications_errorSnackBar_emergencyNumber(String number) {
+    return '$number is an emergency number and cannot be dialed from the app';
+  }
+
+  @override
+  String get notifications_errorSnackBarAction_emergencyNumber => 'Open dialer';
+
+  @override
   String get notifications_errorSnackBar_SignalingSessionMissed => 'Authentication error, please re-login';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1367,6 +1367,14 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String notifications_errorSnackBar_emergencyNumber(String number) {
+    return '$number e un numero di emergenza e non puo essere chiamato dall\'app';
+  }
+
+  @override
+  String get notifications_errorSnackBarAction_emergencyNumber => 'Apri il telefono';
+
+  @override
   String get notifications_errorSnackBar_SignalingSessionMissed =>
       'Errore di autenticazione, effettuare nuovamente l\'accesso';
 

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1368,7 +1368,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String notifications_errorSnackBar_emergencyNumber(String number) {
-    return '$number e un numero di emergenza e non puo essere chiamato dall\'app';
+    return '$number è un numero di emergenza e non può essere chiamato dall\'app';
   }
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1370,6 +1370,14 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String notifications_errorSnackBar_emergencyNumber(String number) {
+    return '$number - екстрений номер, його не можна набрати з застосунку';
+  }
+
+  @override
+  String get notifications_errorSnackBarAction_emergencyNumber => 'Відкрити дайлер';
+
+  @override
   String get notifications_errorSnackBar_SignalingSessionMissed => 'Помилка автентифікації, будь ласка увійдіть знову';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1149,6 +1149,19 @@
       }
     }
   },
+  "notifications_errorSnackBar_emergencyNumber": "{number} is an emergency number and cannot be dialed from the app",
+  "@notifications_errorSnackBar_emergencyNumber": {
+    "description": "Shown in a snackbar when the user tries to call a number the device recognizes as an emergency number (e.g. 999, 112, 911). The app cannot place emergency calls itself, so it offers to open the system phone dialer instead. The action button label is notifications_errorSnackBarAction_emergencyNumber.",
+    "placeholders": {
+      "number": {
+        "type": "String"
+      }
+    }
+  },
+  "notifications_errorSnackBarAction_emergencyNumber": "Open dialer",
+  "@notifications_errorSnackBarAction_emergencyNumber": {
+    "description": "Action button on the emergency-number snackbar. Tapping it opens the system phone dialer pre-filled with the emergency number so the user can place the call there."
+  },
   "notifications_errorSnackBar_SignalingSessionMissed": "Authentication error, please re-login",
   "@notifications_errorSnackBar_SignalingSessionMissed": {
     "description": "Shown in a notification or snackbar when the app's signaling session for the signed-in user is lost or rejected and re-authentication is required. Typical causes: expired or revoked access/refresh tokens, failed token refresh, authentication rejected by the core (e.g. SIP/WebTrit 401 Unauthorized), or the signaling server closing the session. Advise the user to sign in again to restore full functionality."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1149,6 +1149,16 @@
       }
     }
   },
+  "notifications_errorSnackBar_emergencyNumber": "{number} e un numero di emergenza e non puo essere chiamato dall'app",
+  "@notifications_errorSnackBar_emergencyNumber": {
+    "placeholders": {
+      "number": {
+        "type": "String"
+      }
+    }
+  },
+  "notifications_errorSnackBarAction_emergencyNumber": "Apri il telefono",
+  "@notifications_errorSnackBarAction_emergencyNumber": {},
   "notifications_errorSnackBar_SignalingSessionMissed": "Errore di autenticazione, effettuare nuovamente l'accesso",
   "@notifications_errorSnackBar_SignalingSessionMissed": {
     "description": "Shown in a notification or snackbar when the app's signaling session for the signed-in user is lost or rejected and re-authentication is required. Typical causes: expired or revoked access/refresh tokens, failed token refresh, authentication rejected by the core (e.g. SIP/WebTrit 401 Unauthorized), or the signaling server closing the session. Advise the user to sign in again to restore full functionality."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1149,7 +1149,7 @@
       }
     }
   },
-  "notifications_errorSnackBar_emergencyNumber": "{number} e un numero di emergenza e non puo essere chiamato dall'app",
+  "notifications_errorSnackBar_emergencyNumber": "{number} è un numero di emergenza e non può essere chiamato dall'app",
   "@notifications_errorSnackBar_emergencyNumber": {
     "placeholders": {
       "number": {

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1149,6 +1149,16 @@
       }
     }
   },
+  "notifications_errorSnackBar_emergencyNumber": "{number} - екстрений номер, його не можна набрати з застосунку",
+  "@notifications_errorSnackBar_emergencyNumber": {
+    "placeholders": {
+      "number": {
+        "type": "String"
+      }
+    }
+  },
+  "notifications_errorSnackBarAction_emergencyNumber": "Відкрити дайлер",
+  "@notifications_errorSnackBarAction_emergencyNumber": {},
   "notifications_errorSnackBar_SignalingSessionMissed": "Помилка автентифікації, будь ласка увійдіть знову",
   "@notifications_errorSnackBar_SignalingSessionMissed": {
     "description": "Shown in a notification or snackbar when the app's signaling session for the signed-in user is lost or rejected and re-authentication is required. Typical causes: expired or revoked access/refresh tokens, failed token refresh, authentication rejected by the core (e.g. SIP/WebTrit 401 Unauthorized), or the signaling server closing the session. Advise the user to sign in again to restore full functionality."


### PR DESCRIPTION
## Overview

Dialing a number Android treats as an emergency number (e.g. `999`) silently dropped the call: the call screen opened and immediately closed, the line was released, and the user got neither the native dialer nor a notification.

callkeep correctly returns `CallkeepCallRequestError.emergencyNumber` (a self-managed phone account is not allowed to place emergency calls). The Dart handler that acted on this was lost, and even when restored, the bare hand-off to the system dialer was confusing (the app silently switched away with no explanation).

## Root cause

The three-way handler in the outgoing-call path used to:
1. launch the system dialer via a `tel:` URI for `emergencyNumber`,
2. record `selfManagedPhoneAccountNotRegistered` to Crashlytics,
3. report diagnostics for other errors.

It was collapsed into a single log-and-pop branch during the mutation-queue refactor (#1220, shipped in 1.15.1), so `__onMutationControlStart` only logged the error and popped the call.

## Change

- Restore the three-way handling in `__onMutationControlStart` (`lib/features/call/bloc/call_bloc.dart`).
- Instead of silently launching the dialer, show an explanatory snackbar with an action button:
  - new `EmergencyNumberNotification` (`lib/features/call/models/notification.dart`) - message "{number} is an emergency number and cannot be dialed from the app" plus an "Open dialer" `SnackBarAction` that launches the `tel:` URI on tap.
  - new l10n keys `notifications_errorSnackBar_emergencyNumber` / `notifications_errorSnackBarAction_emergencyNumber` (en/uk/it), regenerated localizations + mapper.
- The system dialer cannot show a custom title/explanation (the `tel:` URI carries only the number), so the explanation is surfaced in-app before the hand-off.

Local to `webtrit_phone`; no callkeep change needed.

## Verification

- `flutter analyze` clean.
- pre-push: analyze + full test suite (740 tests) pass.
- Manual: dialing `999` now shows "999 is an emergency number..." with an "Open dialer" button; tapping it opens the system dialer pre-filled with 999.

Ref: WT-1600