### PR TITLE
fix(call): make hold and resume act on the focused call

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -1,7 +1,7 @@
 # Call
 
 The in-app calling experience: placing and receiving SIP/WebRTC calls, the
-full-screen call UI, multi-call handling (hold, swap, transfer), and the native
+full-screen call UI, multi-call handling (hold/resume, transfer), and the native
 CallKit / ConnectionService integration.
 
 Last reviewed: 2026-06-10
@@ -60,7 +60,7 @@ Single call:
 - **1 incoming** - caller info + Decline / Answer.
 - **1 active** - caller info + control grid (mute, camera, speaker, transfer,
   hold, keypad) + hang up.
-- **1 on hold** - same grid with Hold shown as Resume.
+- **1 on hold** - same grid with Hold shown as Resume (play glyph).
 
 Multiple calls (list-based):
 
@@ -123,7 +123,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 | Focused actions | "Acting on" hint + two-button ringing focus (single answerFocused intent); combined-icon buttons removed | Merged (PR #1380) |
 | Cleanup / edges | Dead-code and obsolete l10n removal; scaffold-level widget tests for single/multi/3-call states | Merged (PR #1381) |
 | Toolbar status | Signaling/connectivity status, media failures and stream quality move to the AppBar status line (global, worst across calls); the central info block keeps only name/description/duration | Merged (PR #1385) |
-| Visual alignment | Status dots on rows, short Incoming/Outgoing trailing labels, central info block single-call only, acting-on hint as a translucent pill with highlighted names | In review |
+| Visual alignment | Status dots on rows, short Incoming/Outgoing trailing labels, central info block single-call only, acting-on hint as a translucent pill with highlighted names | Merged (PR #1386) |
+| Hold/Resume on focus | The hold slot always acts on the focused call (pause/play glyph); Resume holds the other live calls first; the swap button is gone - switching lines = focus a row + Resume | In review |
 
 The redesign lands on the `refactor/call` integration branch - every stage is a
 PR into that branch, and once the whole flow is tested there a single PR merges

--- a/lib/app/keys.dart
+++ b/lib/app/keys.dart
@@ -42,7 +42,6 @@ const callActionsMuteKey = Key('callActionsMute');
 const callActionsVideoCallKey = Key('callActionsVideoCall');
 const callActionsSpeakerKey = Key('callActionsSpeaker');
 const callActionsHoldKey = Key('callActionsHold');
-const callActionsSwapKey = Key('callActionsSwap');
 const callActionsKeypadKey = Key('callActionsKeypad');
 const callActionsHangupKey = Key('callActionsHangup');
 const callActionsTransferMenuKey = Key('callActionsTransferMenu');

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1353,7 +1353,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _CallControlEventAnswered() => __onCallControlEventAnswered(event, emit),
       _CallControlEventAnsweredEndingOthers() => __onCallControlEventAnsweredEndingOthers(event, emit),
       _CallControlEventAnsweredHoldingOthers() => __onCallControlEventAnsweredHoldingOthers(event, emit),
-      _CallControlEventSwapped() => __onCallControlEventSwapped(event, emit),
+      _CallControlEventResumedHoldingOthers() => __onCallControlEventResumedHoldingOthers(event, emit),
       _CallControlEventEnded() => __onCallControlEventEnded(event, emit),
       _CallControlEventSetHeld() => __onCallControlEventSetHeld(event, emit),
       _CallControlEventSetMuted() => __onCallControlEventSetMuted(event, emit),
@@ -1433,9 +1433,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     CallControlEvent.answerHoldingOthersPlan(event.callId, state.otherCallIds(event.callId)).forEach(add);
   }
 
-  /// Swap: holds [event.callId], then resumes the other calls.
-  Future<void> __onCallControlEventSwapped(_CallControlEventSwapped event, Emitter<CallState> emit) async {
-    CallControlEvent.swapPlan(event.callId, state.otherCallIds(event.callId)).forEach(add);
+  /// Resume on a held focus: holds the other live calls, then resumes
+  /// [event.callId], so exactly one call stays live.
+  Future<void> __onCallControlEventResumedHoldingOthers(
+    _CallControlEventResumedHoldingOthers event,
+    Emitter<CallState> emit,
+  ) async {
+    CallControlEvent.resumeHoldingOthersPlan(event.callId, state.otherCallIdsToHold(event.callId)).forEach(add);
   }
 
   /// Submitting the answer intent to system when answer button is pressed from app ui

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -596,10 +596,14 @@ sealed class CallControlEvent extends CallEvent {
     CallControlEvent.answered(callId),
   ];
 
-  /// Swap plan: hold [callId], then resume every other call.
-  static List<CallControlEvent> swapPlan(String callId, List<String> otherCallIds) => [
-    CallControlEvent.setHeld(callId, true),
-    for (final otherCallId in otherCallIds) CallControlEvent.setHeld(otherCallId, false),
+  /// Resume plan for the focused held call: put the other unheld answered
+  /// calls on hold first ([otherCallIdsToHold], from
+  /// [CallState.otherCallIdsToHold]) so only one call is live, then resume
+  /// [callId]. With two calls this is the classic swap; switching which call
+  /// is live is done by focusing its row and pressing Resume.
+  static List<CallControlEvent> resumeHoldingOthersPlan(String callId, List<String> otherCallIdsToHold) => [
+    for (final otherCallId in otherCallIdsToHold) CallControlEvent.setHeld(otherCallId, true),
+    CallControlEvent.setHeld(callId, false),
   ];
 
   /// The single Answer intent for the focused ringing call: hold the other
@@ -642,8 +646,9 @@ sealed class CallControlEvent extends CallEvent {
   /// "Hold & Answer" action for a second incoming call, as a single intent.
   const factory CallControlEvent.answeredHoldingOthers(String callId) = _CallControlEventAnsweredHoldingOthers;
 
-  /// Swaps the active and held calls: holds [callId] and resumes the others.
-  const factory CallControlEvent.swapped(String callId) = _CallControlEventSwapped;
+  /// Resumes the focused held call [callId] after putting the other live
+  /// calls on hold, as a single intent (the Resume button on a held focus).
+  const factory CallControlEvent.resumedHoldingOthers(String callId) = _CallControlEventResumedHoldingOthers;
 
   const factory CallControlEvent.ended(String callId) = _CallControlEventEnded;
 
@@ -752,8 +757,8 @@ class _CallControlEventAnsweredHoldingOthers extends CallControlEvent {
   List<Object?> get props => [callId];
 }
 
-class _CallControlEventSwapped extends CallControlEvent {
-  const _CallControlEventSwapped(this.callId);
+class _CallControlEventResumedHoldingOthers extends CallControlEvent {
+  const _CallControlEventResumedHoldingOthers(this.callId);
 
   final String callId;
 

--- a/lib/features/call/bloc/call_state.dart
+++ b/lib/features/call/bloc/call_state.dart
@@ -253,6 +253,14 @@ class CallState with _$CallState {
     for (final call in activeCalls)
       if (call.callId != callId) call.callId,
   ];
+
+  /// Ids of every other answered, not-yet-held call - the ones that must be
+  /// put on hold before resuming [callId] so only one call stays live. Pure
+  /// data query for the event-layer plans.
+  List<String> otherCallIdsToHold(String callId) => [
+    for (final call in activeCalls)
+      if (call.callId != callId && call.wasAccepted && !call.held) call.callId,
+  ];
 }
 
 @freezed

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -314,21 +314,18 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                             })
                                                     : null,
                                                 heldValue: focusedCall.held,
+                                                // Hold pauses just the focused call; Resume brings it
+                                                // back as the only live one (the other live calls are
+                                                // put on hold first). Switching lines = focus the other
+                                                // row and press Resume - there is no separate swap.
                                                 onHeldChanged: (bool value) {
-                                                  _callBloc.add(CallControlEvent.setHeld(focusedCall.callId, value));
+                                                  _callBloc.add(
+                                                    value
+                                                        ? CallControlEvent.setHeld(focusedCall.callId, true)
+                                                        : CallControlEvent.resumedHoldingOthers(focusedCall.callId),
+                                                  );
                                                   dispatchInteractionDebounce();
                                                 },
-                                                // Swap keeps acting on the derived current call: its
-                                                // semantics are "hold the active one, resume the rest"
-                                                // regardless of which row is focused.
-                                                onSwapPressed: activeCalls.length == 2
-                                                    ? () {
-                                                        _callBloc.add(
-                                                          CallControlEvent.swapped(activeCalls.current.callId),
-                                                        );
-                                                        dispatchInteractionDebounce();
-                                                      }
-                                                    : null,
                                                 onHangupPressed: () {
                                                   _callBloc.add(CallControlEvent.ended(focusedCall.callId));
                                                   dispatchInteractionDebounce();

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -36,7 +36,6 @@ class ActiveCallActions extends StatefulWidget {
     required this.onAttendedTransferSubmitted,
     required this.heldValue,
     this.onHeldChanged,
-    this.onSwapPressed,
     this.onHangupPressed,
     this.onKeyPressed,
     this.style,
@@ -60,7 +59,6 @@ class ActiveCallActions extends StatefulWidget {
   final void Function(ActiveCall call)? onAttendedTransferSubmitted;
   final bool heldValue;
   final ValueChanged<bool>? onHeldChanged;
-  final void Function()? onSwapPressed;
   final void Function()? onHangupPressed;
   final void Function(String value)? onKeyPressed;
 
@@ -156,9 +154,8 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     final onBlindTransferInitiated = widget.onBlindTransferInitiated;
     final onAttendedTransferInitiated = widget.onAttendedTransferInitiated;
     final onAttendedTransferSubmitted = widget.onAttendedTransferSubmitted;
-    // Hold and swap send signaling requests and trigger renegotiation.
+    // Hold/resume sends signaling requests and triggers renegotiation.
     final onHeldChanged = widget.enableInteractions ? widget.onHeldChanged : null;
-    final onSwapPressed = widget.enableInteractions ? widget.onSwapPressed : null;
     final onKeyPressed = widget.enableInteractions ? widget.onKeyPressed : null;
 
     // Always allow the user to hang up or answer the call
@@ -426,29 +423,18 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
               ),
             ),
           ),
-        if (onSwapPressed == null)
-          Tooltip(
-            key: callActionsHoldKey,
-            message: widget.heldValue
-                ? context.l10n.call_CallActionsTooltip_unhold
-                : context.l10n.call_CallActionsTooltip_hold,
-            child: TextButton(
-              onPressed: onHeldChanged == null ? null : () => onHeldChanged(!widget.heldValue),
-              statesController: _heldStatesController..update(WidgetState.selected, widget.heldValue),
-              style: widget.style?.held,
-              child: Icon(Icons.pause, size: actionPadIconSize),
-            ),
+        Tooltip(
+          key: callActionsHoldKey,
+          message: widget.heldValue
+              ? context.l10n.call_CallActionsTooltip_unhold
+              : context.l10n.call_CallActionsTooltip_hold,
+          child: TextButton(
+            onPressed: onHeldChanged == null ? null : () => onHeldChanged(!widget.heldValue),
+            statesController: _heldStatesController..update(WidgetState.selected, widget.heldValue),
+            style: widget.style?.held,
+            child: Icon(widget.heldValue ? Icons.play_arrow : Icons.pause, size: actionPadIconSize),
           ),
-        if (onSwapPressed != null)
-          Tooltip(
-            key: callActionsSwapKey,
-            message: context.l10n.call_CallActionsTooltip_swap,
-            child: TextButton(
-              onPressed: onSwapPressed,
-              style: widget.style?.speaker,
-              child: Icon(Icons.swap_calls, size: actionPadIconSize),
-            ),
-          ),
+        ),
         Tooltip(
           key: callActionsKeypadKey,
           message: context.l10n.call_CallActionsTooltip_showKeypad,

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -297,12 +297,6 @@ abstract class AppLocalizations {
   /// **'Show keypad'**
   String get call_CallActionsTooltip_showKeypad;
 
-  /// No description provided for @call_CallActionsTooltip_swap.
-  ///
-  /// In en, this message translates to:
-  /// **'Swap calls'**
-  String get call_CallActionsTooltip_swap;
-
   /// No description provided for @call_CallActionsTooltip_transfer.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -73,7 +73,6 @@ extension AppLocalizationsExtension on AppLocalizations {
       'call_CallActionsTooltip_mute' => call_CallActionsTooltip_mute,
       'call_CallActionsTooltip_showKeypad' =>
         call_CallActionsTooltip_showKeypad,
-      'call_CallActionsTooltip_swap' => call_CallActionsTooltip_swap,
       'call_CallActionsTooltip_transfer' => call_CallActionsTooltip_transfer,
       'call_CallActionsTooltip_transfer_choose' =>
         call_CallActionsTooltip_transfer_choose,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -153,9 +153,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get call_CallActionsTooltip_showKeypad => 'Show keypad';
 
   @override
-  String get call_CallActionsTooltip_swap => 'Swap calls';
-
-  @override
   String get call_CallActionsTooltip_transfer => 'Transfer';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -154,9 +154,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get call_CallActionsTooltip_showKeypad => 'Mostra tastiera';
 
   @override
-  String get call_CallActionsTooltip_swap => 'Scambio chiamate';
-
-  @override
   String get call_CallActionsTooltip_transfer => 'Trasferimento';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -162,9 +162,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get call_CallActionsTooltip_showKeypad => 'Показати клавіатуру';
 
   @override
-  String get call_CallActionsTooltip_swap => 'Перемкнути дзвінки';
-
-  @override
   String get call_CallActionsTooltip_transfer => 'Переадресація';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -101,8 +101,6 @@
   "@call_CallActionsTooltip_mute": {},
   "call_CallActionsTooltip_showKeypad": "Show keypad",
   "@call_CallActionsTooltip_showKeypad": {},
-  "call_CallActionsTooltip_swap": "Swap calls",
-  "@call_CallActionsTooltip_swap": {},
   "call_CallActionsTooltip_transfer": "Transfer",
   "@call_CallActionsTooltip_transfer": {},
   "call_CallActionsTooltip_transfer_choose": "Choose number",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -101,8 +101,6 @@
   "@call_CallActionsTooltip_mute": {},
   "call_CallActionsTooltip_showKeypad": "Mostra tastiera",
   "@call_CallActionsTooltip_showKeypad": {},
-  "call_CallActionsTooltip_swap": "Scambio chiamate",
-  "@call_CallActionsTooltip_swap": {},
   "call_CallActionsTooltip_transfer": "Trasferimento",
   "@call_CallActionsTooltip_transfer": {},
   "call_CallActionsTooltip_transfer_choose": "Scegliere il numero",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -101,8 +101,6 @@
   "@call_CallActionsTooltip_mute": {},
   "call_CallActionsTooltip_showKeypad": "Показати клавіатуру",
   "@call_CallActionsTooltip_showKeypad": {},
-  "call_CallActionsTooltip_swap": "Перемкнути дзвінки",
-  "@call_CallActionsTooltip_swap": {},
   "call_CallActionsTooltip_transfer": "Переадресація",
   "@call_CallActionsTooltip_transfer": {},
   "call_CallActionsTooltip_transfer_choose": "Вибрати номер",

--- a/test/features/call/bloc/call_state_test.dart
+++ b/test/features/call/bloc/call_state_test.dart
@@ -530,7 +530,8 @@ void main() {
   // ---------------------------------------------------------------------------
   // Combined-action plans
   //
-  // The single intents (answeredEndingOthers / answeredHoldingOthers / swapped)
+  // The single intents (answeredEndingOthers / answeredHoldingOthers /
+  // resumedHoldingOthers)
   // dispatch exactly these ordered primitive events. The state layer only
   // supplies the other-call ids (CallState.otherCallIds); the plans live on the
   // event layer (CallControlEvent). This pins the semantics the call screen
@@ -580,12 +581,30 @@ void main() {
     });
   });
 
-  group('CallControlEvent.swapPlan', () {
-    test('holds the target first, then resumes the other call', () {
-      expect(CallControlEvent.swapPlan('active', ['held']), const [
+  group('CallControlEvent.resumeHoldingOthersPlan', () {
+    test('holds the live others first, then resumes the target', () {
+      expect(CallControlEvent.resumeHoldingOthersPlan('held', ['active']), const [
         CallControlEvent.setHeld('active', true),
         CallControlEvent.setHeld('held', false),
       ]);
+    });
+
+    test('just resumes when nothing else is live', () {
+      expect(CallControlEvent.resumeHoldingOthersPlan('held', []), const [CallControlEvent.setHeld('held', false)]);
+    });
+  });
+
+  group('CallState.otherCallIdsToHold', () {
+    test('returns only the other answered, not-held calls', () {
+      final live = _makeCall(callId: 'live', acceptedTime: DateTime(2024));
+      final held = _makeCall(callId: 'held', acceptedTime: DateTime(2024), held: true);
+      final ringing = _makeCall(callId: 'ringing', processingStatus: CallProcessingStatus.incomingFromOffer);
+      final target = _makeCall(callId: 'target', acceptedTime: DateTime(2024), held: true);
+      final state = CallState(activeCalls: [live, held, ringing, target]);
+
+      // Already-held and still-ringing calls do not need holding; the target
+      // itself is excluded.
+      expect(state.otherCallIdsToHold('target'), ['live']);
     });
   });
 

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -173,6 +173,28 @@ void main() {
     });
   });
 
+  group('CallActiveScaffold - hold and resume on the focused call', () {
+    testWidgets('Hold on an active focus holds just that call', (tester) async {
+      final held = _makeCall(callId: 'held', acceptedTime: DateTime(2024), held: true, displayName: 'Clara Diaz');
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [held, active], focusedCall: active));
+
+      await tester.tap(find.byIcon(Icons.pause));
+      verify(() => callBloc.add(const CallControlEvent.setHeld('active', true))).called(1);
+      await _teardown(tester);
+    });
+
+    testWidgets('Resume on a held focus holds the live call and resumes the focused one', (tester) async {
+      final held = _makeCall(callId: 'held', acceptedTime: DateTime(2024), held: true, displayName: 'Clara Diaz');
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [held, active], focusedCall: held));
+
+      // The slot is a Resume affordance for a held focus - no swap button.
+      expect(find.byIcon(Icons.swap_calls), findsNothing);
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      verify(() => callBloc.add(const CallControlEvent.resumedHoldingOthers('held'))).called(1);
+      await _teardown(tester);
+    });
+  });
+
   group('CallActiveScaffold - 3 calls (held + active + incoming)', () {
     testWidgets('three rows, ringing focus keeps two buttons and the hint', (tester) async {
       final held = _makeCall(callId: 'held', acceptedTime: DateTime(2024), held: true, displayName: 'Clara Diaz');


### PR DESCRIPTION
## Overview

QA finding on the list-based screen (targets `refactor/call`): hold and the
row focus were out of sync. With two calls the hold slot in the control grid
was REPLACED by the swap button, so a held call could never simply be resumed,
and pressing the button always switched lines via the derived current call -
ignoring which row the user had focused. The focus model makes swap redundant:
switching lines is just focusing the other row.

## Root cause

- `ActiveCallActions` rendered the hold slot as either Hold OR Swap:
  `onSwapPressed != null` (passed whenever `activeCalls.length == 2`) hid the
  Hold/Resume button entirely.
- The swap callback dispatched `swapped(activeCalls.current.callId)` - bound
  to the derived current call, not the focused one.

## Changes

- The hold slot is now **always Hold/Resume for the focused call**, with a
  pause/play glyph reflecting the state.
- **Resume** dispatches the new `resumedHoldingOthers` intent: the other
  answered, not-yet-held calls are put on hold first
  (`CallState.otherCallIdsToHold` - held and still-ringing calls are skipped),
  then the focused call is resumed, so exactly one call stays live. With two
  calls this covers everything swap did, but driven by focus.
- **Hold** stays a plain `setHeld(focused, true)`.
- Removed: the swap button and its callback chain, the `swapped` event and
  `swapPlan`, `callActionsSwapKey`, and the swap tooltip l10n keys (en/it/uk).

## Tests

- `resumeHoldingOthersPlan`: holds the live others first, then resumes; plain
  resume when nothing else is live.
- `otherCallIdsToHold`: skips already-held calls, ringing calls and the target.
- Scaffold: Hold on an active focus dispatches `setHeld(true)`; a held focus
  shows the play glyph, no swap button, and Resume dispatches the new intent.
- Full suite green via pre-push (450 call-feature tests among them).