### PR TITLE
refactor: centralize local-vs-external contact collision tie-break

### DIFF
--- a/packages/data/AGENTS.md
+++ b/packages/data/AGENTS.md
@@ -54,6 +54,26 @@ dart test test/contacts_dao_test.dart
 - `watch()` methods for reactive UI updates.
 - Never edit `.g.dart` manually.
 
+#### Contact source priority (number collisions)
+
+The same phone number can belong to BOTH a local (device phonebook) contact and an
+external (PBX) contact. Any query that resolves a number to a single display contact
+MUST make the winner deterministic instead of leaving it to SQLite's unspecified row
+order. Use the shared ordering term, never an ad-hoc `ORDER BY sourceType`:
+
+```dart
+..orderBy(contactsTable.sourcePriorityOrder()) // defaults to external (PBX) first
+```
+
+`sourcePriorityOrder` lives in `daos/contact_source_priority.dart`. It uses an explicit
+CASE (independent of the enum's int encoding) and takes a `ContactSourcePreference`
+for the rare case where local priority is intentional.
+
+- Single-contact lookups (`LIMIT 1`): add the ordering before the limit.
+- Entry-centric joins (call_log/voicemail -> contact_phones -> contacts): a colliding
+  number yields one joined row per contact, so order by the term AND collapse to one
+  contact per entry (keep the first, which is the preferred source).
+
 ### Domain Areas
 
 | Domain        | Tables                                                                         | DAO                                                    |

--- a/packages/data/app_database/lib/src/daos/contact_source_priority.dart
+++ b/packages/data/app_database/lib/src/daos/contact_source_priority.dart
@@ -1,0 +1,38 @@
+import 'package:drift/drift.dart';
+
+import 'package:app_database/src/app_database.dart';
+
+/// Which contact source should win when a single phone number is shared by both
+/// a local (device phonebook) contact and an external (PBX) contact.
+///
+/// The default everywhere is [externalFirst]: the PBX entry wins. Pass
+/// [localFirst] only where local priority is an explicit, intentional decision.
+enum ContactSourcePreference { externalFirst, localFirst }
+
+extension ContactSourcePriorityOrdering on $ContactsTableTable {
+  /// Ordering terms that place the preferred contact source first.
+  ///
+  /// This is the single definition of the collision tie-break. Apply it to any
+  /// query that may return both a local and an external contact for the same
+  /// number so the winner is deterministic instead of left to SQLite's
+  /// unspecified row order.
+  ///
+  /// It uses an explicit CASE rather than ordering on [sourceType] directly, so
+  /// the behaviour does NOT depend on the integer encoding of
+  /// [ContactSourceTypeEnum] (a future enum value or reorder cannot silently
+  /// flip the policy).
+  List<OrderingTerm> sourcePriorityOrder([ContactSourcePreference preference = ContactSourcePreference.externalFirst]) {
+    final preferred = preference == ContactSourcePreference.externalFirst
+        ? ContactSourceTypeEnum.external
+        : ContactSourceTypeEnum.local;
+
+    return [
+      OrderingTerm.asc(
+        CaseWhenExpression<int>(
+          cases: [CaseWhen(sourceType.equalsValue(preferred), then: const Constant(0))],
+          orElse: const Constant(1),
+        ),
+      ),
+    ];
+  }
+}

--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -174,7 +174,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Future<FullContactData?> getContactByPhoneNumber(String number) async {
     final query = _joinFullData(select(contactsTable))
       ..where(contactPhonesTable.number.equals(number))
-      ..orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)])
+      ..orderBy(contactsTable.sourcePriorityOrder())
       ..limit(1);
 
     return query.get().then(_gatherSingleContact);
@@ -199,7 +199,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Stream<FullContactData?> watchContactByPhoneNumber(String number) {
     final query = _joinFullData(select(contactsTable))
       ..where(contactPhonesTable.number.equals(number))
-      ..orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)])
+      ..orderBy(contactsTable.sourcePriorityOrder())
       ..limit(1);
 
     return query.watch().map(_gatherSingleContact);
@@ -208,7 +208,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Future<FullContactData?> getContactByPhoneMatchedEnding(String number) {
     final query = _joinFullData(select(contactsTable));
     query.where(contactPhonesTable.number.regexp('.*$number', caseSensitive: false));
-    query.orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)]);
+    query.orderBy(contactsTable.sourcePriorityOrder());
     query.limit(1);
 
     return query.get().then(_gatherSingleContact);
