### PR TITLE
fix(call): match the call row overlay polarity to the design

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -124,7 +124,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 | Cleanup / edges | Dead-code and obsolete l10n removal; scaffold-level widget tests for single/multi/3-call states | Merged (PR #1381) |
 | Toolbar status | Signaling/connectivity status, media failures and stream quality move to the AppBar status line (global, worst across calls); the central info block keeps only name/description/duration | Merged (PR #1385) |
 | Visual alignment | Status dots on rows, short Incoming/Outgoing trailing labels, central info block single-call only, acting-on hint as a translucent pill with highlighted names | Merged (PR #1386) |
-| Hold/Resume on focus | The hold slot always acts on the focused call (pause/play glyph); Resume holds the other live calls first; the swap button is gone - switching lines = focus a row + Resume | In review |
+| Hold/Resume on focus | The hold slot always acts on the focused call (pause/play glyph); Resume holds the other live calls first; the swap button is gone - switching lines = focus a row + Resume | Merged (PR #1387) |
+| Row overlay polish | Call rows use light overlay tints of the on-screen text color: focused = brighter + light border (design polarity), bigger radius and padding | In review |
 
 The redesign lands on the `refactor/call` integration branch - every stage is a
 PR into that branch, and once the whole flow is tested there a single PR merges

--- a/lib/features/call/widgets/call_list.dart
+++ b/lib/features/call/widgets/call_list.dart
@@ -119,23 +119,28 @@ class _CallRowState extends State<CallRow> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     final nameStyle = widget.style?.number ?? const TextStyle();
     final statusStyle = widget.style?.callStatus ?? const TextStyle();
 
+    // Rows are light overlay tints of the on-screen text color (white on the
+    // standard call gradient): the FOCUSED row is the brighter one with a
+    // light border, unfocused rows stay dimmer - matching the design's
+    // polarity regardless of what colorScheme.surface resolves to.
+    final overlayColor = statusStyle.color ?? Theme.of(context).colorScheme.surface;
+
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       child: Material(
-        color: colorScheme.surface.withValues(alpha: widget.focused ? 0.28 : 0.12),
-        borderRadius: BorderRadius.circular(12),
+        color: overlayColor.withValues(alpha: widget.focused ? 0.26 : 0.10),
+        borderRadius: BorderRadius.circular(16),
         child: InkWell(
           onTap: widget.onTap,
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(16),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              border: widget.focused ? Border.all(color: colorScheme.surface.withValues(alpha: 0.6)) : null,
+              borderRadius: BorderRadius.circular(16),
+              border: widget.focused ? Border.all(color: overlayColor.withValues(alpha: 0.55)) : null,
             ),
             child: Row(
               children: [


### PR DESCRIPTION
## Overview

Visual fix on the call list rows (targets `refactor/call`): in the design the
FOCUSED row is the brighter one (light overlay + light border) while the
others stay dimmer - our build had it inverted, with the focused row darker.

## Root cause

The rows tinted themselves with `colorScheme.surface`, which resolves to a
dark color on the standard theme, so a higher alpha made the focused row
darker instead of brighter.

## Changes

- Rows use light overlay tints of the on-screen text color (white on the call
  gradient): focused = alpha 0.26 + a 0.55-alpha border, unfocused = 0.10.
  Theme-agnostic - follows whatever color the call screen text style carries.
- Corner radius 12 -> 16, padding 14/10 -> 16/14, row gap 4 -> 6, matching the
  design proportions.
- docs rollout table: Hold/Resume flipped to merged (post-#1387 leftover),
  this polish added.

No logic changes; existing row/scaffold tests stay green (17 in the touched
suites, full run via pre-push).