### PR TITLE
feat(call): render concurrent calls as a selectable list

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -101,8 +101,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 | Stage | Scope | Status |
 |---|---|---|
 | Focus state | `selectedCallId` + `focusedCall` + `callSelected` event (invisible groundwork) | Merged (PR #1376) |
-| Action intents | Combined actions (hold&accept / hangup&accept / swap) move into bloc intents | In review |
-| Call list | Selectable list of calls + status badges + header | Planned |
+| Action intents | Combined actions (hold&accept / hangup&accept / swap) move into bloc intents | Merged (PR #1378) |
+| Call list | Selectable list of calls + status badges + header; auto-focus (a new ringing call grabs focus, the next ringing one after the focused call ends); info + action area bind to the focused call | In review |
 | Focused actions | Single action area + "Acting on" hint; drop combined-icon buttons | Planned |
 | Cleanup / edges | Single-call polish, dead-code removal, 3-call / transfer / landscape | Planned |
 

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -214,18 +214,28 @@ class CallState with _$CallState {
   }
 
   CallState copyWithPushActiveCall(ActiveCall activeCall) {
-    return copyWith(activeCalls: [...activeCalls, activeCall]);
+    return copyWith(
+      activeCalls: [...activeCalls, activeCall],
+      // A new ringing incoming call demands a decision, so it grabs the focus;
+      // any other call keeps the user's selection.
+      selectedCallId: activeCall.isIncoming && !activeCall.wasAccepted ? activeCall.callId : selectedCallId,
+    );
   }
 
   CallState copyWithPopActiveCall(String callId) {
     final activeCalls = this.activeCalls.where((activeCall) {
       return activeCall.callId != callId;
     }).toList();
+    // When the focused call ends, prefer the next ringing incoming call (it
+    // still demands a decision); otherwise clear so [focusedCall] falls back
+    // to `current`. An unrelated selection is kept as is.
+    final selectedCallId = this.selectedCallId == callId
+        ? activeCalls.firstWhereOrNull((call) => call.isIncoming && !call.wasAccepted)?.callId
+        : this.selectedCallId;
     return copyWith(
       activeCalls: activeCalls,
       minimized: activeCalls.isEmpty ? null : minimized,
-      // Drop a dangling selection so [focusedCall] falls back to `current`.
-      selectedCallId: selectedCallId == callId ? null : selectedCallId,
+      selectedCallId: selectedCallId,
     );
   }
 

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -22,6 +22,7 @@ class CallActiveScaffold extends StatefulWidget {
     super.key,
     required this.callStatus,
     required this.activeCalls,
+    required this.focusedCall,
     required this.audioDevice,
     required this.availableAudioDevices,
     required this.callConfig,
@@ -31,6 +32,10 @@ class CallActiveScaffold extends StatefulWidget {
 
   final CallStatus callStatus;
   final List<ActiveCall> activeCalls;
+
+  /// The call the info block and the action area act on (see
+  /// [CallState.focusedCall]); the call list highlights its row.
+  final ActiveCall focusedCall;
   final CallAudioDevice? audioDevice;
   final List<CallAudioDevice> availableAudioDevices;
   final CallCapabilitiesConfig callConfig;
@@ -128,7 +133,11 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     final nonIncomingRingingCalls = activeCalls.whereNot((call) => incomingRingingCalls.contains(call)).toList();
     final nonIncomingRingingCanBeHolded = nonIncomingRingingCalls.where((call) => call.wasAccepted == true).toList();
 
-    final activeTransfer = activeCall.transfer;
+    // The info block and the action area below act on the focused call; the
+    // media overlay keeps following the derived `current` call.
+    final focusedCall = widget.focusedCall;
+    final focusedIsRinging = focusedCall.isIncoming && !focusedCall.wasAccepted;
+    final focusedTransfer = focusedCall.transfer;
 
     final themeData = Theme.of(context);
     final MediaQueryData mediaQueryData = MediaQuery.of(context);
@@ -198,27 +207,34 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                         child: Column(
                                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                                           children: [
-                                            for (final activeCall in nonIncomingRingingCalls) ...[
-                                              CallInfo(
-                                                transfering: activeTransfer is Transfering,
-                                                requestToAttendedTransfer: false,
-                                                inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
-                                                isIncoming: activeCall.isIncoming,
-                                                held: activeCall.held,
-                                                number: activeCall.handle.value,
-                                                username: activeCall.displayName,
-                                                acceptedTime: activeCall.acceptedTime,
+                                            // List-based call screen: with more than one call every
+                                            // call is a tappable row, and the info block + action
+                                            // area below act on the focused call.
+                                            if (activeCalls.length > 1)
+                                              CallList(
+                                                calls: activeCalls,
+                                                focusedCallId: focusedCall.callId,
                                                 style: style?.callInfo,
-                                                processingStatus: activeCall.processingStatus,
-                                                callStatus: widget.callStatus,
-                                                iceConnectionIssue: activeCall.iceConnectionIssue,
-                                                networkQuality: activeCall.networkQuality,
+                                                onCallTap: (callId) {
+                                                  _callBloc.add(CallControlEvent.callSelected(callId));
+                                                },
                                               ),
-                                            ],
-
-                                            // Not in for because no space for multiple active call, show for current active
-                                            // Only if no icoming ringing calls that beed to be accepted, of se else
-                                            if (incomingRingingCalls.isEmpty)
+                                            CallInfo(
+                                              transfering: focusedTransfer is Transfering,
+                                              requestToAttendedTransfer: false,
+                                              inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
+                                              isIncoming: focusedCall.isIncoming,
+                                              held: focusedCall.held,
+                                              number: focusedCall.handle.value,
+                                              username: focusedCall.displayName,
+                                              acceptedTime: focusedCall.acceptedTime,
+                                              style: style?.callInfo,
+                                              processingStatus: focusedCall.processingStatus,
+                                              callStatus: widget.callStatus,
+                                              iceConnectionIssue: focusedCall.iceConnectionIssue,
+                                              networkQuality: focusedCall.networkQuality,
+                                            ),
+                                            if (!focusedIsRinging)
                                               ActiveCallActions(
                                                 style: style?.actions,
                                                 // Blocks signaling-dependent actions (hold, transfer, camera).
@@ -227,145 +243,135 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                     interactionsDebounceActive == false &&
                                                     widget.callStatus == CallStatus.ready &&
                                                     activeCalls.any((call) => call.updating) == false,
-                                                isIncoming: activeCall.isIncoming,
+                                                isIncoming: focusedCall.isIncoming,
                                                 remoteVideo:
-                                                    activeCall.remoteVideo &&
+                                                    focusedCall.remoteVideo &&
                                                     _hasRenderableRemoteFrame &&
-                                                    activeCall.held == false,
-                                                wasAccepted: activeCall.wasAccepted,
-                                                wasHungUp: activeCall.wasHungUp,
-                                                cameraValue: activeCall.isCameraActive,
-                                                inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
+                                                    focusedCall.held == false,
+                                                wasAccepted: focusedCall.wasAccepted,
+                                                wasHungUp: focusedCall.wasHungUp,
+                                                cameraValue: focusedCall.isCameraActive,
+                                                inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
                                                 onCameraChanged: widget.callConfig.isVideoCallEnabled
                                                     ? (bool value) {
                                                         _callBloc.add(
-                                                          CallControlEvent.cameraEnabled(activeCall.callId, value),
+                                                          CallControlEvent.cameraEnabled(focusedCall.callId, value),
                                                         );
                                                         dispatchInteractionDebounce();
                                                       }
                                                     : null,
-                                                mutedValue: activeCall.muted,
+                                                mutedValue: focusedCall.muted,
                                                 onMutedChanged: (bool value) {
-                                                  _callBloc.add(CallControlEvent.setMuted(activeCall.callId, value));
+                                                  _callBloc.add(CallControlEvent.setMuted(focusedCall.callId, value));
                                                 },
                                                 audioDevice: widget.audioDevice,
                                                 availableAudioDevices: widget.availableAudioDevices,
                                                 onAudioDeviceChanged: (CallAudioDevice device) {
                                                   _callBloc.add(
-                                                    CallControlEvent.audioDeviceSet(activeCall.callId, device),
+                                                    CallControlEvent.audioDeviceSet(focusedCall.callId, device),
                                                   );
                                                 },
                                                 transferableCalls: heldCalls,
                                                 onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
-                                                    ? (!activeCall.wasAccepted || activeTransfer != null
+                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
                                                           ? null
                                                           : () {
                                                               _callBloc.add(
                                                                 CallControlEvent.blindTransferInitiated(
-                                                                  activeCall.callId,
+                                                                  focusedCall.callId,
                                                                 ),
                                                               );
                                                             })
                                                     : null,
                                                 // TODO (Serdun): Simplify complex condition in the widget tree.
                                                 onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
-                                                    ? (!activeCall.wasAccepted || activeTransfer != null
+                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
                                                           ? null
                                                           : () {
                                                               _callBloc.add(
                                                                 CallControlEvent.attendedTransferInitiated(
-                                                                  activeCall.callId,
+                                                                  focusedCall.callId,
                                                                 ),
                                                               );
                                                             })
                                                     : null,
                                                 // TODO (Serdun): Simplify complex condition in the widget tree.
                                                 onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
-                                                    ? (!activeCall.wasAccepted || activeTransfer != null
+                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
                                                           ? null
                                                           : (ActiveCall referorCall) {
                                                               _callBloc.add(
                                                                 CallControlEvent.attendedTransferSubmitted(
                                                                   referorCall: referorCall,
-                                                                  replaceCall: activeCall,
+                                                                  replaceCall: focusedCall,
                                                                 ),
                                                               );
                                                             })
                                                     : null,
-                                                heldValue: activeCall.held,
+                                                heldValue: focusedCall.held,
                                                 onHeldChanged: (bool value) {
-                                                  _callBloc.add(CallControlEvent.setHeld(activeCall.callId, value));
+                                                  _callBloc.add(CallControlEvent.setHeld(focusedCall.callId, value));
                                                   dispatchInteractionDebounce();
                                                 },
+                                                // Swap keeps acting on the derived current call: its
+                                                // semantics are "hold the active one, resume the rest"
+                                                // regardless of which row is focused.
                                                 onSwapPressed: activeCalls.length == 2
                                                     ? () {
-                                                        _callBloc.add(CallControlEvent.swapped(activeCall.callId));
+                                                        _callBloc.add(
+                                                          CallControlEvent.swapped(activeCalls.current.callId),
+                                                        );
                                                         dispatchInteractionDebounce();
                                                       }
                                                     : null,
                                                 onHangupPressed: () {
-                                                  _callBloc.add(CallControlEvent.ended(activeCall.callId));
+                                                  _callBloc.add(CallControlEvent.ended(focusedCall.callId));
                                                   dispatchInteractionDebounce();
                                                 },
 
                                                 onKeyPressed: (value) {
-                                                  _callBloc.add(CallControlEvent.sentDTMF(activeCall.callId, value));
+                                                  _callBloc.add(CallControlEvent.sentDTMF(focusedCall.callId, value));
                                                 },
                                               )
                                             else
-                                              // Show incoming calls info and answer/decline actions grouped by each incoming call
-                                              // Check edge-cases:
+                                              // Answer/decline actions for the focused ringing call.
+                                              // Edge-cases (covered by the call list above):
                                               // - two incoming ringing calls
                                               // - one outgoing ringing + one incoming ringing
-                                              for (final incomingCall in incomingRingingCalls) ...[
-                                                CallInfo(
-                                                  transfering: activeTransfer is Transfering,
-                                                  requestToAttendedTransfer: false,
-                                                  inviteToAttendedTransfer: activeTransfer is InviteToAttendedTransfer,
-                                                  isIncoming: incomingCall.isIncoming,
-                                                  held: incomingCall.held,
-                                                  number: incomingCall.handle.value,
-                                                  username: incomingCall.displayName,
-                                                  acceptedTime: incomingCall.acceptedTime,
-                                                  style: style?.callInfo,
-                                                  processingStatus: incomingCall.processingStatus,
-                                                  callStatus: widget.callStatus,
-                                                ),
-                                                IncomingCallActions(
-                                                  style: style?.actions,
-                                                  inviteToAttendedTransfer: false,
-                                                  enableInteractions:
-                                                      interactionsDebounceActive == false &&
-                                                      widget.callStatus == CallStatus.ready &&
-                                                      activeCalls.any((call) => call.updating) == false,
-                                                  remoteVideo: incomingCall.remoteVideo && incomingCall.held == false,
-                                                  onHangupPressed: () {
-                                                    _callBloc.add(CallControlEvent.ended(incomingCall.callId));
-                                                    dispatchInteractionDebounce();
-                                                  },
-                                                  onAcceptPressed: nonIncomingRingingCalls.isNotEmpty
-                                                      ? null
-                                                      : () {
-                                                          _callBloc.add(CallControlEvent.answered(incomingCall.callId));
-                                                        },
-                                                  onHangupAndAcceptPressed: nonIncomingRingingCalls.isEmpty
-                                                      ? null
-                                                      : () {
-                                                          _callBloc.add(
-                                                            CallControlEvent.answeredEndingOthers(incomingCall.callId),
-                                                          );
-                                                          dispatchInteractionDebounce();
-                                                        },
-                                                  onHoldAndAcceptPressed: nonIncomingRingingCanBeHolded.isEmpty
-                                                      ? null
-                                                      : () {
-                                                          _callBloc.add(
-                                                            CallControlEvent.answeredHoldingOthers(incomingCall.callId),
-                                                          );
-                                                          dispatchInteractionDebounce();
-                                                        },
-                                                ),
-                                              ],
+                                              IncomingCallActions(
+                                                style: style?.actions,
+                                                inviteToAttendedTransfer: false,
+                                                enableInteractions:
+                                                    interactionsDebounceActive == false &&
+                                                    widget.callStatus == CallStatus.ready &&
+                                                    activeCalls.any((call) => call.updating) == false,
+                                                remoteVideo: focusedCall.remoteVideo && focusedCall.held == false,
+                                                onHangupPressed: () {
+                                                  _callBloc.add(CallControlEvent.ended(focusedCall.callId));
+                                                  dispatchInteractionDebounce();
+                                                },
+                                                onAcceptPressed: nonIncomingRingingCalls.isNotEmpty
+                                                    ? null
+                                                    : () {
+                                                        _callBloc.add(CallControlEvent.answered(focusedCall.callId));
+                                                      },
+                                                onHangupAndAcceptPressed: nonIncomingRingingCalls.isEmpty
+                                                    ? null
+                                                    : () {
+                                                        _callBloc.add(
+                                                          CallControlEvent.answeredEndingOthers(focusedCall.callId),
+                                                        );
+                                                        dispatchInteractionDebounce();
+                                                      },
+                                                onHoldAndAcceptPressed: nonIncomingRingingCanBeHolded.isEmpty
+                                                    ? null
+                                                    : () {
+                                                        _callBloc.add(
+                                                          CallControlEvent.answeredHoldingOthers(focusedCall.callId),
+                                                        );
+                                                        dispatchInteractionDebounce();
+                                                      },
+                                              ),
                                           ],
                                         ),
                                       ),

--- a/lib/features/call/view/call_screen.dart
+++ b/lib/features/call/view/call_screen.dart
@@ -68,6 +68,8 @@ class _CallScreenState extends State<CallScreen> with AutoRouteAwareStateMixin {
           return CallActiveScaffold(
             callStatus: state.status,
             activeCalls: state.activeCalls,
+            // isActive guarantees at least one call, so focusedCall is non-null.
+            focusedCall: state.focusedCall!,
             audioDevice: state.audioDevice,
             availableAudioDevices: state.availableAudioDevices,
             callConfig: widget.callConfig,

--- a/lib/features/call/widgets/call_list.dart
+++ b/lib/features/call/widgets/call_list.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:clock/clock.dart';
+
+import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+import '../bloc/call_bloc.dart';
+import '../view/call_screen_style.dart';
+
+/// The list-of-calls roster for the call screen.
+///
+/// Renders every active call as a tappable [CallRow] (name + status badge +
+/// timer) and, when more than one call is in progress, a "N calls - tap to
+/// choose" header. Tapping a row reports the call id via [onCallTap] so the
+/// caller can focus it (see [CallControlEvent.callSelected]); the focused row
+/// is highlighted.
+class CallList extends StatelessWidget {
+  const CallList({super.key, required this.calls, required this.focusedCallId, required this.onCallTap, this.style});
+
+  final List<ActiveCall> calls;
+  final String focusedCallId;
+  final ValueChanged<String> onCallTap;
+  final CallInfoStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (calls.length > 1)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              context.l10n.call_CallList_header(calls.length).toUpperCase(),
+              style: (style?.callStatus ?? const TextStyle()).copyWith(fontSize: 11, letterSpacing: 1.2),
+            ),
+          ),
+        for (final call in calls)
+          CallRow(
+            key: ValueKey('CallRow-${call.callId}'),
+            call: call,
+            focused: call.callId == focusedCallId,
+            onTap: () => onCallTap(call.callId),
+            style: style,
+          ),
+      ],
+    );
+  }
+}
+
+/// One call in the [CallList]: status badge, name/number and a live duration
+/// for answered calls (or the call direction while it is still ringing).
+class CallRow extends StatefulWidget {
+  const CallRow({super.key, required this.call, required this.focused, required this.onTap, this.style});
+
+  final ActiveCall call;
+  final bool focused;
+  final VoidCallback onTap;
+  final CallInfoStyle? style;
+
+  @override
+  State<CallRow> createState() => _CallRowState();
+}
+
+class _CallRowState extends State<CallRow> {
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncTicker();
+  }
+
+  @override
+  void didUpdateWidget(covariant CallRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncTicker();
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  // Keeps the duration label ticking only while the call is answered.
+  void _syncTicker() {
+    if (widget.call.wasAccepted && _ticker == null) {
+      _ticker = Timer.periodic(const Duration(seconds: 1), (_) => setState(() {}));
+    } else if (!widget.call.wasAccepted && _ticker != null) {
+      _ticker?.cancel();
+      _ticker = null;
+    }
+  }
+
+  String _statusBadge(BuildContext context) {
+    final call = widget.call;
+    if (!call.wasAccepted) return context.l10n.callProcessingStatus_ringing;
+    if (call.held) return context.l10n.call_description_held;
+    return context.l10n.call_CallList_statusOnCall;
+  }
+
+  String _trailing(BuildContext context) {
+    final call = widget.call;
+    final acceptedTime = call.acceptedTime;
+    if (acceptedTime != null) return clock.now().difference(acceptedTime).format();
+    return call.isIncoming ? context.l10n.call_description_incoming : context.l10n.call_description_outgoing;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final nameStyle = widget.style?.number ?? const TextStyle();
+    final statusStyle = widget.style?.callStatus ?? const TextStyle();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Material(
+        color: colorScheme.surface.withValues(alpha: widget.focused ? 0.28 : 0.12),
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: widget.onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: widget.focused ? Border.all(color: colorScheme.surface.withValues(alpha: 0.6)) : null,
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _statusBadge(context).toUpperCase(),
+                        style: statusStyle.copyWith(fontSize: 10, letterSpacing: 1.1),
+                      ),
+                      Text(
+                        widget.call.displayName ?? widget.call.handle.value,
+                        style: nameStyle.copyWith(fontSize: 16),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                Text(_trailing(context), style: statusStyle.copyWith(fontSize: 13)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/call/widgets/widgets.dart
+++ b/lib/features/call/widgets/widgets.dart
@@ -2,6 +2,7 @@ export 'incoming_call_actions.dart';
 export 'active_call_actions.dart';
 export 'call_active_thumbnail.dart';
 export 'call_info.dart';
+export 'call_list.dart';
 export 'call_network_quality_meter.dart';
 export 'draggable_thumbnail.dart';
 export 'local_camera_preview_thumbnail.dart';

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -345,6 +345,18 @@ abstract class AppLocalizations {
   /// **'Unmute microphone'**
   String get call_CallActionsTooltip_unmute;
 
+  /// Header above the call list on the call screen when more than one call is in progress.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{{count} call - tap to choose} other{{count} calls - tap to choose}}'**
+  String call_CallList_header(int count);
+
+  /// Status badge in the call list for an answered, not held call.
+  ///
+  /// In en, this message translates to:
+  /// **'On call'**
+  String get call_CallList_statusOnCall;
+
   /// No description provided for @call_description_held.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -177,6 +177,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get call_CallActionsTooltip_unmute => 'Unmute microphone';
 
   @override
+  String call_CallList_header(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count calls - tap to choose',
+      one: '$count call - tap to choose',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get call_CallList_statusOnCall => 'On call';
+
+  @override
   String get call_description_held => 'On hold';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -178,6 +178,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get call_CallActionsTooltip_unmute => 'Attiva il microfono';
 
   @override
+  String call_CallList_header(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chiamate - tocca per scegliere',
+      one: '$count chiamata - tocca per scegliere',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get call_CallList_statusOnCall => 'In chiamata';
+
+  @override
   String get call_description_held => 'In attesa';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -186,6 +186,22 @@ class AppLocalizationsUk extends AppLocalizations {
   String get call_CallActionsTooltip_unmute => 'Увімкнути мікрофон';
 
   @override
+  String call_CallList_header(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count дзвінка - торкніться, щоб вибрати',
+      many: '$count дзвінків - торкніться, щоб вибрати',
+      few: '$count дзвінки - торкніться, щоб вибрати',
+      one: '$count дзвінок - торкніться, щоб вибрати',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get call_CallList_statusOnCall => 'Розмова';
+
+  @override
   String get call_description_held => 'На утриманні';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -117,6 +117,19 @@
   "@call_CallActionsTooltip_unhold": {},
   "call_CallActionsTooltip_unmute": "Unmute microphone",
   "@call_CallActionsTooltip_unmute": {},
+  "call_CallList_header": "{count, plural, one{{count} call - tap to choose} other{{count} calls - tap to choose}}",
+  "@call_CallList_header": {
+    "description": "Header above the call list on the call screen when more than one call is in progress.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "call_CallList_statusOnCall": "On call",
+  "@call_CallList_statusOnCall": {
+    "description": "Status badge in the call list for an answered, not held call."
+  },
   "call_description_held": "On hold",
   "@call_description_held": {},
   "call_description_incoming": "Incoming call",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -117,6 +117,19 @@
   "@call_CallActionsTooltip_unhold": {},
   "call_CallActionsTooltip_unmute": "Attiva il microfono",
   "@call_CallActionsTooltip_unmute": {},
+  "call_CallList_header": "{count, plural, one{{count} chiamata - tocca per scegliere} other{{count} chiamate - tocca per scegliere}}",
+  "@call_CallList_header": {
+    "description": "Header above the call list on the call screen when more than one call is in progress.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "call_CallList_statusOnCall": "In chiamata",
+  "@call_CallList_statusOnCall": {
+    "description": "Status badge in the call list for an answered, not held call."
+  },
   "call_description_held": "In attesa",
   "@call_description_held": {},
   "call_description_incoming": "Chiamata in arrivo",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -117,6 +117,19 @@
   "@call_CallActionsTooltip_unhold": {},
   "call_CallActionsTooltip_unmute": "Увімкнути мікрофон",
   "@call_CallActionsTooltip_unmute": {},
+  "call_CallList_header": "{count, plural, one{{count} дзвінок - торкніться, щоб вибрати} few{{count} дзвінки - торкніться, щоб вибрати} many{{count} дзвінків - торкніться, щоб вибрати} other{{count} дзвінка - торкніться, щоб вибрати}}",
+  "@call_CallList_header": {
+    "description": "Header above the call list on the call screen when more than one call is in progress.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "call_CallList_statusOnCall": "Розмова",
+  "@call_CallList_statusOnCall": {
+    "description": "Status badge in the call list for an answered, not held call."
+  },
   "call_description_held": "На утриманні",
   "@call_description_held": {},
   "call_description_incoming": "Вхідний дзвінок",

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -411,14 +411,25 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('CallState.copyWithPopActiveCall — selection clamp', () {
-    test('clears selectedCallId when the selected call is removed', () {
+    test('clears selectedCallId when the selected call is removed and none is ringing', () {
       final c1 = _makeCall(callId: 'c1');
-      final c2 = _makeCall(callId: 'c2');
+      final c2 = _makeCall(callId: 'c2', acceptedTime: DateTime(2024));
       final state = CallState(activeCalls: [c1, c2], selectedCallId: 'c1');
       final next = state.copyWithPopActiveCall('c1');
       expect(next.selectedCallId, isNull);
       // focusedCall falls back to the surviving call.
       expect(next.focusedCall?.callId, 'c2');
+    });
+
+    test('re-focuses the next ringing incoming call when the selected call is removed', () {
+      final selected = _makeCall(callId: 'selected');
+      final answered = _makeCall(callId: 'answered', acceptedTime: DateTime(2024));
+      final ringing = _makeCall(callId: 'ringing', processingStatus: CallProcessingStatus.incomingFromOffer);
+      final state = CallState(activeCalls: [selected, answered, ringing], selectedCallId: 'selected');
+      final next = state.copyWithPopActiveCall('selected');
+      // The remaining ringing incoming call still demands a decision.
+      expect(next.selectedCallId, 'ringing');
+      expect(next.focusedCall?.callId, 'ringing');
     });
 
     test('keeps selectedCallId when a different call is removed', () {
@@ -428,6 +439,29 @@ void main() {
       final next = state.copyWithPopActiveCall('c1');
       expect(next.selectedCallId, 'c2');
       expect(next.focusedCall?.callId, 'c2');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallState — copyWithPushActiveCall auto-focus
+  // ---------------------------------------------------------------------------
+
+  group('CallState.copyWithPushActiveCall — auto-focus', () {
+    test('a new ringing incoming call grabs the focus', () {
+      final answered = _makeCall(callId: 'answered', acceptedTime: DateTime(2024));
+      final state = CallState(activeCalls: [answered], selectedCallId: 'answered');
+      final incoming = _makeCall(callId: 'incoming', processingStatus: CallProcessingStatus.incomingFromOffer);
+      final next = state.copyWithPushActiveCall(incoming);
+      expect(next.selectedCallId, 'incoming');
+      expect(next.focusedCall?.callId, 'incoming');
+    });
+
+    test('a new outgoing call keeps the existing selection', () {
+      final answered = _makeCall(callId: 'answered', acceptedTime: DateTime(2024));
+      final state = CallState(activeCalls: [answered], selectedCallId: 'answered');
+      final outgoing = _makeCall(callId: 'outgoing', direction: CallDirection.outgoing);
+      final next = state.copyWithPushActiveCall(outgoing);
+      expect(next.selectedCallId, 'answered');
     });
   });
 

--- a/test/features/call/widgets/call_list_test.dart
+++ b/test/features/call/widgets/call_list_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/call/call.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _kHandle = CallkeepHandle.number('+380991234567');
+
+ActiveCall _makeCall({
+  String callId = 'call-1',
+  CallDirection direction = CallDirection.incoming,
+  CallProcessingStatus processingStatus = CallProcessingStatus.connected,
+  bool held = false,
+  DateTime? acceptedTime,
+  CallkeepHandle handle = _kHandle,
+  String? displayName,
+}) {
+  return ActiveCall(
+    callId: callId,
+    direction: direction,
+    line: 0,
+    handle: handle,
+    createdTime: DateTime(2024),
+    video: false,
+    processingStatus: processingStatus,
+    held: held,
+    acceptedTime: acceptedTime,
+    displayName: displayName,
+  );
+}
+
+Widget _buildSubject({
+  required List<ActiveCall> calls,
+  required String focusedCallId,
+  required ValueChanged<String> onCallTap,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: CallList(calls: calls, focusedCallId: focusedCallId, onCallTap: onCallTap),
+    ),
+  );
+}
+
+void main() {
+  final ringing = _makeCall(
+    callId: 'ringing',
+    processingStatus: CallProcessingStatus.incomingFromOffer,
+    displayName: 'Anna Marchenko',
+  );
+  // Accepted moments ago so the elapsed-time label stays in MM:SS form.
+  final onCall = _makeCall(
+    callId: 'on-call',
+    acceptedTime: DateTime.now().subtract(const Duration(seconds: 65)),
+    displayName: 'Boris Klein',
+  );
+  final held = _makeCall(
+    callId: 'held',
+    acceptedTime: DateTime.now().subtract(const Duration(seconds: 65)),
+    held: true,
+    displayName: 'Clara Diaz',
+  );
+
+  group('CallList', () {
+    testWidgets('renders one row per call with its display name', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(calls: [ringing, onCall, held], focusedCallId: 'ringing', onCallTap: (_) {}),
+      );
+
+      expect(find.byType(CallRow), findsNWidgets(3));
+      expect(find.text('Anna Marchenko'), findsOneWidget);
+      expect(find.text('Boris Klein'), findsOneWidget);
+      expect(find.text('Clara Diaz'), findsOneWidget);
+    });
+
+    testWidgets('falls back to the handle when there is no display name', (tester) async {
+      final anonymous = _makeCall(callId: 'anon', processingStatus: CallProcessingStatus.incomingFromOffer);
+      await tester.pumpWidget(_buildSubject(calls: [anonymous, onCall], focusedCallId: 'anon', onCallTap: (_) {}));
+      expect(find.text(_kHandle.value), findsOneWidget);
+    });
+
+    testWidgets('shows the status badge matching each call state', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(calls: [ringing, onCall, held], focusedCallId: 'ringing', onCallTap: (_) {}),
+      );
+      final context = tester.element(find.byType(CallList));
+
+      expect(find.text(context.l10n.callProcessingStatus_ringing.toUpperCase()), findsOneWidget);
+      expect(find.text(context.l10n.call_CallList_statusOnCall.toUpperCase()), findsOneWidget);
+      expect(find.text(context.l10n.call_description_held.toUpperCase()), findsOneWidget);
+    });
+
+    testWidgets('shows the header only when more than one call is present', (tester) async {
+      await tester.pumpWidget(_buildSubject(calls: [ringing], focusedCallId: 'ringing', onCallTap: (_) {}));
+      final context = tester.element(find.byType(CallList));
+      final header = context.l10n.call_CallList_header(1).toUpperCase();
+      expect(find.text(header), findsNothing);
+
+      await tester.pumpWidget(_buildSubject(calls: [ringing, onCall], focusedCallId: 'ringing', onCallTap: (_) {}));
+      final multiHeader = context.l10n.call_CallList_header(2).toUpperCase();
+      expect(find.text(multiHeader), findsOneWidget);
+    });
+
+    testWidgets('tapping a row reports its call id', (tester) async {
+      final tapped = <String>[];
+      await tester.pumpWidget(_buildSubject(calls: [ringing, onCall], focusedCallId: 'ringing', onCallTap: tapped.add));
+
+      await tester.tap(find.byKey(const ValueKey('CallRow-on-call')));
+      expect(tapped, ['on-call']);
+    });
+
+    testWidgets('highlights only the focused row', (tester) async {
+      await tester.pumpWidget(_buildSubject(calls: [ringing, onCall], focusedCallId: 'on-call', onCallTap: (_) {}));
+
+      CallRow rowOf(String callId) => tester.widget<CallRow>(find.byKey(ValueKey('CallRow-$callId')));
+      expect(rowOf('on-call').focused, isTrue);
+      expect(rowOf('ringing').focused, isFalse);
+    });
+
+    testWidgets('shows a ticking duration for an answered call and the direction while ringing', (tester) async {
+      // The answered call shows an elapsed-time label (MM:SS); the ringing
+      // incoming call shows the direction instead.
+      await tester.pumpWidget(_buildSubject(calls: [ringing, onCall], focusedCallId: 'ringing', onCallTap: (_) {}));
+      final context = tester.element(find.byType(CallList));
+
+      expect(find.text(context.l10n.call_description_incoming), findsOneWidget);
+      expect(find.textContaining(RegExp(r'^\d{2}:\d{2}')), findsOneWidget);
+
+      // Let the periodic ticker fire once, then dispose cleanly.
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.textContaining(RegExp(r'^\d{2}:\d{2}')), findsOneWidget);
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+}


### PR DESCRIPTION
## Overview

First visible step of the list-based call screen redesign (targets
`refactor/call`). With more than one call in progress the screen now shows one
tappable row per call instead of stacking a full info block and a button row
per call. Tapping a row focuses that call; the info block and the action area
below act on the focused call only.

## Changes

- **CallList / CallRow** (new widgets): status badge (RINGING / ON CALL /
  ON HOLD), name or handle, live MM:SS duration for answered calls (direction
  label while ringing), focused-row highlight, "N calls - tap to choose" header
  when more than one call exists.
- **Auto-focus rules** in `CallState`:
  - `copyWithPushActiveCall`: a new ringing incoming call grabs the focus.
  - `copyWithPopActiveCall`: when the focused call ends, the next ringing
    incoming call is focused; otherwise focus falls back to the derived
    `current`.
- **CallActiveScaffold**: renders the list (when >1 call), then `CallInfo` and
  the action area for the focused call - `IncomingCallActions` for a ringing
  focus (same enable rules as before, single intents from the previous PR),
  `ActiveCallActions` otherwise. The media overlay keeps following the derived
  `current` call, and swap keeps its hold-the-active semantics.
- **l10n**: `call_CallList_header` (plural) + `call_CallList_statusOnCall` in
  en/it/uk; badges reuse the existing ringing/on-hold keys.
- `docs/features/call.md` rollout statuses updated.

## Behavior notes

- The single-call screen is unchanged (list-of-1 polish is the cleanup stage).
- New capability by design: while a second call is ringing the user can tap the
  active call's row and operate it (mute/hold/end) - previously the incoming
  call's buttons were the only available actions.
- "Focused" is the UI term; `selectedCallId` stays confined to the state field
  (per the review note on #1376).

## Tests

- `call_list_test.dart` (new): rows render, handle fallback, badge per state,
  header visibility 1 vs 2 calls, tap dispatches the call id, focused-row
  highlight, ticking duration vs direction label.
- `call_state_test.dart`: push auto-focus (incoming grabs, outgoing keeps),
  pop re-focus (next ringing preferred, cleared otherwise, unrelated kept).
- Full suite green via pre-push (analyze + 193 call tests among them).