### PR TITLE
style: remove inaccurate comment from voicemail audio cache file guard

### DIFF
--- a/lib/features/settings/features/voicemail/widgets/audio_view.dart
+++ b/lib/features/settings/features/voicemail/widgets/audio_view.dart
@@ -164,6 +164,7 @@ class _AudioViewState extends State<AudioView> with WidgetsBindingObserver {
   }
 
   File? _getCacheFile() {
+    // On iOS, fall back to just_audio's internal hash-based cache; custom path not validated on this platform.
     if (widget.path.isLocalPath || Platform.isIOS) return null;
 
     final rawKey = widget.cacheKey ?? _uri.pathSegments.where((s) => s.isNotEmpty).join('_');

--- a/lib/features/settings/features/voicemail/widgets/audio_view.dart
+++ b/lib/features/settings/features/voicemail/widgets/audio_view.dart
@@ -164,6 +164,7 @@ class _AudioViewState extends State<AudioView> with WidgetsBindingObserver {
   }
 
   File? _getCacheFile() {
+    // Local paths are served via AudioSource.uri directly -- no caching needed.
     // On iOS, fall back to just_audio's internal hash-based cache; custom path not validated on this platform.
     if (widget.path.isLocalPath || Platform.isIOS) return null;
 

--- a/lib/features/settings/features/voicemail/widgets/audio_view.dart
+++ b/lib/features/settings/features/voicemail/widgets/audio_view.dart
@@ -164,9 +164,6 @@ class _AudioViewState extends State<AudioView> with WidgetsBindingObserver {
   }
 
   File? _getCacheFile() {
-    // Do not provide a custom cacheFile on iOS:
-    // just_audio internally handles caching on iOS, and supplying a custom file
-    // may lead to PlayerException (-11828) if the file is not yet created or invalid.
     if (widget.path.isLocalPath || Platform.isIOS) return null;
 
     final rawKey = widget.cacheKey ?? _uri.pathSegments.where((s) => s.isNotEmpty).join('_');


### PR DESCRIPTION
## Overview

Removes a 3-line comment in `_getCacheFile()` (`audio_view.dart`) that incorrectly
described why the iOS guard (`Platform.isIOS -> return null`) exists.

The comment claimed just_audio handles caching differently on iOS and that supplying a
custom `cacheFile` may cause `PlayerException(-11828)` if the file does not exist.
Source analysis of just_audio 0.10.5 shows this is wrong: `LockCachingAudioSource`
uses a local HTTP proxy on all platforms; the native iOS layer (`AVURLAsset`) receives
only the proxy URI and never sees the `cacheFile` path at all. The guard itself is
correct and stays -- it simply uses just_audio's internal hash-based cache path on iOS
instead of our custom `media_cache/` directory.

Verified: iOS voicemail playback works correctly with the guard in place (cache hit
after full playthrough, correct audio content per voicemail).

Related: WT-697