### PR TITLE
feat: notify the caller when an outgoing call fails for an unrecognized reason(WT-1419)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1181,6 +1181,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       case SignalingResponseCode.invalidNumberFormat:
         submitNotification(CallInvalidNumberNotification());
       default:
+        submitNotification(CallUnableToCompleteNotification());
         _logger.severe('onCallSignalingEventHangup: $code');
         CrashlyticsUtils.recordError(
           'CallBloc - onCallSignalingEventHangup ${code.name}}',

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1184,7 +1184,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         submitNotification(CallUnableToCompleteNotification());
         _logger.severe('onCallSignalingEventHangup: $code');
         CrashlyticsUtils.recordError(
-          'CallBloc - onCallSignalingEventHangup ${code.name}}',
+          'CallBloc - onCallSignalingEventHangup ${code.name}',
           information: [
             'callId: ${event.callId}',
             'reason: ${event.reason}',

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -240,6 +240,15 @@ final class CallInvalidNumberNotification extends MessageNotification {
   }
 }
 
+/// Generic neutral fallback shown when an outgoing call fails for a reason we
+/// do not surface with a specific message.
+final class CallUnableToCompleteNotification extends MessageNotification {
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.signalingResponseCode_unableToComplete;
+  }
+}
+
 @Deprecated.instantiate('will be removed, (see [app/notifications/models/notification.dart] for details)')
 final class SipRegistrationFailedNotification extends ErrorNotification {
   SipRegistrationFailedNotification({required this.knownCode, this.systemCode, this.systemReason});

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -4497,7 +4497,7 @@ abstract class AppLocalizations {
   /// Shown when a dialed phone number is not in a valid format. Typical cause: non-numeric input, missing country code, or format not supported by SIP/PBX.
   ///
   /// In en, this message translates to:
-  /// **'The number you entered is invalid.'**
+  /// **'Invalid number format'**
   String get signalingResponseCode_invalidNumberFormat;
 
   /// Shown when the signaling request points to an invalid or unsupported path/endpoint in the server.
@@ -4569,7 +4569,7 @@ abstract class AppLocalizations {
   /// Shown when the call request is rejected by an intermediary (e.g. proxy, SBC, or policy server) before reaching the recipient. SIP 603 Decline or similar.
   ///
   /// In en, this message translates to:
-  /// **'The call was rejected by a machine or process on the way, without reaching the destination... '**
+  /// **'Call rejected'**
   String get signalingResponseCode_rejected;
 
   /// Shown when a signaling request was terminated prematurely. SIP 487 Request Terminated, often due to caller cancelling before answer.
@@ -4701,13 +4701,13 @@ abstract class AppLocalizations {
   /// Shown when the callee is busy (SIP 486 Busy Here).
   ///
   /// In en, this message translates to:
-  /// **'The user you\'re trying to reach is busy. Please try again later.'**
+  /// **'User busy'**
   String get signalingResponseCode_userBusy;
 
   /// Shown when the dialed user is not registered or does not exist in the PBX. SIP 404 Not Found.
   ///
   /// In en, this message translates to:
-  /// **'The user you\'re trying to reach doesn\'t exist.'**
+  /// **'User does not exist'**
   String get signalingResponseCode_userNotExist;
 
   /// Generic neutral fallback shown when an outgoing call fails for an unrecognized reason.

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -4710,6 +4710,12 @@ abstract class AppLocalizations {
   /// **'The user you\'re trying to reach doesn\'t exist.'**
   String get signalingResponseCode_userNotExist;
 
+  /// Generic neutral fallback shown when an outgoing call fails for an unrecognized reason.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to complete the call.'**
+  String get signalingResponseCode_unableToComplete;
+
   /// Shown when a WebRTC operation is attempted in an invalid state (e.g. sending media before offer/answer exchange).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -1240,6 +1240,8 @@ extension AppLocalizationsExtension on AppLocalizations {
       'signalingResponseCode_userBusy' => signalingResponseCode_userBusy,
       'signalingResponseCode_userNotExist' =>
         signalingResponseCode_userNotExist,
+      'signalingResponseCode_unableToComplete' =>
+        signalingResponseCode_unableToComplete,
       'signalingResponseCode_wrongWebrtcState' =>
         signalingResponseCode_wrongWebrtcState,
       'socketError_connectionRefused' => socketError_connectionRefused,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -2427,7 +2427,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Some of the information provided was not valid. Please double-check and try again.';
 
   @override
-  String get signalingResponseCode_invalidNumberFormat => 'The number you entered is invalid.';
+  String get signalingResponseCode_invalidNumberFormat => 'Invalid number format';
 
   @override
   String get signalingResponseCode_invalidPath =>
@@ -2468,8 +2468,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signalingResponseCode_pluginNotFound => 'A required component is missing. Please try restarting the app.';
 
   @override
-  String get signalingResponseCode_rejected =>
-      'The call was rejected by a machine or process on the way, without reaching the destination... ';
+  String get signalingResponseCode_rejected => 'Call rejected';
 
   @override
   String get signalingResponseCode_requestTerminated => 'Your request was terminated. Please try again.';
@@ -2543,10 +2542,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signalingResponseCode_unwanted => 'The recipient marked the call as unwanted.';
 
   @override
-  String get signalingResponseCode_userBusy => 'The user you\'re trying to reach is busy. Please try again later.';
+  String get signalingResponseCode_userBusy => 'User busy';
 
   @override
-  String get signalingResponseCode_userNotExist => 'The user you\'re trying to reach doesn\'t exist.';
+  String get signalingResponseCode_userNotExist => 'User does not exist';
 
   @override
   String get signalingResponseCode_unableToComplete => 'Unable to complete the call.';

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -2549,6 +2549,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signalingResponseCode_userNotExist => 'The user you\'re trying to reach doesn\'t exist.';
 
   @override
+  String get signalingResponseCode_unableToComplete => 'Unable to complete the call.';
+
+  @override
   String get signalingResponseCode_wrongWebrtcState => 'A call-related error occurred. Please hang up and try again.';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -2453,8 +2453,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Alcune delle informazioni fornite non sono valide. Verifica e riprova.';
 
   @override
-  String get signalingResponseCode_invalidNumberFormat =>
-      'Il numero di telefono inserito non è valido. Deve essere inserito nel formato: ';
+  String get signalingResponseCode_invalidNumberFormat => 'Formato del numero non valido';
 
   @override
   String get signalingResponseCode_invalidPath => 'L\'azione richiesta non è disponibile. Prova un\'opzione diversa.';
@@ -2493,7 +2492,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get signalingResponseCode_pluginNotFound => 'Manca un componente necessario. Prova a riavviare l\'app.';
 
   @override
-  String get signalingResponseCode_rejected => 'La tua richiesta è stata rifiutata. Riprova.';
+  String get signalingResponseCode_rejected => 'Chiamata rifiutata';
 
   @override
   String get signalingResponseCode_requestTerminated => 'La tua richiesta è stata terminata. Riprova.';
@@ -2571,11 +2570,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get signalingResponseCode_unwanted => 'La tua richiesta non è gradita. Riprova.';
 
   @override
-  String get signalingResponseCode_userBusy => 'Il destinatario è occupato. Riprova più tardi.';
+  String get signalingResponseCode_userBusy => 'Utente occupato';
 
   @override
-  String get signalingResponseCode_userNotExist =>
-      'Il destinatario non esiste. Controlla il numero di telefono e riprova.';
+  String get signalingResponseCode_userNotExist => 'L\'utente non esiste';
 
   @override
   String get signalingResponseCode_unableToComplete => 'Impossibile completare la chiamata.';

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -2578,6 +2578,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il destinatario non esiste. Controlla il numero di telefono e riprova.';
 
   @override
+  String get signalingResponseCode_unableToComplete => 'Impossibile completare la chiamata.';
+
+  @override
   String get signalingResponseCode_wrongWebrtcState =>
       'Si è verificato un errore relativo alla chiamata. Riaggancia e riprova.';
 

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -2495,7 +2495,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Не знайдено необхідного компонента. Спробуйте перезапустити застосунок.';
 
   @override
-  String get signalingResponseCode_rejected => 'Ваш запит було відхилено. Будь ласка, спробуйте ще раз.';
+  String get signalingResponseCode_rejected => 'Виклик відхилено';
 
   @override
   String get signalingResponseCode_requestTerminated => 'Ваш запит було відхилено. Будь ласка, спробуйте ще раз.';
@@ -2571,11 +2571,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get signalingResponseCode_unwanted => 'Ваш запит не може бути виконаний. Будь ласка, спробуйте ще раз.';
 
   @override
-  String get signalingResponseCode_userBusy =>
-      'Користувач, якого ви намагаєтеся знайти, зайнятий. Будь ласка, спробуйте пізніше.';
+  String get signalingResponseCode_userBusy => 'Користувач зайнятий';
 
   @override
-  String get signalingResponseCode_userNotExist => 'Користувача, якого ви намагаєтеся знайти, не існує.';
+  String get signalingResponseCode_userNotExist => 'Користувача не існує';
 
   @override
   String get signalingResponseCode_unableToComplete => 'Не вдалося здійснити виклик.';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -2578,6 +2578,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get signalingResponseCode_userNotExist => 'Користувача, якого ви намагаєтеся знайти, не існує.';
 
   @override
+  String get signalingResponseCode_unableToComplete => 'Не вдалося здійснити виклик.';
+
+  @override
   String get signalingResponseCode_wrongWebrtcState =>
       'Сталася помилка, пов’язана з викликом. Завершіть виклик і спробуйте ще раз.';
 

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1971,7 +1971,7 @@
   "@signalingResponseCode_invalidJsonObject": {
     "description": "Shown when a JSON object in the request is syntactically valid but contains invalid fields or values (e.g. wrong types or missing mandatory keys)."
   },
-  "signalingResponseCode_invalidNumberFormat": "The number you entered is invalid.",
+  "signalingResponseCode_invalidNumberFormat": "Invalid number format",
   "@signalingResponseCode_invalidNumberFormat": {
     "description": "Shown when a dialed phone number is not in a valid format. Typical cause: non-numeric input, missing country code, or format not supported by SIP/PBX."
   },
@@ -2019,7 +2019,7 @@
   "@signalingResponseCode_pluginNotFound": {
     "description": "Shown when the requested Janus plugin is not found or unavailable. Cause: wrong plugin name, not loaded on server, or removed."
   },
-  "signalingResponseCode_rejected": "The call was rejected by a machine or process on the way, without reaching the destination... ",
+  "signalingResponseCode_rejected": "Call rejected",
   "@signalingResponseCode_rejected": {
     "description": "Shown when the call request is rejected by an intermediary (e.g. proxy, SBC, or policy server) before reaching the recipient. SIP 603 Decline or similar."
   },
@@ -2107,11 +2107,11 @@
   "@signalingResponseCode_unwanted": {
     "description": "Shown when the call is flagged as unwanted by the recipient or network. SIP 607 Unwanted."
   },
-  "signalingResponseCode_userBusy": "The user you're trying to reach is busy. Please try again later.",
+  "signalingResponseCode_userBusy": "User busy",
   "@signalingResponseCode_userBusy": {
     "description": "Shown when the callee is busy (SIP 486 Busy Here)."
   },
-  "signalingResponseCode_userNotExist": "The user you're trying to reach doesn't exist.",
+  "signalingResponseCode_userNotExist": "User does not exist",
   "@signalingResponseCode_userNotExist": {
     "description": "Shown when the dialed user is not registered or does not exist in the PBX. SIP 404 Not Found."
   },

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2115,6 +2115,10 @@
   "@signalingResponseCode_userNotExist": {
     "description": "Shown when the dialed user is not registered or does not exist in the PBX. SIP 404 Not Found."
   },
+  "signalingResponseCode_unableToComplete": "Unable to complete the call.",
+  "@signalingResponseCode_unableToComplete": {
+    "description": "Generic neutral fallback shown when an outgoing call fails for an unrecognized reason."
+  },
   "signalingResponseCode_wrongWebrtcState": "A call-related error occurred. Please hang up and try again.",
   "@signalingResponseCode_wrongWebrtcState": {
     "description": "Shown when a WebRTC operation is attempted in an invalid state (e.g. sending media before offer/answer exchange)."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1968,7 +1968,7 @@
   "@signalingResponseCode_invalidJsonObject": {
     "description": "Shown when a JSON object in the request is syntactically valid but contains invalid fields or values (e.g. wrong types or missing mandatory keys)."
   },
-  "signalingResponseCode_invalidNumberFormat": "Il numero di telefono inserito non è valido. Deve essere inserito nel formato: ",
+  "signalingResponseCode_invalidNumberFormat": "Formato del numero non valido",
   "@signalingResponseCode_invalidNumberFormat": {
     "description": "Shown when a dialed phone number is not in a valid format. Typical cause: non-numeric input, missing country code, or format not supported by SIP/PBX."
   },
@@ -2016,7 +2016,7 @@
   "@signalingResponseCode_pluginNotFound": {
     "description": "Shown when the requested Janus plugin is not found or unavailable. Cause: wrong plugin name, not loaded on server, or removed."
   },
-  "signalingResponseCode_rejected": "La tua richiesta è stata rifiutata. Riprova.",
+  "signalingResponseCode_rejected": "Chiamata rifiutata",
   "@signalingResponseCode_rejected": {
     "description": "Shown when the call request is rejected by an intermediary (e.g. proxy, SBC, or policy server) before reaching the recipient. SIP 603 Decline or similar."
   },
@@ -2104,11 +2104,11 @@
   "@signalingResponseCode_unwanted": {
     "description": "Shown when the call is flagged as unwanted by the recipient or network. SIP 607 Unwanted."
   },
-  "signalingResponseCode_userBusy": "Il destinatario è occupato. Riprova più tardi.",
+  "signalingResponseCode_userBusy": "Utente occupato",
   "@signalingResponseCode_userBusy": {
     "description": "Shown when the callee is busy (SIP 486 Busy Here)."
   },
-  "signalingResponseCode_userNotExist": "Il destinatario non esiste. Controlla il numero di telefono e riprova.",
+  "signalingResponseCode_userNotExist": "L'utente non esiste",
   "@signalingResponseCode_userNotExist": {
     "description": "Shown when the dialed user is not registered or does not exist in the PBX. SIP 404 Not Found."
   },

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -2112,6 +2112,10 @@
   "@signalingResponseCode_userNotExist": {
     "description": "Shown when the dialed user is not registered or does not exist in the PBX. SIP 404 Not Found."
   },
+  "signalingResponseCode_unableToComplete": "Impossibile completare la chiamata.",
+  "@signalingResponseCode_unableToComplete": {
+    "description": "Generic neutral fallback shown when an outgoing call fails for an unrecognized reason."
+  },
   "signalingResponseCode_wrongWebrtcState": "Si è verificato un errore relativo alla chiamata. Riaggancia e riprova.",
   "@signalingResponseCode_wrongWebrtcState": {
     "description": "Shown when a WebRTC operation is attempted in an invalid state (e.g. sending media before offer/answer exchange)."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -2112,6 +2112,10 @@
   "@signalingResponseCode_userNotExist": {
     "description": "Shown when the dialed user is not registered or does not exist in the PBX. SIP 404 Not Found."
   },
+  "signalingResponseCode_unableToComplete": "Не вдалося здійснити виклик.",
+  "@signalingResponseCode_unableToComplete": {
+    "description": "Generic neutral fallback shown when an outgoing call fails for an unrecognized reason."
+  },
   "signalingResponseCode_wrongWebrtcState": "Сталася помилка, пов’язана з викликом. Завершіть виклик і спробуйте ще раз.",
   "@signalingResponseCode_wrongWebrtcState": {
     "description": "Shown when a WebRTC operation is attempted in an invalid state (e.g. sending media before offer/answer exchange)."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -2016,7 +2016,7 @@
   "@signalingResponseCode_pluginNotFound": {
     "description": "Shown when the requested Janus plugin is not found or unavailable. Cause: wrong plugin name, not loaded on server, or removed."
   },
-  "signalingResponseCode_rejected": "Ваш запит було відхилено. Будь ласка, спробуйте ще раз.",
+  "signalingResponseCode_rejected": "Виклик відхилено",
   "@signalingResponseCode_rejected": {
     "description": "Shown when the call request is rejected by an intermediary (e.g. proxy, SBC, or policy server) before reaching the recipient. SIP 603 Decline or similar."
   },
@@ -2104,11 +2104,11 @@
   "@signalingResponseCode_unwanted": {
     "description": "Shown when the call is flagged as unwanted by the recipient or network. SIP 607 Unwanted."
   },
-  "signalingResponseCode_userBusy": "Користувач, якого ви намагаєтеся знайти, зайнятий. Будь ласка, спробуйте пізніше.",
+  "signalingResponseCode_userBusy": "Користувач зайнятий",
   "@signalingResponseCode_userBusy": {
     "description": "Shown when the callee is busy (SIP 486 Busy Here)."
   },
-  "signalingResponseCode_userNotExist": "Користувача, якого ви намагаєтеся знайти, не існує.",
+  "signalingResponseCode_userNotExist": "Користувача не існує",
   "@signalingResponseCode_userNotExist": {
     "description": "Shown when the dialed user is not registered or does not exist in the PBX. SIP 404 Not Found."
   },


### PR DESCRIPTION
## Overview

WT-1419. Today an outgoing call that fails for a known SIP reason already shows a
neutral notification (rejected / busy / not found / invalid number / unwanted), but
every other failure was silent -- the `default` branch of the hangup handler only
logged and recorded to Crashlytics.

This adds the ticket's catch-all row: a generic neutral "Unable to complete the call"
notification for any unrecognized failure code.

## Changes

- New `CallUnableToCompleteNotification` extending `MessageNotification`, so it renders
  neutral (not red), consistent with the other call-failure notifications.
- New l10n key `signalingResponseCode_unableToComplete` in en / it / uk, plus regenerated
  localizations and the l10n key mapper.
- `call_bloc.dart` `__onCallSignalingEventHangup` default branch now submits the new
  notification, keeping the existing Crashlytics record.

## Notes

- Intentionally-silent cases stay silent: `byCode` returns `null` for unknown and
  normal-termination codes (incl. synthetic `0` Janus-detach and normal BYE), which hit
  the silent `null` case, so the catch-all only fires on genuine failure codes.
- Backend context: Core forwards the SIP `code`/`reason` verbatim from Janus with no
  remapping, so the numeric code is the only reliable signal -- the client keys off it and
  renders its own per-code text. An ambiguous 403 cannot be disambiguated client-side
  (tracked separately as WT-1364).

## Verification plan

1. Call a user who declines -> notification appears
2. Call a busy user -> notification appears
3. Call a non-existent number -> notification appears
4. Call a malformed number -> notification appears
5. Trigger another failure code (e.g. no route) -> generic "Unable to complete the call"
6. All notifications are neutral (not red)