### PR TITLE
fix: enforce exclusive voicemail playback via shared AudioPlayer (WT-1363)

### DIFF
--- a/lib/features/settings/features/voicemail/bloc/bloc.dart
+++ b/lib/features/settings/features/voicemail/bloc/bloc.dart
@@ -1,1 +1,2 @@
 export 'voicemail_cubit.dart';
+export 'voicemail_playback_controller.dart';

--- a/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
+++ b/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
@@ -24,6 +24,7 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
   String? _activeId;
   bool _isLoading = false;
   Object? _error;
+  Timer? _loadingDebounce;
 
   String? get activeId => _activeId;
   bool get isLoading => _isLoading;
@@ -51,8 +52,15 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
     }
 
     _activeId = id;
-    _isLoading = true;
     _error = null;
+    // Show the player UI immediately (optimistic); only show loading spinner
+    // if setAudioSource takes longer than the debounce threshold (e.g. slow network).
+    // This prevents a blink on cached audio where loading is near-instant.
+    _loadingDebounce?.cancel();
+    _loadingDebounce = Timer(const Duration(milliseconds: 200), () {
+      _isLoading = true;
+      notifyListeners();
+    });
     notifyListeners();
 
     try {
@@ -65,11 +73,17 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
         isLocal: isLocal,
       );
       await _player.setAudioSource(source);