@@ -217,7 +217,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
   Stream<FullContactData?> watchContactByPhoneMatchedEnding(String number) {
     final query = _joinFullData(select(contactsTable));
     query.where(contactPhonesTable.number.regexp('.*$number', caseSensitive: false));
-    query.orderBy([OrderingTerm(expression: contactsTable.sourceType, mode: OrderingMode.desc)]);
+    query.orderBy(contactsTable.sourcePriorityOrder());
     query.limit(1);
 
     return query.watch().map((data) => _gatherMultipleContacts(data).firstOrNull);

--- a/packages/data/app_database/lib/src/daos/daos.dart
+++ b/packages/data/app_database/lib/src/daos/daos.dart
@@ -4,6 +4,7 @@ export 'cdrs_dao.dart';
 export 'chats_dao.dart';
 export 'contact_emails_dao.dart';
 export 'contact_phones_dao.dart';
+export 'contact_source_priority.dart';
 export 'contacts_dao.dart';
 export 'dialog_info_dao.dart';
 export 'favorites_dao.dart';

--- a/packages/data/app_database/test/contact_source_priority_test.dart
+++ b/packages/data/app_database/test/contact_source_priority_test.dart
@@ -1,0 +1,96 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:test/test.dart';
+
+import 'package:app_database/app_database.dart';
+
+void main() {
+  late AppDatabase database;
+
+  setUp(() {
+    database = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  // Insert a local AND an external contact that share the SAME number, so the
+  // sourcePriorityOrder tie-break has a real collision to resolve.
+  Future<void> seedCollision({required bool localFirst}) async {
+    final contactsDao = database.contactsDao;
+    final phonesDao = database.contactPhonesDao;
+
+    Future<void> addLocal() async {
+      final c = await contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.local),
+          sourceId: Value('local-4'),
+          aliasName: Value('Local 4'),
+        ),
+      );
+      await phonesDao.insertOnUniqueConflictUpdateContactPhone(
+        ContactPhoneDataCompanion(contactId: Value(c.id), number: Value('4'), label: Value('mobile')),
+      );
+    }
+
+    Future<void> addExternal() async {
+      final c = await contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.external),
+          sourceId: Value('ext-4'),
+          aliasName: Value('PBX 4'),
+        ),
+      );
+      await phonesDao.insertOnUniqueConflictUpdateContactPhone(
+        ContactPhoneDataCompanion(contactId: Value(c.id), number: Value('4'), label: Value('ext')),
+      );
+    }
+
+    if (localFirst) {
+      await addLocal();
+      await addExternal();
+    } else {
+      await addExternal();
+      await addLocal();
+    }
+  }
+
+  // Run a minimal number lookup that applies only the tie-break ordering, so the
+  // assertion isolates sourcePriorityOrder() and nothing else.
+  Future<ContactSourceTypeEnum?> winningSource([ContactSourcePreference? preference]) async {
+    final contacts = database.contactsTable;
+    final phones = database.contactPhonesTable;
+
+    final query = database.select(contacts).join([innerJoin(phones, phones.contactId.equalsExp(contacts.id))])
+      ..where(phones.number.equals('4'))
+      ..orderBy(preference == null ? contacts.sourcePriorityOrder() : contacts.sourcePriorityOrder(preference))
+      ..limit(1);
+
+    final row = await query.getSingleOrNull();
+    return row?.readTable(contacts).sourceType;
+  }
+
+  group('sourcePriorityOrder', () {
+    for (final localFirst in [true, false]) {
+      test('defaults to external-first (insertion local-first=$localFirst)', () async {
+        await seedCollision(localFirst: localFirst);
+        expect(await winningSource(), ContactSourceTypeEnum.external);
+      });
+
+      test('externalFirst prefers external (insertion local-first=$localFirst)', () async {
+        await seedCollision(localFirst: localFirst);
+        expect(await winningSource(ContactSourcePreference.externalFirst), ContactSourceTypeEnum.external);
+      });
+
+      test('localFirst prefers local (insertion local-first=$localFirst)', () async {
+        await seedCollision(localFirst: localFirst);
+        expect(await winningSource(ContactSourcePreference.localFirst), ContactSourceTypeEnum.local);
+      });
+    }
+
+    test('returns null when no contact carries the number', () async {
+      expect(await winningSource(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Foundation for WT-1024 (mixed contact matching on the recents/voicemail surfaces).

The "external (PBX) contact wins when a phone number is shared by a local and an
external contact" rule (introduced in WT-1037, #1355) was a literal `OrderingTerm`
copied into each `contacts_dao` by-number lookup, and it relied on the accidental
`ContactSourceTypeEnum` integer order (`local=0`/`external=1`). That is easy to
forget in a new DAO and silent to break if the enum is ever reordered.

This PR centralizes the policy so it has a single definition and is hard to
forget or misencode. No behavior change.

## Changes

- New `contact_source_priority.dart`: `ContactSourcePreference { externalFirst, localFirst }`
  and an extension `ContactSourcePriorityOrdering.sourcePriorityOrder([pref])` on the
  contacts table. It uses an explicit CASE (preferred source sorts first), so it does
  not depend on the enum's integer encoding, and exposes a knob for an intentional
  local-priority.
- Migrated the four `contacts_dao` by-number lookups (`getContactByPhoneNumber`,
  `watchContactByPhoneNumber`, `getContactByPhoneMatchedEnding`,
  `watchContactByPhoneMatchedEnding`) onto the shared term.
- Exported the helper from the daos barrel.
- Added `contact_source_priority_test.dart` (external-first default, both
  preferences, both insertion orders, and the no-match case).

## Testing

- `dart analyze` clean.
- `dart test` green, including the existing `contacts_dao` collision suite, which
  confirms this refactor is behavior-preserving.

## Follow-ups (WT-1024)

A shared entry-to-contact join+collapse helper will land with its first consumer
(recents) and is then reused by voicemail, so those surfaces resolve a colliding
number through the same policy.