### PR TITLE
feat: expandable quick actions on contact lists

### DIFF
--- a/lib/features/cdrs/widgets/cdr_tile.dart
+++ b/lib/features/cdrs/widgets/cdr_tile.dart
@@ -13,6 +13,8 @@ class CdrTile extends StatelessWidget {
     this.contact,
     required this.callNumbers,
     this.onTap,
+    this.expanded = false,
+    this.onDialPressed,
     this.onAudioCallPressed,
     this.onVideoCallPressed,
     this.onTransferPressed,
@@ -27,6 +29,8 @@ class CdrTile extends StatelessWidget {
   final Contact? contact;
   final List<String> callNumbers;
   final Function()? onTap;
+  final bool expanded;
+  final Function()? onDialPressed;
   final Function()? onAudioCallPressed;
   final Function()? onVideoCallPressed;
   final Function()? onTransferPressed;
@@ -83,6 +87,8 @@ class CdrTile extends StatelessWidget {
       durationLabel: cdr.duration.format(),
       disconnectReason: disconnectText,
       onTap: onTap,
+      expanded: expanded,
+      onDialPressed: onDialPressed,
       callNumbers: callNumbers,
       onAudioCallPressed: onAudioCallPressed,
       onVideoCallPressed: onVideoCallPressed,

--- a/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
@@ -37,6 +37,11 @@ class _FullRecentCdrsListState extends State<FullRecentCdrsList> {
   late final scrollController = ScrollController();
 
   bool scrolledAway = false;
+  String? _expandedCallId;
+
+  void _toggleExpanded(String callId) {
+    setState(() => _expandedCallId = _expandedCallId == callId ? null : callId);
+  }
 
   @override
   void initState() {
@@ -154,17 +159,20 @@ class _FullRecentCdrsListState extends State<FullRecentCdrsList> {
                                     contact: contact,
                                     callNumbers: callNumbers,
                                     onTap: () {
-                                      if (participantNumber == null) return;
-
                                       if (transfer) {
+                                        if (participantNumber == null) return;
                                         submitTransfer(destination: participantNumber);
                                       } else {
-                                        _callController.createCall(
-                                          destination: participantNumber,
-                                          displayName: contact?.maybeName,
-                                        );
+                                        _toggleExpanded(cdr.callId);
                                       }
                                     },
+                                    expanded: !transfer && _expandedCallId == cdr.callId,
+                                    onDialPressed: !transfer && participantNumber != null
+                                        ? () => _callController.createCall(
+                                            destination: participantNumber,
+                                            displayName: contact?.maybeName,
+                                          )
+                                        : null,
                                     onAudioCallPressed: participantNumber != null
                                         ? () => _callController.createCall(
                                             destination: participantNumber,

--- a/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/full_recent_cdrs_list.dart
@@ -158,14 +158,11 @@ class _FullRecentCdrsListState extends State<FullRecentCdrsList> {
                                     cdr: cdr,
                                     contact: contact,
                                     callNumbers: callNumbers,
-                                    onTap: () {
-                                      if (transfer) {
-                                        if (participantNumber == null) return;
-                                        submitTransfer(destination: participantNumber);
-                                      } else {
-                                        _toggleExpanded(cdr.callId);
-                                      }
-                                    },
+                                    onTap: transfer
+                                        ? (participantNumber != null
+                                              ? () => submitTransfer(destination: participantNumber)
+                                              : null)
+                                        : () => _toggleExpanded(cdr.callId),
                                     expanded: !transfer && _expandedCallId == cdr.callId,
                                     onDialPressed: !transfer && participantNumber != null
                                         ? () => _callController.createCall(

--- a/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
@@ -37,6 +37,11 @@ class _MissedRecentCdrsListState extends State<MissedRecentCdrsList> {
   late final scrollController = ScrollController();
 
   bool scrolledAway = false;
+  String? _expandedCallId;
+
+  void _toggleExpanded(String callId) {
+    setState(() => _expandedCallId = _expandedCallId == callId ? null : callId);
+  }
 
   @override
   void initState() {
@@ -154,17 +159,20 @@ class _MissedRecentCdrsListState extends State<MissedRecentCdrsList> {
                                     contact: contact,
                                     callNumbers: callNumbers,
                                     onTap: () {
-                                      if (participantNumber == null) return;
-
                                       if (transfer) {
+                                        if (participantNumber == null) return;
                                         submitTransfer(destination: participantNumber);
                                       } else {
-                                        _callController.createCall(
-                                          destination: participantNumber,
-                                          displayName: contact?.maybeName,
-                                        );
+                                        _toggleExpanded(cdr.callId);
                                       }
                                     },
+                                    expanded: !transfer && _expandedCallId == cdr.callId,
+                                    onDialPressed: !transfer && participantNumber != null
+                                        ? () => _callController.createCall(
+                                            destination: participantNumber,
+                                            displayName: contact?.maybeName,
+                                          )
+                                        : null,
                                     onAudioCallPressed: participantNumber != null
                                         ? () => _callController.createCall(
                                             destination: participantNumber,

--- a/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
+++ b/lib/features/cdrs/widgets/missed_recent_cdrs_list.dart
@@ -158,14 +158,11 @@ class _MissedRecentCdrsListState extends State<MissedRecentCdrsList> {
                                     cdr: cdr,
                                     contact: contact,
                                     callNumbers: callNumbers,
-                                    onTap: () {
-                                      if (transfer) {
-                                        if (participantNumber == null) return;
-                                        submitTransfer(destination: participantNumber);
-                                      } else {
-                                        _toggleExpanded(cdr.callId);
-                                      }
-                                    },
+                                    onTap: transfer
+                                        ? (participantNumber != null
+                                              ? () => submitTransfer(destination: participantNumber)
+                                              : null)
+                                        : () => _toggleExpanded(cdr.callId),
                                     expanded: !transfer && _expandedCallId == cdr.callId,
                                     onDialPressed: !transfer && participantNumber != null
                                         ? () => _callController.createCall(

--- a/lib/features/contacts/features/contacts_external_tab/view/contacts_external_tab.dart
+++ b/lib/features/contacts/features/contacts_external_tab/view/contacts_external_tab.dart
@@ -1,24 +1,29 @@
 import 'package:flutter/material.dart';
 
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/app/keys.dart';
-import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../../../contacts.dart';
 
-class ContactsExternalTab extends StatelessWidget {
+class ContactsExternalTab extends StatefulWidget {
   const ContactsExternalTab({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    Future routeToContactScreen(int contactId) async {
-      context.router.navigate(ContactScreenPageRoute(contactId: contactId));
-    }
+  State<ContactsExternalTab> createState() => _ContactsExternalTabState();
+}
 
+class _ContactsExternalTabState extends State<ContactsExternalTab> {
+  int? _expandedContactId;
+
+  void _toggleExpanded(int contactId) {
+    setState(() => _expandedContactId = _expandedContactId == contactId ? null : contactId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     Future refreshContacts() async {
       final tabBloc = context.read<ContactsExternalTabBloc>();
       tabBloc.add(const ContactsExternalTabRefreshed());
@@ -37,15 +42,11 @@ class ContactsExternalTab extends StatelessWidget {
               itemBuilder: (context, index) {
                 final contact = state.contacts[index];
 
-                return ContactTile(
-                  key: contactsExtContactTileKey,
-                  displayName: contact.displayTitle,
-                  thumbnail: contact.thumbnail,
-                  thumbnailUrl: contact.thumbnailUrl,
-                  registered: contact.registered,
-                  onTap: () => routeToContactScreen(contact.id),
-                  presenceInfo: contact.presenceInfo,
-                  dialogInfo: contact.dialogInfo,
+                return ContactTileAdapter(
+                  tileKey: contactsExtContactTileKey,
+                  contact: contact,
+                  expanded: _expandedContactId == contact.id,
+                  onToggleExpanded: () => _toggleExpanded(contact.id),
                 );
               },
             ),

--- a/lib/features/contacts/features/contacts_local_tab/view/contacts_local_tab.dart
+++ b/lib/features/contacts/features/contacts_local_tab/view/contacts_local_tab.dart
@@ -20,6 +20,12 @@ class ContactsLocalTab extends StatefulWidget {
 }
 
 class _ContactsLocalTabState extends State<ContactsLocalTab> with WidgetsBindingObserver {
+  int? _expandedContactId;
+
+  void _toggleExpanded(int contactId) {
+    setState(() => _expandedContactId = _expandedContactId == contactId ? null : contactId);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -41,10 +47,6 @@ class _ContactsLocalTabState extends State<ContactsLocalTab> with WidgetsBinding
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final elevatedButtonStyles = theme.extension<ElevatedButtonStyles>();
-
-    Future routeToContactScreen(int contactId) async {
-      context.router.navigate(ContactScreenPageRoute(contactId: contactId));
-    }
 
     Future routeToDiagnosticScreen() async {
       FocusScope.of(context).unfocus();
@@ -72,12 +74,11 @@ class _ContactsLocalTabState extends State<ContactsLocalTab> with WidgetsBinding
               itemCount: state.contacts.length,
               itemBuilder: (context, index) {
                 final contact = state.contacts[index];
-                return ContactTile(
-                  key: contactsLocalContactTileKey,
-                  displayName: contact.displayTitle,
-                  thumbnail: contact.thumbnail,
-                  thumbnailUrl: contact.thumbnailUrl,
-                  onTap: () => routeToContactScreen(contact.id),
+                return ContactTileAdapter(
+                  tileKey: contactsLocalContactTileKey,
+                  contact: contact,
+                  expanded: _expandedContactId == contact.id,
+                  onToggleExpanded: () => _toggleExpanded(contact.id),
                 );
               },
             ),

--- a/lib/features/contacts/widgets/contact_tile.dart
+++ b/lib/features/contacts/widgets/contact_tile.dart
@@ -16,9 +16,20 @@ class ContactTile extends StatelessWidget {
     this.registered,
     this.smart = false,
     this.onTap,
-    this.onLongPress,
+    this.expanded = false,
+    this.onDialPressed,
     this.presenceInfo,
     this.dialogInfo,
+    this.callNumbers = const [],
+    this.onAudioCallPressed,
+    this.onVideoCallPressed,
+    this.onTransferPressed,
+    this.onChatPressed,
+    this.onSendSmsPressed,
+    this.onViewContactPressed,
+    this.onCallLogPressed,
+    this.onCallFrom,
+    this.copyNumber,
   });
 
   final String displayName;
@@ -27,17 +38,24 @@ class ContactTile extends StatelessWidget {
   final bool? registered;
   final bool smart;
   final GestureTapCallback? onTap;
-  final GestureLongPressCallback? onLongPress;
+  final bool expanded;
+  final VoidCallback? onDialPressed;
   final List<PresenceInfo>? presenceInfo;
   final List<DialogInfo>? dialogInfo;
 
+  final List<String> callNumbers;
+  final VoidCallback? onAudioCallPressed;
+  final VoidCallback? onVideoCallPressed;
+  final VoidCallback? onTransferPressed;
+  final VoidCallback? onChatPressed;
+  final VoidCallback? onSendSmsPressed;
+  final VoidCallback? onViewContactPressed;
+  final VoidCallback? onCallLogPressed;
+  final void Function(String)? onCallFrom;
+  final String? copyNumber;
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final textTheme = theme.textTheme;
-    final colorScheme = theme.colorScheme;
-    final contentColor = colorScheme.onSurface;
-
     final presenceParams = PresenceViewParams.of(context);
 
     final title = switch (presenceParams.hybridPresenceSupport) {
@@ -45,7 +63,7 @@ class ContactTile extends StatelessWidget {
       false => displayName,
     };
 
-    Widget? subtitle;
+    String? subName;
 
     if (presenceParams.blfViaSipSupport && (dialogInfo ?? []).isNotEmpty) {
       final dialog = dialogInfo!.first;
@@ -60,68 +78,41 @@ class ContactTile extends StatelessWidget {
       }
 
       if (destination != null) {
-        subtitle = Text(
-          context.l10n.contacts_ContactTile_inCall(destination),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: contentColor.withValues(alpha: 0.7)),
-        );
+        subName = context.l10n.contacts_ContactTile_inCall(destination);
       }
     }
 
     final presenceNote = (presenceInfo ?? []).primaryNote;
 
-    if (subtitle == null && presenceParams.hybridPresenceSupport && presenceNote != null && presenceNote.isNotEmpty) {
-      subtitle = Text(
-        presenceNote,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: Theme.of(context).textTheme.bodySmall,
-      );
+    if (subName == null && presenceParams.hybridPresenceSupport && presenceNote != null && presenceNote.isNotEmpty) {
+      subName = presenceNote;
     }
 
-    final contentColumn = Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(title, maxLines: subtitle != null ? 1 : 2, overflow: TextOverflow.ellipsis, style: textTheme.titleMedium),
-        ?subtitle,
-      ],
-    );
-
-    final leading = LeadingAvatar(
-      username: displayName,
-      thumbnail: thumbnail,
-      thumbnailUrl: thumbnailUrl,
-      registered: registered,
-      smart: smart,
-      presenceInfo: presenceInfo,
-      dialogInfo: dialogInfo,
-    );
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      child: Material(
-        color: colorScheme.surface.withAlpha(25),
-        borderRadius: BorderRadius.circular(16),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(16),
-          splashColor: colorScheme.secondary.withAlpha(50),
-          onTap: onTap,
-          onLongPress: onLongPress,
-          child: Padding(
-            padding: const EdgeInsets.only(left: 8, right: 0, top: 8, bottom: 8),
-            child: Row(
-              children: [
-                leading,
-                const SizedBox(width: 8),
-                Expanded(child: contentColumn),
-                const SizedBox(width: 4),
-              ],
-            ),
-          ),
-        ),
+    return CallTile(
+      leading: LeadingAvatar(
+        username: displayName,
+        thumbnail: thumbnail,
+        thumbnailUrl: thumbnailUrl,
+        registered: registered,
+        smart: smart,
+        presenceInfo: presenceInfo,
+        dialogInfo: dialogInfo,
       ),
+      name: title,
+      subName: subName,
+      onTap: onTap,
+      expanded: expanded,
+      onDialPressed: onDialPressed,
+      callNumbers: callNumbers,
+      onAudioCallPressed: onAudioCallPressed,
+      onVideoCallPressed: onVideoCallPressed,
+      onTransferPressed: onTransferPressed,
+      onChatPressed: onChatPressed,
+      onSendSmsPressed: onSendSmsPressed,
+      onViewContactPressed: onViewContactPressed,
+      onCallLogPressed: onCallLogPressed,
+      onCallFrom: onCallFrom,
+      copyNumber: copyNumber,
     );
   }
 }

--- a/lib/features/contacts/widgets/contact_tile_adapter.dart
+++ b/lib/features/contacts/widgets/contact_tile_adapter.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:webtrit_phone/app/router/app_router.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/features/call/call.dart';
+import 'package:webtrit_phone/features/call_routing/cubit/call_routing_cubit.dart';
+import 'package:webtrit_phone/features/messaging/extensions/contact.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+import 'contact_tile.dart';
+
+/// Wires a contacts-list [ContactTile] to the call/chat/history actions so the
+/// local and external tabs share one behavior: tap expands the quick-actions
+/// bar, the trailing phone icon dials, and blind-transfer mode turns tap into
+/// the transfer submission (same semantics as the recents and favorites lists).
+class ContactTileAdapter extends StatelessWidget {
+  const ContactTileAdapter({
+    super.key,
+    required this.contact,
+    required this.expanded,
+    required this.onToggleExpanded,
+    this.tileKey,
+  });
+
+  final Contact contact;
+  final bool expanded;
+  final VoidCallback onToggleExpanded;
+  final Key? tileKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final callController = CallControllerScope.of(context);
+    final featureAccess = context.read<FeatureAccess>();
+
+    final transferEnabled = featureAccess.callConfig.capabilities.isBlindTransferEnabled;
+    final videoEnabled = featureAccess.callConfig.capabilities.isVideoCallEnabled;
+    final chatsEnabled = featureAccess.messagingConfig.chatsPresent;
+    final cdrsEnabled = featureAccess.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory;
+
+    final number =
+        contact.extension ?? contact.mobileNumber ?? (contact.phones.isNotEmpty ? contact.phones.first.number : null);
+
+    void submitTransfer(String destination) {
+      callController.submitTransfer(destination);
+      context.router.maybePop();
+    }
+
+    void openCallLog(String number) {
+      if (cdrsEnabled == true) {
+        context.router.navigate(NumberCdrsScreenPageRoute(number: number));
+      } else {
+        context.router.navigate(CallLogScreenPageRoute(number: number));
+      }
+    }
+
+    return BlocBuilder<CallBloc, CallState>(
+      buildWhen: (previous, current) =>
+          previous.isBlingTransferInitiated != current.isBlingTransferInitiated ||
+          previous.activeCalls != current.activeCalls,
+      builder: (context, callState) {
+        final transfer = callState.isBlingTransferInitiated;
+        final hasActiveCall = callState.activeCalls.isNotEmpty;
+
+        return BlocBuilder<CallRoutingCubit, CallRoutingState?>(
+          builder: (context, callRoutingState) {
+            return ContactTile(
+              key: tileKey,
+              displayName: contact.displayTitle,
+              thumbnail: contact.thumbnail,
+              thumbnailUrl: contact.thumbnailUrl,
+              registered: contact.registered,
+              presenceInfo: contact.presenceInfo,
+              dialogInfo: contact.dialogInfo,
+              onTap: transfer ? (number != null ? () => submitTransfer(number) : null) : onToggleExpanded,
+              expanded: expanded && !transfer,
+              onDialPressed: !transfer && number != null
+                  ? () => callController.createCall(destination: number, displayName: contact.maybeName, video: false)
+                  : null,
+              callNumbers: callRoutingState?.allNumbers ?? [],
+              onAudioCallPressed: number != null
+                  ? () => callController.createCall(destination: number, displayName: contact.maybeName, video: false)
+                  : null,
+              onVideoCallPressed: number != null && videoEnabled
+                  ? () => callController.createCall(destination: number, displayName: contact.maybeName, video: true)
+                  : null,
+              onTransferPressed: number != null && transferEnabled && hasActiveCall
+                  ? () => submitTransfer(number)
+                  : null,
+              onChatPressed: chatsEnabled && contact.canMessage
+                  ? () => context.router.navigate(ChatConversationScreenPageRoute(participantId: contact.sourceId!))
+                  : null,
+              onViewContactPressed: () => context.router.navigate(ContactScreenPageRoute(contactId: contact.id)),
+              onCallLogPressed: number != null ? () => openCallLog(number) : null,
+              onCallFrom: number != null
+                  ? (fromNumber) => callController.createCall(
+                      destination: number,
+                      displayName: contact.maybeName,
+                      fromNumber: fromNumber,
+                      video: false,
+                    )
+                  : null,
+              copyNumber: number,
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/contacts/widgets/widgets.dart
+++ b/lib/features/contacts/widgets/widgets.dart
@@ -1,2 +1,3 @@
 export 'cleared_text_field.dart';
 export 'contact_tile.dart';
+export 'contact_tile_adapter.dart';

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -272,10 +272,14 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                                               : null,
                                           onCallLogPressed: () => openCallLog(number: favorite.number),
                                           onDelete: () => delete(favorite: favorite),
+                                          onCallFrom: (fromNumber) => _callController.createCall(
+                                            destination: favorite.number,
+                                            displayName: contact?.maybeName ?? favorite.number,
+                                            fromNumber: fromNumber,
+                                            video: false,
+                                          ),
                                         ),
                                       ),
-
-                                      const SizedBox(width: 8),
                                     ],
                                   ),
                                 );

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -213,12 +213,8 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                                           contact: contact,
                                           callNumbers: callRoutingState?.allNumbers ?? [],
                                           onTap: blingTransferInitiated
-                                              ? () {
-                                                  submitTransfer(destination: favorite.number);
-                                                }
-                                              : () {
-                                                  _toggleExpanded('${favorite.number}_${favorite.sourceType.name}');
-                                                },
+                                              ? () => submitTransfer(destination: favorite.number)
+                                              : () => _toggleExpanded('${favorite.number}_${favorite.sourceType.name}'),
                                           expanded:
                                               !blingTransferInitiated &&
                                               !isReorderMode &&

--- a/lib/features/favorites/view/favorites_screen.dart
+++ b/lib/features/favorites/view/favorites_screen.dart
@@ -45,6 +45,11 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   late final _callController = CallControllerScope.of(context);
   bool isReorderMode = false;
   int? draggingIndex;
+  String? _expandedFavoriteId;
+
+  void _toggleExpanded(String favoriteId) {
+    setState(() => _expandedFavoriteId = _expandedFavoriteId == favoriteId ? null : favoriteId);
+  }
 
   void submitTransfer({required String destination}) {
     _callController.submitTransfer(destination);
@@ -211,6 +216,15 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                                               ? () {
                                                   submitTransfer(destination: favorite.number);
                                                 }
+                                              : () {
+                                                  _toggleExpanded('${favorite.number}_${favorite.sourceType.name}');
+                                                },
+                                          expanded:
+                                              !blingTransferInitiated &&
+                                              !isReorderMode &&
+                                              _expandedFavoriteId == '${favorite.number}_${favorite.sourceType.name}',
+                                          onDialPressed: blingTransferInitiated
+                                              ? null
                                               : () {
                                                   _callController.createCall(
                                                     destination: favorite.number,

--- a/lib/features/favorites/widgets/favorite_tile.dart
+++ b/lib/features/favorites/widgets/favorite_tile.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
@@ -7,7 +6,7 @@ import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
-class FavoriteTile extends StatefulWidget {
+class FavoriteTile extends StatelessWidget {
   const FavoriteTile({
     super.key,
     required this.favorite,
@@ -46,75 +45,31 @@ class FavoriteTile extends StatefulWidget {
   final bool gesturesEnabled;
 
   @override
-  State<FavoriteTile> createState() => _FavoriteTileState();
-}
-
-class _FavoriteTileState extends State<FavoriteTile> {
-  late final tileKey = GlobalKey();
-  late final number = widget.favorite.number;
-
-  List<PopupMenuEntry> get actions => [
-    if (widget.onAudioCallPressed != null)
-      PopupMenuItem(onTap: widget.onAudioCallPressed, child: Text(context.l10n.numberActions_audioCall)),
-    if (widget.onVideoCallPressed != null)
-      PopupMenuItem(onTap: widget.onVideoCallPressed, child: Text(context.l10n.numberActions_videoCall)),
-    if (widget.callNumbers.length > 1)
-      for (final callNumber in widget.callNumbers)
-        PopupMenuItem(
-          onTap: () => widget.onCallFrom?.call(callNumber),
-          child: Text(context.l10n.numberActions_callFrom(callNumber)),
-        ),
-    if (widget.onTransferPressed != null)
-      PopupMenuItem(onTap: widget.onTransferPressed, child: Text(context.l10n.numberActions_transfer)),
-    if (widget.onChatPressed != null)
-      PopupMenuItem(onTap: widget.onChatPressed, child: Text(context.l10n.numberActions_chat)),
-    if (widget.onSendSmsPressed != null)
-      PopupMenuItem(onTap: widget.onSendSmsPressed, child: Text(context.l10n.numberActions_sendSms)),
-    if (widget.onViewContactPressed != null)
-      PopupMenuItem(onTap: widget.onViewContactPressed, child: Text(context.l10n.numberActions_viewContact)),
-    if (widget.onCallLogPressed != null)
-      PopupMenuItem(onTap: widget.onCallLogPressed, child: Text(context.l10n.numberActions_callLog)),
-    PopupMenuItem(
-      onTap: () {
-        Clipboard.setData(ClipboardData(text: number));
-      },
-      child: Text(context.l10n.numberActions_copyNumber),
-    ),
-    if (widget.onDelete != null) PopupMenuItem(onTap: widget.onDelete, child: Text(context.l10n.numberActions_delete)),
-  ];
-
-  void onLongPress() {
-    final position = getPosition();
-    showMenu(context: context, position: position, items: actions);
-  }
-
-  RelativeRect getPosition() {
-    final RenderBox renderBox = tileKey.currentContext!.findRenderObject()! as RenderBox;
-    final RenderBox overlay = Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox;
-    final screenSize = MediaQuery.of(context).size;
-    late Offset offset = Offset(screenSize.width - 16, 16);
-    return RelativeRect.fromRect(
-      Rect.fromPoints(
-        renderBox.localToGlobal(offset, ancestor: overlay),
-        renderBox.localToGlobal(renderBox.size.bottomLeft(Offset.zero) + offset, ancestor: overlay),
-      ),
-      Offset.zero & overlay.size,
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    final colorScheme = themeData.colorScheme;
     final presenceParams = PresenceViewParams.of(context);
 
-    final contact = widget.contact;
-    final name = widget.contact?.maybeName ?? widget.favorite.number;
+    final name = contact?.maybeName ?? favorite.number;
+    final title = switch (presenceParams.hybridPresenceSupport) {
+      true => '$name ${contact?.presenceInfo.primaryStatusIcon ?? ''}',
+      false => name,
+    };
 
-    return Dismissible(
-      key: ObjectKey(widget.favorite),
-      background: Container(
-        color: colorScheme.error,
+    return CallTile(
+      dismissibleObject: favorite,
+      leading: LeadingAvatar(
+        username: name,
+        thumbnail: contact?.thumbnail,
+        thumbnailUrl: contact?.thumbnailUrl,
+        registered: contact?.registered,
+        presenceInfo: contact?.presenceInfo,
+        dialogInfo: contact?.dialogInfo,
+      ),
+      name: title,
+      subName: '${favorite.label.capitalize}: ${favorite.number}',
+      dismissible: true,
+      dismissBackground: Container(
+        color: themeData.colorScheme.error,
         padding: const EdgeInsets.only(right: 16),
         child: const Align(alignment: Alignment.centerRight, child: Icon(Icons.delete_outline)),
       ),
@@ -123,70 +78,22 @@ class _FavoriteTileState extends State<FavoriteTile> {
         title: context.l10n.favorites_DeleteConfirmDialog_title,
         content: context.l10n.favorites_DeleteConfirmDialog_content,
       ),
-      onDismissed: widget.onDelete == null ? null : (direction) => widget.onDelete!(),
-      direction: DismissDirection.endToStart,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: ListTile(
-                  key: tileKey,
-                  contentPadding: const EdgeInsets.only(left: 16.0),
-                  leading: LeadingAvatar(
-                    username: name,
-                    thumbnail: contact?.thumbnail,
-                    thumbnailUrl: contact?.thumbnailUrl,
-                    registered: contact?.registered,
-                    presenceInfo: contact?.presenceInfo,
-                    dialogInfo: contact?.dialogInfo,
-                  ),
-                  title: switch (presenceParams.hybridPresenceSupport) {
-                    true => Text(
-                      '$name ${contact?.presenceInfo.primaryStatusIcon ?? ''}',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    false => Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
-                  },
-                  subtitle: Text(
-                    '${widget.favorite.label.capitalize}: ${widget.favorite.number}',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  onTap: widget.gesturesEnabled ? widget.onTap : null,
-                  onLongPress: widget.gesturesEnabled ? onLongPress : null,
-                ),
-              ),
-              if (widget.gesturesEnabled)
-                widget.onDialPressed != null
-                    ? IconButton(
-                        onPressed: widget.onDialPressed,
-                        icon: Icon(Icons.call, color: colorScheme.primary),
-                      )
-                    : GestureDetector(onTap: onLongPress, child: const Icon(Icons.more_vert)),
-            ],
-          ),
-          AnimatedSize(
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeInOut,
-            alignment: Alignment.topCenter,
-            child: widget.expanded && widget.gesturesEnabled
-                ? Padding(
-                    padding: const EdgeInsets.only(left: 16, right: 16, bottom: 4),
-                    child: CallTileActionsBar(
-                      onVideoCallPressed: widget.onVideoCallPressed,
-                      onChatPressed: widget.onChatPressed,
-                      onCallLogPressed: widget.onCallLogPressed,
-                      onViewContactPressed: widget.onViewContactPressed,
-                      onMorePressed: onLongPress,
-                    ),
-                  )
-                : const SizedBox(width: double.infinity),
-          ),
-        ],
-      ),
+      onDismiss: onDelete,
+      onTap: onTap,
+      expanded: expanded,
+      onDialPressed: onDialPressed,
+      gesturesEnabled: gesturesEnabled,
+      callNumbers: callNumbers,
+      onAudioCallPressed: onAudioCallPressed,
+      onVideoCallPressed: onVideoCallPressed,
+      onTransferPressed: onTransferPressed,
+      onChatPressed: onChatPressed,
+      onSendSmsPressed: onSendSmsPressed,
+      onViewContactPressed: onViewContactPressed,
+      onCallLogPressed: onCallLogPressed,
+      onCallFrom: onCallFrom,
+      copyNumber: favorite.number,
+      onDelete: onDelete,
     );
   }
 }

--- a/lib/features/favorites/widgets/favorite_tile.dart
+++ b/lib/features/favorites/widgets/favorite_tile.dart
@@ -14,6 +14,8 @@ class FavoriteTile extends StatefulWidget {
     this.contact,
     required this.callNumbers,
     this.onTap,
+    this.expanded = false,
+    this.onDialPressed,
     this.onAudioCallPressed,
     this.onVideoCallPressed,
     this.onTransferPressed,
@@ -30,6 +32,8 @@ class FavoriteTile extends StatefulWidget {
   final Contact? contact;
   final List<String> callNumbers;
   final Function()? onTap;
+  final bool expanded;
+  final Function()? onDialPressed;
   final Function()? onAudioCallPressed;
   final Function()? onVideoCallPressed;
   final Function()? onTransferPressed;
@@ -121,38 +125,66 @@ class _FavoriteTileState extends State<FavoriteTile> {
       ),
       onDismissed: widget.onDelete == null ? null : (direction) => widget.onDelete!(),
       direction: DismissDirection.endToStart,
-      child: Row(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
-            child: ListTile(
-              key: tileKey,
-              contentPadding: const EdgeInsets.only(left: 16.0),
-              leading: LeadingAvatar(
-                username: name,
-                thumbnail: contact?.thumbnail,
-                thumbnailUrl: contact?.thumbnailUrl,
-                registered: contact?.registered,
-                presenceInfo: contact?.presenceInfo,
-                dialogInfo: contact?.dialogInfo,
-              ),
-              title: switch (presenceParams.hybridPresenceSupport) {
-                true => Text(
-                  '$name ${contact?.presenceInfo.primaryStatusIcon ?? ''}',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+          Row(
+            children: [
+              Expanded(
+                child: ListTile(
+                  key: tileKey,
+                  contentPadding: const EdgeInsets.only(left: 16.0),
+                  leading: LeadingAvatar(
+                    username: name,
+                    thumbnail: contact?.thumbnail,
+                    thumbnailUrl: contact?.thumbnailUrl,
+                    registered: contact?.registered,
+                    presenceInfo: contact?.presenceInfo,
+                    dialogInfo: contact?.dialogInfo,
+                  ),
+                  title: switch (presenceParams.hybridPresenceSupport) {
+                    true => Text(
+                      '$name ${contact?.presenceInfo.primaryStatusIcon ?? ''}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    false => Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
+                  },
+                  subtitle: Text(
+                    '${widget.favorite.label.capitalize}: ${widget.favorite.number}',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  onTap: widget.gesturesEnabled ? widget.onTap : null,
+                  onLongPress: widget.gesturesEnabled ? onLongPress : null,
                 ),
-                false => Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
-              },
-              subtitle: Text(
-                '${widget.favorite.label.capitalize}: ${widget.favorite.number}',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
               ),
-              onTap: widget.gesturesEnabled ? widget.onTap : null,
-              onLongPress: widget.gesturesEnabled ? onLongPress : null,
-            ),
+              if (widget.gesturesEnabled)
+                widget.onDialPressed != null
+                    ? IconButton(
+                        onPressed: widget.onDialPressed,
+                        icon: Icon(Icons.call, color: colorScheme.primary),
+                      )
+                    : GestureDetector(onTap: onLongPress, child: const Icon(Icons.more_vert)),
+            ],
           ),
-          if (widget.gesturesEnabled) GestureDetector(onTap: onLongPress, child: const Icon(Icons.more_vert)),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            alignment: Alignment.topCenter,
+            child: widget.expanded && widget.gesturesEnabled
+                ? Padding(
+                    padding: const EdgeInsets.only(left: 16, right: 16, bottom: 4),
+                    child: CallTileActionsBar(
+                      onVideoCallPressed: widget.onVideoCallPressed,
+                      onChatPressed: widget.onChatPressed,
+                      onCallLogPressed: widget.onCallLogPressed,
+                      onViewContactPressed: widget.onViewContactPressed,
+                      onMorePressed: onLongPress,
+                    ),
+                  )
+                : const SizedBox(width: double.infinity),
+          ),
         ],
       ),
     );

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -46,6 +46,11 @@ class RecentsScreen extends StatefulWidget {
 class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProviderStateMixin {
   late final _callController = CallControllerScope.of(context);
   late TabController _tabController;
+  int? _expandedRecentId;
+
+  void _toggleExpanded(int callLogEntryId) {
+    setState(() => _expandedRecentId = _expandedRecentId == callLogEntryId ? null : callLogEntryId);
+  }
 
   @override
   void initState() {
@@ -194,6 +199,12 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
                                       ? () {
                                           submitTransfer(destination: callLogEntry.number);
                                         }
+                                      : () {
+                                          _toggleExpanded(callLogEntry.id);
+                                        },
+                                  expanded: !transfer && _expandedRecentId == callLogEntry.id,
+                                  onDialPressed: transfer
+                                      ? null
                                       : () {
                                           _callController.createCall(
                                             destination: callLogEntry.number,

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -196,12 +196,8 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
                                   callNumbers: callRoutingState?.allNumbers ?? [],
                                   dateFormat: context.read<RecentsBloc>().dateFormat,
                                   onTap: transfer
-                                      ? () {
-                                          submitTransfer(destination: callLogEntry.number);
-                                        }
-                                      : () {
-                                          _toggleExpanded(callLogEntry.id);
-                                        },
+                                      ? () => submitTransfer(destination: callLogEntry.number)
+                                      : () => _toggleExpanded(callLogEntry.id),
                                   expanded: !transfer && _expandedRecentId == callLogEntry.id,
                                   onDialPressed: transfer
                                       ? null

--- a/lib/features/recents/widgets/recent_tile.dart
+++ b/lib/features/recents/widgets/recent_tile.dart
@@ -16,6 +16,8 @@ class RecentTile extends StatelessWidget {
     required this.callNumbers,
     required this.dateFormat,
     this.onTap,
+    this.expanded = false,
+    this.onDialPressed,
     this.onAudioCallPressed,
     this.onVideoCallPressed,
     this.onTransferPressed,
@@ -31,6 +33,8 @@ class RecentTile extends StatelessWidget {
   final List<String> callNumbers;
   final DateFormat dateFormat;
   final Function()? onTap;
+  final bool expanded;
+  final Function()? onDialPressed;
   final Function()? onAudioCallPressed;
   final Function()? onVideoCallPressed;
   final Function()? onTransferPressed;
@@ -94,6 +98,8 @@ class RecentTile extends StatelessWidget {
       ),
       onDismiss: onDelete,
       onTap: onTap,
+      expanded: expanded,
+      onDialPressed: onDialPressed,
       callNumbers: callNumbers,
       onAudioCallPressed: onAudioCallPressed,
       onVideoCallPressed: onVideoCallPressed,

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -177,6 +177,30 @@ abstract class AppLocalizations {
   /// **'Successfully retrieved your settings, your app is ready to use'**
   String get autoprovision_successSnackBar_used;
 
+  /// Label of the expanded call tile action that opens the contact details screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Contact'**
+  String get callTileActions_contact;
+
+  /// Label of the expanded call tile action that opens the call history for the number.
+  ///
+  /// In en, this message translates to:
+  /// **'History'**
+  String get callTileActions_history;
+
+  /// Label of the expanded call tile action that opens a chat with the contact.
+  ///
+  /// In en, this message translates to:
+  /// **'Message'**
+  String get callTileActions_message;
+
+  /// Label of the expanded call tile action that opens the full actions menu.
+  ///
+  /// In en, this message translates to:
+  /// **'More'**
+  String get callTileActions_more;
+
   /// No description provided for @call_CallActionsTooltip_accept.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -93,6 +93,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoprovision_successSnackBar_used => 'Successfully retrieved your settings, your app is ready to use';
 
   @override
+  String get callTileActions_contact => 'Contact';
+
+  @override
+  String get callTileActions_history => 'History';
+
+  @override
+  String get callTileActions_message => 'Message';
+
+  @override
+  String get callTileActions_more => 'More';
+
+  @override
   String get call_CallActionsTooltip_accept => 'Accept';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -94,6 +94,18 @@ class AppLocalizationsIt extends AppLocalizations {
       'Le vostre impostazioni sono state recuperate con successo, l\'App è pronta per l\'uso';
 
   @override
+  String get callTileActions_contact => 'Contatto';
+
+  @override
+  String get callTileActions_history => 'Cronologia';
+
+  @override
+  String get callTileActions_message => 'Messaggio';
+
+  @override
+  String get callTileActions_more => 'Altro';
+
+  @override
   String get call_CallActionsTooltip_accept => 'Accetta chiamata';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -102,6 +102,18 @@ class AppLocalizationsUk extends AppLocalizations {
       'Ваші налаштування було успішно отримано, застосунок готовий до використання';
 
   @override
+  String get callTileActions_contact => 'Контакт';
+
+  @override
+  String get callTileActions_history => 'Історія';
+
+  @override
+  String get callTileActions_message => 'Повідомлення';
+
+  @override
+  String get callTileActions_more => 'Більше';
+
+  @override
   String get call_CallActionsTooltip_accept => 'Прийняти';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -61,6 +61,22 @@
   "@autoprovision_ReloginDialog_title": {},
   "autoprovision_successSnackBar_used": "Successfully retrieved your settings, your app is ready to use",
   "@autoprovision_successSnackBar_used": {},
+  "callTileActions_contact": "Contact",
+  "@callTileActions_contact": {
+    "description": "Label of the expanded call tile action that opens the contact details screen."
+  },
+  "callTileActions_history": "History",
+  "@callTileActions_history": {
+    "description": "Label of the expanded call tile action that opens the call history for the number."
+  },
+  "callTileActions_message": "Message",
+  "@callTileActions_message": {
+    "description": "Label of the expanded call tile action that opens a chat with the contact."
+  },
+  "callTileActions_more": "More",
+  "@callTileActions_more": {
+    "description": "Label of the expanded call tile action that opens the full actions menu."
+  },
   "call_CallActionsTooltip_accept": "Accept",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Accept transfer",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -61,6 +61,22 @@
   "@autoprovision_ReloginDialog_title": {},
   "autoprovision_successSnackBar_used": "Le vostre impostazioni sono state recuperate con successo, l'App è pronta per l'uso",
   "@autoprovision_successSnackBar_used": {},
+  "callTileActions_contact": "Contatto",
+  "@callTileActions_contact": {
+    "description": "Label of the expanded call tile action that opens the contact details screen."
+  },
+  "callTileActions_history": "Cronologia",
+  "@callTileActions_history": {
+    "description": "Label of the expanded call tile action that opens the call history for the number."
+  },
+  "callTileActions_message": "Messaggio",
+  "@callTileActions_message": {
+    "description": "Label of the expanded call tile action that opens a chat with the contact."
+  },
+  "callTileActions_more": "Altro",
+  "@callTileActions_more": {
+    "description": "Label of the expanded call tile action that opens the full actions menu."
+  },
   "call_CallActionsTooltip_accept": "Accetta chiamata",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Accetta trasferimento",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -61,6 +61,22 @@
   "@autoprovision_ReloginDialog_title": {},
   "autoprovision_successSnackBar_used": "Ваші налаштування було успішно отримано, застосунок готовий до використання",
   "@autoprovision_successSnackBar_used": {},
+  "callTileActions_contact": "Контакт",
+  "@callTileActions_contact": {
+    "description": "Label of the expanded call tile action that opens the contact details screen."
+  },
+  "callTileActions_history": "Історія",
+  "@callTileActions_history": {
+    "description": "Label of the expanded call tile action that opens the call history for the number."
+  },
+  "callTileActions_message": "Повідомлення",
+  "@callTileActions_message": {
+    "description": "Label of the expanded call tile action that opens a chat with the contact."
+  },
+  "callTileActions_more": "Більше",
+  "@callTileActions_more": {
+    "description": "Label of the expanded call tile action that opens the full actions menu."
+  },
   "call_CallActionsTooltip_accept": "Прийняти",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Прийняти переадресацію",

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -84,7 +84,7 @@ class CallTileActionsBar extends StatelessWidget {
   final VoidCallback? onChatPressed;
   final VoidCallback? onCallLogPressed;
   final VoidCallback? onViewContactPressed;
-  final VoidCallback onMorePressed;
+  final VoidCallback? onMorePressed;
 
   @override
   Widget build(BuildContext context) {
@@ -119,9 +119,10 @@ class CallTileActionsBar extends StatelessWidget {
               onTap: onViewContactPressed!,
             ),
           ),
-        Expanded(
-          child: _CallTileAction(icon: Icons.more_horiz, label: l10n.callTileActions_more, onTap: onMorePressed),
-        ),
+        if (onMorePressed != null)
+          Expanded(
+            child: _CallTileAction(icon: Icons.more_horiz, label: l10n.callTileActions_more, onTap: onMorePressed!),
+          ),
       ],
     );
   }
@@ -225,6 +226,21 @@ class CallTile extends StatefulWidget {
 
 class _CallTileState extends State<CallTile> {
   late final tileKey = GlobalKey();
+
+  /// Mirrors the gating of [buildNumberActions] so menu affordances (the
+  /// trailing button and the More action) are hidden when the menu is empty.
+  bool get hasMenuActions =>
+      widget.onAudioCallPressed != null ||
+      widget.onVideoCallPressed != null ||
+      (widget.callNumbers.length > 1 && widget.onCallFrom != null) ||
+      widget.onTransferPressed != null ||
+      widget.onChatPressed != null ||
+      widget.onSendSmsPressed != null ||
+      widget.onViewContactPressed != null ||
+      widget.onCallLogPressed != null ||
+      widget.copyNumber != null ||
+      widget.copyCallId != null ||
+      widget.onDelete != null;
 
   void showMenuPopup() {
     final items = buildNumberActions(
@@ -353,7 +369,7 @@ class _CallTileState extends State<CallTile> {
                           onPressed: widget.onDialPressed,
                           icon: Icon(Icons.call, color: colorScheme.primary),
                         )
-                      else
+                      else if (hasMenuActions)
                         TileMenuButton(onTap: showMenuPopup),
                   ],
                 ),
@@ -369,7 +385,7 @@ class _CallTileState extends State<CallTile> {
                             onChatPressed: widget.onChatPressed,
                             onCallLogPressed: widget.onCallLogPressed,
                             onViewContactPressed: widget.onViewContactPressed,
-                            onMorePressed: showMenuPopup,
+                            onMorePressed: hasMenuActions ? showMenuPopup : null,
                           ),
                         )
                       : const SizedBox(width: double.infinity),

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -162,12 +162,13 @@ class CallTile extends StatefulWidget {
     required this.name,
     this.subName,
     this.subtitleLeading,
-    required this.timeLabel,
+    this.timeLabel,
     this.durationLabel,
     this.disconnectReason,
     this.onTap,
     this.expanded = false,
     this.onDialPressed,
+    this.gesturesEnabled = true,
     this.dismissible = false,
     this.dismissibleObject,
     this.dismissBackground,
@@ -191,12 +192,13 @@ class CallTile extends StatefulWidget {
   final String name;
   final String? subName;
   final Widget? subtitleLeading;
-  final String timeLabel;
+  final String? timeLabel;
   final String? durationLabel;
   final String? disconnectReason;
   final VoidCallback? onTap;
   final bool expanded;
   final VoidCallback? onDialPressed;
+  final bool gesturesEnabled;
 
   final bool dismissible;
   final Object? dismissibleObject;
@@ -322,8 +324,8 @@ class _CallTileState extends State<CallTile> {
           borderRadius: BorderRadius.circular(16),
           splashColor: colorScheme.secondary.withAlpha(50),
           key: tileKey,
-          onTap: widget.onTap,
-          onLongPress: showMenuPopup,
+          onTap: widget.gesturesEnabled ? widget.onTap : null,
+          onLongPress: widget.gesturesEnabled ? showMenuPopup : null,
           child: Padding(
             padding: const EdgeInsets.only(left: 8, right: 0, top: 8, bottom: 8),
             child: Column(
@@ -334,31 +336,33 @@ class _CallTileState extends State<CallTile> {
                     widget.leading,
                     const SizedBox(width: 8),
                     Expanded(child: contentColumn),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(widget.timeLabel, style: themeData.textTheme.labelSmall),
-                        if (widget.durationLabel != null) ...[
-                          const SizedBox(height: 2),
-                          Text(widget.durationLabel!, style: themeData.textTheme.labelSmall),
+                    if (widget.timeLabel != null)
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(widget.timeLabel!, style: themeData.textTheme.labelSmall),
+                          if (widget.durationLabel != null) ...[
+                            const SizedBox(height: 2),
+                            Text(widget.durationLabel!, style: themeData.textTheme.labelSmall),
+                          ],
                         ],
-                      ],
-                    ),
+                      ),
                     const SizedBox(width: 4),
-                    if (widget.onDialPressed != null)
-                      IconButton(
-                        onPressed: widget.onDialPressed,
-                        icon: Icon(Icons.call, color: colorScheme.primary),
-                      )
-                    else
-                      TileMenuButton(onTap: showMenuPopup),
+                    if (widget.gesturesEnabled)
+                      if (widget.onDialPressed != null)
+                        IconButton(
+                          onPressed: widget.onDialPressed,
+                          icon: Icon(Icons.call, color: colorScheme.primary),
+                        )
+                      else
+                        TileMenuButton(onTap: showMenuPopup),
                   ],
                 ),
                 AnimatedSize(
                   duration: const Duration(milliseconds: 200),
                   curve: Curves.easeInOut,
                   alignment: Alignment.topCenter,
-                  child: widget.expanded
+                  child: widget.expanded && widget.gesturesEnabled
                       ? Padding(
                           padding: const EdgeInsets.only(top: 4, right: 8),
                           child: CallTileActionsBar(

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -70,6 +70,91 @@ List<PopupMenuEntry<dynamic>> buildNumberActions(
   ];
 }
 
+class CallTileActionsBar extends StatelessWidget {
+  const CallTileActionsBar({
+    super.key,
+    this.onVideoCallPressed,
+    this.onChatPressed,
+    this.onCallLogPressed,
+    this.onViewContactPressed,
+    required this.onMorePressed,
+  });
+
+  final VoidCallback? onVideoCallPressed;
+  final VoidCallback? onChatPressed;
+  final VoidCallback? onCallLogPressed;
+  final VoidCallback? onViewContactPressed;
+  final VoidCallback onMorePressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Row(
+      children: [
+        if (onVideoCallPressed != null)
+          Expanded(
+            child: _CallTileAction(
+              icon: Icons.videocam_outlined,
+              label: l10n.numberActions_videoCall,
+              onTap: onVideoCallPressed!,
+            ),
+          ),
+        if (onChatPressed != null)
+          Expanded(
+            child: _CallTileAction(
+              icon: Icons.chat_outlined,
+              label: l10n.callTileActions_message,
+              onTap: onChatPressed!,
+            ),
+          ),
+        if (onCallLogPressed != null)
+          Expanded(
+            child: _CallTileAction(icon: Icons.history, label: l10n.callTileActions_history, onTap: onCallLogPressed!),
+          ),
+        if (onViewContactPressed != null)
+          Expanded(
+            child: _CallTileAction(
+              icon: Icons.person_outline,
+              label: l10n.callTileActions_contact,
+              onTap: onViewContactPressed!,
+            ),
+          ),
+        Expanded(
+          child: _CallTileAction(icon: Icons.more_horiz, label: l10n.callTileActions_more, onTap: onMorePressed),
+        ),
+      ],
+    );
+  }
+}
+
+class _CallTileAction extends StatelessWidget {
+  const _CallTileAction({required this.icon, required this.label, required this.onTap});
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 22, color: themeData.colorScheme.primary),
+            const SizedBox(height: 2),
+            Text(label, maxLines: 1, overflow: TextOverflow.ellipsis, style: themeData.textTheme.labelSmall),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class CallTile extends StatefulWidget {
   const CallTile({
     super.key,
@@ -81,6 +166,8 @@ class CallTile extends StatefulWidget {
     this.durationLabel,
     this.disconnectReason,
     this.onTap,
+    this.expanded = false,
+    this.onDialPressed,
     this.dismissible = false,
     this.dismissibleObject,
     this.dismissBackground,
@@ -108,6 +195,8 @@ class CallTile extends StatefulWidget {
   final String? durationLabel;
   final String? disconnectReason;
   final VoidCallback? onTap;
+  final bool expanded;
+  final VoidCallback? onDialPressed;
 
   final bool dismissible;
   final Object? dismissibleObject;
@@ -237,23 +326,51 @@ class _CallTileState extends State<CallTile> {
           onLongPress: showMenuPopup,
           child: Padding(
             padding: const EdgeInsets.only(left: 8, right: 0, top: 8, bottom: 8),
-            child: Row(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                widget.leading,
-                const SizedBox(width: 8),
-                Expanded(child: contentColumn),
-                Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
+                Row(
                   children: [
-                    Text(widget.timeLabel, style: themeData.textTheme.labelSmall),
-                    if (widget.durationLabel != null) ...[
-                      const SizedBox(height: 2),
-                      Text(widget.durationLabel!, style: themeData.textTheme.labelSmall),
-                    ],
+                    widget.leading,
+                    const SizedBox(width: 8),
+                    Expanded(child: contentColumn),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(widget.timeLabel, style: themeData.textTheme.labelSmall),
+                        if (widget.durationLabel != null) ...[
+                          const SizedBox(height: 2),
+                          Text(widget.durationLabel!, style: themeData.textTheme.labelSmall),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(width: 4),
+                    if (widget.onDialPressed != null)
+                      IconButton(
+                        onPressed: widget.onDialPressed,
+                        icon: Icon(Icons.call, color: colorScheme.primary),
+                      )
+                    else
+                      TileMenuButton(onTap: showMenuPopup),
                   ],
                 ),
-                const SizedBox(width: 4),
-                TileMenuButton(onTap: showMenuPopup),
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeInOut,
+                  alignment: Alignment.topCenter,
+                  child: widget.expanded
+                      ? Padding(
+                          padding: const EdgeInsets.only(top: 4, right: 8),
+                          child: CallTileActionsBar(
+                            onVideoCallPressed: widget.onVideoCallPressed,
+                            onChatPressed: widget.onChatPressed,
+                            onCallLogPressed: widget.onCallLogPressed,
+                            onViewContactPressed: widget.onViewContactPressed,
+                            onMorePressed: showMenuPopup,
+                          ),
+                        )
+                      : const SizedBox(width: double.infinity),
+                ),
               ],
             ),
           ),

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -227,25 +227,24 @@ class _CallTileState extends State<CallTile> {
   late final tileKey = GlobalKey();
 
   void showMenuPopup() {
-    showMenu(
-      context: context,
-      position: getPosition(),
-      items: buildNumberActions(
-        context,
-        callNumbers: widget.callNumbers,
-        onAudioCallPressed: widget.onAudioCallPressed,
-        onVideoCallPressed: widget.onVideoCallPressed,
-        onTransferPressed: widget.onTransferPressed,
-        onChatPressed: widget.onChatPressed,
-        onSendSmsPressed: widget.onSendSmsPressed,
-        onViewContactPressed: widget.onViewContactPressed,
-        onCallLogPressed: widget.onCallLogPressed,
-        onCallFrom: widget.onCallFrom,
-        copyNumber: widget.copyNumber,
-        copyCallId: widget.copyCallId,
-        onDelete: widget.onDelete,
-      ),
+    final items = buildNumberActions(
+      context,
+      callNumbers: widget.callNumbers,
+      onAudioCallPressed: widget.onAudioCallPressed,
+      onVideoCallPressed: widget.onVideoCallPressed,
+      onTransferPressed: widget.onTransferPressed,
+      onChatPressed: widget.onChatPressed,
+      onSendSmsPressed: widget.onSendSmsPressed,
+      onViewContactPressed: widget.onViewContactPressed,
+      onCallLogPressed: widget.onCallLogPressed,
+      onCallFrom: widget.onCallFrom,
+      copyNumber: widget.copyNumber,
+      copyCallId: widget.copyCallId,
+      onDelete: widget.onDelete,
     );
+    if (items.isEmpty) return;
+
+    showMenu(context: context, position: getPosition(), items: items);
   }
 
   RelativeRect getPosition() {

--- a/test/features/contacts/widgets/contact_tile_test.dart
+++ b/test/features/contacts/widgets/contact_tile_test.dart
@@ -9,6 +9,7 @@ import 'package:webtrit_phone/utils/utils.dart';
 void main() {
   Widget buildTestable(Widget child) {
     return MaterialApp(
+      locale: const Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: PresenceViewParams(

--- a/test/features/contacts/widgets/contact_tile_test.dart
+++ b/test/features/contacts/widgets/contact_tile_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/contacts/widgets/contact_tile.dart';
+import 'package:webtrit_phone/l10n/app_localizations.g.dart';
+import 'package:webtrit_phone/utils/utils.dart';
+
+void main() {
+  Widget buildTestable(Widget child) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: PresenceViewParams(
+        hybridPresenceSupport: false,
+        blfViaSipSupport: false,
+        presenceViaSipSupport: false,
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  ContactTile buildTile({
+    VoidCallback? onTap,
+    bool expanded = false,
+    VoidCallback? onDialPressed,
+    VoidCallback? onVideoCallPressed,
+    VoidCallback? onChatPressed,
+    VoidCallback? onCallLogPressed,
+    VoidCallback? onViewContactPressed,
+  }) {
+    return ContactTile(
+      displayName: 'John Doe',
+      onTap: onTap,
+      expanded: expanded,
+      onDialPressed: onDialPressed,
+      onVideoCallPressed: onVideoCallPressed,
+      onChatPressed: onChatPressed,
+      onCallLogPressed: onCallLogPressed,
+      onViewContactPressed: onViewContactPressed,
+    );
+  }
+
+  group('ContactTile expansion', () {
+    testWidgets('collapsed tile does not show the actions bar', (tester) async {
+      await tester.pumpWidget(buildTestable(buildTile(onVideoCallPressed: () {}, onCallLogPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsNothing);
+      expect(find.text('History'), findsNothing);
+      expect(find.text('More'), findsNothing);
+    });
+
+    testWidgets('expanded tile shows actions for non-null callbacks', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(
+          buildTile(expanded: true, onVideoCallPressed: () {}, onCallLogPressed: () {}, onViewContactPressed: () {}),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsOneWidget);
+      expect(find.text('History'), findsOneWidget);
+      expect(find.text('Contact'), findsOneWidget);
+      expect(find.text('More'), findsOneWidget);
+      expect(find.text('Message'), findsNothing);
+    });
+
+    testWidgets('row tap calls onTap and not onDialPressed', (tester) async {
+      var tapped = false;
+      var dialed = false;
+      await tester.pumpWidget(buildTestable(buildTile(onTap: () => tapped = true, onDialPressed: () => dialed = true)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('John Doe'));
+      expect(tapped, isTrue);
+      expect(dialed, isFalse);
+    });
+
+    testWidgets('dial button calls onDialPressed', (tester) async {
+      var dialed = false;
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () => dialed = true)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.call));
+      expect(dialed, isTrue);
+    });
+
+    testWidgets('expanded action buttons fire their callbacks', (tester) async {
+      var contactOpened = false;
+      await tester.pumpWidget(
+        buildTestable(buildTile(expanded: true, onViewContactPressed: () => contactOpened = true)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Contact'));
+      expect(contactOpened, isTrue);
+    });
+  });
+}

--- a/test/features/favorites/widgets/favorite_tile_test.dart
+++ b/test/features/favorites/widgets/favorite_tile_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/favorites/widgets/favorite_tile.dart';
+import 'package:webtrit_phone/l10n/app_localizations.g.dart';
+import 'package:webtrit_phone/models/favorite.dart';
+import 'package:webtrit_phone/utils/utils.dart';
+
+void main() {
+  const favorite = Favorite(
+    number: '1001',
+    sourceType: FavoriteSourceType.pbx,
+    sourceId: '1',
+    label: 'work',
+    position: 0,
+  );
+
+  Widget buildTestable(Widget child) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: PresenceViewParams(
+        hybridPresenceSupport: false,
+        blfViaSipSupport: false,
+        presenceViaSipSupport: false,
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  FavoriteTile buildTile({
+    VoidCallback? onTap,
+    bool expanded = false,
+    bool gesturesEnabled = true,
+    VoidCallback? onDialPressed,
+    VoidCallback? onVideoCallPressed,
+    VoidCallback? onChatPressed,
+    VoidCallback? onCallLogPressed,
+    VoidCallback? onViewContactPressed,
+  }) {
+    return FavoriteTile(
+      favorite: favorite,
+      callNumbers: const [],
+      onTap: onTap,
+      expanded: expanded,
+      gesturesEnabled: gesturesEnabled,
+      onDialPressed: onDialPressed,
+      onVideoCallPressed: onVideoCallPressed,
+      onChatPressed: onChatPressed,
+      onCallLogPressed: onCallLogPressed,
+      onViewContactPressed: onViewContactPressed,
+    );
+  }
+
+  group('FavoriteTile expansion', () {
+    testWidgets('collapsed tile does not show the actions bar', (tester) async {
+      await tester.pumpWidget(buildTestable(buildTile(onVideoCallPressed: () {}, onCallLogPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsNothing);
+      expect(find.text('History'), findsNothing);
+      expect(find.text('More'), findsNothing);
+    });
+
+    testWidgets('expanded tile shows actions for non-null callbacks', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(buildTile(expanded: true, onVideoCallPressed: () {}, onCallLogPressed: () {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsOneWidget);
+      expect(find.text('History'), findsOneWidget);
+      expect(find.text('More'), findsOneWidget);
+      expect(find.text('Message'), findsNothing);
+      expect(find.text('Contact'), findsNothing);
+    });
+
+    testWidgets('row tap calls onTap and not onDialPressed', (tester) async {
+      var tapped = false;
+      var dialed = false;
+      await tester.pumpWidget(buildTestable(buildTile(onTap: () => tapped = true, onDialPressed: () => dialed = true)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Work: 1001'));
+      expect(tapped, isTrue);
+      expect(dialed, isFalse);
+    });
+
+    testWidgets('dial button calls onDialPressed', (tester) async {
+      var dialed = false;
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () => dialed = true)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.call));
+      expect(dialed, isTrue);
+    });
+
+    testWidgets('reorder mode hides dial button and actions bar', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(buildTile(expanded: true, gesturesEnabled: false, onDialPressed: () {}, onCallLogPressed: () {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.call), findsNothing);
+      expect(find.text('History'), findsNothing);
+    });
+
+    testWidgets('expanded action buttons fire their callbacks', (tester) async {
+      var history = false;
+      await tester.pumpWidget(buildTestable(buildTile(expanded: true, onCallLogPressed: () => history = true)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('History'));
+      expect(history, isTrue);
+    });
+  });
+}

--- a/test/features/favorites/widgets/favorite_tile_test.dart
+++ b/test/features/favorites/widgets/favorite_tile_test.dart
@@ -18,6 +18,7 @@ void main() {
 
   Widget buildTestable(Widget child) {
     return MaterialApp(
+      locale: const Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: PresenceViewParams(

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -8,6 +8,7 @@ import 'package:webtrit_phone/widgets/call/call_tile.dart';
 void main() {
   Widget buildTestable(Widget child) {
     return MaterialApp(
+      locale: const Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(body: child),
@@ -31,6 +32,7 @@ void main() {
       subName: '1001',
       timeLabel: '12:00',
       callNumbers: const [],
+      copyNumber: '1001',
       onTap: onTap,
       expanded: expanded,
       gesturesEnabled: gesturesEnabled,
@@ -149,6 +151,24 @@ void main() {
       expect(find.byIcon(Icons.call), findsNothing);
       expect(find.byIcon(Icons.more_vert), findsNothing);
       expect(find.text('History'), findsNothing);
+    });
+
+    testWidgets('without any menu actions hides the menu button and More', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(
+          const CallTile(
+            leading: CircleAvatar(),
+            name: 'John Doe',
+            timeLabel: '12:00',
+            callNumbers: [],
+            expanded: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.more_vert), findsNothing);
+      expect(find.text('More'), findsNothing);
     });
 
     testWidgets('More opens the full actions menu', (tester) async {

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/l10n/app_localizations.g.dart';
+import 'package:webtrit_phone/widgets/call/call_tile.dart';
+
+void main() {
+  Widget buildTestable(Widget child) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    );
+  }
+
+  CallTile buildTile({
+    VoidCallback? onTap,
+    bool expanded = false,
+    VoidCallback? onDialPressed,
+    VoidCallback? onAudioCallPressed,
+    VoidCallback? onVideoCallPressed,
+    VoidCallback? onChatPressed,
+    VoidCallback? onCallLogPressed,
+    VoidCallback? onViewContactPressed,
+  }) {
+    return CallTile(
+      leading: const CircleAvatar(),
+      name: 'John Doe',
+      subName: '1001',
+      timeLabel: '12:00',
+      callNumbers: const [],
+      onTap: onTap,
+      expanded: expanded,
+      onDialPressed: onDialPressed,
+      onAudioCallPressed: onAudioCallPressed,
+      onVideoCallPressed: onVideoCallPressed,
+      onChatPressed: onChatPressed,
+      onCallLogPressed: onCallLogPressed,
+      onViewContactPressed: onViewContactPressed,
+    );
+  }
+
+  group('CallTile expansion', () {
+    testWidgets('collapsed tile does not show the actions bar', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(
+          buildTile(
+            onVideoCallPressed: () {},
+            onChatPressed: () {},
+            onCallLogPressed: () {},
+            onViewContactPressed: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsNothing);
+      expect(find.text('Message'), findsNothing);
+      expect(find.text('History'), findsNothing);
+      expect(find.text('Contact'), findsNothing);
+      expect(find.text('More'), findsNothing);
+    });
+
+    testWidgets('expanded tile shows actions for non-null callbacks', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(
+          buildTile(
+            expanded: true,
+            onVideoCallPressed: () {},
+            onChatPressed: () {},
+            onCallLogPressed: () {},
+            onViewContactPressed: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsOneWidget);
+      expect(find.text('Message'), findsOneWidget);
+      expect(find.text('History'), findsOneWidget);
+      expect(find.text('Contact'), findsOneWidget);
+      expect(find.text('More'), findsOneWidget);
+    });
+
+    testWidgets('expanded tile hides actions whose callbacks are null', (tester) async {
+      await tester.pumpWidget(buildTestable(buildTile(expanded: true, onCallLogPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsNothing);
+      expect(find.text('Message'), findsNothing);
+      expect(find.text('Contact'), findsNothing);
+      expect(find.text('History'), findsOneWidget);
+      expect(find.text('More'), findsOneWidget);
+    });
+
+    testWidgets('row tap calls onTap and not onDialPressed', (tester) async {
+      var tapped = false;
+      var dialed = false;
+      await tester.pumpWidget(buildTestable(buildTile(onTap: () => tapped = true, onDialPressed: () => dialed = true)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('John Doe'));
+      expect(tapped, isTrue);
+      expect(dialed, isFalse);
+    });
+
+    testWidgets('dial button calls onDialPressed', (tester) async {
+      var dialed = false;
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () => dialed = true)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.call));
+      expect(dialed, isTrue);
+    });
+
+    testWidgets('without onDialPressed falls back to the menu button', (tester) async {
+      await tester.pumpWidget(buildTestable(buildTile()));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.call), findsNothing);
+      expect(find.byIcon(Icons.more_vert), findsOneWidget);
+    });
+
+    testWidgets('expanded action buttons fire their callbacks', (tester) async {
+      var video = false;
+      var history = false;
+      await tester.pumpWidget(
+        buildTestable(
+          buildTile(expanded: true, onVideoCallPressed: () => video = true, onCallLogPressed: () => history = true),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Video call'));
+      await tester.tap(find.text('History'));
+      expect(video, isTrue);
+      expect(history, isTrue);
+    });
+
+    testWidgets('More opens the full actions menu', (tester) async {
+      await tester.pumpWidget(buildTestable(buildTile(expanded: true, onAudioCallPressed: () {})));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('More'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Audio call'), findsOneWidget);
+    });
+  });
+}

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -17,6 +17,7 @@ void main() {
   CallTile buildTile({
     VoidCallback? onTap,
     bool expanded = false,
+    bool gesturesEnabled = true,
     VoidCallback? onDialPressed,
     VoidCallback? onAudioCallPressed,
     VoidCallback? onVideoCallPressed,
@@ -32,6 +33,7 @@ void main() {
       callNumbers: const [],
       onTap: onTap,
       expanded: expanded,
+      gesturesEnabled: gesturesEnabled,
       onDialPressed: onDialPressed,
       onAudioCallPressed: onAudioCallPressed,
       onVideoCallPressed: onVideoCallPressed,
@@ -136,6 +138,17 @@ void main() {
       await tester.tap(find.text('History'));
       expect(video, isTrue);
       expect(history, isTrue);
+    });
+
+    testWidgets('disabled gestures hide dial button and actions bar', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(buildTile(expanded: true, gesturesEnabled: false, onDialPressed: () {}, onCallLogPressed: () {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.call), findsNothing);
+      expect(find.byIcon(Icons.more_vert), findsNothing);
+      expect(find.text('History'), findsNothing);
     });
 
     testWidgets('More opens the full actions menu', (tester) async {


### PR DESCRIPTION
## Overview

WT-529

On every tap-to-dial list a tap on a row used to place a call immediately, which made accidental dials easy and hid the rest of the actions behind a long-press. This PR reworks the list item interaction to the pattern used by stock dialer apps:

- Tap on a row expands it in place into a quick-actions bar: Video call / Message / History / Contact / More (each action appears only when available for the entry).
- A dedicated trailing phone icon is what actually dials, so a row tap never places a call by itself.
- More opens the full actions menu (same items as the long-press menu, which is kept).

Covered lists: Recents, CDR history (All and Missed), Favorites, Contacts (local and external tabs).

### Standardization

All list tiles now render through the shared CallTile, so the five lists look and behave identically:

- FavoriteTile and ContactTile are rewritten as thin wrappers over CallTile (their standalone layouts and duplicated popup-menu builders are removed).
- New shared ContactTileAdapter wires both contacts tabs to the call/chat/history actions in one place.
- CallTile gained optional timeLabel, gesturesEnabled, onDialPressed, expanded and the CallTileActionsBar widget; menu popup is guarded against an empty action set.
- Favorites call-from menu items are now functional (the screen previously never supplied the callback, so they were silent no-ops).

### Mode handling

- Blind transfer: a row tap still submits the transfer; expansion and the dial icon are suppressed. On the contacts tabs a tap now submits the transfer to the contact primary number (extension, then mobile, then first), where it previously opened the contact details.
- Favorites reorder mode suppresses tap, long-press, the dial icon and the expansion bar.
- A contact without phone numbers expands with no call actions (message and details only).

### Behavior changes to verify

- Contacts tab: tap no longer opens contact details directly; details are available via the Contact quick action or More > View Contact.
- Recents: the dial icon repeats the call with the original type (video stays video); CDR lists and Favorites dial audio as before.

### Localization

Four new keys (callTileActions_contact / history / message / more) added to en, it and uk; the Video call label reuses the existing one.

### Tests

20 new widget tests for CallTile, FavoriteTile and ContactTile expansion behavior (bar visibility, callback gating, tap vs dial separation, gesture suppression, menu fallback). Full suite green.