### PR TITLE
feat(call): mark video lines in the call list

### DIFF
--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -66,7 +66,8 @@ Multiple calls (list-based):
 
 - The screen shows one tappable `CallRow` per call - colored status dot +
   badge (RINGING / ON CALL / ON HOLD), name, live duration or a short
-  Incoming/Outgoing label - under an "N calls - tap to choose" header. Tapping
+  Incoming/Outgoing label, and a camera glyph on video lines - under an
+  "N calls - tap to choose" header. Tapping
   a row focuses that call. With multiple calls the rows carry the per-call
   info; the central info block appears for a single call only.
 - The `CallInfo` block and the action area below act on the focused call only.
@@ -125,7 +126,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 | Toolbar status | Signaling/connectivity status, media failures and stream quality move to the AppBar status line (global, worst across calls); the central info block keeps only name/description/duration | Merged (PR #1385) |
 | Visual alignment | Status dots on rows, short Incoming/Outgoing trailing labels, central info block single-call only, acting-on hint as a translucent pill with highlighted names | Merged (PR #1386) |
 | Hold/Resume on focus | The hold slot always acts on the focused call (pause/play glyph); Resume holds the other live calls first; the swap button is gone - switching lines = focus a row + Resume | Merged (PR #1387) |
-| Row overlay polish | Call rows use light overlay tints of the on-screen text color: focused = brighter + light border (design polarity), bigger radius and padding | In review |
+| Row overlay polish | Call rows use light overlay tints of the on-screen text color: focused = brighter + light border (design polarity), bigger radius and padding | Merged (PR #1388) |
+| Video line badge | A camera glyph next to the trailing label marks video lines in the call list | In review |
 
 The redesign lands on the `refactor/call` integration branch - every stage is a
 PR into that branch, and once the whole flow is tested there a single PR merges

--- a/lib/features/call/widgets/call_list.dart
+++ b/lib/features/call/widgets/call_list.dart
@@ -167,6 +167,12 @@ class _CallRowState extends State<CallRow> {
                     ],
                   ),
                 ),
+                // Video lines carry a camera glyph next to the trailing
+                // duration/direction label.
+                if (widget.call.remoteVideo) ...[
+                  Icon(Icons.videocam, key: const ValueKey('CallRowVideoBadge'), size: 16, color: statusStyle.color),
+                  const SizedBox(width: 6),
+                ],
                 Text(_trailing(context), style: statusStyle.copyWith(fontSize: 13)),
               ],
             ),

--- a/test/features/call/widgets/call_list_test.dart
+++ b/test/features/call/widgets/call_list_test.dart
@@ -16,6 +16,7 @@ ActiveCall _makeCall({
   CallDirection direction = CallDirection.incoming,
   CallProcessingStatus processingStatus = CallProcessingStatus.connected,
   bool held = false,
+  bool video = false,
   DateTime? acceptedTime,
   CallkeepHandle handle = _kHandle,
   String? displayName,
@@ -26,7 +27,7 @@ ActiveCall _makeCall({
     line: 0,
     handle: handle,
     createdTime: DateTime(2024),
-    video: false,
+    video: video,
     processingStatus: processingStatus,
     held: held,
     acceptedTime: acceptedTime,
@@ -121,6 +122,20 @@ void main() {
       CallRow rowOf(String callId) => tester.widget<CallRow>(find.byKey(ValueKey('CallRow-$callId')));
       expect(rowOf('on-call').focused, isTrue);
       expect(rowOf('ringing').focused, isFalse);
+    });
+
+    testWidgets('marks a video line with the camera glyph', (tester) async {
+      final video = _makeCall(callId: 'video', acceptedTime: DateTime.now(), video: true, displayName: 'Video Vlad');
+      await tester.pumpWidget(_buildSubject(calls: [video, onCall], focusedCallId: 'video', onCallTap: (_) {}));
+
+      expect(find.byKey(const ValueKey('CallRowVideoBadge')), findsOneWidget);
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('voice lines carry no camera glyph', (tester) async {
+      await tester.pumpWidget(_buildSubject(calls: [ringing, onCall], focusedCallId: 'ringing', onCallTap: (_) {}));
+      expect(find.byKey(const ValueKey('CallRowVideoBadge')), findsNothing);
+      await tester.pumpWidget(const SizedBox());
     });
 
     testWidgets('shows a ticking duration for an answered call and the direction while ringing', (tester) async {


### PR DESCRIPTION
## Overview

Small visual addition on the call list (targets `refactor/call`): rows whose
call carries video get a camera glyph next to the trailing duration/direction
label, as in the design frame.

## Changes

- `CallRow`: a 16px `videocam` icon (keyed `CallRowVideoBadge`) rendered when
  `ActiveCall.remoteVideo` is true - a confirmed remote video track or the
  negotiated video flag, the same predicate the rest of the screen uses for
  video affordances.
- docs rollout table updated (row overlay polish flipped to merged after
  #1388, this badge added).

## Tests

A video line shows the glyph, voice lines do not (9 in the suite, full run via
pre-push).