### PR TITLE
fix: handle messaging socket connect failures at the source (WT-961)

### DIFF
--- a/lib/features/messaging/bloc/messaging_bloc.dart
+++ b/lib/features/messaging/bloc/messaging_bloc.dart
@@ -71,7 +71,20 @@ class MessagingBloc extends Bloc<MessagingEvent, MessagingState> {
     // wipeData()
 
     emit(state.copyWith(status: ConnectionStatus.connecting));
-    _client.connect();
+
+    // This connect() is fire-and-forget; without a handler its error would escape to
+    // runZonedGuarded and be recorded as a FATAL crash. See _onConnectError.
+    unawaited(_client.connect().catchError(_onConnectError));
+  }
+
+  // Handle a connect-time transport failure (DNS "Failed host lookup", connection
+  // timeout, TLS) at the socket owner: route it through the existing _ClientError path
+  // so it surfaces as the bloc error state instead of an uncaught FATAL. The Phoenix
+  // socket reconnects on its own.
+  PhoenixSocket? _onConnectError(Object e, StackTrace s) {
+    _logger.warning('_connect failed', e, s);
+    if (!isClosed) add(_ClientError(e));
+    return null;
   }
 
   void _refresh(Refresh event, Emitter<MessagingState> emit) async {


### PR DESCRIPTION
## Overview

On poor connectivity (roaming, VPN, weak signal) the messaging Phoenix socket connect
could surface a transport error -- a DNS "Failed host lookup", connection timeout or TLS
error. `MessagingBloc._connect` fired the connect as fire-and-forget (`_client.connect()`
with no `await` and no error handler), so that error had nowhere to go and escaped to
`runZonedGuarded` in `main.dart`, where it was recorded as a **FATAL** crash -- even
though the Phoenix socket reconnects on its own.

Fix it at the source (the socket owner) rather than by reclassifying errors at the global
zone guard.

## Changes

- `MessagingBloc._connect`: attach a `catchError` to `_client.connect()` that routes the
  failure through the existing `_ClientError` event, so it surfaces as the bloc error
  state instead of crashing. Guarded by `isClosed` to avoid adding an event after the bloc
  is closed.

## Notes

- The crashing socket is the **Phoenix messaging** socket (`phoenix_socket`), not the
  `webtrit_signaling` call socket -- the ticket title `[webtrit_signaling]` is misleading.
- `phoenix_socket` ^0.8.0 already reconnects internally with backoff + jitter, so no extra
  reconnect logic is needed here; this PR only stops the connect error from being an
  uncaught FATAL.

Refs WT-961. Related: WT-952 (Phoenix protocol-error 1002 variant).