### PR TITLE
fix: resolve recents number collisions to the external contact (WT-1024)

### DIFF
--- a/packages/data/app_database/lib/src/daos/recents_dao.dart
+++ b/packages/data/app_database/lib/src/daos/recents_dao.dart
@@ -27,20 +27,27 @@ class RecentsDao extends DatabaseAccessor<AppDatabase> with _$RecentsDaoMixin {
   RecentsDao(super.db);
 
   Stream<List<RecentData>> watchLastRecents([Duration period = const Duration(days: 14)]) {
-    final callsQuery = select(callLogsTable)
-      ..where((t) => t.createdAt.isBiggerOrEqualValue(clock.agoBy(period)))
-      ..orderBy([(t) => OrderingTerm.desc(t.createdAt), (t) => OrderingTerm.desc(t.hungUpAt.unixepoch)]);
+    final callsQuery = select(callLogsTable)..where((t) => t.createdAt.isBiggerOrEqualValue(clock.agoBy(period)));
 
     final sourcePhone = alias(contactPhonesTable, 'source_phone');
     final contactPhones = alias(contactPhonesTable, 'contact_phones');
 
-    final recentsQuery = callsQuery.join([
-      leftOuterJoin(sourcePhone, callLogsTable.number.equalsExp(sourcePhone.number), useColumns: false),
-      leftOuterJoin(contactsTable, contactsTable.id.equalsExp(sourcePhone.contactId)),
-      leftOuterJoin(contactEmailsTable, contactEmailsTable.contactId.equalsExp(contactsTable.id)),
-      leftOuterJoin(contactPhones, contactPhones.contactId.equalsExp(contactsTable.id)),
-      leftOuterJoin(presenceInfoTable, presenceInfoTable.number.equalsExp(contactPhonesTable.number)),
-    ]);
+    final recentsQuery =
+        callsQuery.join([
+            leftOuterJoin(sourcePhone, callLogsTable.number.equalsExp(sourcePhone.number), useColumns: false),
+            leftOuterJoin(contactsTable, contactsTable.id.equalsExp(sourcePhone.contactId)),
+            leftOuterJoin(contactEmailsTable, contactEmailsTable.contactId.equalsExp(contactsTable.id)),
+            leftOuterJoin(contactPhones, contactPhones.contactId.equalsExp(contactsTable.id)),
+            leftOuterJoin(presenceInfoTable, presenceInfoTable.number.equalsExp(contactPhonesTable.number)),
+          ])
+          // createdAt/hungUpAt define the recents order; the trailing source-priority term is a
+          // per-call-log tie-break so a number shared by a local and an external (PBX) contact
+          // resolves to the external one (the first row kept by _rowsToRecent).
+          ..orderBy([
+            OrderingTerm.desc(callLogsTable.createdAt),
+            OrderingTerm.desc(callLogsTable.hungUpAt.unixepoch),
+            ...contactsTable.sourcePriorityOrder(),
+          ]);
 
     return recentsQuery.watch().map(_rowsToRecent);
   }
@@ -51,7 +58,7 @@ class RecentsDao extends DatabaseAccessor<AppDatabase> with _$RecentsDaoMixin {
       leftOuterJoin(contactsTable, contactsTable.id.equalsExp(contactPhonesTable.contactId)),
       leftOuterJoin(contactEmailsTable, contactEmailsTable.contactId.equalsExp(contactsTable.id)),
       leftOuterJoin(presenceInfoTable, presenceInfoTable.number.equalsExp(contactPhonesTable.number)),
-    ]);
+    ])..orderBy(contactsTable.sourcePriorityOrder());
     return q.get().then((rows) => _rowsToRecent(rows).first);
   }
 

