### PR TITLE
feat(call): focused-call action area with acting-on hint

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -53,32 +53,37 @@ Single call:
   hold, keypad) + hang up.
 - **1 on hold** - same grid with Hold shown as Resume.
 
-Multiple calls today (stacked layout):
+Multiple calls (list-based):
 
-- The screen stacks a `CallInfo` block per call. The "current" call is derived,
-  not explicitly chosen: `activeCalls.current` = the last non-held call.
-- For a second incoming call while one is active, `IncomingCallActions` shows
-  combined-icon buttons: End & Answer (`call_end` + `call`), Decline (`call_end`),
-  Hold & Answer (`pause` + `call`). Hold is impossible while a call is ringing,
-  so the user answers first; the combined actions end or hold the other call,
-  then answer.
+- The screen shows one tappable `CallRow` per call - status badge (RINGING /
+  ON CALL / ON HOLD), name, live duration - under an "N calls - tap to choose"
+  header. Tapping a row focuses that call.
+- The `CallInfo` block and the action area below act on the focused call only.
+  A ringing focus gets exactly Decline / Answer plus an "Acting on: <name>"
+  hint that spells out the side effect ("<name> will be put on hold" or
+  "will be ended"); an active/held focus gets the control grid + End.
+- Answer is one intent (`CallControlEvent.answerFocused`): it holds the
+  answered calls when possible, ends the non-holdable ones (e.g. an outgoing
+  call still ringing), and leaves another ringing incoming call ringing.
 
 ### Focused call
 
 `CallState.selectedCallId` + the `focusedCall` getter express which call the
-action area acts on. `focusedCall` returns the explicitly selected call when it
-still maps to a live call, otherwise the derived `current`; it is `null` only
-when there are no active calls. Today nothing sets `selectedCallId`, so
-`focusedCall` mirrors `current`. This is the seam the list-based UI consumes
-(see below).
+info block and action area act on: the explicitly selected call when it still
+maps to a live call, otherwise the derived `current` (= last non-held call).
+Auto-focus: a new ringing incoming call grabs the focus; when the focused call
+ends, the next ringing incoming call is focused. The media overlay keeps
+following the derived `current` call.
 
 ## Key widgets
 
 | Widget | File | Role |
 |---|---|---|
-| `CallActiveScaffold` | `view/call_active_scaffold.dart` | Active call screen; lays out info + actions per call |
-| `CallInfo` | `widgets/call_info.dart` | Per-call name / number / status / timer / network quality |
-| `IncomingCallActions` | `widgets/incoming_call_actions.dart` | Ringing-call buttons (decline / answer / combined) |
+| `CallActiveScaffold` | `view/call_active_scaffold.dart` | Active call screen; list + focused info + actions |
+| `CallList` / `CallRow` | `widgets/call_list.dart` | Tappable per-call rows with status badge + duration |
+| `FocusedActionHint` | `widgets/focused_action_hint.dart` | "Acting on" hint + answer side effect |
+| `CallInfo` | `widgets/call_info.dart` | Focused-call name / number / status / timer / network quality |
+| `IncomingCallActions` | `widgets/incoming_call_actions.dart` | Decline / Answer for the focused ringing call |
 | `ActiveCallActions` | `widgets/active_call_actions.dart` | In-call control grid + hang up + keypad |
 
 ## Redesign / in progress - list-based call flow
