### PR TITLE
feat: add Play Core in-app update flow for Android (WT-945)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,6 +21,7 @@ A feature doc should link to those rather than repeat them.
 
 | Feature | Doc | Status |
 |---|---|---|
+| App update / version compatibility | [app-update.md](app-update.md) | Active - force-update (app side) and iOS pending |
 | Call | [call.md](call.md) | Active - UI redesign in progress |
 
 ## Conventions

--- a/docs/features/app-update.md
+++ b/docs/features/app-update.md
@@ -1,0 +1,124 @@
+# App update / version compatibility
+
+How the app detects that it is incompatible with the backend, and how it
+prompts the user to update when a newer build is published: the core-version
+compatibility dialog and the Play Core in-app update flow.
+
+Last reviewed: 2026-06-11
+
+## Where it lives
+
+- `lib/services/app_update_service.dart` - `AppUpdateService`: the Play Core
+  in-app update flow (Android).
+- `lib/app/router/main_shell.dart` - calls `AppUpdateService.check()` on
+  startup and on every foreground resume.
+- `lib/features/main/` - the core-compatibility check and dialog:
+  - `bloc/main_bloc.dart` - `MainBloc`: core-version verification + store lookup.
+  - `bloc/main_state.dart` - `CoreVersionState` (`Unknown` / `Compatible` /
+    `Incompatible` with optional `updateStoreUrl`).
+  - `view/main_screen.dart` - `BlocListener` that shows the dialog.
+  - `widgets/compatibility_issue_dialog.dart` - the dialog itself.
+- `packages/store_info_extractor/` - workspace package that fetches the latest
+  published app version from the platform store (its only consumer is `MainBloc`).
+
+## Soft update prompt (Android) - Play Core in-app updates
+
+When a newer build is published in Google Play, the app surfaces the native
+Play Core update UI - no in-app dialogs and no client-side version comparison
+(Play compares the installed and published version codes itself).
+
+`AppUpdateService.check()` runs on startup and on every foreground resume:
+
+1. An interrupted immediate update (`developerTriggeredUpdateInProgress`) is
+   resumed - Play requires the app to finish it.
+2. A flexible download that finished while the app was away
+   (`InstallStatus.downloaded`) is installed right away, otherwise the user
+   keeps running the old version until a cold restart.
+3. An available update runs as:
+   - **flexible** (background download, install on completion) - the default;
+   - **immediate** (blocking native overlay) - only when the release was
+     published with in-app update priority >= 4 (Google Play Developer API
+     `inAppUpdatePriority`, defaults to 0) or when flexible is not allowed.
+4. A declined flexible update is remembered by version code and not
+   re-prompted until a newer build is published (in-memory, resets on app
+   restart).
+
+The whole flow is a silent no-op on non-Android platforms, on devices without
+Google Play services (some white-label fleets), and on sideloaded/debug builds
+(Play Core fails there and the failure is swallowed).
+
+Note on version semantics: builds get their `versionName`/`versionCode` from
+`--build-name`/`--build-number` at build time (per client); the repo's
+`app_version` field never reaches the binary. Publishing any higher version
+code triggers the prompt.
+
+Verification: the real flow cannot be exercised locally - it requires a build
+installed from Google Play (internal testing track with a lower version code
+on the device).
+
+## Compatibility dialog (core version)
+
+When the backend (core) version falls outside the app's supported constraint,
+a non-dismissible `AlertDialog` appears ("Compatibility issue") with:
+
+- **Update** - shown only when the store has a newer app version than the one
+  installed; opens the store page via `url_launcher` (external browser/store).
+- **Logout** - always shown; logs the user out.
+
+```
+SystemInfoRepository.infoStream (backend system info)
+  -> MainBloc._onSystemInfoArrived
+       core version vs EnvironmentConfig.CORE_VERSION_CONSTRAINT
+         |- supported   -> Compatible (nothing shown)
+         '- unsupported -> StoreInfoExtractor.getStoreInfo(packageName)
+                             |- store version > installed -> Incompatible(updateStoreUrl)
+                             '- else / lookup error       -> Incompatible(no url)
+  -> MainScreen BlocListener -> CompatibilityIssueDialog.show(...)
+       Update -> MainBlocAppUpdatePressed -> launchUrl(storeUrl, externalApplication)
+```
+
+The store lookup runs **only** when the core is already incompatible - it
+answers "can an app update fix this?", not "is there an update".
+
+### store_info_extractor package
+
+`StoreInfoExtractor.getStoreInfo(appPackageName)` picks a client by platform:
+
+| Platform | Client | Method |
+|---|---|---|
+| Android | `GooglePlayStoreClient` | HTTP GET `play.google.com/store/apps/details?id=<pkg>`, regex `[[["x.y.z"]]]` over the HTML |
+| iOS / macOS | `AppleAppStoreClient` | iTunes lookup JSON API (`itunes.apple.com/lookup?bundleId=<pkg>`) |
+| Web | `StubStoreClient` | always `null` |
+
+Known limitations: the Android HTML scraping is fragile and is now redundant
+for the soft-update use case (Play Core covers it); it remains only as the
+Update-button source inside the compatibility dialog. Debug/sideloaded builds
+carry version `0.0.0`, so any store version compares as newer there.
+
+## Redesign / in progress
+
+| Mechanism | Trigger | UX | Status |
+|---|---|---|---|
+| Soft update prompt (above) | newer build published in Google Play | native Play Core prompt, app keeps working | this PR |
+| Core compatibility (above) | core version outside the app's constraint | blocking dialog, Update button when the store is newer | shipped |
+| Backend-driven force update | backend declares `min_supported_app_version` above the app's version | non-dismissible update prompt + signaling socket not connected | backend done, app side TODO |
+| iOS soft update | newer version in the App Store | custom prompt -> App Store (no native API on iOS) | future |
+
+- **Backend-driven force update**: the backend already exposes an optional
+  `min_supported_app_version` (semver) in `GET /api/v1/system-info` (`null` =
+  not enforced). The app side still needs to read the field, compare against
+  its own version, and on failure show a non-dismissible update prompt and
+  skip connecting the signaling socket. Open question for white-label builds:
+  which version to compare - the per-client `versionName` differs from the
+  canonical phone release line.
+- **iOS soft update (future)**: plug into the same `MainShell` seam (a single
+  `check()` on startup/resume); extract an interface from `AppUpdateService`
+  with platform implementations. iOS has no native update UI, so its
+  implementation must surface a custom prompt (service code cannot touch
+  `BuildContext` - emit an event/notification instead) and needs a version
+  source: the kept `AppleAppStoreClient`, or Firebase Remote Config if a
+  priority-like signal is wanted.
+- **Scraper cleanup**: `GooglePlayStoreClient` (and the `updateStoreUrl`
+  branch in `MainBloc` on Android) becomes removable once the force-update
+  flow above defines the compatibility dialog's fate. It also contains a stray
+  debug `print` to drop with it.

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -155,7 +155,9 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   }
 
   @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
