### PR TITLE
fix(call): route the redesign colors through the theme pipeline

### DIFF
--- a/assets/themes/original.page.dark.config.json
+++ b/assets/themes/original.page.dark.config.json
@@ -145,6 +145,18 @@
     }
   },
   "dialing": {
+    "callList": {
+      "rowBackgroundColor": "#1AFFFFFF",
+      "rowFocusedBackgroundColor": "#42FFFFFF",
+      "rowFocusedBorderColor": "#8CFFFFFF",
+      "dotRingingColor": "#FFD54F",
+      "dotOnCallColor": "#9CCC65",
+      "dotHeldColor": "#8CFFFFFF"
+    },
+    "actingOnHint": {
+      "backgroundColor": "#40000000",
+      "affectedNameColor": "#FFE082"
+    },
     "background": {
       "type": "gradient",
       "colors": [

--- a/assets/themes/original.page.light.config.json
+++ b/assets/themes/original.page.light.config.json
@@ -139,6 +139,18 @@
     }
   },
   "dialing": {
+    "callList": {
+      "rowBackgroundColor": "#1AFFFFFF",
+      "rowFocusedBackgroundColor": "#42FFFFFF",
+      "rowFocusedBorderColor": "#8CFFFFFF",
+      "dotRingingColor": "#FFD54F",
+      "dotOnCallColor": "#9CCC65",
+      "dotHeldColor": "#8CFFFFFF"
+    },
+    "actingOnHint": {
+      "backgroundColor": "#40000000",
+      "affectedNameColor": "#FFE082"
+    },
     "background": {
       "type": "gradient",
       "colors": [

--- a/docs/features/call.md
+++ b/docs/features/call.md
@@ -127,7 +127,8 @@ Rollout is incremental (foundations first, then UI), each step behind tests:
 | Visual alignment | Status dots on rows, short Incoming/Outgoing trailing labels, central info block single-call only, acting-on hint as a translucent pill with highlighted names | Merged (PR #1386) |
 | Hold/Resume on focus | The hold slot always acts on the focused call (pause/play glyph); Resume holds the other live calls first; the swap button is gone - switching lines = focus a row + Resume | Merged (PR #1387) |
 | Row overlay polish | Call rows use light overlay tints of the on-screen text color: focused = brighter + light border (design polarity), bigger radius and padding | Merged (PR #1388) |
-| Video line badge | A camera glyph next to the trailing label marks video lines in the call list | In review |
+| Video line badge | A camera glyph next to the trailing label marks video lines in the call list | Merged (PR #1389) |
+| Themed color roles | Call-list rows/dots and the acting-on hint take colors from the theme pipeline: CallPageListConfig/CallPageHintConfig in webtrit_appearance_theme -> assets/themes JSONs -> CallListStyle/FocusedActionHintStyle; no fixed colors in widgets | In review |
 
 The redesign lands on the `refactor/call` integration branch - every stage is a
 PR into that branch, and once the whole flow is tested there a single PR merges

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -224,6 +224,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 calls: activeCalls,
                                                 focusedCallId: focusedCall.callId,
                                                 style: style?.callInfo,
+                                                listStyle: style?.list,
                                                 onCallTap: (callId) {
                                                   _callBloc.add(CallControlEvent.callSelected(callId));
                                                 },
@@ -365,6 +366,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                                 call.displayName ?? call.handle.value,
                                                             ],
                                                       style: style?.callInfo,
+                                                      hintStyle: style?.hint,
                                                     ),
                                                   IncomingCallActions(
                                                     style: style?.actions,

--- a/lib/features/call/view/call_screen_style.dart
+++ b/lib/features/call/view/call_screen_style.dart
@@ -5,12 +5,22 @@ import 'package:flutter/services.dart';
 import 'package:webtrit_phone/theme/styles/styles.dart';
 
 class CallScreenStyle with Diagnosticable {
-  CallScreenStyle({this.background, this.systemUiOverlayStyle, this.appBar, this.callInfo, this.actions});
+  CallScreenStyle({
+    this.background,
+    this.systemUiOverlayStyle,
+    this.appBar,
+    this.callInfo,
+    this.list,
+    this.hint,
+    this.actions,
+  });
 
   final BackgroundStyle? background;
   final SystemUiOverlayStyle? systemUiOverlayStyle;
   final AppBarStyle? appBar;
   final CallInfoStyle? callInfo;
+  final CallListStyle? list;
+  final FocusedActionHintStyle? hint;
   final CallScreenActionsStyle? actions;
 
   static CallScreenStyle? lerp(CallScreenStyle? a, CallScreenStyle? b, double t) {
@@ -20,6 +30,8 @@ class CallScreenStyle with Diagnosticable {
       background: BackgroundStyle.lerp(a?.background, b?.background, t),
       systemUiOverlayStyle: b?.systemUiOverlayStyle ?? a?.systemUiOverlayStyle,
       callInfo: CallInfoStyle.lerp(a?.callInfo, b?.callInfo, t),
+      list: CallListStyle.lerp(a?.list, b?.list, t),
+      hint: FocusedActionHintStyle.lerp(a?.hint, b?.hint, t),
       appBar: AppBarStyle.lerp(a?.appBar, b?.appBar, t),
       actions: CallScreenActionsStyle.lerp(a?.actions, b?.actions, t),
     );
@@ -33,7 +45,80 @@ class CallScreenStyle with Diagnosticable {
       ..add(DiagnosticsProperty<SystemUiOverlayStyle?>('systemUiOverlayStyle', systemUiOverlayStyle))
       ..add(DiagnosticsProperty<AppBarStyle?>('appBar', appBar))
       ..add(DiagnosticsProperty<CallInfoStyle?>('callInfo', callInfo))
+      ..add(DiagnosticsProperty<CallListStyle?>('list', list))
+      ..add(DiagnosticsProperty<FocusedActionHintStyle?>('hint', hint))
       ..add(DiagnosticsProperty<CallScreenActionsStyle?>('actions', actions));
+  }
+}
+
+/// Colors of the call-list rows: overlays, the focused border and the
+/// per-state status dots.
+class CallListStyle with Diagnosticable {
+  const CallListStyle({
+    this.rowBackground,
+    this.rowFocusedBackground,
+    this.rowFocusedBorder,
+    this.dotRinging,
+    this.dotOnCall,
+    this.dotHeld,
+  });
+
+  final Color? rowBackground;
+  final Color? rowFocusedBackground;
+  final Color? rowFocusedBorder;
+  final Color? dotRinging;
+  final Color? dotOnCall;
+  final Color? dotHeld;
+
+  static CallListStyle? lerp(CallListStyle? a, CallListStyle? b, double t) {
+    if (identical(a, b)) return a;
+
+    return CallListStyle(
+      rowBackground: Color.lerp(a?.rowBackground, b?.rowBackground, t),
+      rowFocusedBackground: Color.lerp(a?.rowFocusedBackground, b?.rowFocusedBackground, t),
+      rowFocusedBorder: Color.lerp(a?.rowFocusedBorder, b?.rowFocusedBorder, t),
+      dotRinging: Color.lerp(a?.dotRinging, b?.dotRinging, t),
+      dotOnCall: Color.lerp(a?.dotOnCall, b?.dotOnCall, t),
+      dotHeld: Color.lerp(a?.dotHeld, b?.dotHeld, t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(ColorProperty('rowBackground', rowBackground))
+      ..add(ColorProperty('rowFocusedBackground', rowFocusedBackground))
+      ..add(ColorProperty('rowFocusedBorder', rowFocusedBorder))
+      ..add(ColorProperty('dotRinging', dotRinging))
+      ..add(ColorProperty('dotOnCall', dotOnCall))
+      ..add(ColorProperty('dotHeld', dotHeld));
+  }
+}
+
+/// Colors of the "Acting on" hint pill: the pill background and the
+/// highlighted affected-call names.
+class FocusedActionHintStyle with Diagnosticable {
+  const FocusedActionHintStyle({this.background, this.affectedName});
+
+  final Color? background;
+  final Color? affectedName;
+
+  static FocusedActionHintStyle? lerp(FocusedActionHintStyle? a, FocusedActionHintStyle? b, double t) {
+    if (identical(a, b)) return a;
+
+    return FocusedActionHintStyle(
+      background: Color.lerp(a?.background, b?.background, t),
+      affectedName: Color.lerp(a?.affectedName, b?.affectedName, t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(ColorProperty('background', background))
+      ..add(ColorProperty('affectedName', affectedName));
   }
 }
 

--- a/lib/features/call/widgets/call_list.dart
+++ b/lib/features/call/widgets/call_list.dart
@@ -18,12 +18,20 @@ import '../view/call_screen_style.dart';
 /// caller can focus it (see [CallControlEvent.callSelected]); the focused row
 /// is highlighted.
 class CallList extends StatelessWidget {
-  const CallList({super.key, required this.calls, required this.focusedCallId, required this.onCallTap, this.style});
+  const CallList({
+    super.key,
+    required this.calls,
+    required this.focusedCallId,
+    required this.onCallTap,
+    this.style,
+    this.listStyle,
+  });
 
   final List<ActiveCall> calls;
   final String focusedCallId;
   final ValueChanged<String> onCallTap;
   final CallInfoStyle? style;
+  final CallListStyle? listStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -45,6 +53,7 @@ class CallList extends StatelessWidget {
             focused: call.callId == focusedCallId,
             onTap: () => onCallTap(call.callId),
             style: style,
+            listStyle: listStyle,
           ),
       ],
     );
@@ -54,12 +63,20 @@ class CallList extends StatelessWidget {
 /// One call in the [CallList]: status badge, name/number and a live duration
 /// for answered calls (or the call direction while it is still ringing).
 class CallRow extends StatefulWidget {
-  const CallRow({super.key, required this.call, required this.focused, required this.onTap, this.style});
+  const CallRow({
+    super.key,
+    required this.call,
+    required this.focused,
+    required this.onTap,
+    this.style,
+    this.listStyle,
+  });
 
   final ActiveCall call;
   final bool focused;
   final VoidCallback onTap;
   final CallInfoStyle? style;
+  final CallListStyle? listStyle;
 
   @override
   State<CallRow> createState() => _CallRowState();
@@ -110,11 +127,15 @@ class _CallRowState extends State<CallRow> {
     return call.isIncoming ? context.l10n.call_CallList_incoming : context.l10n.call_CallList_outgoing;
   }
 
-  Color _statusDotColor() {
+  /// Status dot from the themed call-list palette (CallListStyle, fed by the
+  /// theme JSONs); the fallback is the row text color so an unthemed harness
+  /// stays legible without any fixed colors.
+  Color _statusDotColor(Color base) {
     final call = widget.call;
-    if (!call.wasAccepted) return Colors.amber.shade300;
-    if (call.held) return Colors.blueGrey.shade200;
-    return Colors.lightGreen.shade400;
+    final listStyle = widget.listStyle;
+    if (!call.wasAccepted) return listStyle?.dotRinging ?? base;
+    if (call.held) return listStyle?.dotHeld ?? base;
+    return listStyle?.dotOnCall ?? base;
   }
 
   @override
@@ -122,16 +143,20 @@ class _CallRowState extends State<CallRow> {
     final nameStyle = widget.style?.number ?? const TextStyle();
     final statusStyle = widget.style?.callStatus ?? const TextStyle();
 
-    // Rows are light overlay tints of the on-screen text color (white on the
-    // standard call gradient): the FOCUSED row is the brighter one with a
-    // light border, unfocused rows stay dimmer - matching the design's
-    // polarity regardless of what colorScheme.surface resolves to.
-    final overlayColor = statusStyle.color ?? Theme.of(context).colorScheme.surface;
+    // Row colors come from the themed call-list palette (CallListStyle, fed
+    // by the theme JSONs); the fallbacks derive from the row text color so an
+    // unthemed harness keeps the design polarity (focused = brighter).
+    final base = statusStyle.color ?? Theme.of(context).colorScheme.surface;
+    final listStyle = widget.listStyle;
+    final rowColor = widget.focused
+        ? (listStyle?.rowFocusedBackground ?? base.withValues(alpha: 0.26))
+        : (listStyle?.rowBackground ?? base.withValues(alpha: 0.10));
+    final borderColor = listStyle?.rowFocusedBorder ?? base.withValues(alpha: 0.55);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       child: Material(
-        color: overlayColor.withValues(alpha: widget.focused ? 0.26 : 0.10),
+        color: rowColor,
         borderRadius: BorderRadius.circular(16),
         child: InkWell(
           onTap: widget.onTap,
@@ -140,7 +165,7 @@ class _CallRowState extends State<CallRow> {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(16),
-              border: widget.focused ? Border.all(color: overlayColor.withValues(alpha: 0.55)) : null,
+              border: widget.focused ? Border.all(color: borderColor) : null,
             ),
             child: Row(
               children: [
@@ -148,7 +173,7 @@ class _CallRowState extends State<CallRow> {
                   width: 8,
                   height: 8,
                   margin: const EdgeInsets.only(right: 10),
-                  decoration: BoxDecoration(shape: BoxShape.circle, color: _statusDotColor()),
+                  decoration: BoxDecoration(shape: BoxShape.circle, color: _statusDotColor(base)),
                 ),
                 Expanded(
                   child: Column(

--- a/lib/features/call/widgets/focused_action_hint.dart
+++ b/lib/features/call/widgets/focused_action_hint.dart
@@ -18,6 +18,7 @@ class FocusedActionHint extends StatelessWidget {
     this.willBeHeldNames = const [],
     this.willBeEndedNames = const [],
     this.style,
+    this.hintStyle,
   });
 
   final String focusedName;
@@ -31,6 +32,9 @@ class FocusedActionHint extends StatelessWidget {
   final List<String> willBeEndedNames;
 
   final CallInfoStyle? style;
+
+  /// Pill and highlight colors from the themed palette (theme JSONs).
+  final FocusedActionHintStyle? hintStyle;
 
   /// Builds a span for [text] with the [highlight] substring emphasized via
   /// [emphasis]. The localized templates inline the names as plain text, so
@@ -54,13 +58,19 @@ class FocusedActionHint extends StatelessWidget {
     final actingOnStyle = baseStyle.copyWith(fontSize: 13);
     final focusedNameStyle = actingOnStyle.copyWith(fontWeight: FontWeight.w700);
     final sideEffectStyle = baseStyle.copyWith(fontSize: 12);
-    final affectedNameStyle = sideEffectStyle.copyWith(color: Colors.amber.shade200, fontWeight: FontWeight.w600);
+    // Colors come from the themed palette (FocusedActionHintStyle, fed by the
+    // theme JSONs); the fallbacks derive from the ambient scheme/text color.
+    final affectedNameStyle = sideEffectStyle.copyWith(
+      color: hintStyle?.affectedName ?? sideEffectStyle.color,
+      fontWeight: FontWeight.w600,
+    );
+    final backgroundColor = hintStyle?.background ?? Theme.of(context).colorScheme.scrim.withValues(alpha: 0.25);
 
     return Container(
       width: double.infinity,
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-      decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.25), borderRadius: BorderRadius.circular(14)),
+      decoration: BoxDecoration(color: backgroundColor, borderRadius: BorderRadius.circular(14)),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/theme/factory/styles/call_screen_style_factory.dart
+++ b/lib/theme/factory/styles/call_screen_style_factory.dart
@@ -37,8 +37,33 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
         systemUiOverlayStyle: pageConfig?.systemUiOverlayStyle?.toSystemUiOverlayStyle(),
         appBar: _mapAppBarStyle(appBarCfg),
         callInfo: _mapCallInfoStyle(infoCfg),
+        list: _mapCallListStyle(pageConfig?.callList),
+        hint: _mapHintStyle(pageConfig?.actingOnHint),
         actions: _resolveActionsStyle(fromPage: pageConfig?.actions, fromLegacy: legacyCallActionsConfig),
       ),
+    );
+  }
+
+  /// Call-list row colors. Theme JSON values win; the defaults are
+  /// scheme-derived tints of [ColorScheme.surface] (the call-screen text
+  /// color), keeping the focused row the brighter one.
+  CallListStyle _mapCallListStyle(CallPageListConfig? cfg) {
+    return CallListStyle(
+      rowBackground: cfg?.rowBackgroundColor?.toColor() ?? colors.surface.withValues(alpha: 0.10),
+      rowFocusedBackground: cfg?.rowFocusedBackgroundColor?.toColor() ?? colors.surface.withValues(alpha: 0.26),
+      rowFocusedBorder: cfg?.rowFocusedBorderColor?.toColor() ?? colors.surface.withValues(alpha: 0.55),
+      dotRinging: cfg?.dotRingingColor?.toColor() ?? colors.tertiary,
+      dotOnCall: cfg?.dotOnCallColor?.toColor() ?? colors.tertiaryContainer,
+      dotHeld: cfg?.dotHeldColor?.toColor() ?? colors.surface.withValues(alpha: 0.55),
+    );
+  }
+
+  /// "Acting on" hint pill colors. Theme JSON values win; the defaults are a
+  /// scrim tint for the pill and the tertiary accent for the affected names.
+  FocusedActionHintStyle _mapHintStyle(CallPageHintConfig? cfg) {
+    return FocusedActionHintStyle(
+      background: cfg?.backgroundColor?.toColor() ?? colors.scrim.withValues(alpha: 0.25),
+      affectedName: cfg?.affectedNameColor?.toColor() ?? colors.tertiary,
     );
   }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -293,6 +293,8 @@ class CallPageConfig with _$CallPageConfig implements BasePageConfig {
   const CallPageConfig({
     this.systemUiOverlayStyle,
     this.callInfo,
+    this.callList,
+    this.actingOnHint,
     this.actions,
     this.background,
     this.appBarStyle,
@@ -307,6 +309,12 @@ class CallPageConfig with _$CallPageConfig implements BasePageConfig {
 
   @override
   final CallPageInfoConfig? callInfo;
+
+  @override
+  final CallPageListConfig? callList;
+
+  @override
+  final CallPageHintConfig? actingOnHint;
 
   @override
   final CallPageActionsConfig? actions;
@@ -395,6 +403,62 @@ class CallPageInfoConfig with _$CallPageInfoConfig {
   factory CallPageInfoConfig.fromJson(Map<String, Object?> json) => _$CallPageInfoConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$CallPageInfoConfigToJson(this);
+}
+
+/// Colors of the call-list rows on the **Call Screen** (the list-based
+/// multi-call layout): row overlays, the focused border and the per-state
+/// status dots. CSS hex strings, alpha-first (#AARRGGBB) supported.
+@freezed
+@JsonSerializable(explicitToJson: true)
+class CallPageListConfig with _$CallPageListConfig {
+  const CallPageListConfig({
+    this.rowBackgroundColor,
+    this.rowFocusedBackgroundColor,
+    this.rowFocusedBorderColor,
+    this.dotRingingColor,
+    this.dotOnCallColor,
+    this.dotHeldColor,
+  });
+
+  @override
+  final String? rowBackgroundColor;
+
+  @override
+  final String? rowFocusedBackgroundColor;
+
+  @override
+  final String? rowFocusedBorderColor;
+
+  @override
+  final String? dotRingingColor;
+
+  @override
+  final String? dotOnCallColor;
+
+  @override
+  final String? dotHeldColor;
+
+  factory CallPageListConfig.fromJson(Map<String, Object?> json) => _$CallPageListConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$CallPageListConfigToJson(this);
+}
+
+/// Colors of the "Acting on" hint pill on the **Call Screen**: the pill
+/// background and the highlighted affected-call names.
+@freezed
+@JsonSerializable(explicitToJson: true)
+class CallPageHintConfig with _$CallPageHintConfig {
+  const CallPageHintConfig({this.backgroundColor, this.affectedNameColor});
+
+  @override
+  final String? backgroundColor;
+
+  @override
+  final String? affectedNameColor;
+
+  factory CallPageHintConfig.fromJson(Map<String, Object?> json) => _$CallPageHintConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$CallPageHintConfigToJson(this);
 }
 
 /// Declarative configuration for the **Keypad Screen**.

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -1905,7 +1905,7 @@ case _:
 /// @nodoc
 mixin _$CallPageConfig {
 
- OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageActionsConfig? get actions; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
+ OverlayStyleModel? get systemUiOverlayStyle; AppBarConfig? get appBarStyle; CallPageInfoConfig? get callInfo; CallPageListConfig? get callList; CallPageHintConfig? get actingOnHint; CallPageActionsConfig? get actions; PageBackground? get background; BlurredSurfaceConfig? get appBarBlurredSurface;
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1916,16 +1916,16 @@ $CallPageConfigCopyWith<CallPageConfig> get copyWith => _$CallPageConfigCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageConfig&&(identical(other.systemUiOverlayStyle, systemUiOverlayStyle) || other.systemUiOverlayStyle == systemUiOverlayStyle)&&(identical(other.appBarStyle, appBarStyle) || other.appBarStyle == appBarStyle)&&(identical(other.callInfo, callInfo) || other.callInfo == callInfo)&&(identical(other.callList, callList) || other.callList == callList)&&(identical(other.actingOnHint, actingOnHint) || other.actingOnHint == actingOnHint)&&(identical(other.actions, actions) || other.actions == actions)&&(identical(other.background, background) || other.background == background)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,actions,background,appBarBlurredSurface);
+int get hashCode => Object.hash(runtimeType,systemUiOverlayStyle,appBarStyle,callInfo,callList,actingOnHint,actions,background,appBarBlurredSurface);
 
 @override
 String toString() {
-  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, actions: $actions, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
+  return 'CallPageConfig(systemUiOverlayStyle: $systemUiOverlayStyle, appBarStyle: $appBarStyle, callInfo: $callInfo, callList: $callList, actingOnHint: $actingOnHint, actions: $actions, background: $background, appBarBlurredSurface: $appBarBlurredSurface)';
 }
 
 
@@ -1936,7 +1936,7 @@ abstract mixin class $CallPageConfigCopyWith<$Res>  {
   factory $CallPageConfigCopyWith(CallPageConfig value, $Res Function(CallPageConfig) _then) = _$CallPageConfigCopyWithImpl;
 @useResult
 $Res call({
- OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle, BlurredSurfaceConfig? appBarBlurredSurface
+ OverlayStyleModel? systemUiOverlayStyle, CallPageInfoConfig? callInfo, CallPageListConfig? callList, CallPageHintConfig? actingOnHint, CallPageActionsConfig? actions, PageBackground? background, AppBarConfig? appBarStyle, BlurredSurfaceConfig? appBarBlurredSurface
 });
 
 
@@ -1953,11 +1953,13 @@ class _$CallPageConfigCopyWithImpl<$Res>
 
 /// Create a copy of CallPageConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? systemUiOverlayStyle = freezed,Object? callInfo = freezed,Object? callList = freezed,Object? actingOnHint = freezed,Object? actions = freezed,Object? background = freezed,Object? appBarStyle = freezed,Object? appBarBlurredSurface = freezed,}) {
   return _then(CallPageConfig(
 systemUiOverlayStyle: freezed == systemUiOverlayStyle ? _self.systemUiOverlayStyle : systemUiOverlayStyle // ignore: cast_nullable_to_non_nullable
 as OverlayStyleModel?,callInfo: freezed == callInfo ? _self.callInfo : callInfo // ignore: cast_nullable_to_non_nullable
-as CallPageInfoConfig?,actions: freezed == actions ? _self.actions : actions // ignore: cast_nullable_to_non_nullable
+as CallPageInfoConfig?,callList: freezed == callList ? _self.callList : callList // ignore: cast_nullable_to_non_nullable
+as CallPageListConfig?,actingOnHint: freezed == actingOnHint ? _self.actingOnHint : actingOnHint // ignore: cast_nullable_to_non_nullable
+as CallPageHintConfig?,actions: freezed == actions ? _self.actions : actions // ignore: cast_nullable_to_non_nullable
 as CallPageActionsConfig?,background: freezed == background ? _self.background : background // ignore: cast_nullable_to_non_nullable
 as PageBackground?,appBarStyle: freezed == appBarStyle ? _self.appBarStyle : appBarStyle // ignore: cast_nullable_to_non_nullable
 as AppBarConfig?,appBarBlurredSurface: freezed == appBarBlurredSurface ? _self.appBarBlurredSurface : appBarBlurredSurface // ignore: cast_nullable_to_non_nullable
@@ -2477,6 +2479,384 @@ case _:
 
 
 /// @nodoc
+mixin _$CallPageListConfig {
+
+ String? get rowBackgroundColor; String? get rowFocusedBackgroundColor; String? get rowFocusedBorderColor; String? get dotRingingColor; String? get dotOnCallColor; String? get dotHeldColor;
+/// Create a copy of CallPageListConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CallPageListConfigCopyWith<CallPageListConfig> get copyWith => _$CallPageListConfigCopyWithImpl<CallPageListConfig>(this as CallPageListConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageListConfig&&(identical(other.rowBackgroundColor, rowBackgroundColor) || other.rowBackgroundColor == rowBackgroundColor)&&(identical(other.rowFocusedBackgroundColor, rowFocusedBackgroundColor) || other.rowFocusedBackgroundColor == rowFocusedBackgroundColor)&&(identical(other.rowFocusedBorderColor, rowFocusedBorderColor) || other.rowFocusedBorderColor == rowFocusedBorderColor)&&(identical(other.dotRingingColor, dotRingingColor) || other.dotRingingColor == dotRingingColor)&&(identical(other.dotOnCallColor, dotOnCallColor) || other.dotOnCallColor == dotOnCallColor)&&(identical(other.dotHeldColor, dotHeldColor) || other.dotHeldColor == dotHeldColor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,rowBackgroundColor,rowFocusedBackgroundColor,rowFocusedBorderColor,dotRingingColor,dotOnCallColor,dotHeldColor);
+
+@override
+String toString() {
+  return 'CallPageListConfig(rowBackgroundColor: $rowBackgroundColor, rowFocusedBackgroundColor: $rowFocusedBackgroundColor, rowFocusedBorderColor: $rowFocusedBorderColor, dotRingingColor: $dotRingingColor, dotOnCallColor: $dotOnCallColor, dotHeldColor: $dotHeldColor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CallPageListConfigCopyWith<$Res>  {
+  factory $CallPageListConfigCopyWith(CallPageListConfig value, $Res Function(CallPageListConfig) _then) = _$CallPageListConfigCopyWithImpl;
+@useResult
+$Res call({
+ String? rowBackgroundColor, String? rowFocusedBackgroundColor, String? rowFocusedBorderColor, String? dotRingingColor, String? dotOnCallColor, String? dotHeldColor
+});
+
+
+
+
+}
+/// @nodoc
+class _$CallPageListConfigCopyWithImpl<$Res>
+    implements $CallPageListConfigCopyWith<$Res> {
+  _$CallPageListConfigCopyWithImpl(this._self, this._then);
+
+  final CallPageListConfig _self;
+  final $Res Function(CallPageListConfig) _then;
+
+/// Create a copy of CallPageListConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? rowBackgroundColor = freezed,Object? rowFocusedBackgroundColor = freezed,Object? rowFocusedBorderColor = freezed,Object? dotRingingColor = freezed,Object? dotOnCallColor = freezed,Object? dotHeldColor = freezed,}) {
+  return _then(CallPageListConfig(
+rowBackgroundColor: freezed == rowBackgroundColor ? _self.rowBackgroundColor : rowBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,rowFocusedBackgroundColor: freezed == rowFocusedBackgroundColor ? _self.rowFocusedBackgroundColor : rowFocusedBackgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,rowFocusedBorderColor: freezed == rowFocusedBorderColor ? _self.rowFocusedBorderColor : rowFocusedBorderColor // ignore: cast_nullable_to_non_nullable
+as String?,dotRingingColor: freezed == dotRingingColor ? _self.dotRingingColor : dotRingingColor // ignore: cast_nullable_to_non_nullable
+as String?,dotOnCallColor: freezed == dotOnCallColor ? _self.dotOnCallColor : dotOnCallColor // ignore: cast_nullable_to_non_nullable
+as String?,dotHeldColor: freezed == dotHeldColor ? _self.dotHeldColor : dotHeldColor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [CallPageListConfig].
+extension CallPageListConfigPatterns on CallPageListConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$CallPageHintConfig {
+
+ String? get backgroundColor; String? get affectedNameColor;
+/// Create a copy of CallPageHintConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CallPageHintConfigCopyWith<CallPageHintConfig> get copyWith => _$CallPageHintConfigCopyWithImpl<CallPageHintConfig>(this as CallPageHintConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageHintConfig&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.affectedNameColor, affectedNameColor) || other.affectedNameColor == affectedNameColor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,backgroundColor,affectedNameColor);
+
+@override
+String toString() {
+  return 'CallPageHintConfig(backgroundColor: $backgroundColor, affectedNameColor: $affectedNameColor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CallPageHintConfigCopyWith<$Res>  {
+  factory $CallPageHintConfigCopyWith(CallPageHintConfig value, $Res Function(CallPageHintConfig) _then) = _$CallPageHintConfigCopyWithImpl;
+@useResult
+$Res call({
+ String? backgroundColor, String? affectedNameColor
+});
+
+
+
+
+}
+/// @nodoc
+class _$CallPageHintConfigCopyWithImpl<$Res>
+    implements $CallPageHintConfigCopyWith<$Res> {
+  _$CallPageHintConfigCopyWithImpl(this._self, this._then);
+
+  final CallPageHintConfig _self;
+  final $Res Function(CallPageHintConfig) _then;
+
+/// Create a copy of CallPageHintConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? backgroundColor = freezed,Object? affectedNameColor = freezed,}) {
+  return _then(CallPageHintConfig(
+backgroundColor: freezed == backgroundColor ? _self.backgroundColor : backgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,affectedNameColor: freezed == affectedNameColor ? _self.affectedNameColor : affectedNameColor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [CallPageHintConfig].
+extension CallPageHintConfigPatterns on CallPageHintConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
 mixin _$KeypadPageConfig {
 
  OverlayStyleModel? get systemUiOverlayStyle; TextFieldConfig? get textField; TextFieldConfig? get contactName; KeypadStyleConfig? get keypad; ActionPadWidgetConfig? get actionpad; PageBackground? get background; ThemeOverrideConfig get themeOverride; BlurredSurfaceConfig? get appBarBlurredSurface;
@@ -2856,7 +3236,6 @@ case _:
 
 }
 
-
 /// @nodoc
 mixin _$SettingsPageConfig {
 
@@ -2874,7 +3253,7 @@ bool operator ==(Object other) {
   return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsPageConfig&&(identical(other.themeOverride, themeOverride) || other.themeOverride == themeOverride)&&(identical(other.leadingIconsColor, leadingIconsColor) || other.leadingIconsColor == leadingIconsColor)&&(identical(other.userIconColor, userIconColor) || other.userIconColor == userIconColor)&&(identical(other.logoutIconColor, logoutIconColor) || other.logoutIconColor == logoutIconColor)&&(identical(other.groupTitleListTile, groupTitleListTile) || other.groupTitleListTile == groupTitleListTile)&&(identical(other.showSeparators, showSeparators) || other.showSeparators == showSeparators)&&(identical(other.separator, separator) || other.separator == separator)&&(identical(other.background, background) || other.background == background)&&(identical(other.itemTextStyle, itemTextStyle) || other.itemTextStyle == itemTextStyle)&&(identical(other.appBarBlurredSurface, appBarBlurredSurface) || other.appBarBlurredSurface == appBarBlurredSurface));
 }
 
-@JsonKey(includeFromJson: false, includeToJson: false)
+
 @override
 int get hashCode => Object.hash(runtimeType,themeOverride,leadingIconsColor,userIconColor,logoutIconColor,groupTitleListTile,showSeparators,separator,background,itemTextStyle,appBarBlurredSurface);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -318,6 +318,14 @@ CallPageConfig _$CallPageConfigFromJson(
   callInfo: json['callInfo'] == null
       ? null
       : CallPageInfoConfig.fromJson(json['callInfo'] as Map<String, dynamic>),
+  callList: json['callList'] == null
+      ? null
+      : CallPageListConfig.fromJson(json['callList'] as Map<String, dynamic>),
+  actingOnHint: json['actingOnHint'] == null
+      ? null
+      : CallPageHintConfig.fromJson(
+          json['actingOnHint'] as Map<String, dynamic>,
+        ),
   actions: json['actions'] == null
       ? null
       : CallPageActionsConfig.fromJson(json['actions'] as Map<String, dynamic>),
@@ -339,6 +347,8 @@ Map<String, dynamic> _$CallPageConfigToJson(CallPageConfig instance) =>
       'systemUiOverlayStyle': instance.systemUiOverlayStyle?.toJson(),
       'appBarStyle': instance.appBarStyle?.toJson(),
       'callInfo': instance.callInfo?.toJson(),
+      'callList': instance.callList?.toJson(),
+      'actingOnHint': instance.actingOnHint?.toJson(),
       'actions': instance.actions?.toJson(),
       'background': instance.background?.toJson(),
       'appBarBlurredSurface': instance.appBarBlurredSurface?.toJson(),
@@ -438,6 +448,38 @@ Map<String, dynamic> _$CallPageInfoConfigToJson(CallPageInfoConfig instance) =>
       'numberTextStyle': instance.numberTextStyle?.toJson(),
       'callStatusTextStyle': instance.callStatusTextStyle?.toJson(),
       'processingStatusTextStyle': instance.processingStatusTextStyle?.toJson(),
+    };
+
+CallPageListConfig _$CallPageListConfigFromJson(Map<String, dynamic> json) =>
+    CallPageListConfig(
+      rowBackgroundColor: json['rowBackgroundColor'] as String?,
+      rowFocusedBackgroundColor: json['rowFocusedBackgroundColor'] as String?,
+      rowFocusedBorderColor: json['rowFocusedBorderColor'] as String?,
+      dotRingingColor: json['dotRingingColor'] as String?,
+      dotOnCallColor: json['dotOnCallColor'] as String?,
+      dotHeldColor: json['dotHeldColor'] as String?,
+    );
+
+Map<String, dynamic> _$CallPageListConfigToJson(CallPageListConfig instance) =>
+    <String, dynamic>{
+      'rowBackgroundColor': instance.rowBackgroundColor,
+      'rowFocusedBackgroundColor': instance.rowFocusedBackgroundColor,
+      'rowFocusedBorderColor': instance.rowFocusedBorderColor,
+      'dotRingingColor': instance.dotRingingColor,
+      'dotOnCallColor': instance.dotOnCallColor,
+      'dotHeldColor': instance.dotHeldColor,
+    };
+
+CallPageHintConfig _$CallPageHintConfigFromJson(Map<String, dynamic> json) =>
+    CallPageHintConfig(
+      backgroundColor: json['backgroundColor'] as String?,
+      affectedNameColor: json['affectedNameColor'] as String?,
+    );
+
+Map<String, dynamic> _$CallPageHintConfigToJson(CallPageHintConfig instance) =>
+    <String, dynamic>{
+      'backgroundColor': instance.backgroundColor,
+      'affectedNameColor': instance.affectedNameColor,
     };
 
 KeypadPageConfig _$KeypadPageConfigFromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
## Overview

Audit of the `refactor/call` diff for hardcoded colors found five fixed colors
(all from the visual-alignment stage). Per the project rule they now get
proper theme roles instead of inline values: the color roles live in
`webtrit_appearance_theme`, the values in `assets/themes`, and the widgets
consume style objects - branded builds restyle everything from the theme
JSONs.

(The branch was replaced: the first iteration swapped the fixed colors for
semantic-palette fallbacks in the widgets; this version moves them into the
theme pipeline end to end.)

## Pipeline

| Layer | Change |
|---|---|
| `webtrit_appearance_theme` | `CallPageConfig` gains `callList` (`CallPageListConfig`: row / focused-row / focused-border overlays + ringing / on-call / held dot colors) and `actingOnHint` (`CallPageHintConfig`: pill background + affected-name highlight); codegen regenerated |
| `assets/themes` | `original.page.{light,dark}.config.json` set the design values under `dialing` (white overlay tints, amber/green dots, scrim pill, amber highlight; alpha-first `#AARRGGBB`) - a 12-line surgical insert per file |
| Style layer | `CallScreenStyle` gains `CallListStyle` and `FocusedActionHintStyle` (with `lerp`), mapped in `CallScreenStyleFactory`; scheme-derived defaults apply when a theme omits the section |
| Widgets | `CallRow` and `FocusedActionHint` consume `style?.list` / `style?.hint`; the only in-widget fallbacks derive from the ambient text color/scheme - no `Colors.*` or fixed hex anywhere in the call feature |

## Tests

Full call suite green (452); a grep for `Colors.*` / `Color(0x...)` / `.shade`
over the branch diff comes back clean. Theme JSONs stay valid (parsed in the
insert script) and the diff is minimal (+12 lines per file).