@@ -102,8 +107,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 |---|---|---|
 | Focus state | `selectedCallId` + `focusedCall` + `callSelected` event (invisible groundwork) | Merged (PR #1376) |
 | Action intents | Combined actions (hold&accept / hangup&accept / swap) move into bloc intents | Merged (PR #1378) |
-| Call list | Selectable list of calls + status badges + header; auto-focus (a new ringing call grabs focus, the next ringing one after the focused call ends); info + action area bind to the focused call | In review |
-| Focused actions | Single action area + "Acting on" hint; drop combined-icon buttons | Planned |
+| Call list | Selectable list of calls + status badges + header; auto-focus rules; info + action area bind to the focused call | Merged (PR #1379) |
+| Focused actions | "Acting on" hint + two-button ringing focus (single answerFocused intent); combined-icon buttons removed | In review |
 | Cleanup / edges | Single-call polish, dead-code removal, 3-call / transfer / landscape | Planned |
 
 The redesign lands on the `refactor/call` integration branch - every stage is a

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -602,6 +602,21 @@ sealed class CallControlEvent extends CallEvent {
     for (final otherCallId in otherCallIds) CallControlEvent.setHeld(otherCallId, false),
   ];
 
+  /// The single Answer intent for the focused ringing call: hold the other
+  /// calls when at least one is answered (holdable), otherwise end them when
+  /// any non-ringing one exists (e.g. an outgoing call that cannot be held
+  /// yet), otherwise a plain answer. Another ringing incoming call is
+  /// unaffected either way - it keeps ringing.
+  static CallControlEvent answerFocused(
+    String callId, {
+    required bool hasHoldableOthers,
+    required bool hasNonRingingOthers,
+  }) {
+    if (hasHoldableOthers) return CallControlEvent.answeredHoldingOthers(callId);
+    if (hasNonRingingOthers) return CallControlEvent.answeredEndingOthers(callId);
+    return CallControlEvent.answered(callId);
+  }
+
   const factory CallControlEvent.started({
     int? line,
     String? generic,

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -333,11 +333,31 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                   _callBloc.add(CallControlEvent.sentDTMF(focusedCall.callId, value));
                                                 },
                                               )
-                                            else
-                                              // Answer/decline actions for the focused ringing call.
+                                            else ...[
+                                              // Decline / Answer for the focused ringing call -
+                                              // always two buttons. Answering holds the answered
+                                              // calls (or ends the non-holdable ones); the hint
+                                              // names the focused call and spells the side effect.
                                               // Edge-cases (covered by the call list above):
                                               // - two incoming ringing calls
                                               // - one outgoing ringing + one incoming ringing
+                                              if (activeCalls.length > 1)
+                                                FocusedActionHint(
+                                                  focusedName: focusedCall.displayName ?? focusedCall.handle.value,
+                                                  willBeHeldNames: nonIncomingRingingCanBeHolded.isEmpty
+                                                      ? const []
+                                                      : [
+                                                          for (final call in nonIncomingRingingCanBeHolded)
+                                                            if (!call.held) call.displayName ?? call.handle.value,
+                                                        ],
+                                                  willBeEndedNames: nonIncomingRingingCanBeHolded.isNotEmpty
+                                                      ? const []
+                                                      : [
+                                                          for (final call in nonIncomingRingingCalls)
+                                                            call.displayName ?? call.handle.value,
+                                                        ],
+                                                  style: style?.callInfo,
+                                                ),
                                               IncomingCallActions(
                                                 style: style?.actions,
                                                 inviteToAttendedTransfer: false,
@@ -350,28 +370,27 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                   _callBloc.add(CallControlEvent.ended(focusedCall.callId));
                                                   dispatchInteractionDebounce();
                                                 },
-                                                onAcceptPressed: nonIncomingRingingCalls.isNotEmpty
-                                                    ? null
-                                                    : () {
-                                                        _callBloc.add(CallControlEvent.answered(focusedCall.callId));
-                                                      },
-                                                onHangupAndAcceptPressed: nonIncomingRingingCalls.isEmpty
-                                                    ? null
-                                                    : () {
-                                                        _callBloc.add(
-                                                          CallControlEvent.answeredEndingOthers(focusedCall.callId),
-                                                        );
-                                                        dispatchInteractionDebounce();
-                                                      },
-                                                onHoldAndAcceptPressed: nonIncomingRingingCanBeHolded.isEmpty
+                                                // Answering with other calls present mutates them
+                                                // (hold/end), so it is gated by the interactions
+                                                // debounce like any signaling-dependent action.
+                                                onAcceptPressed:
+                                                    nonIncomingRingingCalls.isNotEmpty &&
+                                                        (interactionsDebounceActive ||
+                                                            widget.callStatus != CallStatus.ready ||
+                                                            activeCalls.any((call) => call.updating))
                                                     ? null
                                                     : () {
                                                         _callBloc.add(
-                                                          CallControlEvent.answeredHoldingOthers(focusedCall.callId),
+                                                          CallControlEvent.answerFocused(
+                                                            focusedCall.callId,
+                                                            hasHoldableOthers: nonIncomingRingingCanBeHolded.isNotEmpty,
+                                                            hasNonRingingOthers: nonIncomingRingingCalls.isNotEmpty,
+                                                          ),
                                                         );
                                                         dispatchInteractionDebounce();
                                                       },
                                               ),
+                                            ],
                                           ],
                                         ),
                                       ),

