### PR TITLE
fix(call): end native call on signaling hangup for a call not in state

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2933,11 +2933,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     if (call == null) {
       // The call was never registered in state - the signaling hangup won the race against
       // a still-connecting incoming call (e.g. a push->foreground handoff where the caller hung
-      // up before CallBloc was seeded). Report the end to callkeep so the native tracker marks
-      // the call terminated and suppresses a late connection-state replay that would otherwise
-      // seed a ghost incoming call. reportEndCall does not invoke performEndCall and sends no
-      // server request - signaling already terminated the call.
-      await callkeep.reportEndCall(event.callId, '', CallkeepEndCallReason.remoteEnded);
+      // up before CallBloc was seeded). Report the end to callkeep with the missedWhileConnecting
+      // reason: it marks the call terminated AND flags that the app never presented this call, so a
+      // late connection-state replay that re-drives reportNewIncomingCall for the same callId is
+      // rejected (no ghost). The flag is specific to this never-presented case, so a transfer-back
+      // (which reuses a call the app did know) is unaffected. reportEndCall does not invoke
+      // performEndCall and sends no server request - signaling already terminated the call.
+      await callkeep.reportEndCall(event.callId, '', CallkeepEndCallReason.missedWhileConnecting);
       return;
     }
 

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2930,7 +2930,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _signalingModule.cancelRequestsByCallId(event.callId);
 
     ActiveCall? call = state.retrieveActiveCall(event.callId);
-    if (call == null) return;
+    if (call == null) {
+      // The call was never registered in state - the signaling hangup won the race against
+      // a still-connecting incoming call (e.g. a push->foreground handoff where the caller hung
+      // up before CallBloc was seeded). Report the end to callkeep so the native tracker marks
+      // the call terminated and suppresses a late connection-state replay that would otherwise
+      // seed a ghost incoming call. reportEndCall does not invoke performEndCall and sends no
+      // server request - signaling already terminated the call.
+      await callkeep.reportEndCall(event.callId, '', CallkeepEndCallReason.remoteEnded);
+      return;
+    }
 
     if (call.wasHungUp == false) {
       call = call.copyWith(hungUpTime: clock.now());


### PR DESCRIPTION
## Overview

Fixes the ghost incoming call in the push -> foreground-handoff scenario: the callee taps an incoming-call notification, the app starts, and while signaling is still connecting the caller hangs up. The signaling hangup arrives before the incoming call is registered in `CallBloc`, so `__onMutationSignalingHangup` returned early (`call == null`) and tore down nothing. The native connection-state replay (`ReplayIncomingCall`), still in flight from `:callkeep_core`, then arrived seconds later and seeded a ghost incoming call (ringing/UI) for a call that was already dead.

## Changes

- `__onMutationSignalingHangup`: when the hung-up call is not in state, call `callkeep.reportEndCall(callId, '', remoteEnded)` instead of returning early. This marks the call terminated in the native main-process tracker, which suppresses the late replay (paired callkeep change). `reportEndCall` does not invoke the `performEndCall` delegate callback and sends no server request -- correct here, since signaling already terminated the call.

## Notes

- Requires the paired `webtrit_callkeep` change (PR #336): `deliverIncomingToDelegate` skips delivery for a call already terminated in the main-process tracker, and `reportEndCall` marks termination synchronously.
- Verified against an on-device logcat (Xiaomi, Android 15) where the replay arrived ~4s after the hangup and produced the ghost (call entered state as `incomingFromPush` ~2.3s after the dropped hangup).