### PR TITLE
fix: truncate long contact name in favorites tile (WT-1051)

### DIFF
--- a/lib/features/favorites/widgets/favorite_tile.dart
+++ b/lib/features/favorites/widgets/favorite_tile.dart
@@ -136,10 +136,18 @@ class _FavoriteTileState extends State<FavoriteTile> {
                 dialogInfo: contact?.dialogInfo,
               ),
               title: switch (presenceParams.hybridPresenceSupport) {
-                true => Text('$name ${contact?.presenceInfo.primaryStatusIcon ?? ''}'),
-                false => Text(name),
+                true => Text(
+                  '$name ${contact?.presenceInfo.primaryStatusIcon ?? ''}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                false => Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
               },
-              subtitle: Text('${widget.favorite.label.capitalize}: ${widget.favorite.number}'),
+              subtitle: Text(
+                '${widget.favorite.label.capitalize}: ${widget.favorite.number}',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
               onTap: widget.gesturesEnabled ? widget.onTap : null,
               onLongPress: widget.gesturesEnabled ? onLongPress : null,
             ),


### PR DESCRIPTION
## Overview

WT-1051 reported that a long contact name in the Contacts list was not truncated and overflowed, breaking the list layout. The Contacts tabs were already fixed by WT-1537 (ContactTile now wraps the name in an Expanded with `maxLines` + `TextOverflow.ellipsis`), but the Favorites tile had the same defect left over.

`FavoriteTile` rendered the name and the label/number subtitle through a plain `ListTile` with no line or overflow constraint, so a long favorite name still wrapped over multiple lines.

## Changes

- `favorite_tile.dart`: add `maxLines: 1` + `overflow: TextOverflow.ellipsis` to the title (both presence and non-presence branches) and to the subtitle, matching the truncation behavior of `ContactTile`.

## Testing

- `dart format --set-exit-if-changed` clean.
- `dart analyze` on the file: no issues.
- Pre-push hooks green (flutter analyze + full test suite, 747 tests).