### PR TITLE
docs: explain background signaling reconnect block in CallBloc (WT-1078)

### DIFF
--- a/docs/signaling_architecture_target.md
+++ b/docs/signaling_architecture_target.md
@@ -305,6 +305,25 @@ _signalingSubscription = _signalingModule.events.listen((event) {
 });
 ```
 
+#### Background call-active edge (`onChange`)
+
+`CallBloc.onChange` re-notifies the controller whenever `CallState.isActive` flips.
+This covers a gap the app-lifecycle handler cannot: `_onAppLifecycleStateChanged`
+samples `isActive` only at the instant the app moves between foreground and
+background, so it never re-fires for a call that becomes active (an incoming call
+answered from a push) or ends while the app is *already* backgrounded.
+
+The block acts only while the app is `paused` / `detached` / `inactive`:
+
+| Transition (while backgrounded)  | Call into controller             | Why |
+|----------------------------------|----------------------------------|-----|
+| call became active, socket down  | `notifyForceReconnect()`         | reconnect now so signaling can carry the call, instead of waiting for the next lifecycle/network event |
+| active-call presence changed     | `notifyHasActiveCalls(...)`      | refresh the active-call guard so a background reconnect can fire during the call; disconnect if the call just ended |
+| last call ended                  | `notifyAppPaused(hasActiveCalls: false)` | move to the paused-no-calls state so the controller stops holding the connection open |
+
+The reconnect/notification policy itself stays in `SignalingReconnectController`;
+`onChange` only feeds it lifecycle edges.
+
 ### IsolateManager (background isolates)
 
 **`PushNotificationIsolateManager`** — never reconnects. Opened once per incoming push

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -301,7 +301,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   void onChange(Change<CallState> change) {
     super.onChange(change);
 
-    // TODO: add detailed explanation of the following code and why it is necessary to initialize signaling client in background
+    // Re-notify the reconnect controller when the call-active state flips while
+    // the app is backgrounded - covers the gap the lifecycle handler misses
+    // (it only samples isActive at the instant the app foregrounds/backgrounds).
+    // See docs/signaling_architecture_target.md, section
+    // "CallBloc (main isolate)" > "Background call-active edge (onChange)".
     if (change.currentState.isActive != change.nextState.isActive) {
       final appLifecycleState = change.nextState.currentAppLifecycleState;
       final appInactive =


### PR DESCRIPTION
## Overview

Doc-only change resolving WT-1078: the placeholder `TODO` in `CallBloc.onChange` is replaced with a short pointer comment, and the full explanation now lives in `docs/signaling_architecture_target.md` under a new subsection **"Background call-active edge (onChange)"** (within "CallBloc (main isolate)").

The documented block re-notifies `SignalingReconnectController` whenever `CallState.isActive` flips **while the app is already backgrounded** - a gap `_onAppLifecycleStateChanged` cannot cover, because it samples `isActive` only at the instant the app moves between foreground and background. When a call becomes active (incoming call answered from a push) or ends while the app is paused, the lifecycle handler never re-fires; this block bridges that via the `isActive` edge.

## Changes

- `docs/signaling_architecture_target.md`: new subsection with a table explaining each `notify*` call (`notifyForceReconnect`, `notifyHasActiveCalls`, `notifyAppPaused`) and why the block exists.
- `lib/features/call/bloc/call_bloc.dart`: TODO replaced by a 5-line pointer comment linking to that doc section.

No behaviour change - documentation only.

## Notes

- The block runs in the foreground (Activity) isolate via `CallBloc`, not the push background isolate; the doc and comment describe lifecycle/reconnect rationale, not push-isolate bootstrapping.
- The reconnect/notification policy itself remains owned by `SignalingReconnectController` (documented in the same file); this block only feeds it lifecycle edges.
