### PR TITLE
feat: add min_supported_app_version to system-info models (WT-1628)

### DIFF
--- a/lib/mappers/api/system_info_mapper.dart
+++ b/lib/mappers/api/system_info_mapper.dart
@@ -1,3 +1,5 @@
+import 'package:pub_semver/pub_semver.dart';
+
 import 'package:webtrit_api/webtrit_api.dart' as api;
 
 import 'package:webtrit_phone/models/models.dart';
@@ -10,7 +12,19 @@ mixin SystemInfoApiMapper {
       adapter: systemInfo.adapter != null ? adapterInfoFromApi(systemInfo.adapter!) : null,
       janus: systemInfo.janus != null ? janusInfoFromApi(systemInfo.janus!) : null,
       gorush: systemInfo.gorush != null ? gorushInfoFromApi(systemInfo.gorush!) : null,
+      minSupportedAppVersion: _tryParseVersion(systemInfo.minSupportedAppVersion),
     );
+  }
+
+  /// Parses a backend-provided semver string into a [Version], tolerating null
+  /// or malformed input by returning null (treated as "no minimum enforced").
+  Version? _tryParseVersion(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      return Version.parse(raw);
+    } on FormatException {
+      return null;
+    }
   }
 
   CoreInfo coreInfoFromApi(api.CoreInfo coreInfo) {

--- a/lib/mappers/api/system_info_mapper.dart
+++ b/lib/mappers/api/system_info_mapper.dart
@@ -1,8 +1,7 @@
-import 'package:pub_semver/pub_semver.dart';
-
 import 'package:webtrit_api/webtrit_api.dart' as api;
 
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/utils/version_utils.dart';
 
 mixin SystemInfoApiMapper {
   WebtritSystemInfo systemInfoFromApi(api.SystemInfo systemInfo) {
@@ -12,19 +11,8 @@ mixin SystemInfoApiMapper {
       adapter: systemInfo.adapter != null ? adapterInfoFromApi(systemInfo.adapter!) : null,
       janus: systemInfo.janus != null ? janusInfoFromApi(systemInfo.janus!) : null,
       gorush: systemInfo.gorush != null ? gorushInfoFromApi(systemInfo.gorush!) : null,
-      minSupportedAppVersion: _tryParseVersion(systemInfo.minSupportedAppVersion),
+      minSupportedAppVersion: tryParseVersion(systemInfo.minSupportedAppVersion),
     );
-  }
-
-  /// Parses a backend-provided semver string into a [Version], tolerating null
-  /// or malformed input by returning null (treated as "no minimum enforced").
-  Version? _tryParseVersion(String? raw) {
-    if (raw == null || raw.isEmpty) return null;
-    try {
-      return Version.parse(raw);
-    } on FormatException {
-      return null;
-    }
   }
 
   CoreInfo coreInfoFromApi(api.CoreInfo coreInfo) {

--- a/lib/mappers/json/system_info_mapper.dart
+++ b/lib/mappers/json/system_info_mapper.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:pub_semver/pub_semver.dart';
 
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/utils/version_utils.dart';
 
 mixin SystemInfoJsonMapper {
   WebtritSystemInfo systemInfoFromJson(String json) {
@@ -14,14 +15,13 @@ mixin SystemInfoJsonMapper {
   }
 
   WebtritSystemInfo systemInfoFromMap(Map<String, dynamic> map) {
-    final rawMinSupportedAppVersion = map['min_supported_app_version'];
     return WebtritSystemInfo(
       core: coreInfoFromMap(map['core']),
       postgres: postgresInfoFromMap(map['postgres']),
       adapter: map['adapter'] != null ? adapterInfoFromMap(map['adapter']) : null,
       janus: map['janus'] != null ? janusInfoFromMap(map['janus']) : null,
       gorush: map['gorush'] != null ? gorushInfoFromMap(map['gorush']) : null,
-      minSupportedAppVersion: rawMinSupportedAppVersion != null ? Version.parse(rawMinSupportedAppVersion) : null,
+      minSupportedAppVersion: tryParseVersion(map['min_supported_app_version']),
     );
   }
 

--- a/lib/mappers/json/system_info_mapper.dart
+++ b/lib/mappers/json/system_info_mapper.dart
@@ -14,12 +14,14 @@ mixin SystemInfoJsonMapper {
   }
 
   WebtritSystemInfo systemInfoFromMap(Map<String, dynamic> map) {
+    final rawMinSupportedAppVersion = map['min_supported_app_version'];
     return WebtritSystemInfo(
       core: coreInfoFromMap(map['core']),
       postgres: postgresInfoFromMap(map['postgres']),
       adapter: map['adapter'] != null ? adapterInfoFromMap(map['adapter']) : null,
       janus: map['janus'] != null ? janusInfoFromMap(map['janus']) : null,
       gorush: map['gorush'] != null ? gorushInfoFromMap(map['gorush']) : null,
+      minSupportedAppVersion: rawMinSupportedAppVersion != null ? Version.parse(rawMinSupportedAppVersion) : null,
     );
   }
 
@@ -30,6 +32,7 @@ mixin SystemInfoJsonMapper {
       'adapter': systemInfo.adapter != null ? adapterInfoToMap(systemInfo.adapter!) : null,
       'janus': systemInfo.janus != null ? janusInfoToMap(systemInfo.janus!) : null,
       'gorush': systemInfo.gorush != null ? gorushInfoToMap(systemInfo.gorush!) : null,
+      'min_supported_app_version': systemInfo.minSupportedAppVersion?.toString(),
     };
   }
 

--- a/lib/models/system_info/system_info.dart
+++ b/lib/models/system_info/system_info.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import 'components/adapter_info.dart';
 import 'components/core_info.dart';
@@ -17,7 +18,14 @@ export 'components/websocket.dart';
 export 'components/sip_version.dart';
 
 class WebtritSystemInfo with EquatableMixin {
-  WebtritSystemInfo({required this.core, required this.postgres, this.adapter, this.janus, this.gorush});
+  WebtritSystemInfo({
+    required this.core,
+    required this.postgres,
+    this.adapter,
+    this.janus,
+    this.gorush,
+    this.minSupportedAppVersion,
+  });
 
   final CoreInfo core;
   final PostgresInfo postgres;
@@ -25,8 +33,12 @@ class WebtritSystemInfo with EquatableMixin {
   final JanusInfo? janus;
   final GorushInfo? gorush;
 
+  /// Minimum app version the backend declares it supports. `null` = the
+  /// backend does not enforce a minimum.
+  final Version? minSupportedAppVersion;
+
   @override
-  List<Object?> get props => [core, postgres, adapter, janus, gorush];
+  List<Object?> get props => [core, postgres, adapter, janus, gorush, minSupportedAppVersion];
 
   @override
   bool get stringify => true;

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -23,6 +23,7 @@ export 'regexes.dart';
 export 'string_phone_utils.dart';
 export 'text_matchers.dart';
 export 'ttl_cache.dart';
+export 'version_utils.dart';
 export 'view_params/view_params.dart';
 export 'webtrit_api_client_factory.dart';
 export 'webtrit_signaling_client.dart';

--- a/lib/utils/version_utils.dart
+++ b/lib/utils/version_utils.dart
@@ -1,0 +1,14 @@
+import 'package:pub_semver/pub_semver.dart';
+
+/// Parses [raw] into a semver [Version], tolerating null, non-String, empty or
+/// malformed input by returning null. pub_semver has no built-in tryParse, so
+/// this is the shared safe-parse used wherever a version comes from an
+/// untrusted source (backend payload, persisted cache).
+Version? tryParseVersion(Object? raw) {
+  if (raw is! String || raw.isEmpty) return null;
+  try {
+    return Version.parse(raw);
+  } on FormatException {
+    return null;
+  }
+}

--- a/packages/webtrit_api/lib/src/models/system_info.dart
+++ b/packages/webtrit_api/lib/src/models/system_info.dart
@@ -10,7 +10,14 @@ part 'system_info.g.dart';
 @freezed
 @JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
 class SystemInfo with _$SystemInfo {
-  const SystemInfo({required this.core, required this.postgres, this.adapter, this.janus, this.gorush});
+  const SystemInfo({
+    required this.core,
+    required this.postgres,
+    this.adapter,
+    this.janus,
+    this.gorush,
+    this.minSupportedAppVersion,
+  });
 
   @override
   final CoreInfo core;
@@ -26,6 +33,13 @@ class SystemInfo with _$SystemInfo {
 
   @override
   final GorushInfo? gorush;
+
+  /// Optional minimum app version the backend declares it supports, as a raw
+  /// semver string (JSON key `min_supported_app_version`). `null` = not
+  /// enforced. Kept as a `String?` here so the API layer stays a dumb
+  /// transport; the domain mapper parses it into a [Version].
+  @override
+  final String? minSupportedAppVersion;
 
   factory SystemInfo.fromJson(Map<String, Object?> json) => _$SystemInfoFromJson(json);
 

--- a/packages/webtrit_api/lib/src/models/system_info.freezed.dart
+++ b/packages/webtrit_api/lib/src/models/system_info.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SystemInfo {
 
- CoreInfo get core; PostgresInfo get postgres; AdapterInfo? get adapter; JanusInfo? get janus; GorushInfo? get gorush;
+ CoreInfo get core; PostgresInfo get postgres; AdapterInfo? get adapter; JanusInfo? get janus; GorushInfo? get gorush; String? get minSupportedAppVersion;
 /// Create a copy of SystemInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $SystemInfoCopyWith<SystemInfo> get copyWith => _$SystemInfoCopyWithImpl<SystemI
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SystemInfo&&(identical(other.core, core) || other.core == core)&&(identical(other.postgres, postgres) || other.postgres == postgres)&&(identical(other.adapter, adapter) || other.adapter == adapter)&&(identical(other.janus, janus) || other.janus == janus)&&(identical(other.gorush, gorush) || other.gorush == gorush));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SystemInfo&&(identical(other.core, core) || other.core == core)&&(identical(other.postgres, postgres) || other.postgres == postgres)&&(identical(other.adapter, adapter) || other.adapter == adapter)&&(identical(other.janus, janus) || other.janus == janus)&&(identical(other.gorush, gorush) || other.gorush == gorush)&&(identical(other.minSupportedAppVersion, minSupportedAppVersion) || other.minSupportedAppVersion == minSupportedAppVersion));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,core,postgres,adapter,janus,gorush);
+int get hashCode => Object.hash(runtimeType,core,postgres,adapter,janus,gorush,minSupportedAppVersion);
 
 @override
 String toString() {
-  return 'SystemInfo(core: $core, postgres: $postgres, adapter: $adapter, janus: $janus, gorush: $gorush)';
+  return 'SystemInfo(core: $core, postgres: $postgres, adapter: $adapter, janus: $janus, gorush: $gorush, minSupportedAppVersion: $minSupportedAppVersion)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $SystemInfoCopyWith<$Res>  {
   factory $SystemInfoCopyWith(SystemInfo value, $Res Function(SystemInfo) _then) = _$SystemInfoCopyWithImpl;
 @useResult
 $Res call({
- CoreInfo core, PostgresInfo postgres, AdapterInfo? adapter, JanusInfo? janus, GorushInfo? gorush
+ CoreInfo core, PostgresInfo postgres, AdapterInfo? adapter, JanusInfo? janus, GorushInfo? gorush, String? minSupportedAppVersion
 });
 
 
@@ -63,14 +63,15 @@ class _$SystemInfoCopyWithImpl<$Res>
 
 /// Create a copy of SystemInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? core = null,Object? postgres = null,Object? adapter = freezed,Object? janus = freezed,Object? gorush = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? core = null,Object? postgres = null,Object? adapter = freezed,Object? janus = freezed,Object? gorush = freezed,Object? minSupportedAppVersion = freezed,}) {
   return _then(SystemInfo(
 core: null == core ? _self.core : core // ignore: cast_nullable_to_non_nullable
 as CoreInfo,postgres: null == postgres ? _self.postgres : postgres // ignore: cast_nullable_to_non_nullable
 as PostgresInfo,adapter: freezed == adapter ? _self.adapter : adapter // ignore: cast_nullable_to_non_nullable
 as AdapterInfo?,janus: freezed == janus ? _self.janus : janus // ignore: cast_nullable_to_non_nullable
 as JanusInfo?,gorush: freezed == gorush ? _self.gorush : gorush // ignore: cast_nullable_to_non_nullable
-as GorushInfo?,
+as GorushInfo?,minSupportedAppVersion: freezed == minSupportedAppVersion ? _self.minSupportedAppVersion : minSupportedAppVersion // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/packages/webtrit_api/lib/src/models/system_info.g.dart
+++ b/packages/webtrit_api/lib/src/models/system_info.g.dart
@@ -18,6 +18,7 @@ SystemInfo _$SystemInfoFromJson(Map<String, dynamic> json) => SystemInfo(
   gorush: json['gorush'] == null
       ? null
       : GorushInfo.fromJson(json['gorush'] as Map<String, dynamic>),
+  minSupportedAppVersion: json['min_supported_app_version'] as String?,
 );
 
 Map<String, dynamic> _$SystemInfoToJson(SystemInfo instance) =>
@@ -27,6 +28,7 @@ Map<String, dynamic> _$SystemInfoToJson(SystemInfo instance) =>
       'adapter': instance.adapter?.toJson(),
       'janus': instance.janus?.toJson(),
       'gorush': instance.gorush?.toJson(),
+      'min_supported_app_version': instance.minSupportedAppVersion,
     };
 
 CoreInfo _$CoreInfoFromJson(Map<String, dynamic> json) => CoreInfo(

--- a/packages/webtrit_api/test/webtrit_api_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_test.dart
@@ -84,6 +84,7 @@ void main() {
               'supported': ['feat1', 'feat2'],
               'custom': {'abc': 'qwe'},
             },
+            'min_supported_app_version': '1.5.0',
           }),
           200,
           request: request,
@@ -105,6 +106,35 @@ void main() {
                 supported: ['feat1', 'feat2'],
                 custom: {'abc': 'qwe'},
               ),
+              postgres: PostgresInfo(version: '1.0.0'),
+              minSupportedAppVersion: '1.5.0',
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('get info without min_supported_app_version yields null', () {
+      Future<Response> handler(Request request) async {
+        return Response(
+          jsonEncode({
+            'core': {'version': '1.0.0'},
+            'postgres': {'version': '1.0.0'},
+          }),
+          200,
+          request: request,
+        );
+      }
+
+      final httpClient = MockClient(expectAsync1(handler));
+      final apiClient = WebtritApiClient.inner(Uri.https(authority), '', httpClient: httpClient);
+
+      expect(
+        apiClient.getSystemInfo(),
+        completion(
+          equals(
+            SystemInfo(
+              core: CoreInfo(version: Version(1, 0, 0)),
               postgres: PostgresInfo(version: '1.0.0'),
             ),
           ),

--- a/test/mappers/system_info_mapper_test.dart
+++ b/test/mappers/system_info_mapper_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:webtrit_api/webtrit_api.dart' as api;
+
+import 'package:webtrit_phone/mappers/mappers.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+class _Mapper with SystemInfoApiMapper, SystemInfoJsonMapper {}
+
+void main() {
+  final mapper = _Mapper();
+
+  api.SystemInfo apiInfo({String? minSupportedAppVersion}) {
+    return api.SystemInfo(
+      core: api.CoreInfo(version: Version(1, 0, 0)),
+      postgres: api.PostgresInfo(version: '15.0'),
+      minSupportedAppVersion: minSupportedAppVersion,
+    );
+  }
+
+  WebtritSystemInfo domainInfo({Version? minSupportedAppVersion}) {
+    return WebtritSystemInfo(
+      core: CoreInfo(version: Version(1, 0, 0)),
+      postgres: PostgresInfo(version: '15.0'),
+      minSupportedAppVersion: minSupportedAppVersion,
+    );
+  }
+
+  group('SystemInfoApiMapper.systemInfoFromApi minSupportedAppVersion', () {
+    test('parses a valid semver string into a Version', () {
+      expect(
+        mapper.systemInfoFromApi(apiInfo(minSupportedAppVersion: '1.5.0')).minSupportedAppVersion,
+        Version(1, 5, 0),
+      );
+    });
+
+    test('maps null to null', () {
+      expect(mapper.systemInfoFromApi(apiInfo(minSupportedAppVersion: null)).minSupportedAppVersion, isNull);
+    });
+
+    test('maps a malformed string to null instead of throwing', () {
+      expect(mapper.systemInfoFromApi(apiInfo(minSupportedAppVersion: '1.x')).minSupportedAppVersion, isNull);
+    });
+  });
+
+  group('SystemInfoJsonMapper minSupportedAppVersion round-trip', () {
+    test('round-trips a non-null version through to/from map', () {
+      final map = mapper.systemInfoToMap(domainInfo(minSupportedAppVersion: Version(1, 5, 0)));
+      expect(map['min_supported_app_version'], '1.5.0');
+      expect(mapper.systemInfoFromMap(map).minSupportedAppVersion, Version(1, 5, 0));
+    });
+
+    test('round-trips null', () {
+      final map = mapper.systemInfoToMap(domainInfo(minSupportedAppVersion: null));
+      expect(map['min_supported_app_version'], isNull);
+      expect(mapper.systemInfoFromMap(map).minSupportedAppVersion, isNull);
+    });
+
+    test('reads a malformed cached value as null instead of throwing', () {
+      final map = mapper.systemInfoToMap(domainInfo())..['min_supported_app_version'] = 'garbage';
+      expect(mapper.systemInfoFromMap(map).minSupportedAppVersion, isNull);
+    });
+  });
+}

--- a/test/utils/version_utils_test.dart
+++ b/test/utils/version_utils_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:webtrit_phone/utils/version_utils.dart';
+
+void main() {
+  group('tryParseVersion', () {
+    test('parses a valid semver string', () {
+      expect(tryParseVersion('1.5.0'), Version(1, 5, 0));
+      expect(tryParseVersion('1.5.0-alpha.1'), Version(1, 5, 0, pre: 'alpha.1'));
+    });
+
+    test('returns null for null', () {
+      expect(tryParseVersion(null), isNull);
+    });
+
+    test('returns null for an empty string', () {
+      expect(tryParseVersion(''), isNull);
+    });
+
+    test('returns null for a malformed string', () {
+      expect(tryParseVersion('not-a-version'), isNull);
+      expect(tryParseVersion('1.x'), isNull);
+    });
+
+    test('returns null for a non-String value', () {
+      expect(tryParseVersion(123), isNull);
+      expect(tryParseVersion(const {}), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Groundwork for the upcoming force-update gate, split out so it can land independently. This PR only threads the new backend field through the model/data layers - **no behavior, gates, helper, dialog or l10n changes**.

The backend exposes an optional `min_supported_app_version` (semver string) at the top level of `GET /api/v1/system-info` (env `MIN_SUPPORTED_APP_VERSION`, `null` = not enforced). Nothing reads it yet; this just makes it available in the parsed model and survive caching.

## Changes

- `api.SystemInfo`: new optional top-level `min_supported_app_version`, carried as a raw `String?` so the API package stays a dumb transport (freezed/json regenerated).
- `WebtritSystemInfo`: new parsed `Version? minSupportedAppVersion` field + `props`.
- API->domain mapper: safe parse `String?` -> `Version?` (malformed/empty -> `null`).
- JSON cache mapper: persist the field so cached system-info round-trips.
- Shared `tryParseVersion(Object?)` util reused by both mappers so a corrupt/empty/non-String cached value yields `null` instead of throwing.

## Notes

- No field reads, no force-update logic, no UI. Those land in the follow-up PR stacked on top of this one.
- Tests: util unit, API->domain + JSON cache round-trip (valid / null / malformed-stays-null), and the api wire contract (field present + absent).
- `melos run check` (fmt + analyze) clean; suite green.