### PR TITLE
docs(call): add living feature overview under docs/features

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,34 @@
+# Feature docs
+
+Living, feature-oriented overviews of the app. Each file describes one user-facing
+feature: what it does, the UX states, the widgets and bloc that back it, and what
+is currently changing. These are kept up to date as the feature evolves - update
+the relevant file in the same PR that changes the feature.
+
+How these differ from the other docs:
+
+- **Feature docs (here)** - product-level: what the user sees, the screen states,
+  the in-progress redesigns, and pointers into the deeper docs.
+- **Architecture docs** (e.g. [`../call_architecture.md`](../call_architecture.md),
+  [`../signaling_architecture_target.md`](../signaling_architecture_target.md)) -
+  implementation deep-dives: blocs, events, state machines, isolates.
+- **Scenario docs** (e.g. [`../incoming_call_scenarios.md`](../incoming_call_scenarios.md))
+  - specific flows with diagrams.
+
+A feature doc should link to those rather than repeat them.
+
+## Index
+
+| Feature | Doc | Status |
+|---|---|---|
+| Call | [call.md](call.md) | Active - UI redesign in progress |
+
+## Conventions
+
+- One file per feature, kebab-case (`call.md`, `contacts.md`).
+- Start with a one-line summary and a `Last reviewed:` date.
+- Describe the CURRENT behavior first; put in-progress work under a clearly
+  marked "Redesign / in progress" section so the doc never lies about what ships.
+- Link code by relative path (`lib/features/<name>/...`) and link sibling docs
+  relatively.
+- Plain ASCII only (matches the repo convention).