-      _isLoading = false;
-      notifyListeners();
+      _loadingDebounce?.cancel();
+      _loadingDebounce = null;
+      if (_isLoading) {
+        _isLoading = false;
+        notifyListeners();
+      }
       await _player.play();
     } catch (e, s) {
       _logger.warning('Playback error for $uri', e, s);
+      _loadingDebounce?.cancel();
+      _loadingDebounce = null;
       _isLoading = false;
       _error = e;
       notifyListeners();
@@ -128,6 +142,7 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _loadingDebounce?.cancel();
     _playerStateSub?.cancel();
     _player.stopAndDispose();
     super.dispose();

--- a/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
+++ b/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 
 final _logger = Logger('VoicemailPlaybackController');
 
@@ -24,7 +25,7 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
   String? _activeId;
   bool _isLoading = false;
   Object? _error;
-  Timer? _loadingDebounce;
+  final _loadingDebounce = Debounce(const Duration(milliseconds: 200));
 
   String? get activeId => _activeId;
   bool get isLoading => _isLoading;
@@ -56,8 +57,7 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
     // Show the player UI immediately (optimistic); only show loading spinner
     // if setAudioSource takes longer than the debounce threshold (e.g. slow network).
     // This prevents a blink on cached audio where loading is near-instant.
-    _loadingDebounce?.cancel();
-    _loadingDebounce = Timer(const Duration(milliseconds: 200), () {
+    _loadingDebounce.schedule(() {
       _isLoading = true;
       notifyListeners();
     });
@@ -73,8 +73,7 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
         isLocal: isLocal,
       );
       await _player.setAudioSource(source);
-      _loadingDebounce?.cancel();
-      _loadingDebounce = null;
+      _loadingDebounce.cancel();
       if (_isLoading) {
         _isLoading = false;
         notifyListeners();
@@ -82,8 +81,7 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
       await _player.play();
     } catch (e, s) {
       _logger.warning('Playback error for $uri', e, s);
-      _loadingDebounce?.cancel();
-      _loadingDebounce = null;
+      _loadingDebounce.cancel();
       _isLoading = false;
       _error = e;
       notifyListeners();
@@ -142,7 +140,7 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _loadingDebounce?.cancel();
+    _loadingDebounce.dispose();
     _playerStateSub?.cancel();
     _player.stopAndDispose();
     super.dispose();

--- a/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
+++ b/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+
+import 'package:audio_session/audio_session.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:webtrit_phone/extensions/extensions.dart';
+
+final _logger = Logger('VoicemailPlaybackController');
+
+class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObserver {
+  VoicemailPlaybackController() {
+    WidgetsBinding.instance.addObserver(this);
+    _playerStateSub = _player.playerStateStream.listen(_onPlayerStateChanged);
+  }
+
+  final AudioPlayer _player = AudioPlayer();
+  StreamSubscription<PlayerState>? _playerStateSub;
+
+  String? _activeId;
+  bool _isLoading = false;
+  Object? _error;
+
+  String? get activeId => _activeId;
+  bool get isLoading => _isLoading;
+  Object? get error => _error;
+  AudioPlayer get player => _player;
+
+  bool get isPlaying => _player.playing;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) _player.stop();
+  }
+
+  Future<void> play({
+    required String id,
+    required Uri uri,
+    Map<String, String>? headers,
+    String? cacheBasePath,
+    String? cacheKey,
+    bool isLocal = false,
+  }) async {
+    if (_activeId == id) {
+      if (!_player.playing && !_isLoading) await _player.play();
+      return;
+    }
+
+    _activeId = id;
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      await _setupAudioSession();
+      final source = await _buildSource(
+        uri: uri,
+        headers: headers,
+        cacheBasePath: cacheBasePath,
+        cacheKey: cacheKey,
+        isLocal: isLocal,
+      );
+      await _player.setAudioSource(source);
+      _isLoading = false;
+      notifyListeners();
+      await _player.play();
+    } catch (e, s) {
+      _logger.warning('Playback error for $uri', e, s);
+      _isLoading = false;
+      _error = e;
+      notifyListeners();
+    }
+  }
+
+  Future<void> pause() => _player.pause();
+
+  Future<void> resume() => _player.play();
+
+  void seek(Duration position) => _player.seek(position);
+
+  Future<void> _setupAudioSession() async {
+    final session = await AudioSession.instance;
+    await session.configure(const AudioSessionConfiguration.speech());
+  }
+
+  Future<AudioSource> _buildSource({
+    required Uri uri,
+    required Map<String, String>? headers,
+    required String? cacheBasePath,
+    required String? cacheKey,
+    required bool isLocal,
+  }) async {
+    if (isLocal) return AudioSource.uri(uri);
+
+    // No stable caching alternative exists in just_audio (0.10.5).
+    // LockCachingAudioSource is the only built-in caching API and has been actively maintained since 2020.
+    // ignore: experimental_member_use
+    if (Platform.isIOS) return LockCachingAudioSource(uri, headers: headers);
+
+    if (cacheBasePath != null) {
+      await Directory(cacheBasePath).create(recursive: true);
+    }
+    final cacheFile = _resolveCacheFile(cacheBasePath: cacheBasePath, uri: uri, cacheKey: cacheKey);
+    // ignore: experimental_member_use
+    return LockCachingAudioSource(uri, headers: headers, cacheFile: cacheFile);
+  }
+
+  File? _resolveCacheFile({required String? cacheBasePath, required Uri uri, required String? cacheKey}) {
+    if (cacheBasePath == null) return null;
+    final rawKey = cacheKey ?? uri.pathSegments.where((s) => s.isNotEmpty).join('_');
+    if (rawKey.isEmpty) return null;
+    // Prevent path traversal from server-provided cacheKey values.
+    final key = rawKey.replaceAll(RegExp(r'[/\\]'), '_');
+    return File(path.join(cacheBasePath, key));
+  }
+
+  void _onPlayerStateChanged(PlayerState state) {
+    if (state.processingState == ProcessingState.completed) {
+      _player.stop();
+      _player.seek(Duration.zero);
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _playerStateSub?.cancel();
+    _player.stopAndDispose();
+    super.dispose();
+  }
+}

--- a/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
+++ b/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
@@ -14,18 +14,27 @@ import 'package:webtrit_phone/utils/utils.dart';
 final _logger = Logger('VoicemailPlaybackController');
 
 class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObserver {
-  VoicemailPlaybackController() {
+  VoicemailPlaybackController({AudioPlayer? player, Future<void> Function()? setupAudioSession})
+    : _player = player ?? AudioPlayer(),
+      _setupAudioSession = setupAudioSession ?? _defaultSetupAudioSession {
     WidgetsBinding.instance.addObserver(this);
     _playerStateSub = _player.playerStateStream.listen(_onPlayerStateChanged);
   }
 
-  final AudioPlayer _player = AudioPlayer();
+  static Future<void> _defaultSetupAudioSession() async {
+    final session = await AudioSession.instance;
+    await session.configure(const AudioSessionConfiguration.speech());
+  }
+
+  final AudioPlayer _player;
+  final Future<void> Function() _setupAudioSession;
   StreamSubscription<PlayerState>? _playerStateSub;
 
   String? _activeId;
   bool _isLoading = false;
   Object? _error;
   final _loadingDebounce = Debounce(const Duration(milliseconds: 200));
+  int _generation = 0;
 
   String? get activeId => _activeId;
   bool get isLoading => _isLoading;
@@ -47,10 +56,13 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
     String? cacheKey,
     bool isLocal = false,
   }) async {
-    if (_activeId == id) {
+    // Resume same track -- but fall through if previous attempt left an error.
+    if (_activeId == id && _error == null) {
       if (!_player.playing && !_isLoading) await _player.play();
       return;
     }
+
+    final generation = ++_generation;
 
     _activeId = id;
     _error = null;
@@ -58,13 +70,17 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
     // if setAudioSource takes longer than the debounce threshold (e.g. slow network).
     // This prevents a blink on cached audio where loading is near-instant.
     _loadingDebounce.schedule(() {
-      _isLoading = true;
-      notifyListeners();
+      if (_generation == generation) {
+        _isLoading = true;
+        notifyListeners();
+      }
     });
     notifyListeners();
 
     try {
       await _setupAudioSession();
+      if (_generation != generation) return;
+
       final source = await _buildSource(
         uri: uri,
         headers: headers,
@@ -72,7 +88,11 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
         cacheKey: cacheKey,
         isLocal: isLocal,
       );
+      if (_generation != generation) return;
+
       await _player.setAudioSource(source);
+      if (_generation != generation) return;
+
       _loadingDebounce.cancel();
       if (_isLoading) {
         _isLoading = false;
@@ -80,10 +100,12 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
       }
       await _player.play();
     } catch (e, s) {
+      if (_generation != generation) return;
       _logger.warning('Playback error for $uri', e, s);
       _loadingDebounce.cancel();
       _isLoading = false;
       _error = e;
+      _player.stop();
       notifyListeners();
     }
   }
@@ -93,11 +115,6 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
   Future<void> resume() => _player.play();
 
   void seek(Duration position) => _player.seek(position);
-
-  Future<void> _setupAudioSession() async {
-    final session = await AudioSession.instance;
-    await session.configure(const AudioSessionConfiguration.speech());
-  }
 
   Future<AudioSource> _buildSource({
     required Uri uri,
@@ -116,17 +133,21 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
     if (cacheBasePath != null) {
       await Directory(cacheBasePath).create(recursive: true);
     }
-    final cacheFile = _resolveCacheFile(cacheBasePath: cacheBasePath, uri: uri, cacheKey: cacheKey);
+    final cacheFile = resolveCacheFile(cacheBasePath: cacheBasePath, uri: uri, cacheKey: cacheKey);
     // ignore: experimental_member_use
     return LockCachingAudioSource(uri, headers: headers, cacheFile: cacheFile);
   }
 
-  File? _resolveCacheFile({required String? cacheBasePath, required Uri uri, required String? cacheKey}) {
+  @visibleForTesting
+  File? resolveCacheFile({required String? cacheBasePath, required Uri uri, required String? cacheKey}) {
     if (cacheBasePath == null) return null;
     final rawKey = cacheKey ?? uri.pathSegments.where((s) => s.isNotEmpty).join('_');
     if (rawKey.isEmpty) return null;
-    // Prevent path traversal from server-provided cacheKey values.
+    // Prevent path traversal from server-provided cacheKey values: strip path
+    // separators, and reject the special directory names `.`/`..` which would
+    // otherwise escape cacheBasePath via path.join even without a separator.
     final key = rawKey.replaceAll(RegExp(r'[/\\]'), '_');
+    if (key == '.' || key == '..') return null;
     return File(path.join(cacheBasePath, key));
   }
 

--- a/lib/features/settings/features/voicemail/view/voicemail_screen_page.dart
+++ b/lib/features/settings/features/voicemail/view/voicemail_screen_page.dart
@@ -9,7 +9,7 @@ import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
-import '../bloc/voicemail_cubit.dart';
+import '../bloc/bloc.dart';
 import '../models/models.dart';
 import '../utils/utils.dart';
 
@@ -36,13 +36,19 @@ class VoicemailScreenPage extends StatelessWidget {
       mediaHeaders: mediaHeaders,
     );
 
-    return BlocProvider(
-      create: (context) => VoicemailCubit(
-        repository: context.read<VoicemailRepository>(),
-        onCallStarted: (number) => callBloc.add(CallControlEvent.started(number: number, video: false)),
-        onSubmitNotification: (n) => notificationsBloc.add(NotificationsSubmitted(n)),
-      ),
-      child: Provider<VoicemailScreenContext>(create: (context) => screenContext, child: const VoicemailScreen()),
+    return MultiProvider(
+      providers: [
+        BlocProvider(
+          create: (context) => VoicemailCubit(
+            repository: context.read<VoicemailRepository>(),
+            onCallStarted: (number) => callBloc.add(CallControlEvent.started(number: number, video: false)),
+            onSubmitNotification: (n) => notificationsBloc.add(NotificationsSubmitted(n)),
+          ),
+        ),
+        Provider<VoicemailScreenContext>(create: (_) => screenContext),
+        ChangeNotifierProvider(create: (_) => VoicemailPlaybackController()),
+      ],
+      child: const VoicemailScreen(),
     );
   }
 }

--- a/lib/features/settings/features/voicemail/widgets/audio_view.dart
+++ b/lib/features/settings/features/voicemail/widgets/audio_view.dart
@@ -90,7 +90,9 @@ class _InactiveAudioView extends StatelessWidget {
         ),
         const SizedBox(width: 16),
         Expanded(
-          child: AudioSlider(position: Duration.zero, duration: Duration.zero, onSeek: (_) {}),
+          child: IgnorePointer(
+            child: AudioSlider(position: Duration.zero, duration: Duration.zero, onSeek: (_) {}),
+          ),
         ),
       ],
     );

--- a/lib/features/settings/features/voicemail/widgets/audio_view.dart
+++ b/lib/features/settings/features/voicemail/widgets/audio_view.dart
@@ -1,207 +1,99 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-import 'package:audio_session/audio_session.dart';
-import 'package:just_audio/just_audio.dart';
-import 'package:logging/logging.dart';
-import 'package:path/path.dart' as path;
 import 'package:provider/provider.dart';
 
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 
+import '../bloc/bloc.dart';
 import '../models/models.dart';
 import 'audio_player_interface.dart';
+import 'audio_slider.dart';
 
-final _logger = Logger('AudioView');
-
-class AudioView extends StatefulWidget {
+class AudioView extends StatelessWidget {
   const AudioView({required this.path, super.key, this.cacheKey, this.onPlaybackStarted});
 
   final String path;
   final String? cacheKey;
   final VoidCallback? onPlaybackStarted;
 
-  @override
-  State<AudioView> createState() => _AudioViewState();
-}
-
-class _AudioViewState extends State<AudioView> with WidgetsBindingObserver {
-  final _player = AudioPlayer();
-
-  StreamSubscription<PlaybackEvent>? _playbackSub;
-  StreamSubscription<PlayerState>? _playerStateSub;
-
-  late final String _cachePath;
-  late final Map<String, String>? _headers;
-  late final Uri _uri;
-
-  bool _isLoading = true;
-  Object? _error;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-
-    final voicemailContext = context.read<VoicemailScreenContext>();
-    _cachePath = voicemailContext.mediaCacheBasePath;
-    _headers = voicemailContext.mediaHeaders;
-    _uri = Uri.parse(widget.path);
-
-    _initialize();
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    _cancelSubscriptions();
-    _player.stopAndDispose();
-    super.dispose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.paused) {
-      _player.stop();
-    }
-  }
-
-  Future<void> _initialize() async {
-    try {
-      _setLoadingState();
-
-      // Cancel previous subscriptions if retrying
-      _cancelSubscriptions();
-
-      await _setupAudioSession();
-      if (!mounted) return;
-
-      if (!widget.path.isLocalPath && !Platform.isIOS) {
-        await Directory(_cachePath).create(recursive: true);
-      }
-
-      await _player.setAudioSource(_createAudioSource());
-      if (!mounted) return;
-
-      _playbackSub = _player.playbackEventStream.listen(_onPlaybackEvent, onError: _handleError);
-
-      _playerStateSub = _player.playerStateStream.listen(_onPlayerStateChanged);
-
-      _setSuccessState();
-    } catch (e, s) {
-      _handleError(e, s);
-    }
-  }
-
-  void _cancelSubscriptions() {
-    _playbackSub?.cancel();
-    _playerStateSub?.cancel();
-    _playbackSub = null;
-    _playerStateSub = null;
-  }
-
-  void _setLoadingState() {
-    if (mounted) {
-      setState(() {
-        _isLoading = true;
-        _error = null;
-      });
-    }
-  }
-
-  void _setSuccessState() {
-    if (mounted) {
-      setState(() => _isLoading = false);
-    }
-  }
-
-  void _handleError(Object e, [StackTrace? stackTrace]) {
-    _logger.warning('Playback error for $_uri', e, stackTrace);
-
-    if (!mounted) return;
-
-    _player.stop();
-    _cancelSubscriptions();
-
-    setState(() {
-      _error = e;
-      _isLoading = false;
-    });
-  }
-
-  void _onPlaybackEvent(PlaybackEvent event) {
-    if (mounted) setState(() {});
-  }
-
-  void _onPlayerStateChanged(PlayerState state) {
-    if (state.processingState == ProcessingState.completed) {
-      _resetPlayer();
-    }
-  }
-
-  void _resetPlayer() {
-    _player.stop();
-    _player.seek(Duration.zero);
-  }
-
-  Future<void> _setupAudioSession() async {
-    final session = await AudioSession.instance;
-    await session.configure(const AudioSessionConfiguration.speech());
-  }
-
-  AudioSource _createAudioSource() {
-    if (widget.path.isLocalPath) {
-      return AudioSource.uri(_uri);
-    }
-
-    // No stable caching alternative exists in just_audio (0.10.5).
-    // LockCachingAudioSource is the only built-in caching API and has been actively maintained since 2020.
-    // ignore: experimental_member_use
-    return LockCachingAudioSource(_uri, headers: _headers, cacheFile: _getCacheFile());
-  }
-
-  File? _getCacheFile() {
-    // Local paths are served via AudioSource.uri directly -- no caching needed.
-    // On iOS, fall back to just_audio's internal hash-based cache; custom path not validated on this platform.
-    if (widget.path.isLocalPath || Platform.isIOS) return null;
-
-    final rawKey = widget.cacheKey ?? _uri.pathSegments.where((s) => s.isNotEmpty).join('_');
-    if (rawKey.isEmpty) return null;
-
-    // Prevent path traversal from server-provided cacheKey values.
-    final key = rawKey.replaceAll(RegExp(r'[/\\]'), '_');
-    return File(path.join(_cachePath, key));
-  }
-
-  Future<void> _handleTogglePlayback() async {
-    try {
-      if (_player.playing) {
-        await _player.pause();
-      } else {
-        widget.onPlaybackStarted?.call();
-        await _player.play();
-      }
-    } catch (e) {
-      _handleError(e);
-    }
-  }
-
-  void _handleSeek(Duration position) => _player.seek(position);
+  String get _id => cacheKey ?? path;
 
   @override
   Widget build(BuildContext context) {
-    if (_error != null) {
-      return _AudioErrorView(onRetry: () => unawaited(_initialize()));
-    }
+    final controller = context.watch<VoicemailPlaybackController>();
+    final isActive = controller.activeId == _id;
 
-    if (_isLoading) {
+    if (isActive && controller.isLoading) {
       return const _AudioLoadingView();
     }
+    if (isActive && controller.error != null) {
+      return _AudioErrorView(onRetry: () => _startPlayback(context));
+    }
+    if (isActive) {
+      return AudioPlayerInterface(
+        player: controller.player,
+        onToggle: () => _handleToggle(context, controller),
+        onSeek: controller.seek,
+      );
+    }
 
-    return AudioPlayerInterface(player: _player, onToggle: _handleTogglePlayback, onSeek: _handleSeek);
+    return _InactiveAudioView(onPlay: () => _startPlayback(context));
+  }
+
+  void _startPlayback(BuildContext context) {
+    final controller = context.read<VoicemailPlaybackController>();
+    final vmContext = context.read<VoicemailScreenContext>();
+    onPlaybackStarted?.call();
+    unawaited(
+      controller.play(
+        id: _id,
+        uri: Uri.parse(path),
+        headers: vmContext.mediaHeaders,
+        cacheBasePath: vmContext.mediaCacheBasePath,
+        cacheKey: cacheKey,
+        isLocal: path.isLocalPath,
+      ),
+    );
+  }
+
+  void _handleToggle(BuildContext context, VoicemailPlaybackController controller) {
+    if (controller.isPlaying) {
+      unawaited(controller.pause());
+    } else {
+      onPlaybackStarted?.call();
+      unawaited(controller.resume());
+    }
+  }
+}
+
+class _InactiveAudioView extends StatelessWidget {
+  const _InactiveAudioView({required this.onPlay});
+
+  final VoidCallback onPlay;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      children: [
+        GestureDetector(
+          onTap: onPlay,
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(shape: BoxShape.circle, color: colorScheme.primary),
+            child: Icon(Icons.play_arrow, color: colorScheme.onPrimary, size: 24),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: AudioSlider(position: Duration.zero, duration: Duration.zero, onSeek: (_) {}),
+        ),
+      ],
+    );
   }
 }
 
