### PR TITLE
fix(call): drop the programmatic uppercase on call row badges

### DIFF
--- a/lib/features/call/widgets/call_list.dart
+++ b/lib/features/call/widgets/call_list.dart
@@ -179,10 +179,7 @@ class _CallRowState extends State<CallRow> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        _statusBadge(context).toUpperCase(),
-                        style: statusStyle.copyWith(fontSize: 10, letterSpacing: 1.1),
-                      ),
+                      Text(_statusBadge(context), style: statusStyle.copyWith(fontSize: 10, letterSpacing: 1.1)),
                       Text(
                         widget.call.displayName ?? widget.call.handle.value,
                         style: nameStyle.copyWith(fontSize: 16),

--- a/test/features/call/widgets/call_list_test.dart
+++ b/test/features/call/widgets/call_list_test.dart
@@ -92,9 +92,9 @@ void main() {
       );
       final context = tester.element(find.byType(CallList));
 
-      expect(find.text(context.l10n.callProcessingStatus_ringing.toUpperCase()), findsOneWidget);
-      expect(find.text(context.l10n.call_CallList_statusOnCall.toUpperCase()), findsOneWidget);
-      expect(find.text(context.l10n.call_description_held.toUpperCase()), findsOneWidget);
+      expect(find.text(context.l10n.callProcessingStatus_ringing), findsOneWidget);
+      expect(find.text(context.l10n.call_CallList_statusOnCall), findsOneWidget);
+      expect(find.text(context.l10n.call_description_held), findsOneWidget);
     });
 
     testWidgets('shows the header only when more than one call is present', (tester) async {


### PR DESCRIPTION
## Overview

Follow-up from the patrol audit on `refactor/call`. The row status badge
uppercased its localized text at render time (`.toUpperCase()` on
`call_description_held` etc., introduced with the call list in #1379). That
was a typographic hack: it mangled the translated strings and it is exactly
what broke the patrol transfer assertion (`textContaining('On hold')` cannot
match `ON HOLD`).

## Changes

- `CallRow` renders the badge localization as is - no `.toUpperCase()`.
- The patrol transfer assertion stays in its original form and matches the
  badge again; net patrol diff is zero.
- Widget tests assert the plain badge strings.
- The list header keeps its uppercase for now (same pattern); say the word
  and it goes too.

If the caps look is still wanted visually, it belongs to the text style in
the theme pipeline, not to string mangling.

## Audit summary (unchanged from the original PR)

The rest of `patrol_test/` remains valid against the redesign: single-call
hold/unhold flow, answer taps by `Icons.call`, the duration helper against
ticking row timers, and the removed swap key/tooltips were never referenced.
`flutter analyze` clean over lib, tests and patrol_test; 19 widget/scaffold
tests green.