### PR TITLE
fix(call): align the multi-call screen visuals with the design

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -64,13 +64,16 @@ Single call:
 
 Multiple calls (list-based):
 
-- The screen shows one tappable `CallRow` per call - status badge (RINGING /
-  ON CALL / ON HOLD), name, live duration - under an "N calls - tap to choose"
-  header. Tapping a row focuses that call.
+- The screen shows one tappable `CallRow` per call - colored status dot +
+  badge (RINGING / ON CALL / ON HOLD), name, live duration or a short
+  Incoming/Outgoing label - under an "N calls - tap to choose" header. Tapping
+  a row focuses that call. With multiple calls the rows carry the per-call
+  info; the central info block appears for a single call only.
 - The `CallInfo` block and the action area below act on the focused call only.
   A ringing focus gets exactly Decline / Answer plus an "Acting on: <name>"
-  hint that spells out the side effect ("<name> will be put on hold" or
-  "will be ended"); an active/held focus gets the control grid + End.
+  hint - a translucent pill with the focused name in bold and the affected
+  names highlighted - that spells out the side effect ("<name> will be put on
+  hold" or "will be ended"); an active/held focus gets the control grid + End.
 - Answer is one intent (`CallControlEvent.answerFocused`): it holds the
   answered calls when possible, ends the non-holdable ones (e.g. an outgoing
   call still ringing), and leaves another ringing incoming call ringing.
@@ -119,7 +122,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 | Call list | Selectable list of calls + status badges + header; auto-focus rules; info + action area bind to the focused call | Merged (PR #1379) |
 | Focused actions | "Acting on" hint + two-button ringing focus (single answerFocused intent); combined-icon buttons removed | Merged (PR #1380) |
 | Cleanup / edges | Dead-code and obsolete l10n removal; scaffold-level widget tests for single/multi/3-call states | Merged (PR #1381) |
-| Toolbar status | Signaling/connectivity status, media failures and stream quality move to the AppBar status line (global, worst across calls); the central info block keeps only name/description/duration | In review |
+| Toolbar status | Signaling/connectivity status, media failures and stream quality move to the AppBar status line (global, worst across calls); the central info block keeps only name/description/duration | Merged (PR #1385) |
+| Visual alignment | Status dots on rows, short Incoming/Outgoing trailing labels, central info block single-call only, acting-on hint as a translucent pill with highlighted names | In review |
 
 The redesign lands on the `refactor/call` integration branch - every stage is a
 PR into that branch, and once the whole flow is tested there a single PR merges

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -228,18 +228,21 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                   _callBloc.add(CallControlEvent.callSelected(callId));
                                                 },
                                               ),
-                                            CallInfo(
-                                              transfering: focusedTransfer is Transfering,
-                                              requestToAttendedTransfer: false,
-                                              inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
-                                              isIncoming: focusedCall.isIncoming,
-                                              held: focusedCall.held,
-                                              number: focusedCall.handle.value,
-                                              username: focusedCall.displayName,
-                                              acceptedTime: focusedCall.acceptedTime,
-                                              style: style?.callInfo,
-                                              processingStatus: focusedCall.processingStatus,
-                                            ),
+                                            // With multiple calls the list rows carry the per-call
+                                            // info, so the central info block is single-call only.
+                                            if (activeCalls.length == 1)
+                                              CallInfo(
+                                                transfering: focusedTransfer is Transfering,
+                                                requestToAttendedTransfer: false,
+                                                inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
+                                                isIncoming: focusedCall.isIncoming,
+                                                held: focusedCall.held,
+                                                number: focusedCall.handle.value,
+                                                username: focusedCall.displayName,
+                                                acceptedTime: focusedCall.acceptedTime,
+                                                style: style?.callInfo,
+                                                processingStatus: focusedCall.processingStatus,
+                                              ),
                                             if (!focusedIsRinging)
                                               ActiveCallActions(
                                                 style: style?.actions,
@@ -335,60 +338,68 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                   _callBloc.add(CallControlEvent.sentDTMF(focusedCall.callId, value));
                                                 },
                                               )
-                                            else ...[
+                                            else
                                               // Decline / Answer for the focused ringing call -
                                               // always two buttons. Answering holds the answered
                                               // calls (or ends the non-holdable ones); the hint
                                               // names the focused call and spells the side effect.
+                                              // The hint and the buttons are one column child so
+                                              // the spaceBetween layout keeps them glued together
+                                              // at the bottom.
                                               // Edge-cases (covered by the call list above):
                                               // - two incoming ringing calls
                                               // - one outgoing ringing + one incoming ringing
-                                              if (activeCalls.length > 1)
-                                                FocusedActionHint(
-                                                  focusedName: focusedCall.displayName ?? focusedCall.handle.value,
-                                                  willBeHeldNames: nonIncomingRingingCanBeHolded.isEmpty
-                                                      ? const []
-                                                      : [
-                                                          for (final call in nonIncomingRingingCanBeHolded)
-                                                            if (!call.held) call.displayName ?? call.handle.value,
-                                                        ],
-                                                  willBeEndedNames: nonIncomingRingingCanBeHolded.isNotEmpty
-                                                      ? const []
-                                                      : [
-                                                          for (final call in nonIncomingRingingCalls)
-                                                            call.displayName ?? call.handle.value,
-                                                        ],
-                                                  style: style?.callInfo,
-                                                ),
-                                              IncomingCallActions(
-                                                style: style?.actions,
-                                                inviteToAttendedTransfer: false,
-                                                remoteVideo: focusedCall.remoteVideo && focusedCall.held == false,
-                                                onHangupPressed: () {
-                                                  _callBloc.add(CallControlEvent.ended(focusedCall.callId));
-                                                  dispatchInteractionDebounce();
-                                                },
-                                                // Answering with other calls present mutates them
-                                                // (hold/end), so it is gated by the interactions
-                                                // debounce like any signaling-dependent action.
-                                                onAcceptPressed:
-                                                    nonIncomingRingingCalls.isNotEmpty &&
-                                                        (interactionsDebounceActive ||
-                                                            widget.callStatus != CallStatus.ready ||
-                                                            activeCalls.any((call) => call.updating))
-                                                    ? null
-                                                    : () {
-                                                        _callBloc.add(
-                                                          CallControlEvent.answerFocused(
-                                                            focusedCall.callId,
-                                                            hasHoldableOthers: nonIncomingRingingCanBeHolded.isNotEmpty,
-                                                            hasNonRingingOthers: nonIncomingRingingCalls.isNotEmpty,
-                                                          ),
-                                                        );
-                                                        dispatchInteractionDebounce();
-                                                      },
+                                              Column(
+                                                mainAxisSize: MainAxisSize.min,
+                                                children: [
+                                                  if (activeCalls.length > 1)
+                                                    FocusedActionHint(
+                                                      focusedName: focusedCall.displayName ?? focusedCall.handle.value,
+                                                      willBeHeldNames: nonIncomingRingingCanBeHolded.isEmpty
+                                                          ? const []
+                                                          : [
+                                                              for (final call in nonIncomingRingingCanBeHolded)
+                                                                if (!call.held) call.displayName ?? call.handle.value,
+                                                            ],
+                                                      willBeEndedNames: nonIncomingRingingCanBeHolded.isNotEmpty
+                                                          ? const []
+                                                          : [
+                                                              for (final call in nonIncomingRingingCalls)
+                                                                call.displayName ?? call.handle.value,
+                                                            ],
+                                                      style: style?.callInfo,
+                                                    ),
+                                                  IncomingCallActions(
+                                                    style: style?.actions,
+                                                    inviteToAttendedTransfer: false,
+                                                    remoteVideo: focusedCall.remoteVideo && focusedCall.held == false,
+                                                    onHangupPressed: () {
+                                                      _callBloc.add(CallControlEvent.ended(focusedCall.callId));
+                                                      dispatchInteractionDebounce();
+                                                    },
+                                                    // Answering with other calls present mutates them
+                                                    // (hold/end), so it is gated by the interactions
+                                                    // debounce like any signaling-dependent action.
+                                                    onAcceptPressed:
+                                                        nonIncomingRingingCalls.isNotEmpty &&
+                                                            (interactionsDebounceActive ||
+                                                                widget.callStatus != CallStatus.ready ||
+                                                                activeCalls.any((call) => call.updating))
+                                                        ? null
+                                                        : () {
+                                                            _callBloc.add(
+                                                              CallControlEvent.answerFocused(
+                                                                focusedCall.callId,
+                                                                hasHoldableOthers:
+                                                                    nonIncomingRingingCanBeHolded.isNotEmpty,
+                                                                hasNonRingingOthers: nonIncomingRingingCalls.isNotEmpty,
+                                                              ),
+                                                            );
+                                                            dispatchInteractionDebounce();
+                                                          },
+                                                  ),
+                                                ],
                                               ),
-                                            ],
                                           ],
                                         ),
                                       ),

