### PR TITLE
refactor(call): move combined call actions into CallBloc intents

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -100,14 +100,16 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 
 | Stage | Scope | Status |
 |---|---|---|
-| Focus state | `selectedCallId` + `focusedCall` + `callSelected` event (invisible groundwork) | In review (PR #1376) |
-| Action intents | Combined actions (hold&accept / hangup&accept / swap) move into bloc intents | Planned |
+| Focus state | `selectedCallId` + `focusedCall` + `callSelected` event (invisible groundwork) | Merged (PR #1376) |
+| Action intents | Combined actions (hold&accept / hangup&accept / swap) move into bloc intents | In review |
 | Call list | Selectable list of calls + status badges + header | Planned |
 | Focused actions | Single action area + "Acting on" hint; drop combined-icon buttons | Planned |
 | Cleanup / edges | Single-call polish, dead-code removal, 3-call / transfer / landscape | Planned |
 
-The visible UI stages are gated behind a feature flag so `develop` stays
-shippable while the redesign lands piece by piece.
+The redesign lands on the `refactor/call` integration branch - every stage is a
+PR into that branch, and once the whole flow is tested there a single PR merges
+it into `develop`. `develop` therefore stays shippable throughout; no feature
+flag is involved.
 
 ## Keeping this doc current
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1411,17 +1411,18 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   // Combined-action intents. Each re-dispatches the ordered primitive events
-  // produced by the pure planners on [CallState] (planAnswerEndingOthers /
-  // planAnswerHoldingOthers / planSwap), replacing the per-call loops the call
-  // screen used to synthesize itself. The primitives go through the same
-  // sequential CallControlEvent queue as before, so semantics are unchanged.
+  // produced by the pure plans on [CallControlEvent]; state only supplies the
+  // other-call ids ([CallState.otherCallIds]). This replaces the per-call loops
+  // the call screen used to synthesize itself. The primitives go through the
+  // same sequential CallControlEvent queue as before, so semantics are
+  // unchanged.
 
   /// "End & Answer": ends every other active call, then answers [event.callId].
   Future<void> __onCallControlEventAnsweredEndingOthers(
     _CallControlEventAnsweredEndingOthers event,
     Emitter<CallState> emit,
   ) async {
-    state.planAnswerEndingOthers(event.callId).forEach(add);
+    CallControlEvent.answerEndingOthersPlan(event.callId, state.otherCallIds(event.callId)).forEach(add);
   }
 
   /// "Hold & Answer": holds every other active call, then answers [event.callId].
@@ -1429,12 +1430,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _CallControlEventAnsweredHoldingOthers event,
     Emitter<CallState> emit,
   ) async {
-    state.planAnswerHoldingOthers(event.callId).forEach(add);
+    CallControlEvent.answerHoldingOthersPlan(event.callId, state.otherCallIds(event.callId)).forEach(add);
   }
 
   /// Swap: holds [event.callId], then resumes the other calls.
   Future<void> __onCallControlEventSwapped(_CallControlEventSwapped event, Emitter<CallState> emit) async {
-    state.planSwap(event.callId).forEach(add);
+    CallControlEvent.swapPlan(event.callId, state.otherCallIds(event.callId)).forEach(add);
   }
 
   /// Submitting the answer intent to system when answer button is pressed from app ui

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1351,6 +1351,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _CallControlEventStarted() => __onCallControlEventStarted(event, emit),
       _CallControlEventCallSelected() => __onCallControlEventCallSelected(event, emit),
       _CallControlEventAnswered() => __onCallControlEventAnswered(event, emit),
+      _CallControlEventAnsweredEndingOthers() => __onCallControlEventAnsweredEndingOthers(event, emit),
+      _CallControlEventAnsweredHoldingOthers() => __onCallControlEventAnsweredHoldingOthers(event, emit),
+      _CallControlEventSwapped() => __onCallControlEventSwapped(event, emit),
       _CallControlEventEnded() => __onCallControlEventEnded(event, emit),
       _CallControlEventSetHeld() => __onCallControlEventSetHeld(event, emit),
       _CallControlEventSetMuted() => __onCallControlEventSetMuted(event, emit),
@@ -1405,6 +1408,33 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// a live call via [CallState.copyWithSelectedCall] (no media side effects).
   Future<void> __onCallControlEventCallSelected(_CallControlEventCallSelected event, Emitter<CallState> emit) async {
     emit(state.copyWithSelectedCall(event.callId));
+  }
+
+  // Combined-action intents. Each re-dispatches the ordered primitive events
+  // produced by the pure planners on [CallState] (planAnswerEndingOthers /
+  // planAnswerHoldingOthers / planSwap), replacing the per-call loops the call
+  // screen used to synthesize itself. The primitives go through the same
+  // sequential CallControlEvent queue as before, so semantics are unchanged.
+
+  /// "End & Answer": ends every other active call, then answers [event.callId].
+  Future<void> __onCallControlEventAnsweredEndingOthers(
+    _CallControlEventAnsweredEndingOthers event,
+    Emitter<CallState> emit,
+  ) async {
+    state.planAnswerEndingOthers(event.callId).forEach(add);
+  }
+
+  /// "Hold & Answer": holds every other active call, then answers [event.callId].
+  Future<void> __onCallControlEventAnsweredHoldingOthers(
+    _CallControlEventAnsweredHoldingOthers event,
+    Emitter<CallState> emit,
+  ) async {
+    state.planAnswerHoldingOthers(event.callId).forEach(add);
+  }
+
+  /// Swap: holds [event.callId], then resumes the other calls.
+  Future<void> __onCallControlEventSwapped(_CallControlEventSwapped event, Emitter<CallState> emit) async {
+    state.planSwap(event.callId).forEach(add);
   }
 
   /// Submitting the answer intent to system when answer button is pressed from app ui

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -579,6 +579,29 @@ class _CallPushEventIncoming extends CallEvent {
 sealed class CallControlEvent extends CallEvent {
   const CallControlEvent();
 
+  // Pure plans for the combined call actions. Each returns the ordered list of
+  // primitive events the corresponding intent dispatches ([otherCallIds] comes
+  // from [CallState.otherCallIds]), keeping the multi-step semantics
+  // unit-testable without a full [CallBloc].
+
+  /// "End & Answer" plan: end every other call, then answer [callId].
+  static List<CallControlEvent> answerEndingOthersPlan(String callId, List<String> otherCallIds) => [
+    for (final otherCallId in otherCallIds) CallControlEvent.ended(otherCallId),
+    CallControlEvent.answered(callId),
+  ];
+
+  /// "Hold & Answer" plan: put every other call on hold, then answer [callId].
+  static List<CallControlEvent> answerHoldingOthersPlan(String callId, List<String> otherCallIds) => [
+    for (final otherCallId in otherCallIds) CallControlEvent.setHeld(otherCallId, true),
+    CallControlEvent.answered(callId),
+  ];
+
+  /// Swap plan: hold [callId], then resume every other call.
+  static List<CallControlEvent> swapPlan(String callId, List<String> otherCallIds) => [
+    CallControlEvent.setHeld(callId, true),
+    for (final otherCallId in otherCallIds) CallControlEvent.setHeld(otherCallId, false),
+  ];
+
   const factory CallControlEvent.started({
     int? line,
     String? generic,

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -596,6 +596,17 @@ sealed class CallControlEvent extends CallEvent {
   /// sets [CallState.selectedCallId] so the action area acts on that call.
   const factory CallControlEvent.callSelected(String callId) = _CallControlEventCallSelected;
 
+  /// Answers [callId] after ending every other active call - the "End & Answer"
+  /// action for a second incoming call, as a single intent.
+  const factory CallControlEvent.answeredEndingOthers(String callId) = _CallControlEventAnsweredEndingOthers;
+
+  /// Answers [callId] after putting every other active call on hold - the
+  /// "Hold & Answer" action for a second incoming call, as a single intent.
+  const factory CallControlEvent.answeredHoldingOthers(String callId) = _CallControlEventAnsweredHoldingOthers;
+
+  /// Swaps the active and held calls: holds [callId] and resumes the others.
+  const factory CallControlEvent.swapped(String callId) = _CallControlEventSwapped;
+
   const factory CallControlEvent.ended(String callId) = _CallControlEventEnded;
 
   const factory CallControlEvent.setHeld(String callId, bool onHold) = _CallControlEventSetHeld;
@@ -678,6 +689,33 @@ class _CallControlEventAnswered extends CallControlEvent {
 
 class _CallControlEventCallSelected extends CallControlEvent {
   const _CallControlEventCallSelected(this.callId);
+
+  final String callId;
+
+  @override
+  List<Object?> get props => [callId];
+}
+
+class _CallControlEventAnsweredEndingOthers extends CallControlEvent {
+  const _CallControlEventAnsweredEndingOthers(this.callId);
+
+  final String callId;
+
+  @override
+  List<Object?> get props => [callId];
+}
+
+class _CallControlEventAnsweredHoldingOthers extends CallControlEvent {
+  const _CallControlEventAnsweredHoldingOthers(this.callId);
+
+  final String callId;
+
+  @override
+  List<Object?> get props => [callId];
+}
+
+class _CallControlEventSwapped extends CallControlEvent {
+  const _CallControlEventSwapped(this.callId);
 
   final String callId;
 

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -236,31 +236,12 @@ class CallState with _$CallState {
     return copyWith(selectedCallId: callId);
   }
 
-  // Pure planners for the combined call actions. Each returns the ordered list
-  // of primitive [CallControlEvent]s the corresponding intent dispatches, so
-  // the multi-step semantics stay unit-testable without a full [CallBloc].
-
-  /// "End & Answer" plan for [callId]: end every other active call, then
-  /// answer [callId].
-  List<CallControlEvent> planAnswerEndingOthers(String callId) => [
+  /// Ids of every active call except [callId], in list order. Pure data query;
+  /// the event layer (see the combined-action plans on [CallControlEvent])
+  /// turns these into the primitive events to dispatch.
+  List<String> otherCallIds(String callId) => [
     for (final call in activeCalls)
-      if (call.callId != callId) CallControlEvent.ended(call.callId),
-    CallControlEvent.answered(callId),
-  ];
-
-  /// "Hold & Answer" plan for [callId]: put every other active call on hold,
-  /// then answer [callId].
-  List<CallControlEvent> planAnswerHoldingOthers(String callId) => [
-    for (final call in activeCalls)
-      if (call.callId != callId) CallControlEvent.setHeld(call.callId, true),
-    CallControlEvent.answered(callId),
-  ];
-
-  /// Swap plan for [callId]: hold [callId], then resume every other call.
-  List<CallControlEvent> planSwap(String callId) => [
-    CallControlEvent.setHeld(callId, true),
-    for (final call in activeCalls)
-      if (call.callId != callId) CallControlEvent.setHeld(call.callId, false),
+      if (call.callId != callId) call.callId,
   ];
 }
 

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -235,6 +235,33 @@ class CallState with _$CallState {
     if (retrieveActiveCall(callId) == null) return this;
     return copyWith(selectedCallId: callId);
   }
+
+  // Pure planners for the combined call actions. Each returns the ordered list
+  // of primitive [CallControlEvent]s the corresponding intent dispatches, so
+  // the multi-step semantics stay unit-testable without a full [CallBloc].
+
+  /// "End & Answer" plan for [callId]: end every other active call, then
+  /// answer [callId].
+  List<CallControlEvent> planAnswerEndingOthers(String callId) => [
+    for (final call in activeCalls)
+      if (call.callId != callId) CallControlEvent.ended(call.callId),
+    CallControlEvent.answered(callId),
+  ];
+
+  /// "Hold & Answer" plan for [callId]: put every other active call on hold,
+  /// then answer [callId].
+  List<CallControlEvent> planAnswerHoldingOthers(String callId) => [
+    for (final call in activeCalls)
+      if (call.callId != callId) CallControlEvent.setHeld(call.callId, true),
+    CallControlEvent.answered(callId),
+  ];
+
+  /// Swap plan for [callId]: hold [callId], then resume every other call.
+  List<CallControlEvent> planSwap(String callId) => [
+    CallControlEvent.setHeld(callId, true),
+    for (final call in activeCalls)
+      if (call.callId != callId) CallControlEvent.setHeld(call.callId, false),
+  ];
 }
 
 @freezed

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -299,16 +299,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 },
                                                 onSwapPressed: activeCalls.length == 2
                                                     ? () {
-                                                        _callBloc.add(
-                                                          CallControlEvent.setHeld(activeCall.callId, true),
-                                                        );
-                                                        for (final otherActiveCall in activeCalls) {
-                                                          if (otherActiveCall.callId != activeCall.callId) {
-                                                            _callBloc.add(
-                                                              CallControlEvent.setHeld(otherActiveCall.callId, false),
-                                                            );
-                                                          }
-                                                        }
+                                                        _callBloc.add(CallControlEvent.swapped(activeCall.callId));
                                                         dispatchInteractionDebounce();
                                                       }
                                                     : null,
@@ -360,27 +351,17 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                   onHangupAndAcceptPressed: nonIncomingRingingCalls.isEmpty
                                                       ? null
                                                       : () {
-                                                          for (final otherActiveCall in activeCalls) {
-                                                            if (otherActiveCall.callId != incomingCall.callId) {
-                                                              _callBloc.add(
-                                                                CallControlEvent.ended(otherActiveCall.callId),
-                                                              );
-                                                            }
-                                                          }
-                                                          _callBloc.add(CallControlEvent.answered(incomingCall.callId));
+                                                          _callBloc.add(
+                                                            CallControlEvent.answeredEndingOthers(incomingCall.callId),
+                                                          );
                                                           dispatchInteractionDebounce();
                                                         },
                                                   onHoldAndAcceptPressed: nonIncomingRingingCanBeHolded.isEmpty
                                                       ? null
                                                       : () {
-                                                          for (final otherActiveCall in activeCalls) {
-                                                            if (otherActiveCall.callId != incomingCall.callId) {
-                                                              _callBloc.add(
-                                                                CallControlEvent.setHeld(otherActiveCall.callId, true),
-                                                              );
-                                                            }
-                                                          }
-                                                          _callBloc.add(CallControlEvent.answered(incomingCall.callId));
+                                                          _callBloc.add(
+                                                            CallControlEvent.answeredHoldingOthers(incomingCall.callId),
+                                                          );
                                                           dispatchInteractionDebounce();
                                                         },
                                                 ),

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -432,60 +432,61 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // CallState — combined-action planners
+  // Combined-action plans
   //
   // The single intents (answeredEndingOthers / answeredHoldingOthers / swapped)
-  // dispatch exactly these ordered primitive events; this pins the semantics
-  // the call screen used to synthesize with per-call loops.
+  // dispatch exactly these ordered primitive events. The state layer only
+  // supplies the other-call ids (CallState.otherCallIds); the plans live on the
+  // event layer (CallControlEvent). This pins the semantics the call screen
+  // used to synthesize with per-call loops.
   // ---------------------------------------------------------------------------
 
-  group('CallState.planAnswerEndingOthers', () {
-    test('ends every other call (in list order), then answers the target', () {
+  group('CallState.otherCallIds', () {
+    test('returns every other call id in list order', () {
       final held = _makeCall(callId: 'held', held: true, acceptedTime: DateTime(2024));
       final active = _makeCall(callId: 'active', acceptedTime: DateTime(2024));
       final incoming = _makeCall(callId: 'incoming', processingStatus: CallProcessingStatus.incomingFromOffer);
       final state = CallState(activeCalls: [held, active, incoming]);
 
-      expect(state.planAnswerEndingOthers('incoming'), const [
+      expect(state.otherCallIds('incoming'), ['held', 'active']);
+    });
+
+    test('returns empty when the target is the only call', () {
+      final state = CallState(activeCalls: [_makeCall(callId: 'incoming')]);
+      expect(state.otherCallIds('incoming'), isEmpty);
+    });
+  });
+
+  group('CallControlEvent.answerEndingOthersPlan', () {
+    test('ends every other call (in given order), then answers the target', () {
+      expect(CallControlEvent.answerEndingOthersPlan('incoming', ['held', 'active']), const [
         CallControlEvent.ended('held'),
         CallControlEvent.ended('active'),
         CallControlEvent.answered('incoming'),
       ]);
     });
 
-    test('only answers when the target is the only call', () {
-      final incoming = _makeCall(callId: 'incoming');
-      final state = CallState(activeCalls: [incoming]);
-      expect(state.planAnswerEndingOthers('incoming'), const [CallControlEvent.answered('incoming')]);
+    test('only answers when there are no other calls', () {
+      expect(CallControlEvent.answerEndingOthersPlan('incoming', []), const [CallControlEvent.answered('incoming')]);
     });
   });
 
-  group('CallState.planAnswerHoldingOthers', () {
-    test('holds every other call (in list order), then answers the target', () {
-      final active = _makeCall(callId: 'active', acceptedTime: DateTime(2024));
-      final incoming = _makeCall(callId: 'incoming', processingStatus: CallProcessingStatus.incomingFromOffer);
-      final state = CallState(activeCalls: [active, incoming]);
-
-      expect(state.planAnswerHoldingOthers('incoming'), const [
+  group('CallControlEvent.answerHoldingOthersPlan', () {
+    test('holds every other call (in given order), then answers the target', () {
+      expect(CallControlEvent.answerHoldingOthersPlan('incoming', ['active']), const [
         CallControlEvent.setHeld('active', true),
         CallControlEvent.answered('incoming'),
       ]);
     });
 
-    test('only answers when the target is the only call', () {
-      final incoming = _makeCall(callId: 'incoming');
-      final state = CallState(activeCalls: [incoming]);
-      expect(state.planAnswerHoldingOthers('incoming'), const [CallControlEvent.answered('incoming')]);
+    test('only answers when there are no other calls', () {
+      expect(CallControlEvent.answerHoldingOthersPlan('incoming', []), const [CallControlEvent.answered('incoming')]);
     });
   });
 
-  group('CallState.planSwap', () {
+  group('CallControlEvent.swapPlan', () {
     test('holds the target first, then resumes the other call', () {
-      final active = _makeCall(callId: 'active', acceptedTime: DateTime(2024));
-      final held = _makeCall(callId: 'held', held: true, acceptedTime: DateTime(2024));
-      final state = CallState(activeCalls: [active, held]);
-
-      expect(state.planSwap('active'), const [
+      expect(CallControlEvent.swapPlan('active', ['held']), const [
         CallControlEvent.setHeld('active', true),
         CallControlEvent.setHeld('held', false),
       ]);

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -432,6 +432,67 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // CallState — combined-action planners
+  //
+  // The single intents (answeredEndingOthers / answeredHoldingOthers / swapped)
+  // dispatch exactly these ordered primitive events; this pins the semantics
+  // the call screen used to synthesize with per-call loops.
+  // ---------------------------------------------------------------------------
+
+  group('CallState.planAnswerEndingOthers', () {
+    test('ends every other call (in list order), then answers the target', () {
+      final held = _makeCall(callId: 'held', held: true, acceptedTime: DateTime(2024));
+      final active = _makeCall(callId: 'active', acceptedTime: DateTime(2024));
+      final incoming = _makeCall(callId: 'incoming', processingStatus: CallProcessingStatus.incomingFromOffer);
+      final state = CallState(activeCalls: [held, active, incoming]);
+
+      expect(state.planAnswerEndingOthers('incoming'), const [
+        CallControlEvent.ended('held'),
+        CallControlEvent.ended('active'),
+        CallControlEvent.answered('incoming'),
+      ]);
+    });
+
+    test('only answers when the target is the only call', () {
+      final incoming = _makeCall(callId: 'incoming');
+      final state = CallState(activeCalls: [incoming]);
+      expect(state.planAnswerEndingOthers('incoming'), const [CallControlEvent.answered('incoming')]);
+    });
+  });
+
+  group('CallState.planAnswerHoldingOthers', () {
+    test('holds every other call (in list order), then answers the target', () {
+      final active = _makeCall(callId: 'active', acceptedTime: DateTime(2024));
+      final incoming = _makeCall(callId: 'incoming', processingStatus: CallProcessingStatus.incomingFromOffer);
+      final state = CallState(activeCalls: [active, incoming]);
+
+      expect(state.planAnswerHoldingOthers('incoming'), const [
+        CallControlEvent.setHeld('active', true),
+        CallControlEvent.answered('incoming'),
+      ]);
+    });
+
+    test('only answers when the target is the only call', () {
+      final incoming = _makeCall(callId: 'incoming');
+      final state = CallState(activeCalls: [incoming]);
+      expect(state.planAnswerHoldingOthers('incoming'), const [CallControlEvent.answered('incoming')]);
+    });
+  });
+
+  group('CallState.planSwap', () {
+    test('holds the target first, then resumes the other call', () {
+      final active = _makeCall(callId: 'active', acceptedTime: DateTime(2024));
+      final held = _makeCall(callId: 'held', held: true, acceptedTime: DateTime(2024));
+      final state = CallState(activeCalls: [active, held]);
+
+      expect(state.planSwap('active'), const [
+        CallControlEvent.setHeld('active', true),
+        CallControlEvent.setHeld('held', false),
+      ]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CallState — display
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Overview

Second foundation PR for the list-based call screen redesign (targets the
`refactor/call` integration branch). The call screen used to synthesize
multi-step actions itself by dispatching several primitive events in a loop;
the upcoming single action area needs one intent per action.

## Changes

- New `CallControlEvent` intents: `answeredEndingOthers` ("End & Answer"),
  `answeredHoldingOthers` ("Hold & Answer"), `swapped`.
- Pure planners on `CallState` (`planAnswerEndingOthers` /
  `planAnswerHoldingOthers` / `planSwap`) return the ordered primitive events;
  the bloc handlers just dispatch them.
- `CallActiveScaffold` now dispatches one intent per action instead of looping
  over `activeCalls`.
- `docs/features/call.md`: rollout section now reflects the `refactor/call`
  integration branch (the feature-flag wording shipped in the doc was already
  outdated) and updates stage statuses.

## Why behavior is unchanged

The intents re-dispatch exactly the primitive events the scaffold used to add
(`ended`/`setHeld` for the others, then `answered`), in the same order, through
the same sequential `CallControlEvent` queue. The only difference is the plan is
computed from bloc state at handling time instead of widget build time - same
data, marginally fresher.

## Tests

`call_state_test.dart` planner groups pin the semantics: end/hold every other
call in list order then answer; swap holds the target first then resumes the
rest; only-call edge cases collapse to a plain answer. Full suite green via
pre-push (analyze + 781 tests).