### PR TITLE
feat: generalized session side-issues with avatar indicator and account summary

### DIFF
--- a/lib/extensions/extensions.dart
+++ b/lib/extensions/extensions.dart
@@ -25,6 +25,7 @@ export 'request_failure.dart';
 export 'route_match.dart';
 export 'rtc_peer_connection_extension.dart';
 export 'secure_storage_extension.dart';
+export 'session_issue.dart';
 export 'session_status.dart';
 export 'signaling_exception.dart';
 export 'signaling_hangup_failure.dart';

--- a/lib/extensions/session_issue.dart
+++ b/lib/extensions/session_issue.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+extension SessionIssueSeverityColor on SessionIssueSeverity {
+  // TODO(Serdun): Move to color scheme
+  Color color(BuildContext context) {
+    switch (this) {
+      case SessionIssueSeverity.critical:
+        return Colors.red;
+      case SessionIssueSeverity.warning:
+        return Colors.orange;
+      case SessionIssueSeverity.info:
+        return Colors.blueGrey;
+    }
+  }
+}
+
+extension SessionIssueL10n on SessionIssue {
+  /// Short title shown where a single line is available (e.g. account row title).
+  String title(BuildContext context) {
+    switch (id) {
+      case SessionIssueId.limitedStandaloneCallMode:
+        return context.l10n.sessionStatus_issue_limitedStandaloneCallMode_title;
+    }
+  }
+
+  /// One-line caption summarizing the issue (e.g. account row subtitle).
+  String caption(BuildContext context) {
+    switch (id) {
+      case SessionIssueId.limitedStandaloneCallMode:
+        return context.l10n.sessionStatus_issue_limitedStandaloneCallMode_caption;
+    }
+  }
+
+  Color color(BuildContext context) => severity.color(context);
+}

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -4,6 +4,8 @@ import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
 
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
+
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
 
@@ -22,6 +24,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     _callSubscription = callBloc.stream.listen(_onCallChanged);
 
     _emitCombinedStatus();
+    _fetchCallDeliveryMode();
   }
 
   late final StreamSubscription<PushTokensState> _pushTokensSubscription;
@@ -29,6 +32,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
 
   PushTokensState? _lastPushTokensState;
   CallState? _lastCallState;
+  CallkeepAndroidCallDeliveryMode _callDeliveryMode = CallkeepAndroidCallDeliveryMode.unknown;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
     _lastPushTokensState = pushTokens;
@@ -38,6 +42,29 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   void _onCallChanged(CallState call) {
     _lastCallState = call;
     _emitCombinedStatus();
+  }
+
+  /// The call-delivery mode is a device capability that does not change at
+  /// runtime, so it is fetched once at session start.
+  Future<void> _fetchCallDeliveryMode() async {
+    try {
+      _callDeliveryMode = await WebtritCallkeepPermissions().getCallDeliveryMode();
+      _emitCombinedStatus();
+    } catch (e) {
+      _logger.warning('fetchCallDeliveryMode', e);
+    }
+  }
+
+  /// Builds the generic side-issue list from the known sources. Add a source
+  /// here to surface a new issue; the UI consumes the list generically.
+  List<SessionIssue> _buildIssues() {
+    final issues = <SessionIssue>[];
+    if (_callDeliveryMode == CallkeepAndroidCallDeliveryMode.standalone) {
+      issues.add(
+        const SessionIssue(id: SessionIssueId.limitedStandaloneCallMode, severity: SessionIssueSeverity.warning),
+      );
+    }
+    return issues;
   }
 
   void _emitCombinedStatus() {
@@ -56,6 +83,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     emit(
       state.copyWith(
         status: SessionStatus(signalingStatus: call.status, pushTokenError: pushTokenError),
+        issues: _buildIssues(),
       ),
     );
   }

