### PR TITLE
fix: pin active call actions to the bottom for audio-only calls

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -228,10 +228,6 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                     widget.callStatus == CallStatus.ready &&
                                                     activeCalls.any((call) => call.updating) == false,
                                                 isIncoming: activeCall.isIncoming,
-                                                remoteVideo:
-                                                    activeCall.remoteVideo &&
-                                                    _hasRenderableRemoteFrame &&
-                                                    activeCall.held == false,
                                                 wasAccepted: activeCall.wasAccepted,
                                                 wasHungUp: activeCall.wasHungUp,
                                                 cameraValue: activeCall.isCameraActive,

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -20,7 +20,6 @@ class ActiveCallActions extends StatefulWidget {
     super.key,
     required this.enableInteractions,
     required this.isIncoming,
-    required this.remoteVideo,
     required this.wasAccepted,
     required this.wasHungUp,
     required this.cameraValue,
@@ -45,7 +44,6 @@ class ActiveCallActions extends StatefulWidget {
 
   final bool enableInteractions;
   final bool isIncoming;
-  final bool remoteVideo;
   final bool wasAccepted;
   final bool wasHungUp;
   final bool cameraValue;
@@ -114,12 +112,6 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
   }
 
   @override
-  void didUpdateWidget(covariant ActiveCallActions oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.remoteVideo != widget.remoteVideo) computeDimensions();
-  }
-
-  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _mediaQueryData = MediaQuery.of(context);
@@ -137,11 +129,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     _dimension = min(_mediaQueryData.size.width, _mediaQueryData.size.height) / 5;
     if (_isOrientationPortrait) {
       _actionsDelimiterDimension = _dimension / 5;
-      if (widget.remoteVideo) {
-        _hangupDelimiterDimension = _actionsDelimiterDimension;
-      } else {
-        _hangupDelimiterDimension = _actionsDelimiterDimension * 3 + _dimension * 2;
-      }
+      _hangupDelimiterDimension = _actionsDelimiterDimension;
       _horizontalPadding = _dimension / 2;
     } else {
       _actionsDelimiterDimension = _dimension / 9;


### PR DESCRIPTION
## Overview

Previously the active call actions grid used a conditional delimiter before the hangup row: for audio-only calls the delimiter was inflated (two button rows plus three gaps), pushing the actions toward the center of the screen, while video calls used a compact delimiter that kept the block at the bottom.

This change removes that conditional layout so the actions block is always compact and pinned to the bottom, regardless of whether the call has a renderable remote video track.

- Use the regular actions delimiter before the hangup row unconditionally in portrait orientation.
- Drop the now-unused remoteVideo parameter from ActiveCallActions and its wiring in CallActiveScaffold (including the dimension recompute on remoteVideo changes).