+  void didChangeAppLifecycleState(AppLifecycleState state) => _handleAppLifecycleState(state);
+
+  void _handleAppLifecycleState(AppLifecycleState state) {
     _polling?.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
       unawaited(_appUpdateService.check());

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -63,6 +63,10 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// The [PollingService] instance that handles periodic polling of repositories.
   late PollingService? _polling;
 
+  /// Drives the native Play Core update prompt; checked on startup and on
+  /// every foreground resume. No-op outside Android.
+  final AppUpdateService _appUpdateService = AppUpdateService();
+
   /// Lazily initialised on first [build] once [CallBloc], [CallRoutingCubit],
   /// and [NotificationsBloc] are available in the widget tree. The `??=`
   /// assignment guarantees a single instance for the lifetime of this [State],
@@ -114,6 +118,8 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
       performLogout: _onSessionGuardLogout,
       onPreLogout: _onSessionGuardPreLogout,
     );
+
+    unawaited(_appUpdateService.check());
   }
 
   /// Maps an unauthorized [Exception] to a logout reason and triggers logout.
@@ -151,6 +157,9 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     _polling?.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      unawaited(_appUpdateService.check());
+    }
   }
 
   @override

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -63,8 +63,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   /// The [PollingService] instance that handles periodic polling of repositories.
   late PollingService? _polling;
 
-  /// Drives the native Play Core update prompt; checked on startup and on
-  /// every foreground resume. No-op outside Android.
+  /// Drives the native Play Core update prompt; checked once on startup. No-op outside Android.
   final AppUpdateService _appUpdateService = AppUpdateService();
 
   /// Lazily initialised on first [build] once [CallBloc], [CallRoutingCubit],
@@ -155,14 +154,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   }
 
   @override