--- a/lib/features/session_status/bloc/session_status_cubit.freezed.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SessionStatusState {
 
- SessionStatus get status;
+ SessionStatus get status; List<SessionIssue> get issues;
 /// Create a copy of SessionStatusState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $SessionStatusStateCopyWith<SessionStatusState> get copyWith => _$SessionStatusS
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionStatusState&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionStatusState&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other.issues, issues));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,status);
+int get hashCode => Object.hash(runtimeType,status,const DeepCollectionEquality().hash(issues));
 
 @override
 String toString() {
-  return 'SessionStatusState(status: $status)';
+  return 'SessionStatusState(status: $status, issues: $issues)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $SessionStatusStateCopyWith<$Res>  {
   factory $SessionStatusStateCopyWith(SessionStatusState value, $Res Function(SessionStatusState) _then) = _$SessionStatusStateCopyWithImpl;
 @useResult
 $Res call({
- SessionStatus status
+ SessionStatus status, List<SessionIssue> issues
 });
 
 
@@ -62,10 +62,11 @@ class _$SessionStatusStateCopyWithImpl<$Res>
 
 /// Create a copy of SessionStatusState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? issues = null,}) {
   return _then(SessionStatusState(
 status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
-as SessionStatus,
+as SessionStatus,issues: null == issues ? _self.issues : issues // ignore: cast_nullable_to_non_nullable
+as List<SessionIssue>,
   ));
 }
 

--- a/lib/features/session_status/bloc/session_status_state.dart
+++ b/lib/features/session_status/bloc/session_status_state.dart
@@ -2,8 +2,22 @@ part of 'session_status_cubit.dart';
 
 @freezed
 class SessionStatusState with _$SessionStatusState {
-  const SessionStatusState({this.status = const SessionStatus(signalingStatus: CallStatus.inProgress)});
+  const SessionStatusState({
+    this.status = const SessionStatus(signalingStatus: CallStatus.inProgress),
+    this.issues = const [],
+  });
 
   @override
   final SessionStatus status;
+
+  /// Side issues independent of the primary signaling [status] (e.g. limited
+  /// standalone call mode). Drives the avatar indicator and account summary.
+  @override
+  final List<SessionIssue> issues;
+
+  bool get hasIssues => issues.isNotEmpty;
+
+  /// The most severe issue (ties resolved by first occurrence), or null.
+  SessionIssue? get topIssue =>
+      issues.isEmpty ? null : issues.reduce((a, b) => b.severity.index > a.severity.index ? b : a);
 }

--- a/lib/features/session_status/session_status.dart
+++ b/lib/features/session_status/session_status.dart
@@ -1,2 +1,3 @@
 export 'bloc/session_status_cubit.dart';
 export 'view/view.dart';
+export 'widgets/widgets.dart';

--- a/lib/features/session_status/widgets/session_issue_badge.dart
+++ b/lib/features/session_status/widgets/session_issue_badge.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Small circular "!" badge used to flag that the session has at least one side
+/// issue. Color is driven by the issue severity; callers position it as an
+/// overlay (e.g. on the user avatar).
+class SessionIssueBadge extends StatelessWidget {
+  const SessionIssueBadge({super.key, required this.color, this.size = 14});
+
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        border: Border.all(color: Theme.of(context).colorScheme.surface, width: 1.5),
+      ),
+      child: Icon(Icons.priority_high, color: Colors.white, size: size),
+    );
+  }
+}

