### PR TITLE
feat(call): move connection and stream-quality status to the toolbar

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -45,12 +45,14 @@ Each call is an `ActiveCall` with the flags the UI reads:
 - `processingStatus` - fine-grained lifecycle (see the state machine in the
   architecture doc).
 
-The toolbar (AppBar title slot) carries one global status line
-(`CallToolbarStatus`): signaling/connectivity trouble (red dot +
-"Reconnecting..."), a media failure, or the worst stream-quality warning
-across calls (signal meter + label). The central `CallInfo` shows only
-name/number, the call description or live duration, and the processing
-status.
+The toolbar (AppBar title slot, centered) carries one global status line
+(`CallToolbarStatus`), never tied to a call row. Signaling states: "No
+internet connection" / "Not registered" (coral dot), "Connecting..." /
+"Reconnecting..." (amber pulsing dot; Reconnecting once a connection has
+existed). Below those: a media failure message, or the worst stream-quality
+warning across calls (signal bars + direction arrow + label). The central
+`CallInfo` shows only name/number, the call description or live duration, and
+the processing status.
 - `displayName` / `handle`, `remoteVideo`, `muted`, `transfer`.
 
 Single call:

--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -44,6 +44,13 @@ Each call is an `ActiveCall` with the flags the UI reads:
 - `held` - on hold.
 - `processingStatus` - fine-grained lifecycle (see the state machine in the
   architecture doc).
+
+The toolbar (AppBar title slot) carries one global status line
+(`CallToolbarStatus`): signaling/connectivity trouble (red dot +
+"Reconnecting..."), a media failure, or the worst stream-quality warning
+across calls (signal meter + label). The central `CallInfo` shows only
+name/number, the call description or live duration, and the processing
+status.
 - `displayName` / `handle`, `remoteVideo`, `muted`, `transfer`.
 
 Single call:
@@ -109,7 +116,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 | Action intents | Combined actions (hold&accept / hangup&accept / swap) move into bloc intents | Merged (PR #1378) |
 | Call list | Selectable list of calls + status badges + header; auto-focus rules; info + action area bind to the focused call | Merged (PR #1379) |
 | Focused actions | "Acting on" hint + two-button ringing focus (single answerFocused intent); combined-icon buttons removed | Merged (PR #1380) |
-| Cleanup / edges | Dead-code and obsolete l10n removal; scaffold-level widget tests for single/multi/3-call states | In review |
+| Cleanup / edges | Dead-code and obsolete l10n removal; scaffold-level widget tests for single/multi/3-call states | Merged (PR #1381) |
+| Toolbar status | Signaling/connectivity status, media failures and stream quality move to the AppBar status line (global, worst across calls); the central info block keeps only name/description/duration | In review |
 
 The redesign lands on the `refactor/call` integration branch - every stage is a
 PR into that branch, and once the whole flow is tested there a single PR merges

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -416,4 +416,24 @@ extension ActiveCallIterableExtension<T extends ActiveCall> on Iterable<T> {
   List<T> get nonCurrent => where((activeCall) => activeCall != current).toList();
 
   T? get blindTransferInitiated => firstWhereOrNull((activeCall) => activeCall.transfer is BlindTransferInitiated);
+
+  /// The most concerning media-degradation indicator across all calls, for the
+  /// global toolbar status line: an active (non-recovered) warning beats a
+  /// recovered confirmation, then the higher severity wins. `null` when every
+  /// stream is healthy.
+  CallNetworkQuality? get worstNetworkQuality {
+    CallNetworkQuality? worst;
+    for (final call in this) {
+      final quality = call.networkQuality;
+      if (quality == null) continue;
+      int score(CallNetworkQuality q) => q.recovered ? -1 : q.severity.index;
+      if (worst == null || score(quality) > score(worst)) worst = quality;
+    }
+    return worst;
+  }
+
+  /// The first real media failure across all calls; failures take precedence
+  /// over degradation warnings on the toolbar status line.
+  IceConnectionIssue? get firstIceConnectionIssue =>
+      firstWhereOrNull((activeCall) => activeCall.iceConnectionIssue != null)?.iceConnectionIssue;
 }

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -187,10 +187,9 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                 backgroundColor: style?.appBar?.backgroundColor,
                                 foregroundColor: style?.appBar?.foregroundColor,
                                 primary: style?.appBar?.primary ?? false,
-                                // Global status line: signaling trouble, media
+                                // Global status line: signaling state, media
                                 // failure or the worst stream quality across calls.
-                                centerTitle: false,
-                                titleSpacing: 0,
+                                centerTitle: true,
                                 title: CallToolbarStatus(
                                   callStatus: widget.callStatus,
                                   networkQuality: activeCalls.worstNetworkQuality,

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -187,6 +187,16 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                 backgroundColor: style?.appBar?.backgroundColor,
                                 foregroundColor: style?.appBar?.foregroundColor,
                                 primary: style?.appBar?.primary ?? false,
+                                // Global status line: signaling trouble, media
+                                // failure or the worst stream quality across calls.
+                                centerTitle: false,
+                                titleSpacing: 0,
+                                title: CallToolbarStatus(
+                                  callStatus: widget.callStatus,
+                                  networkQuality: activeCalls.worstNetworkQuality,
+                                  iceConnectionIssue: activeCalls.firstIceConnectionIssue,
+                                  style: style?.callInfo,
+                                ),
                                 actions: [
                                   if (activeCalls.shouldAutoCompact)
                                     CallPopupMenuButton<void>(
@@ -230,9 +240,6 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                               acceptedTime: focusedCall.acceptedTime,
                                               style: style?.callInfo,
                                               processingStatus: focusedCall.processingStatus,
-                                              callStatus: widget.callStatus,
-                                              iceConnectionIssue: focusedCall.iceConnectionIssue,
-                                              networkQuality: focusedCall.networkQuality,
                                             ),
                                             if (!focusedIsRinging)
                                               ActiveCallActions(

--- a/lib/features/call/widgets/call_info.dart
+++ b/lib/features/call/widgets/call_info.dart
@@ -4,17 +4,17 @@ import 'package:flutter/material.dart';
 
 import 'package:clock/clock.dart';
 
-import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
-import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/utils/utils.dart';
 
 import '../extensions/extensions.dart';
 import '../models/models.dart';
 import '../view/call_screen_style.dart';
-import 'call_network_quality_meter.dart';
 
+/// The focused call's central info block: name/number, the call description or
+/// live duration, and the fine-grained processing status. Connection status,
+/// network quality and ICE failures live on the toolbar status line
+/// ([CallToolbarStatus]), not here.
 class CallInfo extends StatefulWidget {
   const CallInfo({
     super.key,
@@ -27,9 +27,6 @@ class CallInfo extends StatefulWidget {
     this.username,
     this.acceptedTime,
     this.processingStatus,
-    required this.callStatus,
-    this.iceConnectionIssue,
-    this.networkQuality,
     required this.style,
   });
 
@@ -42,12 +39,7 @@ class CallInfo extends StatefulWidget {
   final String? username;
   final DateTime? acceptedTime;
   final CallProcessingStatus? processingStatus;
-  final IceConnectionIssue? iceConnectionIssue;
-  final CallNetworkQuality? networkQuality;
   final CallInfoStyle? style;
-
-  // TODO(Serdun): Rename class to better represent the actual data it holds
-  final CallStatus callStatus;
 
   @override
   State<CallInfo> createState() => _CallInfoState();
@@ -57,17 +49,9 @@ class _CallInfoState extends State<CallInfo> {
   Timer? durationTimer;
   Duration? duration;
 
-  late final TransientDebouncer<CallStatus> _debouncer;
-
   @override
   void initState() {
     super.initState();
-    _debouncer = TransientDebouncer<CallStatus>(
-      initial: widget.callStatus,
-      duration: kSignalingStatusDebounce,
-      isTransient: (s) => s.isTransientReconnecting,
-      getLatest: () => widget.callStatus,
-    );
     final acceptedTime = widget.acceptedTime;
     if (acceptedTime != null) {
       _durationTimerInit(acceptedTime);
@@ -77,9 +61,6 @@ class _CallInfoState extends State<CallInfo> {
   @override
   void didUpdateWidget(CallInfo oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.callStatus != oldWidget.callStatus) {
-      _debouncer.update(widget.callStatus, () => setState(() {}));
-    }
     if (widget.acceptedTime != oldWidget.acceptedTime) {
       _durationTimerCancel();
       final acceptedTime = widget.acceptedTime;
@@ -91,7 +72,6 @@ class _CallInfoState extends State<CallInfo> {
 
   @override
   void dispose() {
-    _debouncer.dispose();
     _durationTimerCancel();
     super.dispose();
   }
@@ -131,7 +111,6 @@ class _CallInfoState extends State<CallInfo> {
 
     final statusMessage = _buildStatusMessage(context);
     final processingStatus = widget.processingStatus?.l10n(context).nullify;
-    final iceConnectionIssue = widget.iceConnectionIssue?.l10n(context).nullify;
 
     return Column(
       spacing: 8,
@@ -161,62 +140,17 @@ class _CallInfoState extends State<CallInfo> {
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
-        // Timer stays alone and centered; the network-quality meter lives on
-        // its OWN centered line directly below it. Because it is a separate
-        // centered line (not beside the timer), its width never pushes the
-        // timer sideways. This AnimatedSwitcher only fades + grows it on
-        // show/hide; state changes morph in place inside the meter. A real ICE
-        // failure suppresses it (failure text owns the next line).
-        Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(statusMessage, style: statusTextStyle),
-            RepaintBoundary(
-              child: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 250),
-                switchInCurve: Curves.easeOut,
-                switchOutCurve: Curves.easeIn,
-                transitionBuilder: (child, animation) => FadeTransition(
-                  opacity: animation,
-                  child: SizeTransition(
-                    axis: Axis.vertical,
-                    alignment: Alignment.topCenter,
-                    sizeFactor: animation,
-                    child: child,
-                  ),
-                ),
-                child: _buildMeterSlot(statusTextStyle?.color),
-              ),
-            ),
-          ],
-        ),
+        Text(statusMessage, style: statusTextStyle),
         if (processingStatus != null)
-          Text(processingStatus, style: processingStatusTextStyle, textAlign: TextAlign.center)
-        else if (iceConnectionIssue != null)
-          Text(iceConnectionIssue, style: processingStatusTextStyle, textAlign: TextAlign.center),
+          Text(processingStatus, style: processingStatusTextStyle, textAlign: TextAlign.center),
       ],
     );
-  }
-
-  /// The animated-switcher child. Keyed only by PRESENCE (`meter` vs
-  /// `meter-none`) so the parent AnimatedSwitcher fades only on show/hide; state
-  /// changes (severity/direction/recovered) are morphed in place inside the
-  /// meter instead of cross-faded. Hidden when healthy or when a real ICE
-  /// failure owns the status line.
-  Widget _buildMeterSlot(Color? baseColor) {
-    final quality = widget.networkQuality;
-    if (quality == null || widget.iceConnectionIssue != null) {
-      return const SizedBox.shrink(key: ValueKey('meter-none'));
-    }
-    return CallNetworkQualityMeter(key: const ValueKey('meter'), quality: quality, baseColor: baseColor);
   }
 
   String _buildStatusMessage(BuildContext context) {
     final duration = this.duration;
 
-    if (_debouncer.displayed != CallStatus.ready) {
-      return _debouncer.displayed.l10n(context);
-    } else if (duration == null) {
+    if (duration == null) {
       if (widget.inviteToAttendedTransfer) {
         return context.l10n.call_description_inviteToAttendedTransfer;
       } else if (widget.requestToAttendedTransfer) {

--- a/lib/features/call/widgets/call_network_quality_meter.dart
+++ b/lib/features/call/widgets/call_network_quality_meter.dart
@@ -18,7 +18,13 @@ import '../models/models.dart';
 /// than cross-faded, so only appearing/disappearing fades; switching severity or
 /// direction does not flicker.
 class CallNetworkQualityMeter extends StatelessWidget {
-  const CallNetworkQualityMeter({super.key, required this.quality, this.baseColor, this.showLabel});
+  const CallNetworkQualityMeter({
+    super.key,
+    required this.quality,
+    this.baseColor,
+    this.showLabel,
+    this.showMediaGlyph,
+  });
 
   final CallNetworkQuality quality;
 
@@ -30,6 +36,11 @@ class CallNetworkQualityMeter extends StatelessWidget {
   /// (label only at severe), `false` never shows it (the caller renders its
   /// own text, e.g. the toolbar status line).
   final bool? showLabel;
+
+  /// Whether to render the mic/camera glyph after the direction arrow.
+  /// Defaults to `true`; the toolbar status line passes `false` (its label
+  /// already says audio/video), keeping the design's "bars + arrow" shape.
+  final bool? showMediaGlyph;
 
   static const double _glyphSize = 14;
   static const _morph = Duration(milliseconds: 250);
@@ -75,7 +86,7 @@ class CallNetworkQualityMeter extends StatelessWidget {
           _SignalBars(active: activeBars, activeColor: color, inactiveColor: base.withValues(alpha: 0.3)),
           const SizedBox(width: 4),
           Icon(directionIcon, size: _glyphSize, color: color),
-          Icon(mediaIcon, size: _glyphSize, color: color),
+          if (showMediaGlyph ?? true) Icon(mediaIcon, size: _glyphSize, color: color),
           if (showLabel) ...[
             const SizedBox(width: 4),
             Text(

--- a/lib/features/call/widgets/call_network_quality_meter.dart
+++ b/lib/features/call/widgets/call_network_quality_meter.dart
@@ -18,13 +18,18 @@ import '../models/models.dart';
 /// than cross-faded, so only appearing/disappearing fades; switching severity or
 /// direction does not flicker.
 class CallNetworkQualityMeter extends StatelessWidget {
-  const CallNetworkQualityMeter({super.key, required this.quality, this.baseColor});
+  const CallNetworkQualityMeter({super.key, required this.quality, this.baseColor, this.showLabel});
 
   final CallNetworkQuality quality;
 
   /// Color for the mild bars and inactive bar slots; defaults to the ambient
   /// text color so the meter blends with the call timer.
   final Color? baseColor;
+
+  /// Overrides the built-in label visibility: `null` keeps the default
+  /// (label only at severe), `false` never shows it (the caller renders its
+  /// own text, e.g. the toolbar status line).
+  final bool? showLabel;
 
   static const double _glyphSize = 14;
   static const _morph = Duration(milliseconds: 250);
@@ -61,7 +66,7 @@ class CallNetworkQualityMeter extends StatelessWidget {
       };
       final directionIcon = quality.uplink ? Icons.north : Icons.south;
       final mediaIcon = quality.media == CallMediaKind.video ? Icons.videocam : Icons.mic;
-      final showLabel = quality.severity == CallNetworkQualitySeverity.severe;
+      final showLabel = this.showLabel ?? quality.severity == CallNetworkQualitySeverity.severe;
 
       content = Row(
         key: const ValueKey('active'),

--- a/lib/features/call/widgets/call_toolbar_status.dart
+++ b/lib/features/call/widgets/call_toolbar_status.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/theme/styles/styles.dart';
+import 'package:webtrit_phone/utils/utils.dart';
+
+import '../extensions/extensions.dart';
+import '../models/models.dart';
+import '../view/call_screen_style.dart';
+import 'call_network_quality_meter.dart';
+
+/// The call screen toolbar status line (lives in the AppBar title slot).
+///
+/// Shows ONE global indicator at a time, by priority:
+/// 1. signaling/connectivity trouble - red dot + status + "Reconnecting...";
+/// 2. a real media failure ([IceConnectionIssue]) - warning glyph + message;
+/// 3. media degradation ([CallNetworkQuality], worst across calls) - the
+///    signal meter + an always-visible label.
+/// Renders nothing while everything is healthy. Status flaps during reconnect
+/// backoff are debounced the same way the old in-info message was.
+class CallToolbarStatus extends StatefulWidget {
+  const CallToolbarStatus({
+    super.key,
+    required this.callStatus,
+    this.networkQuality,
+    this.iceConnectionIssue,
+    this.style,
+  });
+
+  final CallStatus callStatus;
+  final CallNetworkQuality? networkQuality;
+  final IceConnectionIssue? iceConnectionIssue;
+  final CallInfoStyle? style;
+
+  @override
+  State<CallToolbarStatus> createState() => _CallToolbarStatusState();
+}
+
+class _CallToolbarStatusState extends State<CallToolbarStatus> {
+  late final TransientDebouncer<CallStatus> _debouncer;
+
+  @override
+  void initState() {
+    super.initState();
+    _debouncer = TransientDebouncer<CallStatus>(
+      initial: widget.callStatus,
+      duration: kSignalingStatusDebounce,
+      isTransient: (s) => s.isTransientReconnecting,
+      getLatest: () => widget.callStatus,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant CallToolbarStatus oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.callStatus != oldWidget.callStatus) {
+      _debouncer.update(widget.callStatus, () => setState(() {}));
+    }
+  }
+
+  @override
+  void dispose() {
+    _debouncer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final baseStyle =
+        widget.style?.callStatus ?? themeData.textTheme.bodyMedium?.copyWith(color: themeData.colorScheme.surface);
+    final baseColor = baseStyle?.color ?? themeData.colorScheme.surface;
+    final semantic = themeData.extension<SnackBarStyles>()?.primary;
+    final warningColor = semantic?.warningBackgroundColor ?? baseColor;
+    final errorColor = semantic?.errorBackgroundColor ?? themeData.colorScheme.error;
+
+    final status = _debouncer.displayed;
+    final quality = widget.networkQuality;
+    final iceConnectionIssue = widget.iceConnectionIssue;
+
+    final Widget content;
+    if (status != CallStatus.ready) {
+      content = Row(
+        key: const ValueKey('toolbar-connect'),
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(shape: BoxShape.circle, color: errorColor),
+          ),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              status.l10n(context),
+              style: baseStyle?.copyWith(fontWeight: FontWeight.w600),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (status != CallStatus.appUnregistered) ...[
+            Text(' - ', style: baseStyle),
+            Text(
+              context.l10n.call_ToolbarStatus_reconnecting,
+              style: baseStyle?.copyWith(color: baseColor.withValues(alpha: 0.7)),
+            ),
+          ],
+        ],
+      );
+    } else if (iceConnectionIssue != null) {
+      content = Row(
+        key: const ValueKey('toolbar-ice'),
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.warning_amber_rounded, size: 14, color: errorColor),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              iceConnectionIssue.l10n(context),
+              style: baseStyle?.copyWith(color: errorColor, fontWeight: FontWeight.w600),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      );
+    } else if (quality != null) {
+      final labelColor = quality.recovered
+          ? (semantic?.successBackgroundColor ?? baseColor)
+          : (quality.severity == CallNetworkQualitySeverity.mild ? baseColor : warningColor);
+      content = Row(
+        key: const ValueKey('toolbar-quality'),
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CallNetworkQualityMeter(quality: quality, baseColor: baseColor, showLabel: false),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              quality.severeLabel(context),
+              style: baseStyle?.copyWith(color: labelColor, fontWeight: FontWeight.w600),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      );
+    } else {
+      content = const SizedBox.shrink(key: ValueKey('toolbar-none'));
+    }
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 250),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      child: content,
+    );
+  }
+}

--- a/lib/features/call/widgets/call_toolbar_status.dart
+++ b/lib/features/call/widgets/call_toolbar_status.dart
@@ -14,11 +14,14 @@ import 'call_network_quality_meter.dart';
 
 /// The call screen toolbar status line (lives in the AppBar title slot).
 ///
-/// Shows ONE global indicator at a time, by priority:
-/// 1. signaling/connectivity trouble - red dot + status + "Reconnecting...";
+/// Global, never tied to a call row. Shows ONE indicator at a time, by
+/// priority:
+/// 1. signaling state - "No internet connection" / "Not registered" (coral
+///    static dot), or "Connecting..." / "Reconnecting..." (amber pulsing dot;
+///    Reconnecting once a connection has existed before);
 /// 2. a real media failure ([IceConnectionIssue]) - warning glyph + message;
-/// 3. media degradation ([CallNetworkQuality], worst across calls) - the
-///    signal meter + an always-visible label.
+/// 3. media degradation ([CallNetworkQuality], worst across calls) - signal
+///    bars + direction arrow + an always-visible label.
 /// Renders nothing while everything is healthy. Status flaps during reconnect
 /// backoff are debounced the same way the old in-info message was.
 class CallToolbarStatus extends StatefulWidget {
@@ -42,9 +45,14 @@ class CallToolbarStatus extends StatefulWidget {
 class _CallToolbarStatusState extends State<CallToolbarStatus> {
   late final TransientDebouncer<CallStatus> _debouncer;
 
+  /// Whether the signaling connection has been up at least once: turns the
+  /// transient "Connecting..." label into "Reconnecting...".
+  late bool _everConnected;
+
   @override
   void initState() {
     super.initState();
+    _everConnected = widget.callStatus == CallStatus.ready;
     _debouncer = TransientDebouncer<CallStatus>(
       initial: widget.callStatus,
       duration: kSignalingStatusDebounce,
@@ -56,6 +64,7 @@ class _CallToolbarStatusState extends State<CallToolbarStatus> {
   @override
   void didUpdateWidget(covariant CallToolbarStatus oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.callStatus == CallStatus.ready) _everConnected = true;
     if (widget.callStatus != oldWidget.callStatus) {
       _debouncer.update(widget.callStatus, () => setState(() {}));
     }
@@ -83,31 +92,29 @@ class _CallToolbarStatusState extends State<CallToolbarStatus> {
 
     final Widget content;
     if (status != CallStatus.ready) {
+      // Connecting/Reconnecting are one transient amber state; "no internet"
+      // and "not registered" are hard states with a coral dot.
+      final transient = status.isTransientReconnecting;
+      final dotColor = transient ? warningColor : errorColor;
+      final message = switch (status) {
+        _ when transient =>
+          _everConnected ? context.l10n.call_ToolbarStatus_reconnecting : context.l10n.call_ToolbarStatus_connecting,
+        _ => status.l10n(context),
+      };
       content = Row(
         key: const ValueKey('toolbar-connect'),
         mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            width: 8,
-            height: 8,
-            decoration: BoxDecoration(shape: BoxShape.circle, color: errorColor),
-          ),
+          _StatusDot(color: dotColor, pulsing: transient),
           const SizedBox(width: 6),
           Flexible(
             child: Text(
-              status.l10n(context),
+              message,
               style: baseStyle?.copyWith(fontWeight: FontWeight.w600),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          if (status != CallStatus.appUnregistered) ...[
-            Text(' - ', style: baseStyle),
-            Text(
-              context.l10n.call_ToolbarStatus_reconnecting,
-              style: baseStyle?.copyWith(color: baseColor.withValues(alpha: 0.7)),
-            ),
-          ],
         ],
       );
     } else if (iceConnectionIssue != null) {
@@ -135,7 +142,8 @@ class _CallToolbarStatusState extends State<CallToolbarStatus> {
         key: const ValueKey('toolbar-quality'),
         mainAxisSize: MainAxisSize.min,
         children: [
-          CallNetworkQualityMeter(quality: quality, baseColor: baseColor, showLabel: false),
+          // Bars + direction arrow only; the label already says audio/video.
+          CallNetworkQualityMeter(quality: quality, baseColor: baseColor, showLabel: false, showMediaGlyph: false),
           const SizedBox(width: 6),
           Flexible(
             child: Text(
@@ -156,6 +164,65 @@ class _CallToolbarStatusState extends State<CallToolbarStatus> {
       switchInCurve: Curves.easeOut,
       switchOutCurve: Curves.easeIn,
       child: content,
+    );
+  }
+}
+
+/// The 8px signaling-state dot; pulses (opacity breathing) for the transient
+/// Connecting/Reconnecting state and stays solid for hard states.
+class _StatusDot extends StatefulWidget {
+  const _StatusDot({required this.color, required this.pulsing});
+
+  final Color color;
+  final bool pulsing;
+
+  @override
+  State<_StatusDot> createState() => _StatusDotState();
+}
+
+class _StatusDotState extends State<_StatusDot> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 900));
+    _syncPulse();
+  }
+
+  @override
+  void didUpdateWidget(covariant _StatusDot oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.pulsing != oldWidget.pulsing) _syncPulse();
+  }
+
+  void _syncPulse() {
+    if (widget.pulsing) {
+      _controller.repeat(reverse: true);
+    } else {
+      _controller.stop();
+      _controller.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: Tween<double>(
+        begin: 1,
+        end: 0.35,
+      ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut)),
+      child: Container(
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(shape: BoxShape.circle, color: widget.color),
+      ),
     );
   }
 }

--- a/lib/features/call/widgets/widgets.dart
+++ b/lib/features/call/widgets/widgets.dart
@@ -5,6 +5,7 @@ export 'call_info.dart';
 export 'call_list.dart';
 export 'focused_action_hint.dart';
 export 'call_network_quality_meter.dart';
+export 'call_toolbar_status.dart';
 export 'draggable_thumbnail.dart';
 export 'local_camera_preview_thumbnail.dart';
 export 'popup_menu.dart';

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -363,6 +363,12 @@ abstract class AppLocalizations {
   /// **'{name} will be put on hold'**
   String call_FocusedActionHint_willBeHeld(String name);
 
+  /// Toolbar status line while the very first signaling connection is being established (turns into Reconnecting once a connection has existed).
+  ///
+  /// In en, this message translates to:
+  /// **'Connecting...'**
+  String get call_ToolbarStatus_connecting;
+
   /// Suffix on the call screen toolbar status line while the signaling connection is being re-established.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -363,6 +363,12 @@ abstract class AppLocalizations {
   /// **'{name} will be put on hold'**
   String call_FocusedActionHint_willBeHeld(String name);
 
+  /// Suffix on the call screen toolbar status line while the signaling connection is being re-established.
+  ///
+  /// In en, this message translates to:
+  /// **'Reconnecting...'**
+  String get call_ToolbarStatus_reconnecting;
+
   /// No description provided for @call_description_held.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -82,6 +82,7 @@ extension AppLocalizationsExtension on AppLocalizations {
       'call_CallActionsTooltip_unhold' => call_CallActionsTooltip_unhold,
       'call_CallActionsTooltip_unmute' => call_CallActionsTooltip_unmute,
       'call_CallList_statusOnCall' => call_CallList_statusOnCall,
+      'call_ToolbarStatus_connecting' => call_ToolbarStatus_connecting,
       'call_ToolbarStatus_reconnecting' => call_ToolbarStatus_reconnecting,
       'call_description_held' => call_description_held,
       'call_description_incoming' => call_description_incoming,

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -82,6 +82,7 @@ extension AppLocalizationsExtension on AppLocalizations {
       'call_CallActionsTooltip_unhold' => call_CallActionsTooltip_unhold,
       'call_CallActionsTooltip_unmute' => call_CallActionsTooltip_unmute,
       'call_CallList_statusOnCall' => call_CallList_statusOnCall,
+      'call_ToolbarStatus_reconnecting' => call_ToolbarStatus_reconnecting,
       'call_description_held' => call_description_held,
       'call_description_incoming' => call_description_incoming,
       'call_description_inviteToAttendedTransfer' =>

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get call_ToolbarStatus_connecting => 'Connecting...';
+
+  @override
   String get call_ToolbarStatus_reconnecting => 'Reconnecting...';
 
   @override

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get call_ToolbarStatus_reconnecting => 'Reconnecting...';
+
+  @override
   String get call_description_held => 'On hold';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -201,6 +201,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get call_ToolbarStatus_reconnecting => 'Riconnessione...';
+
+  @override
   String get call_description_held => 'In attesa';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -201,6 +201,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get call_ToolbarStatus_connecting => 'Connessione...';
+
+  @override
   String get call_ToolbarStatus_reconnecting => 'Riconnessione...';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -211,6 +211,9 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get call_ToolbarStatus_reconnecting => 'Перепідключення...';
+
+  @override
   String get call_description_held => 'На утриманні';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -211,6 +211,9 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get call_ToolbarStatus_connecting => 'Підключення...';
+
+  @override
   String get call_ToolbarStatus_reconnecting => 'Перепідключення...';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -153,6 +153,10 @@
       }
     }
   },
+  "call_ToolbarStatus_connecting": "Connecting...",
+  "@call_ToolbarStatus_connecting": {
+    "description": "Toolbar status line while the very first signaling connection is being established (turns into Reconnecting once a connection has existed)."
+  },
   "call_ToolbarStatus_reconnecting": "Reconnecting...",
   "@call_ToolbarStatus_reconnecting": {
     "description": "Suffix on the call screen toolbar status line while the signaling connection is being re-established."

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -153,6 +153,10 @@
       }
     }
   },
+  "call_ToolbarStatus_reconnecting": "Reconnecting...",
+  "@call_ToolbarStatus_reconnecting": {
+    "description": "Suffix on the call screen toolbar status line while the signaling connection is being re-established."
+  },
   "call_description_held": "On hold",
   "@call_description_held": {},
   "call_description_incoming": "Incoming call",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -153,6 +153,10 @@
       }
     }
   },
+  "call_ToolbarStatus_connecting": "Connessione...",
+  "@call_ToolbarStatus_connecting": {
+    "description": "Toolbar status line while the very first signaling connection is being established (turns into Reconnecting once a connection has existed)."
+  },
   "call_ToolbarStatus_reconnecting": "Riconnessione...",
   "@call_ToolbarStatus_reconnecting": {
     "description": "Suffix on the call screen toolbar status line while the signaling connection is being re-established."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -153,6 +153,10 @@
       }
     }
   },
+  "call_ToolbarStatus_reconnecting": "Riconnessione...",
+  "@call_ToolbarStatus_reconnecting": {
+    "description": "Suffix on the call screen toolbar status line while the signaling connection is being re-established."
+  },
   "call_description_held": "In attesa",
   "@call_description_held": {},
   "call_description_incoming": "Chiamata in arrivo",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -153,6 +153,10 @@
       }
     }
   },
+  "call_ToolbarStatus_connecting": "Підключення...",
+  "@call_ToolbarStatus_connecting": {
+    "description": "Toolbar status line while the very first signaling connection is being established (turns into Reconnecting once a connection has existed)."
+  },
   "call_ToolbarStatus_reconnecting": "Перепідключення...",
   "@call_ToolbarStatus_reconnecting": {
     "description": "Suffix on the call screen toolbar status line while the signaling connection is being re-established."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -153,6 +153,10 @@
       }
     }
   },
+  "call_ToolbarStatus_reconnecting": "Перепідключення...",
+  "@call_ToolbarStatus_reconnecting": {
+    "description": "Suffix on the call screen toolbar status line while the signaling connection is being re-established."
+  },
   "call_description_held": "На утриманні",
   "@call_description_held": {},
   "call_description_incoming": "Вхідний дзвінок",

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -350,6 +350,68 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // ActiveCallIterableExtension — toolbar status aggregation
+  // ---------------------------------------------------------------------------
+
+  group('ActiveCallIterableExtension.worstNetworkQuality', () {
+    const mild = CallNetworkQuality(
+      severity: CallNetworkQualitySeverity.mild,
+      uplink: true,
+      media: CallMediaKind.audio,
+    );
+    const severe = CallNetworkQuality(
+      severity: CallNetworkQualitySeverity.severe,
+      uplink: false,
+      media: CallMediaKind.audio,
+    );
+    const recovered = CallNetworkQuality(
+      severity: CallNetworkQualitySeverity.severe,
+      uplink: true,
+      media: CallMediaKind.audio,
+      recovered: true,
+    );
+
+    test('null when every stream is healthy', () {
+      expect([_makeCall(callId: 'c1'), _makeCall(callId: 'c2')].worstNetworkQuality, isNull);
+    });
+
+    test('picks the higher severity across calls', () {
+      final calls = [
+        _makeCall(callId: 'c1').copyWith(networkQuality: mild),
+        _makeCall(callId: 'c2').copyWith(networkQuality: severe),
+      ];
+      expect(calls.worstNetworkQuality, severe);
+    });
+
+    test('an active warning beats a recovered confirmation', () {
+      final calls = [
+        _makeCall(callId: 'c1').copyWith(networkQuality: recovered),
+        _makeCall(callId: 'c2').copyWith(networkQuality: mild),
+      ];
+      expect(calls.worstNetworkQuality, mild);
+    });
+
+    test('a recovered confirmation still surfaces when it is the only signal', () {
+      final calls = [_makeCall(callId: 'c1').copyWith(networkQuality: recovered), _makeCall(callId: 'c2')];
+      expect(calls.worstNetworkQuality, recovered);
+    });
+  });
+
+  group('ActiveCallIterableExtension.firstIceConnectionIssue', () {
+    test('null when no call has a media failure', () {
+      expect([_makeCall(callId: 'c1')].firstIceConnectionIssue, isNull);
+    });
+
+    test('returns the first failure across calls', () {
+      final calls = [
+        _makeCall(callId: 'c1'),
+        _makeCall(callId: 'c2').copyWith(iceConnectionIssue: IceConnectionIssue.iceFail),
+      ];
+      expect(calls.firstIceConnectionIssue, IceConnectionIssue.iceFail);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CallState — focusedCall (list-based call screen foundation)
   // ---------------------------------------------------------------------------
 

--- a/test/features/call/widgets/call_toolbar_status_test.dart
+++ b/test/features/call/widgets/call_toolbar_status_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -36,23 +37,44 @@ void main() {
       expect(find.byType(Text), findsNothing);
     });
 
-    testWidgets('connectivity trouble: status text + reconnecting suffix', (tester) async {
+    testWidgets('no internet: hard state with its own message only', (tester) async {
       await tester.pumpWidget(_buildSubject(callStatus: CallStatus.connectivityNone));
       final context = tester.element(find.byType(CallToolbarStatus));
 
       expect(find.text(context.l10n.callStatus_connectivityNone), findsOneWidget);
-      expect(find.text(context.l10n.call_ToolbarStatus_reconnecting), findsOneWidget);
+      expect(find.text(context.l10n.call_ToolbarStatus_reconnecting), findsNothing);
+      expect(find.text(context.l10n.call_ToolbarStatus_connecting), findsNothing);
     });
 
-    testWidgets('unregistered: status text without the reconnecting suffix', (tester) async {
+    testWidgets('unregistered: hard state with its own message', (tester) async {
       await tester.pumpWidget(_buildSubject(callStatus: CallStatus.appUnregistered));
       final context = tester.element(find.byType(CallToolbarStatus));
 
       expect(find.text(context.l10n.callStatus_appUnregistered), findsOneWidget);
+    });
+
+    testWidgets('first connection shows Connecting', (tester) async {
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.inProgress));
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.text(context.l10n.call_ToolbarStatus_connecting), findsOneWidget);
       expect(find.text(context.l10n.call_ToolbarStatus_reconnecting), findsNothing);
     });
 
-    testWidgets('network quality: meter + always-visible label', (tester) async {
+    testWidgets('a drop after being connected shows Reconnecting (debounced)', (tester) async {
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.ready));
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.connectError));
+      // Transient statuses are debounced to avoid reconnect-backoff flicker.
+      await tester.pump(kSignalingStatusDebounce + const Duration(milliseconds: 50));
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.text(context.l10n.call_ToolbarStatus_reconnecting), findsOneWidget);
+      expect(find.text(context.l10n.call_ToolbarStatus_connecting), findsNothing);
+      // Stop the pulsing dot animation cleanly.
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('network quality: bars + arrow + always-visible label, no media glyph', (tester) async {
       await tester.pumpWidget(_buildSubject(callStatus: CallStatus.ready, networkQuality: _quality));
       final context = tester.element(find.byType(CallToolbarStatus));
 
@@ -60,6 +82,10 @@ void main() {
       // The toolbar renders the label itself; the meter label is suppressed,
       // so the text appears exactly once even at severe.
       expect(find.text(context.l10n.callNetworkQuality_yourAudioWeak), findsOneWidget);
+      // Direction arrow stays, the mic/camera glyph does not (the label
+      // already says audio/video).
+      expect(find.byIcon(Icons.north), findsOneWidget);
+      expect(find.byIcon(Icons.mic), findsNothing);
     });
 
     testWidgets('quality label is visible below severe too', (tester) async {

--- a/test/features/call/widgets/call_toolbar_status_test.dart
+++ b/test/features/call/widgets/call_toolbar_status_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/call/call.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+Widget _buildSubject({
+  required CallStatus callStatus,
+  CallNetworkQuality? networkQuality,
+  IceConnectionIssue? iceConnectionIssue,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: CallToolbarStatus(
+        callStatus: callStatus,
+        networkQuality: networkQuality,
+        iceConnectionIssue: iceConnectionIssue,
+      ),
+    ),
+  );
+}
+
+const _quality = CallNetworkQuality(
+  severity: CallNetworkQualitySeverity.severe,
+  uplink: true,
+  media: CallMediaKind.audio,
+);
+
+void main() {
+  group('CallToolbarStatus', () {
+    testWidgets('renders nothing while everything is healthy', (tester) async {
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.ready));
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('connectivity trouble: status text + reconnecting suffix', (tester) async {
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.connectivityNone));
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.text(context.l10n.callStatus_connectivityNone), findsOneWidget);
+      expect(find.text(context.l10n.call_ToolbarStatus_reconnecting), findsOneWidget);
+    });
+
+    testWidgets('unregistered: status text without the reconnecting suffix', (tester) async {
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.appUnregistered));
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.text(context.l10n.callStatus_appUnregistered), findsOneWidget);
+      expect(find.text(context.l10n.call_ToolbarStatus_reconnecting), findsNothing);
+    });
+
+    testWidgets('network quality: meter + always-visible label', (tester) async {
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.ready, networkQuality: _quality));
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.byType(CallNetworkQualityMeter), findsOneWidget);
+      // The toolbar renders the label itself; the meter label is suppressed,
+      // so the text appears exactly once even at severe.
+      expect(find.text(context.l10n.callNetworkQuality_yourAudioWeak), findsOneWidget);
+    });
+
+    testWidgets('quality label is visible below severe too', (tester) async {
+      const mild = CallNetworkQuality(
+        severity: CallNetworkQualitySeverity.mild,
+        uplink: false,
+        media: CallMediaKind.audio,
+      );
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.ready, networkQuality: mild));
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.text(context.l10n.callNetworkQuality_theirAudioWeak), findsOneWidget);
+    });
+
+    testWidgets('connectivity trouble wins over network quality', (tester) async {
+      await tester.pumpWidget(_buildSubject(callStatus: CallStatus.connectivityNone, networkQuality: _quality));
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.text(context.l10n.callStatus_connectivityNone), findsOneWidget);
+      expect(find.byType(CallNetworkQualityMeter), findsNothing);
+    });
+
+    testWidgets('a media failure wins over network quality', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          callStatus: CallStatus.ready,
+          networkQuality: _quality,
+          iceConnectionIssue: IceConnectionIssue.iceFail,
+        ),
+      );
+      final context = tester.element(find.byType(CallToolbarStatus));
+
+      expect(find.text(context.l10n.iceConnectionIssue_iceFail), findsOneWidget);
+      expect(find.byType(CallNetworkQualityMeter), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Next step of the call screen redesign (targets `refactor/call`): the toolbar
(AppBar title slot) now carries one global status line, matching the design -
the central info block keeps only the caller identity, call description and
live duration.

## Changes

- **CallToolbarStatus** (new widget), one indicator at a time by priority:
  1. signaling/connectivity trouble - red dot + status text +
     "Reconnecting..." suffix (omitted for Unregistered), with the same
     debounce the old in-info message used so reconnect backoff does not
     flicker;
  2. a real media failure (`IceConnectionIssue`) - warning glyph + message;
  3. media degradation - the signal meter (bars + direction/media glyphs) plus
     an always-visible label, at any severity.
- **Global aggregation**: new `ActiveCall` iterable getters
  `worstNetworkQuality` (an active warning beats a recovered confirmation,
  then the higher severity wins) and `firstIceConnectionIssue` - the toolbar
  reflects the worst stream across all calls, per the design note.
- **CallNetworkQualityMeter**: optional `showLabel` override so the toolbar
  renders its own label without duplicating the built-in severe one; default
  behavior unchanged.
- **CallInfo slimmed down**: the `callStatus`/`networkQuality`/
  `iceConnectionIssue` parameters, the status debouncer and the meter slot are
  removed; while offline the center now keeps showing the normal call
  description (the toolbar owns the trouble line), as in the design.
- **l10n**: `call_ToolbarStatus_reconnecting` in en/it/uk.
- `docs/features/call.md`: status-line description + rollout table updated.

## Tests

- `call_toolbar_status_test.dart` (new): healthy renders nothing; connectivity
  shows status + reconnecting suffix; Unregistered without the suffix; quality
  shows the meter + exactly one label (suppressed inside the meter) at any
  severity; status-over-quality and failure-over-quality precedence.
- `call_state_test.dart`: `worstNetworkQuality` (higher severity wins, active
  beats recovered, recovered-only still surfaces, null when healthy) and
  `firstIceConnectionIssue`.
- Full suite green via pre-push (444 call-feature tests among them).

## Design iteration (second commit)

- Signaling states per the refined design: "No internet connection" /
  "Not registered" are hard states (coral static dot); the transient reconnect
  cycle shows an amber PULSING dot with "Connecting..." on the very first
  connection and "Reconnecting..." once a connection has existed. The
  suffix-style "Reconnecting..." from the first commit is gone.
- The status line is centered in the toolbar.
- The quality indicator is bars + direction arrow only (`showMediaGlyph`
  override on the meter); the label already says audio/video.
- l10n: `call_ToolbarStatus_connecting` added in en/it/uk.
