### PR TITLE
fix: restore analyze on develop (screenshots + pjsua_companion)

### DIFF
--- a/packages/pjsua_companion/bin/server.dart
+++ b/packages/pjsua_companion/bin/server.dart
@@ -237,7 +237,7 @@ Future<Process> _spawnPjsua(
     '--publish',
     '--log-level=1',
     if (autoAnswer) '--auto-answer=200',
-    if (callTarget != null) callTarget,
+    ?callTarget,
   ]);
 
   final pid = process.pid;

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -182,7 +182,7 @@ class _MainScreenScreenshotState extends State<MainScreenScreenshot> {
       case MainFlavor.keypad:
         return BlocProvider<KeypadCubit>(
           create: (context) => widget.interactive
-              ? KeypadCubit(context.read<ContactsRepository>())
+              ? KeypadCubit(_ScreenshotContactResolver(context.read<ContactsRepository>()))
               : (widget.keypadDialing ? MockKeypadCubit.dialing() : MockKeypadCubit.mainScreen()),
           child: Builder(
             // CallControllerScope is only read when a call action is tapped; provide it so the
@@ -238,6 +238,25 @@ class _MainScreenScreenshotState extends State<MainScreenScreenshot> {
           create: (_) => MockContactsExternalTabBloc.mainScreen(),
           child: const ContactsExternalTab(),
         );
+    }
+  }
+}
+
+/// Resolves contacts through the (mock) [ContactsRepository] for interactive
+/// keypad previews. Skips the self-number check of [DefaultContactResolver],
+/// which needs a [UserRepository] the screenshot harness does not provide.
+class _ScreenshotContactResolver implements ContactResolver {
+  _ScreenshotContactResolver(this._contactsRepository);
+
+  final ContactsRepository _contactsRepository;
+
+  @override
+  Future<Contact?> resolve(String? number) async {
+    if (number == null || number.isEmpty) return null;
+    try {
+      return await _contactsRepository.getContactByPhoneNumber(number);
+    } catch (_) {
+      return null;
     }
   }
 }


### PR DESCRIPTION
## Overview

`flutter analyze` is currently red on develop with two issues unrelated to any single feature, blocking the pre-push hook. This restores a clean analyze.

## Issues fixed

1. **error** - `screenshots/lib/screenshots/main_screen_screenshot.dart:185`: `KeypadCubit` now takes a `ContactResolver`, not a `ContactsRepository` (fallout from the recent contact-resolution refactor). The interactive keypad preview still passed the raw repository.
   - Added a small `_ScreenshotContactResolver` that delegates resolution to the (mock) `ContactsRepository`, preserving the preview behavior. It skips the self-number check of `DefaultContactResolver`, which needs a `UserRepository` the screenshot harness does not provide.
2. **info** - `packages/pjsua_companion/bin/server.dart:240`: replaced `if (callTarget != null) callTarget,` with the null-aware element `?callTarget,` (`use_null_aware_elements`).

## Test plan

- [x] `flutter analyze` -> No issues found.
- [x] Full test suite passes (pre-push hook).