--- a/lib/features/session_status/widgets/widgets.dart
+++ b/lib/features/session_status/widgets/widgets.dart
@@ -1,0 +1,1 @@
+export 'session_issue_badge.dart';

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -67,12 +67,19 @@ class SettingsScreen extends StatelessWidget {
                   ),
                   children: [
                     BlocBuilder<UserInfoCubit, UserInfoState>(
-                      builder: (context, state) => UserInfoListTile(info: state.userInfo),
+                      builder: (context, state) => UserInfoListTile(
+                        info: state.userInfo,
+                        topIssue: context.watch<SessionStatusCubit>().state.topIssue,
+                      ),
                     ),
                     BlocBuilder<SessionStatusCubit, SessionStatusState>(
-                      buildWhen: (previous, current) => previous.status != current.status,
-                      builder: (context, sessionState) =>
-                          SessionStatusListTile(status: sessionState.status, onTap: () => _onDiagnosticTap(context)),
+                      buildWhen: (previous, current) =>
+                          previous.status != current.status || previous.topIssue != current.topIssue,
+                      builder: (context, sessionState) => SessionStatusListTile(
+                        status: sessionState.status,
+                        topIssue: sessionState.topIssue,
+                        onTap: () => _onDiagnosticTap(context),
+                      ),
                     ),
                     if (showSeparators) ListTileSeparator(color: effectiveStyle?.separatorColor),
                     BlocBuilder<RegisterStatusCubit, RegisterStatus>(

--- a/lib/features/settings/widgets/session_status_list_tile.dart
+++ b/lib/features/settings/widgets/session_status_list_tile.dart
@@ -10,9 +10,19 @@ import '../../microphone_status/microphone_status.dart';
 import '../settings.dart';
 
 class SessionStatusListTile extends StatelessWidget {
-  const SessionStatusListTile({super.key, required this.status, this.info, this.onTap, this.contentPadding});
+  const SessionStatusListTile({
+    super.key,
+    required this.status,
+    this.topIssue,
+    this.info,
+    this.onTap,
+    this.contentPadding,
+  });
 
   final SessionStatus status;
+
+  /// Most severe active side issue, surfaced as a warning subtitle. Null hides it.
+  final SessionIssue? topIssue;
   final UserInfo? info;
   final VoidCallback? onTap;
   final EdgeInsetsGeometry? contentPadding;
@@ -35,6 +45,12 @@ class SessionStatusListTile extends StatelessWidget {
                   child: CircleAvatar(radius: 4, backgroundColor: status.color(context)),
                 ),
                 title: Text(status.l10n(context), key: status.key, style: themeData.textTheme.labelLarge),
+                subtitle: topIssue == null
+                    ? null
+                    : Text(
+                        topIssue!.caption(context),
+                        style: themeData.textTheme.bodySmall?.copyWith(color: topIssue!.color(context)),
+                      ),
                 trailing: const Icon(Icons.arrow_right),
               ),
               BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(

--- a/lib/features/settings/widgets/user_info_list_tile.dart
+++ b/lib/features/settings/widgets/user_info_list_tile.dart
@@ -3,13 +3,17 @@ import 'package:flutter/material.dart';
 import 'package:webtrit_phone/models/models.dart';
 
 import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/features/session_status/session_status.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 class UserInfoListTile extends StatelessWidget {
-  const UserInfoListTile({super.key, this.info, this.onEditPressed, this.contentPadding});
+  const UserInfoListTile({super.key, this.info, this.topIssue, this.onEditPressed, this.contentPadding});
 
   final UserInfo? info;
+
+  /// Most severe active side issue, shown as a badge overlay on the avatar. Null hides it.
+  final SessionIssue? topIssue;
   final VoidCallback? onEditPressed;
 
   final EdgeInsetsGeometry? contentPadding;
@@ -37,12 +41,19 @@ class UserInfoListTile extends StatelessWidget {
         minimum: resolvedContentPadding,
         child: Row(
           children: [
-            LeadingAvatar(
-              username: info?.name ?? info?.numbers.main,
-              thumbnailUrl: gravatarThumbnailUrl(info?.email),
-              radius: radius,
-              showLoading: true,
-              loadingPadding: EdgeInsets.zero,
+            Stack(
+              clipBehavior: Clip.none,
+              children: [
+                LeadingAvatar(
+                  username: info?.name ?? info?.numbers.main,
+                  thumbnailUrl: gravatarThumbnailUrl(info?.email),
+                  radius: radius,
+                  showLoading: true,
+                  loadingPadding: EdgeInsets.zero,
+                ),
+                if (topIssue != null)
+                  Positioned(right: -2, bottom: -2, child: SessionIssueBadge(color: topIssue!.color(context))),
+              ],
             ),
             const SizedBox(width: 8),
             Expanded(

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -3312,6 +3312,18 @@ abstract class AppLocalizations {
   /// **'Problem with configuration push notification service'**
   String get sessionStatus_pushNotificationServiceProblem;
 
+  /// No description provided for @sessionStatus_issue_limitedStandaloneCallMode_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Limited call mode'**
+  String get sessionStatus_issue_limitedStandaloneCallMode_title;
+
+  /// No description provided for @sessionStatus_issue_limitedStandaloneCallMode_caption.
+  ///
+  /// In en, this message translates to:
+  /// **'Standalone - delivery may be delayed'**
+  String get sessionStatus_issue_limitedStandaloneCallMode_caption;
+
   /// Status message displayed while the application is performing cleanup during the logout process.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -826,6 +826,10 @@ extension AppLocalizationsExtension on AppLocalizations {
       'sessionStatus_AppBar_connecting' => sessionStatus_AppBar_connecting,
       'sessionStatus_pushNotificationServiceProblem' =>
         sessionStatus_pushNotificationServiceProblem,
+      'sessionStatus_issue_limitedStandaloneCallMode_title' =>
+        sessionStatus_issue_limitedStandaloneCallMode_title,
+      'sessionStatus_issue_limitedStandaloneCallMode_caption' =>
+        sessionStatus_issue_limitedStandaloneCallMode_caption,
       'session_Teardown_progressText' => session_Teardown_progressText,
       'settings_AboutText_ApplicationEmbeddedLinks' =>
         settings_AboutText_ApplicationEmbeddedLinks,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1784,6 +1784,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'Problem with configuration push notification service';
 
   @override
+  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Limited call mode';
+
+  @override
+  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - delivery may be delayed';
+
+  @override
   String get session_Teardown_progressText => 'Signing out...';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1806,6 +1806,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Problema con la configurazione del servizio di notifiche push';
 
   @override
+  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Limited call mode';
+
+  @override
+  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - delivery may be delayed';
+
+  @override
   String get session_Teardown_progressText => 'Disconnessione in corso...';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1806,10 +1806,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Problema con la configurazione del servizio di notifiche push';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Limited call mode';
+  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Modalità chiamate limitata';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - delivery may be delayed';
+  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - possibile ritardo nella consegna';
 
   @override
   String get session_Teardown_progressText => 'Disconnessione in corso...';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1806,6 +1806,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'Проблема з налаштуванням служби пуш-сповіщень';
 
   @override
+  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Limited call mode';
+
+  @override
+  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - delivery may be delayed';
+
+  @override
   String get session_Teardown_progressText => 'Вихід із системи...';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1806,10 +1806,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'Проблема з налаштуванням служби пуш-сповіщень';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Limited call mode';
+  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Обмежений режим дзвінків';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - delivery may be delayed';
+  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone — можлива затримка доставки';
 
   @override
   String get session_Teardown_progressText => 'Вихід із системи...';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1493,6 +1493,10 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Problem with configuration push notification service",
   "@sessionStatus_pushNotificationServiceProblem": {},
+  "sessionStatus_issue_limitedStandaloneCallMode_title": "Limited call mode",
+  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
+  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone - delivery may be delayed",
+  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Signing out...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1490,6 +1490,10 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Problema con la configurazione del servizio di notifiche push",
   "@sessionStatus_pushNotificationServiceProblem": {},
+  "sessionStatus_issue_limitedStandaloneCallMode_title": "Modalità chiamate limitata",
+  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
+  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone - possibile ritardo nella consegna",
+  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Disconnessione in corso...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1490,6 +1490,10 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Проблема з налаштуванням служби пуш-сповіщень",
   "@sessionStatus_pushNotificationServiceProblem": {},
+  "sessionStatus_issue_limitedStandaloneCallMode_title": "Обмежений режим дзвінків",
+  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
+  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone — можлива затримка доставки",
+  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Вихід із системи...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -40,6 +40,7 @@ export 'queued_termination_request.dart';
 export 'recent.dart';
 export 'recents_visibility_filter.dart';
 export 'rtp_codec_profile.dart';
+export 'session_issue.dart';
 export 'session_status.dart';
 export 'settings_flavor.dart';
 export 'settings_sync_metadata.dart';

--- a/lib/models/session_issue.dart
+++ b/lib/models/session_issue.dart
@@ -1,0 +1,31 @@
+/// Severity of a [SessionIssue]. Drives the indicator color and ordering
+/// (higher index = more severe).
+enum SessionIssueSeverity { info, warning, critical }
+
+/// Identifies a side issue surfaced in the session-status indicator.
+///
+/// This is the generic registry of "things worth warning the user about" that
+/// are independent of the primary signaling/connection status. To surface a new
+/// kind of issue: add a value here, produce it from a source in
+/// `SessionStatusCubit`, and add its strings to `SessionIssueL10n`. The UI
+/// (avatar badge, account summary, diagnostic details) stays generic.
+enum SessionIssueId { limitedStandaloneCallMode }
+
+/// A single side issue with its severity. The id resolves to user-facing
+/// strings via the `SessionIssueL10n` extension.
+class SessionIssue {
+  const SessionIssue({required this.id, required this.severity});
+
+  final SessionIssueId id;
+  final SessionIssueSeverity severity;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is SessionIssue && id == other.id && severity == other.severity;
+
+  @override
+  int get hashCode => Object.hash(id, severity);
+
+  @override
+  String toString() => 'SessionIssue(id: $id, severity: $severity)';
+}

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -177,6 +177,18 @@ class _MainAppBarState extends State<MainAppBar> {
                             );
                           },
                         ),
+                        BlocBuilder<SessionStatusCubit, SessionStatusState>(
+                          buildWhen: (previous, current) => previous.topIssue != current.topIssue,
+                          builder: (context, sessionState) {
+                            final topIssue = sessionState.topIssue;
+                            if (topIssue == null) return const SizedBox.shrink();
+                            return Positioned(
+                              right: -2,
+                              bottom: -2,
+                              child: SessionIssueBadge(color: topIssue.color(context), size: 12),
+                            );
+                          },
+                        ),
                       ],
                     ),
                     onPressed: () {

--- a/test/features/session_status/bloc/session_status_state_test.dart
+++ b/test/features/session_status/bloc/session_status_state_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/session_status/bloc/session_status_cubit.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+void main() {
+  group('SessionStatusState issue aggregation', () {
+    const warning = SessionIssue(id: SessionIssueId.limitedStandaloneCallMode, severity: SessionIssueSeverity.warning);
+    const critical = SessionIssue(
+      id: SessionIssueId.limitedStandaloneCallMode,
+      severity: SessionIssueSeverity.critical,
+    );
+    const info = SessionIssue(id: SessionIssueId.limitedStandaloneCallMode, severity: SessionIssueSeverity.info);
+
+    test('empty issues -> no issues, null topIssue', () {
+      const state = SessionStatusState();
+      expect(state.hasIssues, isFalse);
+      expect(state.topIssue, isNull);
+    });
+
+    test('single issue -> hasIssues, topIssue is it', () {
+      const state = SessionStatusState(issues: [warning]);
+      expect(state.hasIssues, isTrue);
+      expect(state.topIssue, warning);
+    });
+
+    test('topIssue picks the most severe', () {
+      const state = SessionStatusState(issues: [info, warning, critical]);
+      expect(state.topIssue, critical);
+    });
+
+    test('topIssue prefers warning over info', () {
+      const state = SessionStatusState(issues: [info, warning]);
+      expect(state.topIssue, warning);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Generalize how session-level problems are surfaced. Instead of hardcoding a single status, `session_status` now carries a generic list of **side issues** (id + severity), independent of the primary signaling/connection status. The UI consumes the aggregated list generically, so new issue sources can be added without touching the indicator widgets.

The first (and currently only) source is the limited standalone call mode (no Android Telecom). It is intentionally pluggable: more sources (battery, push, etc.) can be added later by producing more `SessionIssue`s.

## Behaviour (matches mockups)

- **Top app bar (all tabs)**: a generic orange "!" badge on the user avatar whenever there is >=1 issue, colored by the most severe. The connection status keeps its own signal (avatar ring / dot) - side issues are purely additive.
- **My account**: the same "!" badge on the avatar + a warning subtitle (top issue, e.g. "Standalone - delivery may be delayed") on the status row, which already taps through to Diagnostic for details.

## Changes

- `SessionIssue` model (`id` + `severity`) + `SessionIssueL10n`/severity-color extension.
- `SessionStatusState` gains `List<SessionIssue> issues` with `hasIssues` / `topIssue` helpers.
- `SessionStatusCubit` fetches the call-delivery mode once at session start and produces the standalone issue.
- Reusable `SessionIssueBadge`; wired into `MainAppBar` and `UserInfoListTile`; `SessionStatusListTile` shows the top-issue subtitle.
- l10n `sessionStatus_issue_*` (English base; UK/IT via Localizely).
- Unit tests for issue aggregation (`topIssue` / `hasIssues`).

## Relationship to other PRs

- **Depends on** callkeep `getCallDeliveryMode()` (WebTrit/webtrit_callkeep#310). Via the path dependency, CI here will not build until #310 lands on callkeep develop. Verified locally against the callkeep branch.
- Complementary to #1365 (which adds the standalone **details** section on the Diagnostic screen). This PR adds the **aggregated indicator** (avatar + account). Both branch from develop; minor l10n/codegen overlap is expected at merge.

## Scope

Deliberately minimal per the agreed direction: generic registry + avatar "!" + account summary, with standalone as the first consumer. Microphone permission keeps its existing dedicated badge for now; connection status is not duplicated as an issue. These can migrate into the registry later.
