### PR TITLE
feat(call): add focused-call state to CallBloc

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1349,6 +1349,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   Future<void> _onCallControlEvent(CallControlEvent event, Emitter<CallState> emit) {
     return switch (event) {
       _CallControlEventStarted() => __onCallControlEventStarted(event, emit),
+      _CallControlEventCallSelected() => __onCallControlEventCallSelected(event, emit),
       _CallControlEventAnswered() => __onCallControlEventAnswered(event, emit),
       _CallControlEventEnded() => __onCallControlEventEnded(event, emit),
       _CallControlEventSetHeld() => __onCallControlEventSetHeld(event, emit),
@@ -1398,6 +1399,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         fromReplaces: event.replaces,
       ),
     );
+  }
+
+  /// Focuses a call in the list-based call screen. Pure UI selection: clamps to
+  /// a live call via [CallState.copyWithSelectedCall] (no media side effects).
+  Future<void> __onCallControlEventCallSelected(_CallControlEventCallSelected event, Emitter<CallState> emit) async {
+    emit(state.copyWithSelectedCall(event.callId));
   }
 
   /// Submitting the answer intent to system when answer button is pressed from app ui

--- a/lib/features/call/bloc/call_bloc.freezed.dart
+++ b/lib/features/call/bloc/call_bloc.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CallState {
 
- CallServiceState get callServiceState; AppLifecycleState? get currentAppLifecycleState; int get linesCount; List<ActiveCall> get activeCalls; bool? get minimized; CallAudioDevice? get audioDevice; List<CallAudioDevice> get availableAudioDevices;
+ CallServiceState get callServiceState; AppLifecycleState? get currentAppLifecycleState; int get linesCount; List<ActiveCall> get activeCalls; bool? get minimized; CallAudioDevice? get audioDevice; List<CallAudioDevice> get availableAudioDevices; String? get selectedCallId;
 /// Create a copy of CallState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $CallStateCopyWith<CallState> get copyWith => _$CallStateCopyWithImpl<CallState>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallState&&(identical(other.callServiceState, callServiceState) || other.callServiceState == callServiceState)&&(identical(other.currentAppLifecycleState, currentAppLifecycleState) || other.currentAppLifecycleState == currentAppLifecycleState)&&(identical(other.linesCount, linesCount) || other.linesCount == linesCount)&&const DeepCollectionEquality().equals(other.activeCalls, activeCalls)&&(identical(other.minimized, minimized) || other.minimized == minimized)&&(identical(other.audioDevice, audioDevice) || other.audioDevice == audioDevice)&&const DeepCollectionEquality().equals(other.availableAudioDevices, availableAudioDevices));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallState&&(identical(other.callServiceState, callServiceState) || other.callServiceState == callServiceState)&&(identical(other.currentAppLifecycleState, currentAppLifecycleState) || other.currentAppLifecycleState == currentAppLifecycleState)&&(identical(other.linesCount, linesCount) || other.linesCount == linesCount)&&const DeepCollectionEquality().equals(other.activeCalls, activeCalls)&&(identical(other.minimized, minimized) || other.minimized == minimized)&&(identical(other.audioDevice, audioDevice) || other.audioDevice == audioDevice)&&const DeepCollectionEquality().equals(other.availableAudioDevices, availableAudioDevices)&&(identical(other.selectedCallId, selectedCallId) || other.selectedCallId == selectedCallId));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,callServiceState,currentAppLifecycleState,linesCount,const DeepCollectionEquality().hash(activeCalls),minimized,audioDevice,const DeepCollectionEquality().hash(availableAudioDevices));
+int get hashCode => Object.hash(runtimeType,callServiceState,currentAppLifecycleState,linesCount,const DeepCollectionEquality().hash(activeCalls),minimized,audioDevice,const DeepCollectionEquality().hash(availableAudioDevices),selectedCallId);
 
 @override
 String toString() {
-  return 'CallState(callServiceState: $callServiceState, currentAppLifecycleState: $currentAppLifecycleState, linesCount: $linesCount, activeCalls: $activeCalls, minimized: $minimized, audioDevice: $audioDevice, availableAudioDevices: $availableAudioDevices)';
+  return 'CallState(callServiceState: $callServiceState, currentAppLifecycleState: $currentAppLifecycleState, linesCount: $linesCount, activeCalls: $activeCalls, minimized: $minimized, audioDevice: $audioDevice, availableAudioDevices: $availableAudioDevices, selectedCallId: $selectedCallId)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $CallStateCopyWith<$Res>  {
   factory $CallStateCopyWith(CallState value, $Res Function(CallState) _then) = _$CallStateCopyWithImpl;
 @useResult
 $Res call({
- CallServiceState callServiceState, AppLifecycleState? currentAppLifecycleState, int linesCount, List<ActiveCall> activeCalls, bool? minimized, CallAudioDevice? audioDevice, List<CallAudioDevice> availableAudioDevices
+ CallServiceState callServiceState, AppLifecycleState? currentAppLifecycleState, int linesCount, List<ActiveCall> activeCalls, bool? minimized, CallAudioDevice? audioDevice, List<CallAudioDevice> availableAudioDevices, String? selectedCallId
 });
 
 
@@ -62,7 +62,7 @@ class _$CallStateCopyWithImpl<$Res>
 
 /// Create a copy of CallState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? callServiceState = null,Object? currentAppLifecycleState = freezed,Object? linesCount = null,Object? activeCalls = null,Object? minimized = freezed,Object? audioDevice = freezed,Object? availableAudioDevices = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? callServiceState = null,Object? currentAppLifecycleState = freezed,Object? linesCount = null,Object? activeCalls = null,Object? minimized = freezed,Object? audioDevice = freezed,Object? availableAudioDevices = null,Object? selectedCallId = freezed,}) {
   return _then(CallState(
 callServiceState: null == callServiceState ? _self.callServiceState : callServiceState // ignore: cast_nullable_to_non_nullable
 as CallServiceState,currentAppLifecycleState: freezed == currentAppLifecycleState ? _self.currentAppLifecycleState : currentAppLifecycleState // ignore: cast_nullable_to_non_nullable
@@ -71,7 +71,8 @@ as int,activeCalls: null == activeCalls ? _self.activeCalls : activeCalls // ign
 as List<ActiveCall>,minimized: freezed == minimized ? _self.minimized : minimized // ignore: cast_nullable_to_non_nullable
 as bool?,audioDevice: freezed == audioDevice ? _self.audioDevice : audioDevice // ignore: cast_nullable_to_non_nullable
 as CallAudioDevice?,availableAudioDevices: null == availableAudioDevices ? _self.availableAudioDevices : availableAudioDevices // ignore: cast_nullable_to_non_nullable
-as List<CallAudioDevice>,
+as List<CallAudioDevice>,selectedCallId: freezed == selectedCallId ? _self.selectedCallId : selectedCallId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -592,6 +592,10 @@ sealed class CallControlEvent extends CallEvent {
 
   const factory CallControlEvent.answered(String callId) = _CallControlEventAnswered;
 
+  /// Focuses a call in the call list (list-based call screen). Pure UI state:
+  /// sets [CallState.selectedCallId] so the action area acts on that call.
+  const factory CallControlEvent.callSelected(String callId) = _CallControlEventCallSelected;
+
   const factory CallControlEvent.ended(String callId) = _CallControlEventEnded;
 
   const factory CallControlEvent.setHeld(String callId, bool onHold) = _CallControlEventSetHeld;
@@ -665,6 +669,15 @@ class _CallControlEventStarted extends CallControlEvent with CallControlEventSta
 
 class _CallControlEventAnswered extends CallControlEvent {
   const _CallControlEventAnswered(this.callId);
+
+  final String callId;
+
+  @override
+  List<Object?> get props => [callId];
+}
+
+class _CallControlEventCallSelected extends CallControlEvent {
+  const _CallControlEventCallSelected(this.callId);
 
   final String callId;
 

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -10,6 +10,7 @@ class CallState with _$CallState {
     this.minimized,
     this.audioDevice,
     this.availableAudioDevices = const [],
+    this.selectedCallId,
   });
 
   @override
@@ -33,7 +34,29 @@ class CallState with _$CallState {
   @override
   final List<CallAudioDevice> availableAudioDevices;
 
+  /// The call the user has explicitly focused (e.g. tapped in the call list).
+  ///
+  /// `null` means no explicit selection - consumers fall back to the derived
+  /// [ActiveCallIterableExtension.current]. This is the foundation for the
+  /// list-based call screen, where one bottom action area acts on the focused
+  /// call. Always read it through [focusedCall], which clamps a stale id back
+  /// to `current`.
+  @override
+  final String? selectedCallId;
+
   CallStatus get status => callServiceState.status;
+
+  /// The call the action area should act on: the explicitly [selectedCallId]
+  /// when it still maps to a live call, otherwise the derived `current`.
+  ///
+  /// Returns `null` only when there are no active calls. Behavior is identical
+  /// to `activeCalls.current` until something dispatches
+  /// [CallControlEvent.callSelected], so this is a no-op seam for existing UI.
+  ActiveCall? get focusedCall {
+    if (activeCalls.isEmpty) return null;
+    final selected = selectedCallId == null ? null : retrieveActiveCall(selectedCallId!);
+    return selected ?? activeCalls.current;
+  }
 
   /// Indicates that the handshake phase has completed and registration status is available.
   bool get isHandshakeEstablished => callServiceState.registration?.status != null;
@@ -198,7 +221,19 @@ class CallState with _$CallState {
     final activeCalls = this.activeCalls.where((activeCall) {
       return activeCall.callId != callId;
     }).toList();
-    return copyWith(activeCalls: activeCalls, minimized: activeCalls.isEmpty ? null : minimized);
+    return copyWith(
+      activeCalls: activeCalls,
+      minimized: activeCalls.isEmpty ? null : minimized,
+      // Drop a dangling selection so [focusedCall] falls back to `current`.
+      selectedCallId: selectedCallId == callId ? null : selectedCallId,
+    );
+  }
+
+  /// Focuses the call [callId] when it maps to a live call; otherwise returns
+  /// the state unchanged. Keeps [selectedCallId] clamped to an existing call.
+  CallState copyWithSelectedCall(String callId) {
+    if (retrieveActiveCall(callId) == null) return this;
+    return copyWith(selectedCallId: callId);
   }
 }
 

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -350,6 +350,88 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // CallState — focusedCall (list-based call screen foundation)
+  // ---------------------------------------------------------------------------
+
+  group('CallState.focusedCall', () {
+    test('returns null when there are no active calls', () {
+      const state = CallState();
+      expect(state.focusedCall, isNull);
+    });
+
+    test('falls back to current when no explicit selection', () {
+      final held = _makeCall(callId: 'held', held: true);
+      final active = _makeCall(callId: 'active', held: false);
+      final state = CallState(activeCalls: [held, active]);
+      // selectedCallId is null -> mirrors activeCalls.current (last non-held).
+      expect(state.selectedCallId, isNull);
+      expect(state.focusedCall?.callId, 'active');
+    });
+
+    test('returns the explicitly selected call', () {
+      final held = _makeCall(callId: 'held', held: true);
+      final active = _makeCall(callId: 'active', held: false);
+      final state = CallState(activeCalls: [held, active], selectedCallId: 'held');
+      // Selection wins over the derived current.
+      expect(state.focusedCall?.callId, 'held');
+    });
+
+    test('falls back to current when the selected id no longer maps to a call', () {
+      final active = _makeCall(callId: 'active', held: false);
+      final state = CallState(activeCalls: [active], selectedCallId: 'gone');
+      expect(state.focusedCall?.callId, 'active');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallState — copyWithSelectedCall
+  // ---------------------------------------------------------------------------
+
+  group('CallState.copyWithSelectedCall', () {
+    test('sets selectedCallId when the call exists', () {
+      final c1 = _makeCall(callId: 'c1');
+      final c2 = _makeCall(callId: 'c2');
+      final state = CallState(activeCalls: [c1, c2]);
+      final next = state.copyWithSelectedCall('c2');
+      expect(next.selectedCallId, 'c2');
+      expect(next.focusedCall?.callId, 'c2');
+    });
+
+    test('leaves state unchanged for an unknown call id', () {
+      final c1 = _makeCall(callId: 'c1');
+      final state = CallState(activeCalls: [c1]);
+      final next = state.copyWithSelectedCall('ghost');
+      expect(next.selectedCallId, isNull);
+      expect(next, same(state));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallState — copyWithPopActiveCall clears a dangling selection
+  // ---------------------------------------------------------------------------
+
+  group('CallState.copyWithPopActiveCall — selection clamp', () {
+    test('clears selectedCallId when the selected call is removed', () {
+      final c1 = _makeCall(callId: 'c1');
+      final c2 = _makeCall(callId: 'c2');
+      final state = CallState(activeCalls: [c1, c2], selectedCallId: 'c1');
+      final next = state.copyWithPopActiveCall('c1');
+      expect(next.selectedCallId, isNull);
+      // focusedCall falls back to the surviving call.
+      expect(next.focusedCall?.callId, 'c2');
+    });
+
+    test('keeps selectedCallId when a different call is removed', () {
+      final c1 = _makeCall(callId: 'c1');
+      final c2 = _makeCall(callId: 'c2');
+      final state = CallState(activeCalls: [c1, c2], selectedCallId: 'c2');
+      final next = state.copyWithPopActiveCall('c1');
+      expect(next.selectedCallId, 'c2');
+      expect(next.focusedCall?.callId, 'c2');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CallState — display
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Overview

Foundation PR (1 of several) for the list-based call screen redesign (WT-1462,
folds in WT-1071). It adds an explicit "focused" call to the bloc so the
upcoming UI can do "tap a row to focus, act on that row". Purely additive and
behavior-preserving - nothing dispatches the new event yet.

## Changes

- `CallState.selectedCallId` + `focusedCall` getter: returns the explicitly
  selected call when it still maps to a live call, otherwise the derived
  `current`; `null` only when there are no active calls.
- `CallControlEvent.callSelected(callId)` + bloc handler, clamped to a live
  call via `copyWithSelectedCall`.
- `copyWithPopActiveCall` drops a dangling selection so `focusedCall` falls
  back to `current` when the focused call ends.
- Regenerated `call_bloc.freezed.dart`.

## Why it is invisible

`selectedCallId` stays `null` until something dispatches `callSelected` (a later
UI PR), so `focusedCall` mirrors `activeCalls.current` and existing screens
behave identically. This is the seam the list UI will consume.

## Tests

`call_state_test.dart` extended: `focusedCall` fallback/selection/stale-id,
`copyWithSelectedCall` set + unknown-id no-op, `copyWithPopActiveCall` clears a
dangling selection vs keeps an unrelated one. Full suite green (analyze + 766
tests via pre-push).