-  void didChangeAppLifecycleState(AppLifecycleState state) => _handleAppLifecycleState(state);
-
-  void _handleAppLifecycleState(AppLifecycleState state) {
-    _polling?.didChangeAppLifecycleState(state);
-    if (state == AppLifecycleState.resumed) {
-      unawaited(_appUpdateService.check());
-    }
-  }
+  void didChangeAppLifecycleState(AppLifecycleState state) => _polling?.didChangeAppLifecycleState(state);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:in_app_update/in_app_update.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('AppUpdateService');
+
+/// Function handles over the static [InAppUpdate] API, injectable for tests.
+typedef CheckForUpdate = Future<AppUpdateInfo> Function();
+typedef PerformImmediateUpdate = Future<AppUpdateResult> Function();
+typedef StartFlexibleUpdate = Future<AppUpdateResult> Function();
+typedef CompleteFlexibleUpdate = Future<void> Function();
+
+/// Prompts the user to update the app via the Play Core in-app updates API.
+///
+/// Android only: [check] is a silent no-op on other platforms, on devices
+/// without Google Play services, and on builds not installed from Google Play
+/// (the underlying Play Core call fails there and the failure is swallowed).
+///
+/// All update UI is native Play Core - no in-app dialogs. The update type is
+/// driven by the publish-time priority (Google Play Developer API
+/// `inAppUpdatePriority`): below [immediatePriorityThreshold] the update runs
+/// as a flexible (background download, restart on completion) prompt, at or
+/// above it as an immediate (blocking full-screen) flow. The priority defaults
+/// to 0 on publish, so regular releases surface as a soft ask.
+class AppUpdateService {
+  AppUpdateService({
+    this.immediatePriorityThreshold = 4,
+    CheckForUpdate? checkForUpdate,
+    PerformImmediateUpdate? performImmediateUpdate,
+    StartFlexibleUpdate? startFlexibleUpdate,
+    CompleteFlexibleUpdate? completeFlexibleUpdate,
+  }) : _checkForUpdate = checkForUpdate ?? InAppUpdate.checkForUpdate,
+       _performImmediateUpdate = performImmediateUpdate ?? InAppUpdate.performImmediateUpdate,
+       _startFlexibleUpdate = startFlexibleUpdate ?? InAppUpdate.startFlexibleUpdate,
+       _completeFlexibleUpdate = completeFlexibleUpdate ?? InAppUpdate.completeFlexibleUpdate;
+
+  /// Minimum publish-time update priority (0-5) that escalates the update
+  /// from a flexible prompt to the blocking immediate flow.
+  final int immediatePriorityThreshold;
+
+  final CheckForUpdate _checkForUpdate;
+  final PerformImmediateUpdate _performImmediateUpdate;
+  final StartFlexibleUpdate _startFlexibleUpdate;
+  final CompleteFlexibleUpdate _completeFlexibleUpdate;
+
+  bool _checkInProgress = false;
+  int? _declinedVersionCode;
+
+  bool get _isSupportedPlatform => !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+  /// Checks Google Play for an available update and drives the native flow.
+  ///
+  /// Intended to be called on app startup and on every foreground resume;
+  /// overlapping calls are ignored while a check is in flight.
+  Future<void> check() async {
+    if (!_isSupportedPlatform || _checkInProgress) {
+      return;
+    }
+    _checkInProgress = true;
+    try {
+      await _check();
+    } catch (e, stackTrace) {
+      // Expected on devices without Play services and on sideloaded builds.
+      _logger.fine('check failed - ignore', e, stackTrace);
+    } finally {
+      _checkInProgress = false;
+    }
+  }
+
+  Future<void> _check() async {
+    final info = await _checkForUpdate();
+
+    // An immediate update was interrupted (e.g. the app was restarted
+    // mid-flow); Play requires the app to resume it.
+    if (info.updateAvailability == UpdateAvailability.developerTriggeredUpdateInProgress) {
+      await _performImmediateUpdate();
+      return;
+    }
+
+    // A flexible download finished while the app was away - install it now,
+    // otherwise the user keeps running the old version until a cold restart.
+    if (info.installStatus == InstallStatus.downloaded) {
+      await _completeFlexibleUpdate();
+      return;
+    }
+
+    if (info.updateAvailability != UpdateAvailability.updateAvailable) {
+      return;
+    }
+
+    final immediate =
+        info.immediateUpdateAllowed &&
+        (info.updatePriority >= immediatePriorityThreshold || !info.flexibleUpdateAllowed);
+    if (immediate) {
+      await _performImmediateUpdate();
+    } else if (info.flexibleUpdateAllowed) {
+      await _runFlexibleUpdate(info);
+    }
+  }
+
+  Future<void> _runFlexibleUpdate(AppUpdateInfo info) async {
+    // The user already declined this very version - do not nag on every
+    // resume; a newer version code prompts again.
+    if (info.availableVersionCode != null && info.availableVersionCode == _declinedVersionCode) {
+      return;
+    }
+
+    final result = await _startFlexibleUpdate();
+    switch (result) {
+      case AppUpdateResult.success:
+        await _completeFlexibleUpdate();
+      case AppUpdateResult.userDeniedUpdate:
+        _declinedVersionCode = info.availableVersionCode;
+      case AppUpdateResult.inAppUpdateFailed:
+        _logger.warning('flexible update failed for version code ${info.availableVersionCode}');
+    }
+  }
+}

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -1,3 +1,4 @@
+export 'app_update_service.dart';
 export 'connectivity_lifecycle_service.dart';
 export 'connectivity_service.dart';
 export 'diagnostic/diagnostic.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -993,6 +993,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  in_app_update:
