### PR TITLE
fix(recents): update RecentTile call logic and icons

### DIFF
--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -211,17 +211,17 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
                                         },
                                   onAudioCallPressed: callLogEntry.video
                                       ? () => _callController.createCall(
-                                            destination: callLogEntry.number,
-                                            displayName: contact?.maybeName,
-                                            video: false,
-                                          )
+                                          destination: callLogEntry.number,
+                                          displayName: contact?.maybeName,
+                                          video: false,
+                                        )
                                       : null,
                                   onVideoCallPressed: (!callLogEntry.video && widget.videoEnabled)
                                       ? () => _callController.createCall(
-                                            destination: callLogEntry.number,
-                                            displayName: contact?.maybeName,
-                                            video: true,
-                                          )
+                                          destination: callLogEntry.number,
+                                          displayName: contact?.maybeName,
+                                          video: true,
+                                        )
                                       : null,
                                   onTransferPressed: widget.transferEnabled && hasActiveCall
                                       ? () {

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -209,7 +209,7 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
                                             video: callLogEntry.video && widget.videoEnabled,
                                           );
                                         },
-                                  onAudioCallPressed: callLogEntry.video
+                                  onAudioCallPressed: (callLogEntry.video && widget.videoEnabled)
                                       ? () => _callController.createCall(
                                           destination: callLogEntry.number,
                                           displayName: contact?.maybeName,

--- a/lib/features/recents/view/recents_screen.dart
+++ b/lib/features/recents/view/recents_screen.dart
@@ -193,6 +193,7 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
                                 key: ValueKey(recent),
                                 child: RecentTile(
                                   recent: recent,
+                                  videoEnabled: widget.videoEnabled,
                                   callNumbers: callRoutingState?.allNumbers ?? [],
                                   dateFormat: context.read<RecentsBloc>().dateFormat,
                                   onTap: transfer
@@ -208,17 +209,19 @@ class _RecentsScreenState extends State<RecentsScreen> with SingleTickerProvider
                                             video: callLogEntry.video && widget.videoEnabled,
                                           );
                                         },
-                                  onAudioCallPressed: () => _callController.createCall(
-                                    destination: callLogEntry.number,
-                                    displayName: contact?.maybeName,
-                                    video: false,
-                                  ),
-                                  onVideoCallPressed: widget.videoEnabled
+                                  onAudioCallPressed: callLogEntry.video
                                       ? () => _callController.createCall(
-                                          destination: callLogEntry.number,
-                                          displayName: contact?.maybeName,
-                                          video: true,
-                                        )
+                                            destination: callLogEntry.number,
+                                            displayName: contact?.maybeName,
+                                            video: false,
+                                          )
+                                      : null,
+                                  onVideoCallPressed: (!callLogEntry.video && widget.videoEnabled)
+                                      ? () => _callController.createCall(
+                                            destination: callLogEntry.number,
+                                            displayName: contact?.maybeName,
+                                            video: true,
+                                          )
                                       : null,
                                   onTransferPressed: widget.transferEnabled && hasActiveCall
                                       ? () {

--- a/lib/features/recents/widgets/recent_tile.dart
+++ b/lib/features/recents/widgets/recent_tile.dart
@@ -27,6 +27,7 @@ class RecentTile extends StatelessWidget {
     this.onCallLogPressed,
     this.onDelete,
     this.onCallFrom,
+    this.videoEnabled = true,
   });
 
   final Recent recent;
