### PR TITLE
feat(call): early-attach buffering callkeep delegate to win incoming-vs-hangup race

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -44,6 +44,12 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
   late final Callkeep _callkeep = Callkeep();
   late final CallkeepConnections _callkeepConnections = CallkeepConnections();
 
+  /// Buffering callkeep delegate attached EARLY in [initState] (before [CallBloc] exists)
+  /// so callkeep's onDelegateSet -> native connection-state replay runs during the quiet
+  /// boot window. An in-flight incoming call (push->foreground handoff) is captured here
+  /// and replayed into [CallBloc] the instant it attaches, before a late signaling hangup.
+  late final CallkeepDelegateRelay _callkeepDelegateRelay = CallkeepDelegateRelay();
+
   /// The [SessionGuard] instance that handles session expiration and logout.
   late final SessionGuard _sessionGuard;
 
@@ -95,6 +101,11 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
         ),
       ),
     );
+
+    // Attach the buffering delegate immediately (in parallel with signaling connect below),
+    // long before CallBloc is built, so the native connection-state replay fires early and a
+    // handed-off incoming call is buffered for replay into CallBloc on attach.
+    _callkeep.setDelegate(_callkeepDelegateRelay);
 
     // After authentication, regenerate the labels to include core URL and tenant ID in remote logging labels
     context.read<AppLogger>().updateRemoteLabels();
@@ -563,6 +574,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         isCameraPermissionGranted: () => appPermissions.isPermissionGranted(Permission.camera),
                         callkeep: _callkeep,
                         callkeepConnections: _callkeepConnections,