--- a/lib/features/call/widgets/focused_action_hint.dart
+++ b/lib/features/call/widgets/focused_action_hint.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+import '../view/call_screen_style.dart';
+
+/// "Acting on: `<name>`" hint above the call action area.
+///
+/// Confirms which call the buttons below apply to and spells out the side
+/// effect answering will have on the other calls ("`<name>` will be put on
+/// hold" / "`<name>` will be ended"). Shown only with multiple calls; the
+/// caller computes the affected names (see the answer-intent selection in
+/// [CallControlEvent.answerFocused]).
+class FocusedActionHint extends StatelessWidget {
+  const FocusedActionHint({
+    super.key,
+    required this.focusedName,
+    this.willBeHeldNames = const [],
+    this.willBeEndedNames = const [],
+    this.style,
+  });
+
+  final String focusedName;
+
+  /// Names of the calls that will be put on hold when the focused one is
+  /// answered. Ignored when [willBeHeldNames] is empty.
+  final List<String> willBeHeldNames;
+
+  /// Names of the calls that will be ended when the focused one is answered
+  /// (only when none of the others can be held).
+  final List<String> willBeEndedNames;
+
+  final CallInfoStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final baseStyle = style?.callStatus ?? const TextStyle();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            context.l10n.call_FocusedActionHint_actingOn(focusedName),
+            style: baseStyle.copyWith(fontSize: 13, fontWeight: FontWeight.w600),
+            textAlign: TextAlign.center,
+          ),
+          if (willBeHeldNames.isNotEmpty)
+            Text(
+              context.l10n.call_FocusedActionHint_willBeHeld(willBeHeldNames.join(', ')),
+              style: baseStyle.copyWith(fontSize: 12),
+              textAlign: TextAlign.center,
+            )
+          else if (willBeEndedNames.isNotEmpty)
+            Text(
+              context.l10n.call_FocusedActionHint_willBeEnded(willBeEndedNames.join(', ')),
+              style: baseStyle.copyWith(fontSize: 12),
+              textAlign: TextAlign.center,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/call/widgets/incoming_call_actions.dart
+++ b/lib/features/call/widgets/incoming_call_actions.dart
@@ -10,6 +10,11 @@ import 'package:webtrit_phone/widgets/widgets.dart';
 export 'call_actions_style.dart';
 export 'call_actions_styles.dart';
 
+/// Decline / Answer buttons for the focused ringing call.
+///
+/// Always at most two actions: what happens to the other calls on answer is
+/// decided by the caller (see [CallControlEvent.answerFocused]) and explained
+/// by the hint above the buttons, not by extra combined-icon buttons.
 class IncomingCallActions extends StatefulWidget {
   const IncomingCallActions({
     super.key,
@@ -17,8 +22,6 @@ class IncomingCallActions extends StatefulWidget {
     required this.remoteVideo,
     required this.inviteToAttendedTransfer,
     this.onHangupPressed,
-    this.onHangupAndAcceptPressed,
-    this.onHoldAndAcceptPressed,
     this.onAcceptPressed,
     this.style,
   });
@@ -27,8 +30,6 @@ class IncomingCallActions extends StatefulWidget {
   final bool remoteVideo;
   final bool inviteToAttendedTransfer;
   final void Function()? onHangupPressed;
-  final void Function()? onHangupAndAcceptPressed;
-  final void Function()? onHoldAndAcceptPressed;
   final void Function()? onAcceptPressed;
 
   final CallScreenActionsStyle? style;
@@ -92,9 +93,6 @@ class _IncomingCallActionsState extends State<IncomingCallActions> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
 
-    final onHangupAndAcceptPressed = widget.enableInteractions ? widget.onHangupAndAcceptPressed : null;
-    final onHoldAndAcceptPressed = widget.enableInteractions ? widget.onHoldAndAcceptPressed : null;
-
     final onAcceptPressed = widget.onAcceptPressed;
     final onHangupPressed = widget.onHangupPressed;
 
@@ -124,36 +122,6 @@ class _IncomingCallActionsState extends State<IncomingCallActions> {
             onPressed: onAcceptPressed,
             style: widget.style?.callStart,
             child: Icon(widget.remoteVideo ? Icons.videocam : Icons.call, size: actionPadIconSize),
-          ),
-        ),
-      if (widget.onHangupAndAcceptPressed != null)
-        Tooltip(
-          message: context.l10n.call_CallActionsTooltip_hangupAndAccept,
-          child: TextButton(
-            onPressed: onHangupAndAcceptPressed,
-            style: widget.style?.callStart,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.call_end, size: actionPadIconSize),
-                Icon(widget.remoteVideo ? Icons.videocam : Icons.call, size: actionPadIconSize),
-              ],
-            ),
-          ),
-        ),
-      if (widget.onHoldAndAcceptPressed != null)
-        Tooltip(
-          message: context.l10n.call_CallActionsTooltip_holdAndAccept,
-          child: TextButton(
-            onPressed: onHoldAndAcceptPressed,
-            style: widget.style?.callStart,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.pause, size: actionPadIconSize),
-                Icon(widget.remoteVideo ? Icons.videocam : Icons.call, size: actionPadIconSize),
-              ],
-            ),
           ),
         ),
     ];