--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -1,0 +1,117 @@
+# Call
+
+The in-app calling experience: placing and receiving SIP/WebRTC calls, the
+full-screen call UI, multi-call handling (hold, swap, transfer), and the native
+CallKit / ConnectionService integration.
+
+Last reviewed: 2026-06-10
+
+## Where it lives
+
+- `lib/features/call/` - the whole feature: bloc, views, widgets, extensions.
+  - `bloc/` - `CallBloc`, `CallState`, `CallEvent` (the brain; see below).
+  - `view/call_active_scaffold.dart` - the active call screen layout.
+  - `widgets/` - `CallInfo`, `IncomingCallActions`, `ActiveCallActions`,
+    video overlays, keypad.
+- `webtrit_callkeep` (sibling plugin) - native call UI (CallKit on iOS,
+  ConnectionService on Android).
+
+Deeper references:
+
+- [`../call_architecture.md`](../call_architecture.md) - `CallBloc` responsibilities,
+  event categories, processing-status state machine, isolates, key patterns.
+- [`../incoming_call_scenarios.md`](../incoming_call_scenarios.md) - incoming-call
+  background scenarios (push-bound / persistent / foreground) with diagrams.
+- [`../signaling_architecture_target.md`](../signaling_architecture_target.md) -
+  signaling layer.
+
+## What the user can do
+
+- Place an outgoing audio or video call.
+- Receive an incoming call (foreground, backgrounded, or killed via push).
+- During an active call: mute, toggle camera, switch audio device (earpiece /
+  speaker / Bluetooth), open the keypad (DTMF), hold/resume, transfer (blind or
+  attended), and hang up.
+- Handle a second call: a new incoming call while one is active, or two calls at
+  once - answer one and put the other on hold, or decline.
+
+## Call states (UX)
+
+The active call screen (`CallActiveScaffold`) renders from `CallState.activeCalls`.
+Each call is an `ActiveCall` with the flags the UI reads:
+
+- `isIncoming`, `wasAccepted` (has `acceptedTime`) - ringing vs answered.
+- `held` - on hold.
+- `processingStatus` - fine-grained lifecycle (see the state machine in the
+  architecture doc).
+- `displayName` / `handle`, `remoteVideo`, `muted`, `transfer`.
+
+Single call:
+
+- **1 incoming** - caller info + Decline / Answer.
+- **1 active** - caller info + control grid (mute, camera, speaker, transfer,
+  hold, keypad) + hang up.
+- **1 on hold** - same grid with Hold shown as Resume.
+
+Multiple calls today (stacked layout):
+
+- The screen stacks a `CallInfo` block per call. The "current" call is derived,
+  not explicitly chosen: `activeCalls.current` = the last non-held call.
+- For a second incoming call while one is active, `IncomingCallActions` shows
+  combined-icon buttons: End & Answer (`call_end` + `call`), Decline (`call_end`),
+  Hold & Answer (`pause` + `call`). Hold is impossible while a call is ringing,
+  so the user answers first; the combined actions end or hold the other call,
+  then answer.
+
+### Focused call
+
+`CallState.selectedCallId` + the `focusedCall` getter express which call the
+action area acts on. `focusedCall` returns the explicitly selected call when it
+still maps to a live call, otherwise the derived `current`; it is `null` only
+when there are no active calls. Today nothing sets `selectedCallId`, so
+`focusedCall` mirrors `current`. This is the seam the list-based UI consumes
+(see below).
+
+## Key widgets
+
+| Widget | File | Role |
+|---|---|---|
+| `CallActiveScaffold` | `view/call_active_scaffold.dart` | Active call screen; lays out info + actions per call |
+| `CallInfo` | `widgets/call_info.dart` | Per-call name / number / status / timer / network quality |
+| `IncomingCallActions` | `widgets/incoming_call_actions.dart` | Ringing-call buttons (decline / answer / combined) |
+| `ActiveCallActions` | `widgets/active_call_actions.dart` | In-call control grid + hang up + keypad |
+
+## Redesign / in progress - list-based call flow
+
+The multi-call UI is being reworked into a single, consistent model:
+
+- The screen is always a **list of calls** - 1 call is a list of 1, N calls a
+  list of N. No separate "incoming" vs "active" screen.
+- Each row shows name + a status badge (RINGING / ON CALL / ON HOLD) + timer.
+  When more than one call exists, a header reads "N calls - tap to choose".
+- **Focus, then act**: tap a row to focus it; one bottom action area acts on the
+  focused call only, with an "Acting on: <name>" hint that spells the side effect
+  ("<other> will be put on hold"). At most two action buttons for a ringing
+  focus (Decline / Answer); the in-call control grid for an active/held focus.
+- This removes the combined-icon row, which was hard to read at the worst moment
+  (resolves the "unclear second-incoming buttons" reports, WT-1071 / WT-1462).
+
+Rollout is incremental (foundations first, then UI), each step behind tests:
+
+| Stage | Scope | Status |
+|---|---|---|
+| Focus state | `selectedCallId` + `focusedCall` + `callSelected` event (invisible groundwork) | In review (PR #1376) |
+| Action intents | Combined actions (hold&accept / hangup&accept / swap) move into bloc intents | Planned |
+| Call list | Selectable list of calls + status badges + header | Planned |
+| Focused actions | Single action area + "Acting on" hint; drop combined-icon buttons | Planned |
+| Cleanup / edges | Single-call polish, dead-code removal, 3-call / transfer / landscape | Planned |
+
+The visible UI stages are gated behind a feature flag so `develop` stays
+shippable while the redesign lands piece by piece.
+
+## Keeping this doc current
+
+Update this file in the same PR that changes the call feature - especially the
+"Call states" and "Redesign / in progress" sections, and bump `Last reviewed`.
+When a redesign stage lands, move it to the shipped behavior above and update its
+status here.


### PR DESCRIPTION
## Overview

Adds `docs/features/` for product-level, living feature overviews, kept separate
from the architecture deep-dives. The first entry documents the call feature.

## Contents

- `docs/features/README.md` - the convention: one living doc per feature, current
  behavior first, in-progress work clearly marked, and how it differs from the
  architecture / scenario docs.
- `docs/features/call.md` - where the feature lives, what the user can do, the
  single/multi-call UX states, the `focusedCall` seam, key widgets, and the
  in-progress list-based call-flow redesign with its incremental rollout table.

Links to (rather than repeats) `call_architecture.md`,
`incoming_call_scenarios.md`, and `signaling_architecture_target.md`.

## Note

Docs only. The redesign section is explicitly marked in-progress so the doc never
implies unshipped behavior; the focus-state groundwork it references is in review
(#1376).