--- a/lib/features/call/widgets/call_list.dart
+++ b/lib/features/call/widgets/call_list.dart
@@ -107,7 +107,14 @@ class _CallRowState extends State<CallRow> {
     final call = widget.call;
     final acceptedTime = call.acceptedTime;
     if (acceptedTime != null) return clock.now().difference(acceptedTime).format();
-    return call.isIncoming ? context.l10n.call_description_incoming : context.l10n.call_description_outgoing;
+    return call.isIncoming ? context.l10n.call_CallList_incoming : context.l10n.call_CallList_outgoing;
+  }
+
+  Color _statusDotColor() {
+    final call = widget.call;
+    if (!call.wasAccepted) return Colors.amber.shade300;
+    if (call.held) return Colors.blueGrey.shade200;
+    return Colors.lightGreen.shade400;
   }
 
   @override
@@ -132,6 +139,12 @@ class _CallRowState extends State<CallRow> {
             ),
             child: Row(
               children: [
+                Container(
+                  width: 8,
+                  height: 8,
+                  margin: const EdgeInsets.only(right: 10),
+                  decoration: BoxDecoration(shape: BoxShape.circle, color: _statusDotColor()),
+                ),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/call/widgets/focused_action_hint.dart
+++ b/lib/features/call/widgets/focused_action_hint.dart
@@ -32,30 +32,65 @@ class FocusedActionHint extends StatelessWidget {
 
   final CallInfoStyle? style;
 
+  /// Builds a span for [text] with the [highlight] substring emphasized via
+  /// [emphasis]. The localized templates inline the names as plain text, so
+  /// the name is found by substring rather than by splitting the template.
+  TextSpan _highlightedSpan(String text, String highlight, TextStyle base, TextStyle emphasis) {
+    final index = text.indexOf(highlight);
+    if (index < 0) return TextSpan(text: text, style: base);
+    return TextSpan(
+      style: base,
+      children: [
+        TextSpan(text: text.substring(0, index)),
+        TextSpan(text: highlight, style: emphasis),
+        TextSpan(text: text.substring(index + highlight.length)),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final baseStyle = style?.callStatus ?? const TextStyle();
+    final actingOnStyle = baseStyle.copyWith(fontSize: 13);
+    final focusedNameStyle = actingOnStyle.copyWith(fontWeight: FontWeight.w700);
+    final sideEffectStyle = baseStyle.copyWith(fontSize: 12);
+    final affectedNameStyle = sideEffectStyle.copyWith(color: Colors.amber.shade200, fontWeight: FontWeight.w600);
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.25), borderRadius: BorderRadius.circular(14)),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
-            context.l10n.call_FocusedActionHint_actingOn(focusedName),
-            style: baseStyle.copyWith(fontSize: 13, fontWeight: FontWeight.w600),
+          Text.rich(
+            _highlightedSpan(
+              context.l10n.call_FocusedActionHint_actingOn(focusedName),
+              focusedName,
+              actingOnStyle,
+              focusedNameStyle,
+            ),
             textAlign: TextAlign.center,
           ),
           if (willBeHeldNames.isNotEmpty)
-            Text(
-              context.l10n.call_FocusedActionHint_willBeHeld(willBeHeldNames.join(', ')),
-              style: baseStyle.copyWith(fontSize: 12),
+            Text.rich(
+              _highlightedSpan(
+                context.l10n.call_FocusedActionHint_willBeHeld(willBeHeldNames.join(', ')),
+                willBeHeldNames.join(', '),
+                sideEffectStyle,
+                affectedNameStyle,
+              ),
               textAlign: TextAlign.center,
             )
           else if (willBeEndedNames.isNotEmpty)
-            Text(
-              context.l10n.call_FocusedActionHint_willBeEnded(willBeEndedNames.join(', ')),
-              style: baseStyle.copyWith(fontSize: 12),
+            Text.rich(
+              _highlightedSpan(
+                context.l10n.call_FocusedActionHint_willBeEnded(willBeEndedNames.join(', ')),
+                willBeEndedNames.join(', '),
+                sideEffectStyle,
+                affectedNameStyle,
+              ),
               textAlign: TextAlign.center,
             ),
         ],

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -333,6 +333,18 @@ abstract class AppLocalizations {
   /// **'Unmute microphone'**
   String get call_CallActionsTooltip_unmute;
 
+  /// Trailing label on a ringing incoming row in the call list.
+  ///
+  /// In en, this message translates to:
+  /// **'Incoming'**
+  String get call_CallList_incoming;
+
+  /// Trailing label on a ringing outgoing row in the call list.
+  ///
+  /// In en, this message translates to:
+  /// **'Outgoing'**
+  String get call_CallList_outgoing;
+
   /// Header above the call list on the call screen when more than one call is in progress.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -81,6 +81,8 @@ extension AppLocalizationsExtension on AppLocalizations {
         call_CallActionsTooltip_unattended_transfer,
       'call_CallActionsTooltip_unhold' => call_CallActionsTooltip_unhold,
       'call_CallActionsTooltip_unmute' => call_CallActionsTooltip_unmute,
+      'call_CallList_incoming' => call_CallList_incoming,
+      'call_CallList_outgoing' => call_CallList_outgoing,
       'call_CallList_statusOnCall' => call_CallList_statusOnCall,
       'call_ToolbarStatus_connecting' => call_ToolbarStatus_connecting,
       'call_ToolbarStatus_reconnecting' => call_ToolbarStatus_reconnecting,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -171,6 +171,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get call_CallActionsTooltip_unmute => 'Unmute microphone';
 
   @override
+  String get call_CallList_incoming => 'Incoming';
+
+  @override
+  String get call_CallList_outgoing => 'Outgoing';
+
+  @override
   String call_CallList_header(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -172,6 +172,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get call_CallActionsTooltip_unmute => 'Attiva il microfono';
 
   @override
+  String get call_CallList_incoming => 'In arrivo';
+
+  @override
+  String get call_CallList_outgoing => 'In uscita';
+
+  @override
   String call_CallList_header(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -180,6 +180,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get call_CallActionsTooltip_unmute => 'Увімкнути мікрофон';
 
   @override
+  String get call_CallList_incoming => 'Вхідний';
+
+  @override
+  String get call_CallList_outgoing => 'Вихідний';
+
+  @override
   String call_CallList_header(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -113,6 +113,14 @@
   "@call_CallActionsTooltip_unhold": {},
   "call_CallActionsTooltip_unmute": "Unmute microphone",
   "@call_CallActionsTooltip_unmute": {},
+  "call_CallList_incoming": "Incoming",
+  "@call_CallList_incoming": {
+    "description": "Trailing label on a ringing incoming row in the call list."
+  },
+  "call_CallList_outgoing": "Outgoing",
+  "@call_CallList_outgoing": {
+    "description": "Trailing label on a ringing outgoing row in the call list."
+  },
   "call_CallList_header": "{count, plural, one{{count} call - tap to choose} other{{count} calls - tap to choose}}",
   "@call_CallList_header": {
     "description": "Header above the call list on the call screen when more than one call is in progress.",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -113,6 +113,14 @@
   "@call_CallActionsTooltip_unhold": {},
   "call_CallActionsTooltip_unmute": "Attiva il microfono",
   "@call_CallActionsTooltip_unmute": {},
+  "call_CallList_incoming": "In arrivo",
+  "@call_CallList_incoming": {
+    "description": "Trailing label on a ringing incoming row in the call list."
+  },
+  "call_CallList_outgoing": "In uscita",
+  "@call_CallList_outgoing": {
+    "description": "Trailing label on a ringing outgoing row in the call list."
+  },
   "call_CallList_header": "{count, plural, one{{count} chiamata - tocca per scegliere} other{{count} chiamate - tocca per scegliere}}",
   "@call_CallList_header": {
     "description": "Header above the call list on the call screen when more than one call is in progress.",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -113,6 +113,14 @@
   "@call_CallActionsTooltip_unhold": {},
   "call_CallActionsTooltip_unmute": "Увімкнути мікрофон",
   "@call_CallActionsTooltip_unmute": {},
+  "call_CallList_incoming": "Вхідний",
+  "@call_CallList_incoming": {
+    "description": "Trailing label on a ringing incoming row in the call list."
+  },
+  "call_CallList_outgoing": "Вихідний",
+  "@call_CallList_outgoing": {
+    "description": "Trailing label on a ringing outgoing row in the call list."
+  },
   "call_CallList_header": "{count, plural, one{{count} дзвінок - торкніться, щоб вибрати} few{{count} дзвінки - торкніться, щоб вибрати} many{{count} дзвінків - торкніться, щоб вибрати} other{{count} дзвінка - торкніться, щоб вибрати}}",
   "@call_CallList_header": {
     "description": "Header above the call list on the call screen when more than one call is in progress.",

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -100,6 +100,7 @@ void main() {
       expect(find.byType(ActiveCallActions), findsNothing);
       expect(find.byType(CallList), findsNothing);
       expect(find.byType(FocusedActionHint), findsNothing);
+      expect(find.byType(CallInfo), findsOneWidget);
       await _teardown(tester);
     });
 
@@ -131,10 +132,18 @@ void main() {
       expect(find.byType(CallRow), findsNWidgets(2));
       expect(find.byType(IncomingCallActions), findsOneWidget);
       expect(find.byType(ActiveCallActions), findsNothing);
+      // With multiple calls the rows carry the info; no central block.
+      expect(find.byType(CallInfo), findsNothing);
 
       // The hint names the focused call and the answered call to be held.
-      expect(find.text(context.l10n.call_FocusedActionHint_actingOn('Anna Marchenko')), findsOneWidget);
-      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Boris Klein')), findsOneWidget);
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_actingOn('Anna Marchenko'), findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_willBeHeld('Boris Klein'), findRichText: true),
+        findsOneWidget,
+      );
       await _teardown(tester);
     });
 
@@ -174,7 +183,10 @@ void main() {
       expect(find.byType(IncomingCallActions), findsOneWidget);
       // Only the still-active call is named in the hold side effect; the
       // already-held one does not change state.
-      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Boris Klein')), findsOneWidget);
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_willBeHeld('Boris Klein'), findRichText: true),
+        findsOneWidget,
+      );
       await _teardown(tester);
     });
   });

--- a/test/features/call/widgets/call_list_test.dart
+++ b/test/features/call/widgets/call_list_test.dart
@@ -129,7 +129,7 @@ void main() {
       await tester.pumpWidget(_buildSubject(calls: [ringing, onCall], focusedCallId: 'ringing', onCallTap: (_) {}));
       final context = tester.element(find.byType(CallList));
 
-      expect(find.text(context.l10n.call_description_incoming), findsOneWidget);
+      expect(find.text(context.l10n.call_CallList_incoming), findsOneWidget);
       expect(find.textContaining(RegExp(r'^\d{2}:\d{2}')), findsOneWidget);
 
       // Let the periodic ticker fire once, then dispose cleanly.

--- a/test/features/call/widgets/focused_action_hint_test.dart
+++ b/test/features/call/widgets/focused_action_hint_test.dart
@@ -28,21 +28,30 @@ void main() {
       await tester.pumpWidget(_buildSubject(focusedName: 'Boris Klein'));
       final context = tester.element(find.byType(FocusedActionHint));
 
-      expect(find.text(context.l10n.call_FocusedActionHint_actingOn('Boris Klein')), findsOneWidget);
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_actingOn('Boris Klein'), findRichText: true),
+        findsOneWidget,
+      );
     });
 
     testWidgets('spells out the will-be-held side effect', (tester) async {
       await tester.pumpWidget(_buildSubject(focusedName: 'Boris Klein', willBeHeldNames: const ['Anna Marchenko']));
       final context = tester.element(find.byType(FocusedActionHint));
 
-      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko')), findsOneWidget);
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko'), findRichText: true),
+        findsOneWidget,
+      );
     });
 
     testWidgets('spells out the will-be-ended side effect when nothing can be held', (tester) async {
       await tester.pumpWidget(_buildSubject(focusedName: 'Boris Klein', willBeEndedNames: const ['Anna Marchenko']));
       final context = tester.element(find.byType(FocusedActionHint));
 
-      expect(find.text(context.l10n.call_FocusedActionHint_willBeEnded('Anna Marchenko')), findsOneWidget);
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_willBeEnded('Anna Marchenko'), findRichText: true),
+        findsOneWidget,
+      );
     });
 
     testWidgets('hold side effect wins over ended when both are passed', (tester) async {
@@ -55,8 +64,14 @@ void main() {
       );
       final context = tester.element(find.byType(FocusedActionHint));
 
-      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko')), findsOneWidget);
-      expect(find.text(context.l10n.call_FocusedActionHint_willBeEnded('Clara Diaz')), findsNothing);
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko'), findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_willBeEnded('Clara Diaz'), findRichText: true),
+        findsNothing,
+      );
     });
 
     testWidgets('joins multiple affected names', (tester) async {
@@ -65,7 +80,10 @@ void main() {
       );
       final context = tester.element(find.byType(FocusedActionHint));
 
-      expect(find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko, Clara Diaz')), findsOneWidget);
+      expect(
+        find.text(context.l10n.call_FocusedActionHint_willBeHeld('Anna Marchenko, Clara Diaz'), findRichText: true),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows no side-effect line without affected calls', (tester) async {


### PR DESCRIPTION
## Overview

Visual-alignment pass over the list-based call screen (targets
`refactor/call`), closing the gaps between the current build and the design
frames. Action buttons are intentionally untouched.

## Changes

- **Call rows**: a colored status dot before the badge (amber = ringing,
  green = on call, grey = held); the trailing label on a ringing row is the
  short Incoming/Outgoing form (new `call_CallList_incoming`/`_outgoing` keys
  in en/it/uk) instead of "Incoming call".
- **Central info block is single-call only**: with multiple calls the rows
  already carry the per-call info, so the middle of the screen stays clear, as
  in the design.
- **Acting-on hint as a pill**: translucent dark rounded container pinned
  directly above the action buttons (hint + buttons share one column child so
  the space-between layout keeps them glued at the bottom), with the focused
  name in bold and the affected names highlighted in amber.
- Action buttons (Decline/Answer, control grid) remain exactly as merged - no
  labels under them.

## Tests

Updated for the new visuals: hint assertions match the rich-text spans,
the ringing row asserts the short Incoming label, and the scaffold suite now
pins the central info block presence for a single call and its absence with
multiple calls. Full suite green via pre-push (446 call-feature tests among
them).