--- a/lib/features/call/widgets/widgets.dart
+++ b/lib/features/call/widgets/widgets.dart
@@ -3,6 +3,7 @@ export 'active_call_actions.dart';
 export 'call_active_thumbnail.dart';
 export 'call_info.dart';
 export 'call_list.dart';
+export 'focused_action_hint.dart';
 export 'call_network_quality_meter.dart';
 export 'draggable_thumbnail.dart';
 export 'local_camera_preview_thumbnail.dart';

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -357,6 +357,24 @@ abstract class AppLocalizations {
   /// **'On call'**
   String get call_CallList_statusOnCall;
 
+  /// Hint above the call action buttons naming the focused call the actions apply to.
+  ///
+  /// In en, this message translates to:
+  /// **'Acting on: {name}'**
+  String call_FocusedActionHint_actingOn(String name);
+
+  /// Side-effect line under the acting-on hint: the named call will be ended on answer.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} will be ended'**
+  String call_FocusedActionHint_willBeEnded(String name);
+
+  /// Side-effect line under the acting-on hint: the named call will be put on hold on answer.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} will be put on hold'**
+  String call_FocusedActionHint_willBeHeld(String name);
+
   /// No description provided for @call_description_held.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -191,6 +191,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get call_CallList_statusOnCall => 'On call';
 
   @override
+  String call_FocusedActionHint_actingOn(String name) {
+    return 'Acting on: $name';
+  }
+
+  @override
+  String call_FocusedActionHint_willBeEnded(String name) {
+    return '$name will be ended';
+  }
+
+  @override
+  String call_FocusedActionHint_willBeHeld(String name) {
+    return '$name will be put on hold';
+  }
+
+  @override
   String get call_description_held => 'On hold';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -192,6 +192,21 @@ class AppLocalizationsIt extends AppLocalizations {
   String get call_CallList_statusOnCall => 'In chiamata';
 
   @override
+  String call_FocusedActionHint_actingOn(String name) {
+    return 'Azione su: $name';
+  }
+
+  @override
+  String call_FocusedActionHint_willBeEnded(String name) {
+    return 'La chiamata con $name verrà terminata';
+  }
+
+  @override
+  String call_FocusedActionHint_willBeHeld(String name) {
+    return 'La chiamata con $name sarà messa in attesa';
+  }
+
+  @override
   String get call_description_held => 'In attesa';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -202,6 +202,21 @@ class AppLocalizationsUk extends AppLocalizations {
   String get call_CallList_statusOnCall => 'Розмова';
 
   @override
+  String call_FocusedActionHint_actingOn(String name) {
+    return 'Дія для: $name';
+  }
+
+  @override
+  String call_FocusedActionHint_willBeEnded(String name) {
+    return 'Дзвінок з $name буде завершено';
+  }
+
+  @override
+  String call_FocusedActionHint_willBeHeld(String name) {
+    return 'Дзвінок з $name буде поставлено на утримання';
+  }
+
+  @override
   String get call_description_held => 'На утриманні';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -130,6 +130,33 @@
   "@call_CallList_statusOnCall": {
     "description": "Status badge in the call list for an answered, not held call."
   },
+  "call_FocusedActionHint_actingOn": "Acting on: {name}",
+  "@call_FocusedActionHint_actingOn": {
+    "description": "Hint above the call action buttons naming the focused call the actions apply to.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "call_FocusedActionHint_willBeEnded": "{name} will be ended",
+  "@call_FocusedActionHint_willBeEnded": {
+    "description": "Side-effect line under the acting-on hint: the named call will be ended on answer.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "call_FocusedActionHint_willBeHeld": "{name} will be put on hold",
+  "@call_FocusedActionHint_willBeHeld": {
+    "description": "Side-effect line under the acting-on hint: the named call will be put on hold on answer.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "call_description_held": "On hold",
   "@call_description_held": {},
   "call_description_incoming": "Incoming call",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -130,6 +130,33 @@
   "@call_CallList_statusOnCall": {
     "description": "Status badge in the call list for an answered, not held call."
   },
+  "call_FocusedActionHint_actingOn": "Azione su: {name}",
+  "@call_FocusedActionHint_actingOn": {
+    "description": "Hint above the call action buttons naming the focused call the actions apply to.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "call_FocusedActionHint_willBeEnded": "La chiamata con {name} verrà terminata",
+  "@call_FocusedActionHint_willBeEnded": {
+    "description": "Side-effect line under the acting-on hint: the named call will be ended on answer.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "call_FocusedActionHint_willBeHeld": "La chiamata con {name} sarà messa in attesa",
+  "@call_FocusedActionHint_willBeHeld": {
+    "description": "Side-effect line under the acting-on hint: the named call will be put on hold on answer.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "call_description_held": "In attesa",
   "@call_description_held": {},
   "call_description_incoming": "Chiamata in arrivo",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -130,6 +130,33 @@
   "@call_CallList_statusOnCall": {
     "description": "Status badge in the call list for an answered, not held call."
   },
+  "call_FocusedActionHint_actingOn": "Дія для: {name}",
+  "@call_FocusedActionHint_actingOn": {
+    "description": "Hint above the call action buttons naming the focused call the actions apply to.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "call_FocusedActionHint_willBeEnded": "Дзвінок з {name} буде завершено",
+  "@call_FocusedActionHint_willBeEnded": {
+    "description": "Side-effect line under the acting-on hint: the named call will be ended on answer.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "call_FocusedActionHint_willBeHeld": "Дзвінок з {name} буде поставлено на утримання",
+  "@call_FocusedActionHint_willBeHeld": {
+    "description": "Side-effect line under the acting-on hint: the named call will be put on hold on answer.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "call_description_held": "На утриманні",
   "@call_description_held": {},
   "call_description_incoming": "Вхідний дзвінок",

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -527,6 +527,23 @@ void main() {
     });
   });
 
+  group('CallControlEvent.answerFocused', () {
+    test('holds the others when at least one is answered', () {
+      final event = CallControlEvent.answerFocused('incoming', hasHoldableOthers: true, hasNonRingingOthers: true);
+      expect(event, const CallControlEvent.answeredHoldingOthers('incoming'));
+    });
+
+    test('ends the others when none can be held but some exist', () {
+      final event = CallControlEvent.answerFocused('incoming', hasHoldableOthers: false, hasNonRingingOthers: true);
+      expect(event, const CallControlEvent.answeredEndingOthers('incoming'));
+    });
+
+    test('plain answer when there is nothing else to affect', () {
+      final event = CallControlEvent.answerFocused('incoming', hasHoldableOthers: false, hasNonRingingOthers: false);
+      expect(event, const CallControlEvent.answered('incoming'));
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // CallState — display
   // ---------------------------------------------------------------------------

--- a/test/features/call/widgets/focused_action_hint_test.dart
+++ b/test/features/call/widgets/focused_action_hint_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/call/call.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+Widget _buildSubject({
+  required String focusedName,
+  List<String> willBeHeldNames = const [],
+  List<String> willBeEndedNames = const [],
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: FocusedActionHint(
+        focusedName: focusedName,
+        willBeHeldNames: willBeHeldNames,
+        willBeEndedNames: willBeEndedNames,
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('FocusedActionHint', () {
+    testWidgets('names the focused call', (tester) async {
+      await tester.pumpWidget(_buildSubject(focusedName: 'Boris Klein'));
+      final context = tester.element(find.byType(FocusedActionHint));
+
+      expect(find.text(context.l10n.call_FocusedActionHint_actingOn('Boris Klein')), findsOneWidget);
+    });
+
+    testWidgets('spells out the will-be-held side effect', (tester) async {
+      await tester.pumpWidget(_buildSubject(focusedName: 'Boris Klein', willBeHeldNames: const ['Anna Marchenko']));
+      final context = tester.element(find.byType(FocusedActionHint));
+
+      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko')), findsOneWidget);
+    });
+
+    testWidgets('spells out the will-be-ended side effect when nothing can be held', (tester) async {
+      await tester.pumpWidget(_buildSubject(focusedName: 'Boris Klein', willBeEndedNames: const ['Anna Marchenko']));
+      final context = tester.element(find.byType(FocusedActionHint));
+
+      expect(find.text(context.l10n.call_FocusedActionHint_willBeEnded('Anna Marchenko')), findsOneWidget);
+    });
+
+    testWidgets('hold side effect wins over ended when both are passed', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          focusedName: 'Boris Klein',
+          willBeHeldNames: const ['Anna Marchenko'],
+          willBeEndedNames: const ['Clara Diaz'],
+        ),
+      );
+      final context = tester.element(find.byType(FocusedActionHint));
+
+      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko')), findsOneWidget);
+      expect(find.text(context.l10n.call_FocusedActionHint_willBeEnded('Clara Diaz')), findsNothing);
+    });
+
+    testWidgets('joins multiple affected names', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(focusedName: 'Boris Klein', willBeHeldNames: const ['Anna Marchenko', 'Clara Diaz']),
+      );
+      final context = tester.element(find.byType(FocusedActionHint));
+
+      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko, Clara Diaz')), findsOneWidget);
+    });
+
+    testWidgets('shows no side-effect line without affected calls', (tester) async {
+      await tester.pumpWidget(_buildSubject(focusedName: 'Boris Klein'));
+      // Only the acting-on line is present.
+      expect(find.byType(Text), findsOneWidget);
+    });
+  });
+
+  group('IncomingCallActions', () {
+    Widget buildActions({VoidCallback? onAccept, VoidCallback? onHangup}) {
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: IncomingCallActions(
+            enableInteractions: true,
+            remoteVideo: false,
+            inviteToAttendedTransfer: false,
+            onHangupPressed: onHangup,
+            onAcceptPressed: onAccept,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders only Decline and Answer - no combined-icon buttons', (tester) async {
+      await tester.pumpWidget(buildActions(onAccept: () {}, onHangup: () {}));
+
+      expect(find.byType(TextButton), findsNWidgets(2));
+      expect(find.byIcon(Icons.call_end), findsOneWidget);
+      expect(find.byIcon(Icons.call), findsOneWidget);
+      // The combined "Hold & Answer" pause glyph is gone for good.
+      expect(find.byIcon(Icons.pause), findsNothing);
+    });
+
+    testWidgets('buttons invoke their callbacks', (tester) async {
+      var accepted = 0;
+      var declined = 0;
+      await tester.pumpWidget(buildActions(onAccept: () => accepted++, onHangup: () => declined++));
+
+      await tester.tap(find.byIcon(Icons.call));
+      await tester.tap(find.byIcon(Icons.call_end));
+      expect(accepted, 1);
+      expect(declined, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Core step of the list-based call screen redesign (targets `refactor/call`).
The focused ringing call now gets exactly two buttons - Decline and Answer -
with an "Acting on: <name>" hint above them that spells out what answering
does to the other calls. The combined-icon buttons (call_end+call
"End & Answer", pause+call "Hold & Answer"), which were hard to read while a
call is ringing, are removed. This is the change that resolves the
"unclear second-incoming buttons" reports.

## Changes

- **IncomingCallActions** trimmed to Decline / Answer; the combined-icon
  buttons, their callbacks and tooltip usages are gone (the Row-of-two-icons
  pattern no longer exists).
- **CallControlEvent.answerFocused** (pure, static): selects the single Answer
  intent - `answeredHoldingOthers` when at least one other call is answered
  (holdable), `answeredEndingOthers` when others exist but cannot be held
  (e.g. an outgoing call still ringing), plain `answered` otherwise. Another
  ringing incoming call keeps ringing either way.
- **FocusedActionHint** (new widget): "Acting on: <focused>" + the side effect
  line ("<name> will be put on hold" / "<name> will be ended", multiple names
  joined); rendered only with more than one call.
- Answering with other calls present mutates them, so it is now gated by the
  interactions debounce like any signaling-dependent action (a lone ringing
  call answers ungated, as before).
- **l10n**: `call_FocusedActionHint_{actingOn,willBeHeld,willBeEnded}` in
  en/it/uk. The old combined-button tooltip keys are left in the arb files for
  the cleanup stage.
- `docs/features/call.md`: the multi-call section now documents the list-based
  behavior; widget table and rollout statuses updated.

## Tests

- `focused_action_hint_test.dart` (new): acting-on line, held/ended side
  effects, held-over-ended precedence, multi-name join, no-side-effect case;
  IncomingCallActions renders exactly two buttons (no pause glyph) and wires
  callbacks.
- `call_state_test.dart`: `answerFocused` selection - holdable -> holding
  intent, non-holdable others -> ending intent, alone -> plain answer.
- Full suite green via pre-push (423 call-feature tests among them).