@@ -44,6 +45,7 @@ class RecentTile extends StatelessWidget {
   final Function()? onCallLogPressed;
   final Function()? onDelete;
   final Function(String)? onCallFrom;
+  final bool videoEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -100,6 +102,7 @@ class RecentTile extends StatelessWidget {
       onTap: onTap,
       expanded: expanded,
       onDialPressed: onDialPressed,
+      dialIcon: (callLogEntry.video && videoEnabled) ? Icons.videocam : Icons.call,
       callNumbers: callNumbers,
       onAudioCallPressed: onAudioCallPressed,
       onVideoCallPressed: onVideoCallPressed,

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -73,6 +73,7 @@ List<PopupMenuEntry<dynamic>> buildNumberActions(
 class CallTileActionsBar extends StatelessWidget {
   const CallTileActionsBar({
     super.key,
+    this.onAudioCallPressed,
     this.onVideoCallPressed,
     this.onChatPressed,
     this.onCallLogPressed,
@@ -80,6 +81,7 @@ class CallTileActionsBar extends StatelessWidget {
     required this.onMorePressed,
   });
 
+  final VoidCallback? onAudioCallPressed;
   final VoidCallback? onVideoCallPressed;
   final VoidCallback? onChatPressed;
   final VoidCallback? onCallLogPressed;
@@ -91,6 +93,14 @@ class CallTileActionsBar extends StatelessWidget {
     final l10n = context.l10n;
     return Row(
       children: [
+        if (onAudioCallPressed != null)
+          Expanded(
+            child: _CallTileAction(
+              icon: Icons.call_outlined,
+              label: l10n.numberActions_audioCall, // wait, is this the right l10n? let's check
+              onTap: onAudioCallPressed!,
+            ),
+          ),
         if (onVideoCallPressed != null)
           Expanded(
             child: _CallTileAction(
@@ -169,6 +179,7 @@ class CallTile extends StatefulWidget {
     this.onTap,
     this.expanded = false,
     this.onDialPressed,
+    this.dialIcon,
     this.gesturesEnabled = true,
     this.dismissible = false,
     this.dismissibleObject,
@@ -199,6 +210,7 @@ class CallTile extends StatefulWidget {
   final VoidCallback? onTap;
   final bool expanded;
   final VoidCallback? onDialPressed;
+  final IconData? dialIcon;
   final bool gesturesEnabled;
 
   final bool dismissible;
@@ -367,7 +379,7 @@ class _CallTileState extends State<CallTile> {
                       if (widget.onDialPressed != null)
                         IconButton(
                           onPressed: widget.onDialPressed,
-                          icon: Icon(Icons.call, color: colorScheme.primary),
+                          icon: Icon(widget.dialIcon ?? Icons.call, color: colorScheme.primary),
                         )
                       else if (hasMenuActions)
                         TileMenuButton(onTap: showMenuPopup),
@@ -381,6 +393,7 @@ class _CallTileState extends State<CallTile> {
                       ? Padding(
                           padding: const EdgeInsets.only(top: 4, right: 8),
                           child: CallTileActionsBar(
+                            onAudioCallPressed: widget.onAudioCallPressed,
                             onVideoCallPressed: widget.onVideoCallPressed,
                             onChatPressed: widget.onChatPressed,
                             onCallLogPressed: widget.onCallLogPressed,

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -97,7 +97,7 @@ class CallTileActionsBar extends StatelessWidget {
           Expanded(
             child: _CallTileAction(
               icon: Icons.call_outlined,
-              label: l10n.numberActions_audioCall, // wait, is this the right l10n? let's check
+              label: l10n.numberActions_audioCall,
               onTap: onAudioCallPressed!,
             ),
           ),

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -178,7 +178,7 @@ void main() {
       await tester.tap(find.text('More'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Audio call'), findsOneWidget);
+      expect(find.text('Audio call'), findsNWidgets(2));
     });
   });
 }

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -20,6 +20,7 @@ void main() {
     bool expanded = false,
     bool gesturesEnabled = true,
     VoidCallback? onDialPressed,
+    IconData? dialIcon,
     VoidCallback? onAudioCallPressed,
     VoidCallback? onVideoCallPressed,
     VoidCallback? onChatPressed,
@@ -37,6 +38,7 @@ void main() {
       expanded: expanded,
       gesturesEnabled: gesturesEnabled,
       onDialPressed: onDialPressed,
+      dialIcon: dialIcon,
       onAudioCallPressed: onAudioCallPressed,
       onVideoCallPressed: onVideoCallPressed,
       onChatPressed: onChatPressed,
@@ -115,6 +117,16 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.tap(find.byIcon(Icons.call));
+      expect(dialed, isTrue);
+    });
+
+    testWidgets('dial button shows custom dialIcon when provided', (tester) async {
+      var dialed = false;
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () => dialed = true, dialIcon: Icons.videocam)));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.call), findsNothing);
+      await tester.tap(find.byIcon(Icons.videocam));
       expect(dialed, isTrue);
     });
 

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -139,17 +139,25 @@ void main() {
     });
 
     testWidgets('expanded action buttons fire their callbacks', (tester) async {
+      var audio = false;
       var video = false;
       var history = false;
       await tester.pumpWidget(
         buildTestable(
-          buildTile(expanded: true, onVideoCallPressed: () => video = true, onCallLogPressed: () => history = true),
+          buildTile(
+            expanded: true,
+            onAudioCallPressed: () => audio = true,
+            onVideoCallPressed: () => video = true,
+            onCallLogPressed: () => history = true,
+          ),
         ),
       );
       await tester.pumpAndSettle();
 
+      await tester.tap(find.text('Audio call'));
       await tester.tap(find.text('Video call'));
       await tester.tap(find.text('History'));
+      expect(audio, isTrue);
       expect(video, isTrue);
       expect(history, isTrue);
     });
@@ -187,10 +195,12 @@ void main() {
       await tester.pumpWidget(buildTestable(buildTile(expanded: true, onAudioCallPressed: () {})));
       await tester.pumpAndSettle();
 
+      expect(find.widgetWithText(CallTileActionsBar, 'Audio call'), findsOneWidget);
+
       await tester.tap(find.text('More'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Audio call'), findsNWidgets(2));
+      expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Audio call'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
### Description
This PR fixes issues with the RecentTile widget where the quick access call icon was static and did not always match the intended call type.

### Changes
- Updated `RecentTile` to dynamically change its dial icon based on the last call type (`Icons.videocam` for video, `Icons.call` for audio).
- Modified `RecentsScreen` to ensure that clicking the quick access button initiates the correct call type (audio or video).
- Adjusted the expanded actions bar to show only the alternative call type, avoiding redundancy with the quick access button.
- Updated `CallTile` and `CallTileActionsBar` to support customizable dial icons and audio call actions.
- Updated `call_tile_test.dart` to reflect the changes in `CallTile`.