+    dependency: "direct main"
+    description:
+      name: in_app_update
+      sha256: "9924a3efe592e1c0ec89dda3683b3cfec3d4cd02d908e6de00c24b759038ddb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   integration_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ dependencies:
   html: ^0.15.6
   http: ^1.6.0
   icon_decoration: ^2.1.0
+  in_app_update: ^4.2.5
   intl: any
   json_annotation: ^4.12.0
   just_audio: ^0.10.5

--- a/test/services/app_update_service_test.dart
+++ b/test/services/app_update_service_test.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:in_app_update/in_app_update.dart';
+
+import 'package:webtrit_phone/services/services.dart';
+
+AppUpdateInfo _info({
+  UpdateAvailability updateAvailability = UpdateAvailability.updateNotAvailable,
+  bool immediateUpdateAllowed = false,
+  bool flexibleUpdateAllowed = false,
+  InstallStatus installStatus = InstallStatus.unknown,
+  int updatePriority = 0,
+  int? availableVersionCode,
+}) {
+  return AppUpdateInfo(
+    updateAvailability: updateAvailability,
+    immediateUpdateAllowed: immediateUpdateAllowed,
+    immediateAllowedPreconditions: null,
+    flexibleUpdateAllowed: flexibleUpdateAllowed,
+    flexibleAllowedPreconditions: null,
+    availableVersionCode: availableVersionCode,
+    installStatus: installStatus,
+    packageName: 'com.webtrit.app',
+    clientVersionStalenessDays: null,
+    updatePriority: updatePriority,
+  );
+}
+
+void main() {
+  late List<String> calls;
+  late AppUpdateInfo info;
+  late AppUpdateResult flexibleResult;
+
+  AppUpdateService buildService() {
+    return AppUpdateService(
+      checkForUpdate: () async {
+        calls.add('check');
+        return info;
+      },
+      performImmediateUpdate: () async {
+        calls.add('immediate');
+        return AppUpdateResult.success;
+      },
+      startFlexibleUpdate: () async {
+        calls.add('startFlexible');
+        return flexibleResult;
+      },
+      completeFlexibleUpdate: () async {
+        calls.add('completeFlexible');
+      },
+    );
+  }
+
+  setUp(() {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    calls = [];
+    info = _info();
+    flexibleResult = AppUpdateResult.success;
+  });
+
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('no-op on non-Android platforms', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    await buildService().check();
+
+    expect(calls, isEmpty);
+  });
+
+  test('no update available results in check only', () async {
+    await buildService().check();
+
+    expect(calls, ['check']);
+  });
+
+  test('default priority runs the flexible flow and installs on success', () async {
+    info = _info(
+      updateAvailability: UpdateAvailability.updateAvailable,
+      immediateUpdateAllowed: true,
+      flexibleUpdateAllowed: true,
+      availableVersionCode: 42,
+    );
+
+    await buildService().check();
+
+    expect(calls, ['check', 'startFlexible', 'completeFlexible']);
+  });
+
+  test('priority at the threshold escalates to the immediate flow', () async {
+    info = _info(
+      updateAvailability: UpdateAvailability.updateAvailable,
+      immediateUpdateAllowed: true,
+      flexibleUpdateAllowed: true,
+      updatePriority: 4,
+    );
+
+    await buildService().check();
+
+    expect(calls, ['check', 'immediate']);
+  });
+
+  test('immediate is used when flexible is not allowed regardless of priority', () async {
+    info = _info(
+      updateAvailability: UpdateAvailability.updateAvailable,
+      immediateUpdateAllowed: true,
+      flexibleUpdateAllowed: false,
+    );
+
+    await buildService().check();
+
+    expect(calls, ['check', 'immediate']);
+  });
+
+  test('declined flexible update is not re-prompted until a newer version code', () async {
+    final service = buildService();
+    info = _info(
+      updateAvailability: UpdateAvailability.updateAvailable,
+      flexibleUpdateAllowed: true,
+      availableVersionCode: 42,
+    );
+    flexibleResult = AppUpdateResult.userDeniedUpdate;
+
+    await service.check();
+    await service.check();
+
+    expect(calls, ['check', 'startFlexible', 'check']);
+
+    info = _info(
+      updateAvailability: UpdateAvailability.updateAvailable,
+      flexibleUpdateAllowed: true,
+      availableVersionCode: 43,
+    );
+
+    await service.check();
+
+    expect(calls.last, 'startFlexible');
+  });
+
+  test('download completed while away triggers install without a new prompt', () async {
+    info = _info(installStatus: InstallStatus.downloaded);
+
+    await buildService().check();
+
+    expect(calls, ['check', 'completeFlexible']);
+  });
+
+  test('interrupted immediate update is resumed', () async {
+    info = _info(updateAvailability: UpdateAvailability.developerTriggeredUpdateInProgress);
+
+    await buildService().check();
+
+    expect(calls, ['check', 'immediate']);
+  });
+
+  test('platform errors are swallowed and the next check still runs', () async {
+    var shouldThrow = true;
+    final service = AppUpdateService(
+      checkForUpdate: () async {
+        calls.add('check');
+        if (shouldThrow) throw PlatformException(code: 'API_NOT_AVAILABLE');
+        return info;
+      },
+      performImmediateUpdate: () async => AppUpdateResult.success,
+      startFlexibleUpdate: () async => flexibleResult,
+      completeFlexibleUpdate: () async {},
+    );
+
+    await service.check();
+
+    shouldThrow = false;
+    await service.check();
+
+    expect(calls, ['check', 'check']);
+  });
+
+  test('overlapping checks are ignored while one is in flight', () async {
+    final gate = Completer<AppUpdateInfo>();
+    final service = AppUpdateService(
+      checkForUpdate: () {
+        calls.add('check');
+        return gate.future;
+      },
+      performImmediateUpdate: () async => AppUpdateResult.success,
+      startFlexibleUpdate: () async => flexibleResult,
+      completeFlexibleUpdate: () async {},
+    );
+
+    final first = service.check();
+    final second = service.check();
+    gate.complete(_info());
+    await Future.wait([first, second]);
+
+    expect(calls, ['check']);
+  });
+}

