### PR TITLE
fix: allow switching to earpiece in video calls on iOS (WT-1593)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1428,7 +1428,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   Future<void> _onCallControlEventAudioDeviceSet(_CallControlEventAudioDeviceSet event, Emitter<CallState> emit) async {
     await state.performOnActiveCall(event.callId, (activeCall) async {
-      await _mediaManager.setDevice(event.callId, event.device);
+      await _mediaManager.setDevice(event.callId, event.device, hasVideo: activeCall.video);
     });
   }
 

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -122,14 +122,24 @@ class CallMediaManager {
   /// Android: calls both [Helper.setSpeakerphoneOn] (AudioSwitch/AOSP) and
   /// [WebtritCallkeep.setAudioDevice] (Telecom/MIUI) with the actual device ID
   /// for cross-OEM compatibility.
-  /// iOS: uses [Helper.setSpeakerphoneOn] and [Helper.selectAudioInput].
-  Future<void> setDevice(String callId, CallAudioDevice device) async {
-    _logger.info('setDevice: ${device.type} (id=${device.id}) for call $callId');
+  /// iOS: uses [Helper.setSpeakerphoneOn] and [Helper.selectAudioInput], and
+  /// keeps the AVAudioSession mode in sync with the route — [hasVideo] selects
+  /// VideoChat vs VoiceChat for the speaker so a video call does not get stuck
+  /// in VoiceChat after an earpiece -> speaker toggle.
+  Future<void> setDevice(String callId, CallAudioDevice device, {required bool hasVideo}) async {
+    _logger.info('setDevice: ${device.type} (id=${device.id}) hasVideo=$hasVideo for call $callId');
     if (Platform.isAndroid) {
       await Helper.setSpeakerphoneOn(device.type == CallAudioDeviceType.speaker);
       await _callkeep.setAudioDevice(callId, device.toCallkeep());
     } else if (Platform.isIOS) {
       if (device.type == CallAudioDeviceType.speaker) {
+        // Restore the session mode that matches the call type before enabling
+        // the speaker: VideoChat for a video call (as onVideoEnabled sets),
+        // VoiceChat otherwise. Without this, a prior earpiece switch leaves a
+        // video call stuck in VoiceChat once the user toggles back to speaker.
+        await Helper.setAppleAudioConfiguration(
+          AppleAudioConfiguration(appleAudioMode: hasVideo ? AppleAudioMode.videoChat : AppleAudioMode.voiceChat),
+        );
         await setSpeaker(enabled: true);
       } else {
         // Reset the session mode to VoiceChat before disabling the speaker.

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -132,6 +132,13 @@ class CallMediaManager {
       if (device.type == CallAudioDeviceType.speaker) {
         await setSpeaker(enabled: true);
       } else {
+        // Reset the session mode to VoiceChat before disabling the speaker.
+        // During a video call the mode is VideoChat (set by onVideoEnabled), and
+        // Helper.setSpeakerphoneOn(false) cannot route to the earpiece while that
+        // mode is active — it silently keeps audio on the speaker. Mirrors
+        // onVideoDisabled. Without this the earpiece switch is a no-op for video
+        // calls, including when both cameras are off (WT-1593).
+        await Helper.setAppleAudioConfiguration(AppleAudioConfiguration(appleAudioMode: AppleAudioMode.voiceChat));
         await setSpeaker(enabled: false);
         final deviceId = device.id;
         if (deviceId != null) await Helper.selectAudioInput(deviceId);


### PR DESCRIPTION
## Overview

On iPhone the in-call speaker button is locked to loudspeaker during a video call: tapping it does not switch audio to the earpiece (WT-1593). Affects both a plain video call and the case where both cameras are off but the call is still in video mode.

## Root cause

When video is enabled, the iOS AVAudioSession is put into `VideoChat` mode (`onVideoEnabled`). In that mode `Helper.setSpeakerphoneOn(false)` cannot route audio to the earpiece - it silently keeps the speaker route. The user-triggered routing path `CallMediaManager.setDevice()` only flipped the speaker flag and never reset the mode, so the earpiece tap was a no-op.

The `onVideoDisabled` path already resets `VideoChat -> VoiceChat` before disabling the speaker; `setDevice` was missed when video audio routing was added (#1225).

## Change

In `setDevice()`, iOS branch: when routing to a non-speaker device, reset the Apple audio mode to `voiceChat` before `setSpeakerphoneOn(false)`, mirroring `onVideoDisabled`. This also covers the cameras-off scenario, where the mode is left as `VideoChat` (because `onVideoDisabled` early-returns while the speaker is active).

Android path is unchanged.

## Test plan

- [x] STR#1: start a video call, tap the speaker button -> audio switches to earpiece (camera live).
- [x] STR#2: start a video call, both sides turn the camera off, tap the speaker button -> audio switches to earpiece.
- [x] Switching back to speaker still works.
- [x] Android speaker/earpiece toggle unaffected.
