### PR TITLE
refactor(_wsc): migrate web impl from dart:html to package:web

### DIFF
--- a/packages/_web_socket_channel/lib/_web_socket_channel.dart
+++ b/packages/_web_socket_channel/lib/_web_socket_channel.dart
@@ -7,7 +7,7 @@ import 'package:ssl_certificates/ssl_certificates.dart' show TrustedCertificates
 export 'package:ssl_certificates/ssl_certificates.dart' show TrustedCertificates;
 
 import 'src/_web_socket_channel_stub.dart'
-    if (dart.library.html) 'src/_web_socket_channel_html.dart'
+    if (dart.library.js_interop) 'src/_web_socket_channel_web.dart'
     if (dart.library.io) 'src/_web_socket_channel_io.dart'
     as platform;
 

--- a/packages/_web_socket_channel/lib/src/_web_socket_channel_web.dart
+++ b/packages/_web_socket_channel/lib/src/_web_socket_channel_web.dart
@@ -1,25 +1,27 @@
 import 'dart:async';
+import 'dart:js_interop';
 
 // This import is only used for web builds; not used in production.
-// ignore: deprecated_member_use
-import 'dart:html' as html;
+import 'package:web/web.dart' as web;
 
 import 'package:web_socket_channel/html.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'package:ssl_certificates/ssl_certificates.dart' show TrustedCertificates;
 
-Future<html.WebSocket> connectWebSocket(
+Future<web.WebSocket> connectWebSocket(
   String url, {
   Iterable<String>? protocols,
   Duration? connectionTimeout,
   Duration? pingInterval,
   TrustedCertificates certs = TrustedCertificates.empty,
 }) async {
-  final webSocket = html.WebSocket(url, protocols);
-  if (webSocket.readyState == 1) return webSocket;
+  final webSocket = protocols == null
+      ? web.WebSocket(url)
+      : web.WebSocket(url, protocols.map((e) => e.toJS).toList().toJS);
+  if (webSocket.readyState == web.WebSocket.OPEN) return webSocket;
 
-  final completer = Completer<html.WebSocket>();
+  final completer = Completer<web.WebSocket>();
 
   unawaited(
     webSocket.onOpen.first.then((_) {
@@ -28,9 +30,10 @@ Future<html.WebSocket> connectWebSocket(
   );
 
   unawaited(
-    webSocket.onError.first.then((event) {
-      final error = event is html.ErrorEvent ? event.error : null;
-      completer.completeError(error ?? 'unknown error');
+    webSocket.onError.first.then((_) {
+      // The underlying WebSocket API does not expose any specific information
+      // about the error itself.
+      completer.completeError('WebSocket connection failed.');
     }),
   );
 
@@ -42,6 +45,6 @@ Future<html.WebSocket> connectWebSocket(
 }
 
 /// Creates a [HtmlWebSocketChannel] for the provided [socket].
-WebSocketChannel createWebSocketChannel(html.WebSocket socket) {
+WebSocketChannel createWebSocketChannel(web.WebSocket socket) {
   return HtmlWebSocketChannel(socket);
 }

--- a/packages/_web_socket_channel/pubspec.yaml
+++ b/packages/_web_socket_channel/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   # (https://pub.dev/packages/web_socket_channel/changelog#241)
   web_socket_channel: ^3.0.3
 
+  web: ^1.1.0
+
   ssl_certificates:
     path: ../ssl_certificates
 


### PR DESCRIPTION
## Overview

WT-758. The web `WebSocket` implementation in the internal `_web_socket_channel`
package relied on the deprecated `dart:html`. This migrates it to
`package:web` + `dart:js_interop`, which is required for the package to compile
under the `dart2wasm` web target.

## Changes

- Rewrite the web implementation to use `package:web` `WebSocket` and
  `dart:js_interop` instead of `dart:html` (drops the `deprecated_member_use`
  ignore).
- Rename `src/_web_socket_channel_html.dart` -> `src/_web_socket_channel_web.dart`.
- Select the web implementation via the `dart.library.js_interop` conditional
  import instead of `dart.library.html` (so wasm builds resolve it instead of
  falling through to the unsupported stub).
- Add `web: ^1.1.0` as a direct dependency of the package.

The public API (`connectWebSocket` / `createWebSocketChannel`) is unchanged;
`web_socket_channel`'s `HtmlWebSocketChannel` already accepts a `package:web`
`WebSocket`. The implementation is web-only and not used in production builds.

## Notes

The task description also mentioned a `drift/web.dart` -> `drift/wasm.dart`
migration; that is already done in the codebase (no `drift/web.dart` usages
remain, `app_database` uses `drift/wasm.dart`), so it is out of scope here.

## Test plan

- `dart analyze` clean on the package.
- pre-push: `flutter analyze` + full `flutter test` suite pass (740 tests).