### PR TITLE
docs: explain call finalization on signaling loss in CallBloc (WT-1077)

### DIFF
--- a/docs/signaling_architecture_target.md
+++ b/docs/signaling_architecture_target.md
@@ -324,6 +324,28 @@ The block acts only while the app is `paused` / `detached` / `inactive`:
 The reconnect/notification policy itself stays in `SignalingReconnectController`;
 `onChange` only feeds it lifecycle edges.
 
+#### Call finalization on signaling loss (`onError`)
+
+`CallBloc.onError` is the BLoC catch-all for uncaught exceptions thrown inside event
+handlers (nothing in the call feature calls `addError`). It only logs. It deliberately
+does **not** finalize the active call, even though a stale placeholder once suggested it
+should: `onError` carries no call context (only `error` + `stackTrace`), so it cannot tell
+which `ActiveCall` an exception belongs to, and a live call must survive a transient
+signaling/network drop rather than be torn down on the first error.
+
+Finalization of a call whose signaling drops is instead handled by four narrower paths that
+do have call context:
+
+| Path | Where | Behaviour |
+|------|-------|-----------|
+| Survive-and-recover | `__onSignalingClientEventConnected` (`safeRenegotiate`), `_onConnectivityResultChanged` / `__onMutationIceConnectionFailed` (`restartIce`), the silent disconnect codes | keep the call in `activeCalls` across the outage and recover it on reconnect instead of finalizing it |
+| Remote hangup | `__onCallSignalingEventHangup` -> `__onMutationSignalingHangup` -> `callkeep.reportEndCall` | when signaling reconnects and the server tore the leg down, its hangup ends the call authoritatively |
+| `requestCallIdError` cleanup | `__onSignalingClientEventDisconnected` | for calls already marked `wasHungUp`, completes them once the disconnect confirms the call id is gone |
+| Visible ICE issue | `__onPeerConnectionEventIceConnectionStateChanged` | a persistent ICE failure surfaces `iceConnectionIssue` on the call so the user can end it manually instead of it sitting as an invisible phantom |
+
+So `onError` stays a pure logger by design; the "finalize the affected call" responsibility
+lives in the disconnect / hangup / ICE paths above, not in the catch-all.
+
 ### IsolateManager (background isolates)
 
 **`PushNotificationIsolateManager`** — never reconnects. Opened once per incoming push

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -294,7 +294,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   void onError(Object error, StackTrace stackTrace) {
     super.onError(error, stackTrace);
     _logger.warning('onError', error, stackTrace);
-    // TODO: analise error and finalize necessary active call
+    // onError stays a pure logger by design: it has no call context (only error +
+    // stackTrace) and a live call must survive a transient signaling drop. Finalizing
+    // a call whose signaling is lost is handled by the disconnect/hangup/ICE paths.
+    // See docs/signaling_architecture_target.md, section
+    // "CallBloc (main isolate)" > "Call finalization on signaling loss (onError)".
   }
 
   @override


### PR DESCRIPTION
## Overview

Doc-only change resolving WT-1077: the placeholder `TODO` in `CallBloc.onError` is replaced with a short pointer comment, and the full explanation now lives in `docs/signaling_architecture_target.md` under a new subsection **"Call finalization on signaling loss (onError)"** (within "CallBloc (main isolate)").

`onError` is the BLoC catch-all for uncaught exceptions thrown inside event handlers (nothing in the call feature calls `addError`). It only logs and stays a pure logger **by design**: it has no call context (only `error` + `stackTrace`), so it cannot tell which `ActiveCall` an exception belongs to, and a live call must survive a transient signaling/network drop rather than be torn down on the first error.

Finalizing a call whose signaling drops is instead handled by four narrower paths that do have call context: survive-and-recover (`safeRenegotiate` / `restartIce` / silent disconnect codes), the authoritative remote-hangup path, the `requestCallIdError` cleanup for `wasHungUp` calls, and the visible `iceConnectionIssue` flag.

## Changes

- `docs/signaling_architecture_target.md`: new subsection with a table mapping each finalization path to where it lives and what it does, plus why `onError` deliberately does not finalize.
- `lib/features/call/bloc/call_bloc.dart`: TODO replaced by a 5-line pointer comment linking to that doc section.

No behaviour change - documentation only.

## Notes

- Follows the same doc-pointer pattern as #1403 (WT-1078).
- The reconnect/notification policy stays owned by `SignalingReconnectController`; this change only documents where call finalization happens, it does not move any logic.