+                        callkeepDelegateRelay: _callkeepDelegateRelay,
                         sdpMunger: ModifyWithEncodingSettings(
                           encodingSettingsRepository,
                           encodingConfig,

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -106,6 +106,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   final Callkeep callkeep;
   final CallkeepConnections callkeepConnections;
+
+  /// Optional early-attached buffering delegate relay (see [CallkeepDelegateRelay]).
+  /// When provided, this bloc registers through it (so a pre-bloc incoming buffered
+  /// during app boot is replayed in immediately) instead of calling
+  /// `callkeep.setDelegate(this)` directly.
+  final CallkeepDelegateRelay? callkeepDelegateRelay;
   late final CallMediaManager _mediaManager;
 
   final SDPMunger? sdpMunger;
@@ -159,6 +165,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required this.submitNotification,
     required this.callkeep,
     required this.callkeepConnections,
+    this.callkeepDelegateRelay,
     required this.userMediaBuilder,
     required this.contactResolver,
     required this.callErrorReporter,
@@ -251,7 +258,15 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     WidgetsBinding.instance.addObserver(this);
 
-    callkeep.setDelegate(this);
+    // Register as the callkeep delegate. When an early relay is provided (attached in
+    // MainShell.initState), attach to it so any incoming call buffered during app boot
+    // (push->foreground handoff) is replayed in immediately; otherwise set directly.
+    final relay = callkeepDelegateRelay;
+    if (relay != null) {
+      relay.attach(this);
+    } else {
+      callkeep.setDelegate(this);
+    }
 
     if (sendPresenceSettings) {
       _presenceInfoSyncTimer = Timer.periodic(const Duration(seconds: 5), (_) => syncPresenceSettings());
@@ -260,7 +275,12 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   @override
   Future<void> close() async {
-    callkeep.setDelegate(null);
+    final relay = callkeepDelegateRelay;
+    if (relay != null) {
+      relay.detach();
+    } else {
+      callkeep.setDelegate(null);
+    }
 
     WidgetsBinding.instance.removeObserver(this);
     navigator.mediaDevices.ondevicechange = null;

--- a/lib/features/call/services/callkeep_delegate_relay.dart
+++ b/lib/features/call/services/callkeep_delegate_relay.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
+
+/// A [CallkeepDelegate] attached to callkeep EARLY (in `MainShell.initState`),
+/// before [CallBloc] exists, that BUFFERS delegate callbacks until the real
+/// delegate ([CallBloc]) [attach]es.
+///
+/// Why: callkeep fires `onDelegateSet` -> a native connection-state replay only
+/// once a Flutter delegate is attached. Attaching this relay early makes that
+/// replay run while the app is still booting (a quiet window), so an in-flight
+/// incoming call from a push->foreground handoff is captured into the buffer and
+/// replayed into [CallBloc] the instant it is created -- before the late signaling
+/// hangup, which otherwise hits `call == null` and drops the call (leaving a ghost
+/// incoming).
+///
+/// Once [attach]ed it is a transparent forwarder to the target. It remains the
+/// single registered callkeep delegate for the lifetime of the shell; [CallBloc]
+/// reports through it via [attach] / [detach] instead of calling
+/// `callkeep.setDelegate` directly.
+class CallkeepDelegateRelay implements CallkeepDelegate {
+  CallkeepDelegate? _target;
+  final List<void Function(CallkeepDelegate)> _pending = [];
+
+  /// Set the real delegate and replay any buffered callbacks into it, in order.
+  void attach(CallkeepDelegate target) {
+    _target = target;
+    final pending = List<void Function(CallkeepDelegate)>.of(_pending);
+    _pending.clear();
+    for (final action in pending) {
+      action(target);
+    }
+  }
+
+  /// Detach the real delegate (e.g. on `CallBloc.close()`). Subsequent callbacks
+  /// buffer again until the next [attach].
+  void detach() {
+    _target = null;
+  }
+
+  void _run(void Function(CallkeepDelegate) action) {
+    final target = _target;
+    if (target != null) {
+      action(target);
+    } else {
+      _pending.add(action);
+    }
+  }
+
+  Future<bool> _runFuture(Future<bool> Function(CallkeepDelegate) action) {
+    final target = _target;
+    if (target != null) return action(target);
+    // Defer: native awaits the result, so complete it once the target attaches
+    // and actually handles the call.
+    final completer = Completer<bool>();
+    _pending.add(
+      (d) => action(d).then(completer.complete).catchError((Object e, StackTrace s) {
+        completer.completeError(e, s);
+      }),
+    );
+    return completer.future;
+  }
+
+  @override
+  void didPushIncomingCall(
+    CallkeepHandle handle,
+    String? displayName,
+    bool video,
+    String callId,
+    CallkeepIncomingCallError? error,
+  ) => _run((d) => d.didPushIncomingCall(handle, displayName, video, callId, error));
+
+  @override
+  void continueStartCallIntent(CallkeepHandle handle, String? displayName, bool video) =>
+      _run((d) => d.continueStartCallIntent(handle, displayName, video));
+
+  @override
+  void didActivateAudioSession() => _run((d) => d.didActivateAudioSession());
+
+  @override
+  void didDeactivateAudioSession() => _run((d) => d.didDeactivateAudioSession());
+
+  @override
+  void didReset() => _run((d) => d.didReset());
+
+  @override
+  Future<bool> performStartCall(
+    String callId,
+    CallkeepHandle handle,
+    String? displayNameOrContactIdentifier,
+    bool video,
+  ) => _runFuture((d) => d.performStartCall(callId, handle, displayNameOrContactIdentifier, video));
+
+  @override
+  Future<bool> performAnswerCall(String callId) => _runFuture((d) => d.performAnswerCall(callId));
+
+  @override
+  Future<bool> performEndCall(String callId) => _runFuture((d) => d.performEndCall(callId));
+
+  @override
+  Future<bool> performSetHeld(String callId, bool onHold) => _runFuture((d) => d.performSetHeld(callId, onHold));
+
+  @override
+  Future<bool> performSetMuted(String callId, bool muted) => _runFuture((d) => d.performSetMuted(callId, muted));
+
+  @override
+  Future<bool> performSendDTMF(String callId, String key) => _runFuture((d) => d.performSendDTMF(callId, key));
+
+  @override
+  Future<bool> performAudioDeviceSet(String callId, CallkeepAudioDevice device) =>
+      _runFuture((d) => d.performAudioDeviceSet(callId, device));
+
+  @override
+  Future<bool> performAudioDevicesUpdate(String callId, List<CallkeepAudioDevice> devices) =>
+      _runFuture((d) => d.performAudioDevicesUpdate(callId, devices));
+}

--- a/lib/features/call/services/services.dart
+++ b/lib/features/call/services/services.dart
@@ -1,2 +1,3 @@
 export 'background_isolate_callbacks.dart';
+export 'callkeep_delegate_relay.dart';
 export 'signaling_reconnect_controller.dart';


### PR DESCRIPTION
## Overview

Attaches a buffering `CallkeepDelegate` (`CallkeepDelegateRelay`) early, in `MainShell.initState`, so the native connection-state replay (`onDelegateSet` -> `replayConnectionStates`) can fire as soon as the engine is up -- in parallel with signaling connect -- instead of waiting for `CallBloc` to be lazily created.

The relay buffers every delegate callback until the real target (`CallBloc`) attaches, then drains the queue to it. This shrinks the race window in the push -> foreground-handoff scenario: when the callee opens an incoming-call notification and the caller hangs up while signaling is still connecting, the incoming seed now has a chance to reach `CallBloc` before the hangup arrives, so the hangup carries `direction=incoming` (call already in state) instead of `direction=null` (dropped -> ghost incoming UI/sound).

## Changes

- `CallkeepDelegateRelay` (new) -- implements `CallkeepDelegate`; buffers the 13 callbacks until `attach(target)`, then replays them. `Future<bool>` methods bridge through a `Completer` so callers still get a real future before the target exists.
- `MainShell.initState` -- creates the relay and calls `_callkeep.setDelegate(relay)` right after `setUp`, before `CallBloc` exists.
- `CallBloc` -- new optional `callkeepDelegateRelay`; registers via `relay.attach(this)` (and `detach()` in `close()`) when present, else falls back to `callkeep.setDelegate(this)`.

## Notes

- Experimental window-shrinker, not a deterministic fix. Cross-process broadcast latency (`:callkeep_core` -> `main`) can still lose the race under heavy cold-start load. A deterministic CallBloc-side recently-terminated guard is the follow-up if this proves insufficient on-device.
- Awaiting device-verify (discriminator: hangup `direction=` becomes `incoming`).