--- a/test/services/app_update_service_test.dart
+++ b/test/services/app_update_service_test.dart
@@ -143,6 +143,22 @@ void main() {
     expect(calls.last, 'startFlexible');
   });
 
+  test('failed flexible update neither installs nor suppresses future prompts', () async {
+    final service = buildService();
+    info = _info(
+      updateAvailability: UpdateAvailability.updateAvailable,
+      flexibleUpdateAllowed: true,
+      availableVersionCode: 42,
+    );
+    flexibleResult = AppUpdateResult.inAppUpdateFailed;
+
+    await service.check();
+    await service.check();
+
+    expect(calls, ['check', 'startFlexible', 'check', 'startFlexible']);
+    expect(calls, isNot(contains('completeFlexible')));
+  });
+
   test('download completed while away triggers install without a new prompt', () async {
     info = _info(installStatus: InstallStatus.downloaded);
 


### PR DESCRIPTION
## Overview

Adds a native Play Core in-app update prompt on Android (WT-945). The app checks Google Play for a newer published build on startup and on every foreground resume and drives the native update UI - no in-app dialogs and no client-side version comparison (Play compares version codes itself).

The update type follows the publish-time priority (Google Play Developer API `inAppUpdatePriority`, defaults to 0):

- priority below 4 - flexible flow: background download, install on completion;
- priority 4-5 (or flexible not allowed) - immediate flow: blocking native overlay.

## Details

- `AppUpdateService` (`lib/services/`):
  - resumes an interrupted immediate update (`developerTriggeredUpdateInProgress`);
  - installs a flexible download that finished while the app was away (`InstallStatus.downloaded`);
  - remembers a declined version code and does not re-prompt until a newer build is published;
  - silent no-op on non-Android platforms, devices without Google Play services, and sideloaded builds (Play Core errors are swallowed);
  - guards against overlapping checks; the static `InAppUpdate` API is injectable for tests.
- Wired in `MainShell`: check on `initState` and on `AppLifecycleState.resumed`.
- 10 unit tests covering all branches of the flow.
- The existing core-compatibility dialog and `store_info_extractor` are intentionally untouched.

## Testing

- `flutter analyze` clean, full suite 854/0.
- The real Play flow cannot be exercised locally (Play Core requires a build installed from Google Play); verification is via an internal testing track with a lower version code installed.