### PR TITLE
fix: null check crash in CallToActionsCubit.changeLocale (WT-960)

### DIFF
--- a/lib/features/call_to_actions/bloc/call_to_actions_cubit.dart
+++ b/lib/features/call_to_actions/bloc/call_to_actions_cubit.dart
@@ -36,11 +36,15 @@ class CallToActionsCubit extends Cubit<CallToActionsCubitState> {
     // Emit the updated state with the new locale, resetting flavor and actions
     emit(state.copyWith(locale: locale, flavor: null, actions: {}));
 
-    // Re-fetch actions if a flavor was previously set
-    if (flavor != null) getActions(state.flavor!);
+    // Re-fetch actions for the previously set flavor (no-op if none was set).
+    // Pass the captured local `flavor`, not `state.flavor`, which the emit above
+    // just reset to null.
+    getActions(flavor);
   }
 
-  Future<void> getActions(MainFlavor flavor) async {
+  Future<void> getActions(MainFlavor? flavor) async {
+    if (flavor == null) return;
+
     if (state.flavor == flavor) {
       _logger.finest('Flavor $flavor is already set.');
       return;


### PR DESCRIPTION
## Overview

Fixes a FATAL crash (`Null check operator used on a null value`) when changing the app language while a call-to-actions flavor is active. Reported in WT-960 (Crashlytics, FATAL, long-standing across 4.3.1-4.4.4).

## Root cause

`CallToActionsCubit.changeLocale` captured the previous flavor into a local, then emitted a new state with `flavor: null`, and finally re-fetched actions via `getActions(state.flavor!)`. Because the emit had already reset `state.flavor` to `null`, the `state.flavor!` force-unwrap always threw whenever a flavor was previously set. The method is not wrapped in try/catch, so the exception propagated through `runZonedGuarded` and crashed the app on language change.

```dart
final flavor = state.flavor;
emit(state.copyWith(locale: locale, flavor: null, actions: {})); // state.flavor -> null
if (flavor != null) getActions(state.flavor!);                   // state.flavor! -> throws
```

## Fix

Move the null guard into `getActions` (now `MainFlavor?`) so it cleanly no-ops on a null flavor, and pass the captured local `flavor` instead of the just-nulled `state.flavor`:

```dart
void changeLocale(Locale locale) {
  final flavor = state.flavor;
  emit(state.copyWith(locale: locale, flavor: null, actions: {}));
  getActions(flavor);
}

Future<void> getActions(MainFlavor? flavor) async {
  if (flavor == null) return;
  ...
}
```

The other caller (`main_screen_page.dart`) passes a non-null `MainFlavor` and is unaffected.

Note: PR #1245 ("fix: call to actions null check") addressed a different `!` (`userInfo.email!` in `_loadFlavorActions`); this `changeLocale` crash was untouched and remained live on develop.

## Test plan

- `flutter analyze` clean; full `flutter test` suite passes (pre-push hook).
- Manual: set a call-to-actions flavor, then change the language in Settings -> app no longer crashes and actions re-load for the new locale.