--- a/packages/data/app_database/test/recents_dao_test.dart
+++ b/packages/data/app_database/test/recents_dao_test.dart
@@ -1,0 +1,119 @@
+import 'package:drift/native.dart';
+import 'package:test/test.dart';
+
+import 'package:app_database/app_database.dart';
+
+void main() {
+  late AppDatabase database;
+
+  setUp(() {
+    database = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  // A period large enough that the recents 14-day window never filters test rows.
+  const allTime = Duration(days: 36500);
+
+  Future<void> addLocalContact(String number) async {
+    final c = await database.contactsDao.insertOnUniqueConflictUpdateContact(
+      ContactDataCompanion(
+        sourceType: Value(ContactSourceTypeEnum.local),
+        sourceId: Value('local-$number'),
+        aliasName: Value('Local $number'),
+      ),
+    );
+    await database.contactPhonesDao.insertOnUniqueConflictUpdateContactPhone(
+      ContactPhoneDataCompanion(contactId: Value(c.id), number: Value(number), label: Value('mobile')),
+    );
+  }
+
+  Future<void> addExternalContact(String number) async {
+    final c = await database.contactsDao.insertOnUniqueConflictUpdateContact(
+      ContactDataCompanion(
+        sourceType: Value(ContactSourceTypeEnum.external),
+        sourceId: Value('ext-$number'),
+        aliasName: Value('PBX $number'),
+      ),
+    );
+    await database.contactPhonesDao.insertOnUniqueConflictUpdateContactPhone(
+      ContactPhoneDataCompanion(contactId: Value(c.id), number: Value(number), label: Value('ext')),
+    );
+  }
+
+  Future<int> addCallLog(String number, DateTime createdAt) {
+    return database.callLogsDao.insertCallLog(
+      CallLogDataCompanion(
+        direction: Value(CallLogDirectionEnum.outgoing),
+        number: Value(number),
+        video: Value(false),
+        createdAt: Value(createdAt),
+      ),
+    );
+  }
+
+  group('recents contact source priority (local vs external collision)', () {
+    for (final localFirst in [true, false]) {
+      test('watchLastRecents prefers external (insertion local-first=$localFirst)', () async {
+        if (localFirst) {
+          await addLocalContact('4');
+          await addExternalContact('4');
+        } else {
+          await addExternalContact('4');
+          await addLocalContact('4');
+        }
+        await addCallLog('4', DateTime(2026, 6, 1));
+
+        final recents = await database.recentsDao.watchLastRecents(allTime).first;
+
+        expect(recents, hasLength(1));
+        expect(recents.single.contactData, isNotNull);
+        expect(recents.single.contactData!.sourceType, ContactSourceTypeEnum.external);
+        expect(recents.single.contactData!.aliasName, 'PBX 4');
+      });
+
+      test('getRecentByCallId prefers external (insertion local-first=$localFirst)', () async {
+        if (localFirst) {
+          await addLocalContact('4');
+          await addExternalContact('4');
+        } else {
+          await addExternalContact('4');
+          await addLocalContact('4');
+        }
+        final id = await addCallLog('4', DateTime(2026, 6, 1));
+
+        final recent = await database.recentsDao.getRecentByCallId(id);
+
+        expect(recent.contactData, isNotNull);
+        expect(recent.contactData!.sourceType, ContactSourceTypeEnum.external);
+        expect(recent.contactData!.aliasName, 'PBX 4');
+      });
+    }
+
+    test('watchLastRecents keeps newest-first order (tie-break must not reorder the list)', () async {
+      await addExternalContact('4');
+      await addLocalContact('4');
+      final oldId = await addCallLog('4', DateTime(2026, 5, 1));
+      final newId = await addCallLog('4', DateTime(2026, 6, 1));
+
+      final recents = await database.recentsDao.watchLastRecents(allTime).first;
+
+      expect(recents.map((r) => r.callLogEntry.id).toList(), [newId, oldId]);
+    });
+
+    test('non-colliding numbers still resolve to their single contact', () async {
+      await addLocalContact('5'); // local only
+      await addExternalContact('6'); // external only
+      await addCallLog('5', DateTime(2026, 6, 1));
+      await addCallLog('6', DateTime(2026, 6, 2));
+
+      final recents = await database.recentsDao.watchLastRecents(allTime).first;
+      final sourceByNumber = {for (final r in recents) r.callLogEntry.number: r.contactData?.sourceType};
+
+      expect(sourceByNumber['5'], ContactSourceTypeEnum.local);
+      expect(sourceByNumber['6'], ContactSourceTypeEnum.external);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Fixes the WT-1024 surface: in the Recents list (and the contact opened from it via
"View Contact"), a phone number shared by a local device contact and an external
(PBX) contact resolved to an arbitrary source, so the list/contact card could show
a different identity than the call screen - read as mixed name and avatar.

`recents_dao` joined the call-log number to a contact with no source tie-break, so
the winner was left to SQLite's unspecified row order (the first row kept by
`_rowsToRecent`). This builds on the centralized policy from #1369.

## Changes

- `watchLastRecents` and `getRecentByCallId` now order the joined rows by
  `contactsTable.sourcePriorityOrder()` (external/PBX first), so `_rowsToRecent`
  keeps the external contact deterministically.
- `watchLastRecents` keeps `createdAt`/`hungUpAt` as the primary ordering and adds
  the source priority only as a per-call-log tie-break. Note: `orderBy` on a joined
  statement replaces the term list (it does not append), so the full ordering is
  passed explicitly - otherwise the newest-first list order would be lost.
- No UI change: the tile and "View Contact" already read everything from the single
  resolved contact, so a deterministic pick fixes both at once.

## Testing

- New `recents_dao_test.dart`: external wins on collision for both
  `watchLastRecents` and `getRecentByCallId`, both insertion orders; the list keeps
  newest-first order; non-colliding numbers resolve to their single contact.
- Full `app_database` suite green (281 tests); `dart analyze` clean.

## Follow-up

The same collision exists in voicemail (`voicemail_dao`), which additionally
duplicates a voicemail row on a sender collision. Tracked separately; not part of
this PR.