@@ -211,7 +103,6 @@ class _AudioLoadingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-
     return SizedBox(
       height: 40,
       child: Center(child: LinearProgressIndicator(color: colorScheme.primaryContainer)),

--- a/test/features/settings/features/voicemail/bloc/voicemail_playback_controller_test.dart
+++ b/test/features/settings/features/voicemail/bloc/voicemail_playback_controller_test.dart
@@ -1,0 +1,366 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart';
+
+class _MockAudioPlayer extends Mock implements AudioPlayer {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(AudioSource.uri(Uri.parse('file:///fallback')));
+    registerFallbackValue(Duration.zero);
+  });
+
+  late _MockAudioPlayer player;
+  late StreamController<PlayerState> playerStateController;
+  late VoicemailPlaybackController controller;
+
+  setUp(() {
+    player = _MockAudioPlayer();
+    playerStateController = StreamController<PlayerState>.broadcast(sync: true);
+
+    when(() => player.playerStateStream).thenAnswer((_) => playerStateController.stream);
+    when(() => player.playing).thenReturn(false);
+    when(() => player.stop()).thenAnswer((_) async {});
+    when(() => player.dispose()).thenAnswer((_) async {});
+    when(() => player.seek(any())).thenAnswer((_) async {});
+
+    controller = VoicemailPlaybackController(player: player, setupAudioSession: () async {});
+  });
+
+  tearDown(() async {
+    controller.dispose();
+    await playerStateController.close();
+  });
+
+  final uri = Uri.parse('file:///test/audio.mp3');
+
+  VoicemailPlaybackController build() => VoicemailPlaybackController(player: player, setupAudioSession: () async {});
+
+  group('VoicemailPlaybackController', () {
+    group('initial state', () {
+      test('activeId is null, isLoading is false, error is null', () {
+        expect(controller.activeId, isNull);
+        expect(controller.isLoading, isFalse);
+        expect(controller.error, isNull);
+      });
+    });
+
+    group('play() -- new track', () {
+      test('sets activeId immediately before any await', () {
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+
+        unawaited(controller.play(id: 'track1', uri: uri, isLocal: true));
+
+        expect(controller.activeId, 'track1');
+      });
+
+      test('does not set isLoading immediately (optimistic UI)', () {
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+
+        unawaited(controller.play(id: 'track1', uri: uri, isLocal: true));
+
+        expect(controller.isLoading, isFalse);
+      });
+
+      test('sets isLoading after debounce threshold when source is slow', () {
+        fakeAsync((async) {
+          final completer = Completer<Duration?>();
+          when(() => player.setAudioSource(any())).thenAnswer((_) => completer.future);
+          when(() => player.play()).thenAnswer((_) async {});
+
+          unawaited(controller.play(id: 'track1', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          expect(controller.isLoading, isFalse);
+          async.elapse(const Duration(milliseconds: 200));
+          expect(controller.isLoading, isTrue);
+
+          completer.complete(null);
+        });
+      });
+
+      test('never sets isLoading when source resolves before debounce threshold', () {
+        fakeAsync((async) {
+          when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+          when(() => player.play()).thenAnswer((_) async {});
+
+          unawaited(controller.play(id: 'track1', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          async.elapse(const Duration(milliseconds: 300));
+
+          expect(controller.isLoading, isFalse);
+        });
+      });
+
+      test('calls setAudioSource and play on the player', () async {
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+
+        verify(() => player.setAudioSource(any())).called(1);
+        verify(() => player.play()).called(1);
+      });
+
+      test('notifies listeners when activeId changes', () {
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+
+        var notified = false;
+        controller.addListener(() => notified = true);
+        unawaited(controller.play(id: 'track1', uri: uri, isLocal: true));
+
+        expect(notified, isTrue);
+      });
+
+      test('clears previous error when switching to a new track', () async {
+        when(() => player.setAudioSource(any())).thenThrow(Exception('load error'));
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+        expect(controller.error, isNotNull);
+
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+        unawaited(controller.play(id: 'track2', uri: uri, isLocal: true));
+
+        expect(controller.error, isNull);
+      });
+    });
+
+    group('play() -- same id', () {
+      test('resumes player when same id is tapped while player is stopped', () async {
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+        verify(() => player.play()).called(1);
+
+        when(() => player.playing).thenReturn(false);
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+
+        verify(() => player.play()).called(1); // one more resume call
+        verify(() => player.setAudioSource(any())).called(1); // loaded only once
+      });
+
+      test('does nothing when same id is tapped while already playing', () async {
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+        clearInteractions(player);
+
+        when(() => player.playing).thenReturn(true);
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+
+        verifyNever(() => player.setAudioSource(any()));
+        verifyNever(() => player.play());
+      });
+
+      test('retries setAudioSource when same id is tapped after an error', () async {
+        when(() => player.setAudioSource(any())).thenThrow(Exception('load error'));
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+        expect(controller.error, isNotNull);
+
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+
+        expect(controller.error, isNull);
+        verify(() => player.setAudioSource(any())).called(2);
+      });
+    });
+
+    group('race condition guard', () {
+      test('stale async chain does not update state after a newer play() starts', () {
+        fakeAsync((async) {
+          final completerA = Completer<Duration?>();
+          var callCount = 0;
+          when(() => player.setAudioSource(any())).thenAnswer((_) {
+            callCount++;
+            return callCount == 1 ? completerA.future : Future.value(null);
+          });
+          when(() => player.play()).thenAnswer((_) async {});
+
+          // Start track A -- its setAudioSource hangs
+          unawaited(controller.play(id: 'trackA', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          // Start track B before A completes
+          unawaited(controller.play(id: 'trackB', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          expect(controller.activeId, 'trackB');
+
+          // Now A's setAudioSource completes -- state must remain on B
+          completerA.complete(null);
+          async.flushMicrotasks();
+
+          expect(controller.activeId, 'trackB');
+          expect(controller.error, isNull);
+        });
+      });
+
+      test('debounce loading timer does not fire for stale generation', () {
+        fakeAsync((async) {
+          final completerA = Completer<Duration?>();
+          var callCount = 0;
+          when(() => player.setAudioSource(any())).thenAnswer((_) {
+            callCount++;
+            return callCount == 1 ? completerA.future : Future.value(null);
+          });
+          when(() => player.play()).thenAnswer((_) async {});
+
+          unawaited(controller.play(id: 'trackA', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          // Switch to B before the 200ms debounce fires
+          unawaited(controller.play(id: 'trackB', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          // Advance past debounce -- A's timer was cancelled, B's fires but
+          // B's source already resolved (callCount==2 returns immediately)
+          async.elapse(const Duration(milliseconds: 300));
+
+          expect(controller.isLoading, isFalse);
+
+          completerA.complete(null);
+        });
+      });
+    });
+
+    group('error handling', () {
+      test('sets error and clears isLoading when setAudioSource throws', () async {
+        final exception = Exception('load error');
+        when(() => player.setAudioSource(any())).thenThrow(exception);
+
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+
+        expect(controller.error, exception);
+        expect(controller.isLoading, isFalse);
+        expect(controller.activeId, 'track1');
+      });
+
+      test('stops player on setAudioSource error', () async {
+        when(() => player.setAudioSource(any())).thenThrow(Exception('load error'));
+
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+
+        verify(() => player.stop()).called(1);
+      });
+    });
+
+    group('pause / resume / seek', () {
+      test('pause() delegates to player.pause()', () async {
+        when(() => player.pause()).thenAnswer((_) async {});
+        await controller.pause();
+        verify(() => player.pause()).called(1);
+      });
+
+      test('resume() delegates to player.play()', () async {
+        when(() => player.play()).thenAnswer((_) async {});
+        await controller.resume();
+        verify(() => player.play()).called(1);
+      });
+
+      test('seek() delegates to player.seek()', () {
+        controller.seek(const Duration(seconds: 10));
+        verify(() => player.seek(const Duration(seconds: 10))).called(1);
+      });
+    });
+
+    group('app lifecycle', () {
+      test('stops player when app is paused', () {
+        controller.didChangeAppLifecycleState(AppLifecycleState.paused);
+        verify(() => player.stop()).called(1);
+      });
+
+      test('does not stop player on other lifecycle states', () {
+        controller.didChangeAppLifecycleState(AppLifecycleState.resumed);
+        controller.didChangeAppLifecycleState(AppLifecycleState.inactive);
+        verifyNever(() => player.stop());
+      });
+    });
+
+    group('playback completion', () {
+      test('resets player to start when track finishes', () async {
+        playerStateController.add(PlayerState(false, ProcessingState.completed));
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => player.stop()).called(1);
+        verify(() => player.seek(Duration.zero)).called(1);
+      });
+    });
+
+    group('dispose', () {
+      test('pending loading debounce does not fire after dispose', () {
+        fakeAsync((async) {
+          final c = build();
+          final completer = Completer<Duration?>();
+          when(() => player.setAudioSource(any())).thenAnswer((_) => completer.future);
+
+          unawaited(c.play(id: 'track1', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          c.dispose();
+
+          async.elapse(const Duration(milliseconds: 300));
+          expect(c.isLoading, isFalse);
+
+          completer.complete(null);
+        });
+      });
+
+      test('disposes and stops player on dispose', () async {
+        final c = build();
+        c.dispose();
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => player.stop()).called(1);
+        verify(() => player.dispose()).called(1);
+      });
+    });
+
+    group('resolveCacheFile -- path traversal', () {
+      const base = '/var/cache/voicemail';
+      final remote = Uri.parse('https://example.com/vm/audio.mp3');
+
+      test('returns null when cacheBasePath is null', () {
+        expect(controller.resolveCacheFile(cacheBasePath: null, uri: remote, cacheKey: 'k'), isNull);
+      });
+
+      test('keeps a plain cacheKey under cacheBasePath', () {
+        final file = controller.resolveCacheFile(cacheBasePath: base, uri: remote, cacheKey: 'vm-42');
+        expect(file!.path, '$base/vm-42');
+      });
+
+      test('strips path separators from cacheKey', () {
+        final file = controller.resolveCacheFile(cacheBasePath: base, uri: remote, cacheKey: '../../etc/passwd');
+        expect(file!.path, '$base/.._.._etc_passwd');
+      });
+
+      test('rejects a cacheKey of ".." (would escape via path.join)', () {
+        expect(controller.resolveCacheFile(cacheBasePath: base, uri: remote, cacheKey: '..'), isNull);
+      });
+
+      test('rejects a cacheKey of "."', () {
+        expect(controller.resolveCacheFile(cacheBasePath: base, uri: remote, cacheKey: '.'), isNull);
+      });
+
+      test('falls back to sanitized uri path segments when cacheKey is null', () {
+        final file = controller.resolveCacheFile(cacheBasePath: base, uri: remote, cacheKey: null);
+        expect(file!.path, '$base/vm_audio.mp3');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Multiple voicemails could play simultaneously because each `AudioView` tile
owned its own `AudioPlayer` instance with no cross-tile coordination.

Introduces `VoicemailPlaybackController` -- a `ChangeNotifier` that holds a
single `AudioPlayer` for the entire voicemail screen. Switching to a new
track stops the previous one automatically since only one player exists.

## Changes

- **`VoicemailPlaybackController`** (new) -- `ChangeNotifier` + `WidgetsBindingObserver`
  that owns one `AudioPlayer`. Handles audio session setup,
  `LockCachingAudioSource` construction, playback-completed reset, and
  app-lifecycle pause. Provided via `ChangeNotifierProvider` in
  `VoicemailScreenPage`.
- **`AudioView`** -- refactored from `StatefulWidget` to `StatelessWidget`.
  Reads the controller from context. The active tile (matching `activeId`)
  renders `AudioPlayerInterface` against the shared player; all other tiles
  render a static `_InactiveAudioView` play button. Loading and error states
  are also driven by the controller.
- **`VoicemailScreenContext`** -- unchanged; remains a plain config bag.

## Test plan

- [ ] Open Voicemail screen with multiple messages
- [ ] Tap Play on first message -- it plays
- [ ] Without stopping, tap Play on second message -- first stops, second plays
- [ ] Tap pause on active message -- pauses correctly
- [ ] Tap play again -- resumes from paused position
- [ ] Let a message play to end -- player resets to beginning
- [ ] Background the app while playing -- playback stops
- [ ] Return to foreground -- play button shown correctly
- [ ] Retry after a load error works

WT-1363