### PR TITLE
fix: map password_change_required to a dedicated API exception (WT-950)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -491,18 +491,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> _notifyAccountErrorSafely() async {
     try {
       await userRepository.getRemoteInfo();
+    } on PasswordChangeRequiredException {
+      _logger.info('Account session revoked');
+      submitNotification(const SelfCarePasswordExpiredNotification());
     } on RequestFailure catch (e) {
-      final errorCode = AccountErrorCode.values.firstWhereOrNull((it) => it.value == e.error?.code);
-
-      switch (errorCode) {
-        case AccountErrorCode.passwordChangeRequired:
-          _logger.info('Account session revoked');
-          submitNotification(const SelfCarePasswordExpiredNotification());
-          break;
-        default:
-          _logger.warning('Account error code: $errorCode');
-          break;
-      }
+      _logger.warning('Account error code: ${e.error?.code}');
     } catch (e, st) {
       _logger.warning('Unexpected error during account info refresh', e, st);
     }

--- a/packages/webtrit_api/lib/src/exceptions.dart
+++ b/packages/webtrit_api/lib/src/exceptions.dart
@@ -81,3 +81,16 @@ class SessionMissingException extends RequestFailure {
   @override
   String toString() => 'SessionMissingException(statusCode: $statusCode, requestId: $requestId, url: $url)';
 }
+
+class PasswordChangeRequiredException extends RequestFailure {
+  PasswordChangeRequiredException({
+    required super.url,
+    required super.requestId,
+    required super.statusCode,
+    super.token,
+    super.error,
+  });
+
+  @override
+  String toString() => 'PasswordChangeRequiredException(statusCode: $statusCode, requestId: $requestId, url: $url)';
+}

--- a/packages/webtrit_api/lib/src/exceptions.dart
+++ b/packages/webtrit_api/lib/src/exceptions.dart
@@ -90,7 +90,4 @@ class PasswordChangeRequiredException extends RequestFailure {
     super.token,
     super.error,
   });
-
-  @override
-  String toString() => 'PasswordChangeRequiredException(statusCode: $statusCode, requestId: $requestId, url: $url)';
 }

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -203,6 +203,19 @@ class WebtritApiClient {
             );
           }
 
+          // Map password_change_required (self-care password expired, HTTP 403) to a
+          // dedicated exception so callers can surface the "password expired" message
+          // instead of treating it as a generic, unactionable request failure.
+          if (error?.code == AccountErrorCode.passwordChangeRequired.value) {
+            throw PasswordChangeRequiredException(
+              url: tenantUrl,
+              requestId: xRequestId,
+              statusCode: httpResponse.statusCode,
+              token: token,
+              error: error,
+            );
+          }
+
           throw RequestFailure(
             url: tenantUrl,
             statusCode: httpResponse.statusCode,

--- a/packages/webtrit_api/test/webtrit_api_client_password_change_required_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_client_password_change_required_test.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'package:webtrit_api/webtrit_api.dart';
+
+const authority = 'example.com';
+const baseUri = 'https://$authority';
+const tenantId = 'tenant-id';
+const token = 'fake_token';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+class FakeBaseRequest extends Fake implements http.BaseRequest {}
+
+http.StreamedResponse _jsonResponse(Object json, int status) {
+  final body = jsonEncode(json);
+  return http.StreamedResponse(Stream.value(utf8.encode(body)), status, headers: {'content-type': 'application/json'});
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeBaseRequest());
+  });
+
+  group('PasswordChangeRequiredException', () {
+    late MockHttpClient mockHttpClient;
+    late WebtritApiClient apiClient;
+
+    setUp(() {
+      mockHttpClient = MockHttpClient();
+      apiClient = WebtritApiClient.inner(Uri.parse(baseUri), tenantId, httpClient: mockHttpClient);
+    });
+
+    tearDown(() {
+      apiClient.close();
+      reset(mockHttpClient);
+    });
+
+    test('throws on 403 with code "password_change_required" and does not retry', () async {
+      when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+        return _jsonResponse({'code': 'password_change_required', 'message': 'Password change required'}, 403);
+      });
+
+      await expectLater(
+        () => apiClient.getUserInfo(token),
+        throwsA(
+          isA<PasswordChangeRequiredException>()
+              .having((e) => e.statusCode, 'statusCode', 403)
+              .having((e) => e.error?.code, 'error.code', 'password_change_required'),
+        ),
+      );
+
+      // PasswordChangeRequiredException extends RequestFailure, so the retry loop
+      // must rethrow immediately rather than retrying the server response.
+      verify(() => mockHttpClient.send(any())).called(1);
+      verifyNoMoreInteractions(mockHttpClient);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Closes the remaining edge from WT-950: on the user-info HTTP path, an HTTP 403 with code `password_change_required` fell through to a generic `RequestFailure`, so the self-care password-expired state could only be detected by string-matching the error code. This maps it to a dedicated, typed exception.

> Context: the original WT-950 FATAL crash is already gone (the `UserRepository` rewrite in #1015 removed the `addError` -> stream -> zone -> fatal path; DNS/SocketException and 401/404/422 are handled). This PR only addresses the leftover `password_change_required` typing/UX edge, which was never a crash.

## Change

- New `PasswordChangeRequiredException` (extends `RequestFailure`) in `webtrit_api`.
- `_httpClientExecute` throws it when `error.code == password_change_required`, keyed on the error code like `voicemail_not_configured`. Because it extends `RequestFailure`, the retry loop still rethrows immediately and every existing `RequestFailure` handler keeps working unchanged.
- `CallBloc._notifyAccountErrorSafely` now catches the typed exception directly instead of matching `AccountErrorCode` against `RequestFailure.error.code` (same behavior - submits `SelfCarePasswordExpiredNotification` - just type-safe and simpler).

## Not in scope

Surfacing the notification from the background user-info polling path (`UserRepository.refresh`) is intentionally left out: it would require wiring a notification dispatcher into the repository, and the same state is already surfaced to the user via the signaling-triggered `_notifyAccountErrorSafely`. The dedicated exception now makes that a small follow-up if desired.

## Test plan

- New unit test: 403 + `password_change_required` -> `PasswordChangeRequiredException`, asserts status/code and that it does **not** retry (single `send`).
- `flutter analyze` clean; full `flutter test` suite passes (pre-push hook).