### PR TITLE
refactor: unify contact number actions into a single source of truth

### DIFF
--- a/lib/features/contact/widgets/contact_phone_tile.dart
+++ b/lib/features/contact/widgets/contact_phone_tile.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:webtrit_phone/app/keys.dart';
-import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/widgets/call/number_actions.dart';
 
 class ContactPhoneTile extends StatelessWidget {
   const ContactPhoneTile({
@@ -88,41 +87,19 @@ class ContactPhoneTile extends StatelessWidget {
   Widget _buildMoreMenuButton(BuildContext context) {
     return PopupMenuButton(
       icon: const Icon(Icons.more_vert),
-      itemBuilder: (context) => _buildPopupMenuEntries(context),
-    );
-  }
-
-  List<PopupMenuEntry> _buildPopupMenuEntries(BuildContext context) {
-    final l10n = context.l10n;
-    final entries = <PopupMenuEntry>[];
-
-    if (callNumbers.length > 1 && onCallFrom != null) {
-      for (final fromNumber in callNumbers) {
-        entries.add(
-          PopupMenuItem(onTap: () => onCallFrom!(fromNumber), child: Text(l10n.numberActions_callFrom(fromNumber))),
-        );
-      }
-    }
-
-    if (onTransferPressed != null) {
-      entries.add(PopupMenuItem(onTap: onTransferPressed, child: Text(l10n.numberActions_transfer)));
-    }
-
-    if (onSendSmsPressed != null) {
-      entries.add(PopupMenuItem(onTap: onSendSmsPressed, child: Text(l10n.numberActions_sendSms)));
-    }
-
-    if (onCallLogPressed != null) {
-      entries.add(PopupMenuItem(onTap: onCallLogPressed, child: Text(l10n.numberActions_callLog)));
-    }
-
-    entries.add(
-      PopupMenuItem(
-        onTap: () => Clipboard.setData(ClipboardData(text: number)),
-        child: Text(l10n.numberActions_copyNumber),
+      // Audio/video/message are surfaced as inline icons above, so only the
+      // remaining actions are wired into the shared menu builder here.
+      itemBuilder: (context) => numberActionsToMenu(
+        buildNumberActions(
+          context,
+          callNumbers: callNumbers,
+          onCallLogPressed: onCallLogPressed,
+          onTransferPressed: onTransferPressed,
+          onSendSmsPressed: onSendSmsPressed,
+          onCallFrom: onCallFrom,
+          copyNumber: number,
+        ),
       ),
     );
-
-    return entries;
   }
 }

--- a/lib/widgets/call/call.dart
+++ b/lib/widgets/call/call.dart
@@ -1,1 +1,2 @@
 export 'call_tile.dart';
+export 'number_actions.dart';

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -1,9 +1,9 @@
 // ignore_for_file: prefer_const_literals_to_create_immutables, prefer_const_constructors
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/widgets/call/number_actions.dart';
 
 class TileMenuButton extends StatelessWidget {
   const TileMenuButton({super.key, required this.onTap});
@@ -28,64 +28,13 @@ class TileMenuButton extends StatelessWidget {
   }
 }
 
-List<PopupMenuEntry<dynamic>> buildNumberActions(
-  BuildContext context, {
-  required List<String> callNumbers,
-  VoidCallback? onAudioCallPressed,
-  VoidCallback? onVideoCallPressed,
-  VoidCallback? onTransferPressed,
-  VoidCallback? onChatPressed,
-  VoidCallback? onSendSmsPressed,
-  VoidCallback? onViewContactPressed,
-  VoidCallback? onCallLogPressed,
-  void Function(String)? onCallFrom,
-  String? copyNumber,
-  String? copyCallId,
-  VoidCallback? onDelete,
-}) {
-  final l10n = context.l10n;
-  return [
-    if (onAudioCallPressed != null) PopupMenuItem(onTap: onAudioCallPressed, child: Text(l10n.numberActions_audioCall)),
-    if (onVideoCallPressed != null) PopupMenuItem(onTap: onVideoCallPressed, child: Text(l10n.numberActions_videoCall)),
-    if (callNumbers.length > 1 && onCallFrom != null)
-      for (final number in callNumbers)
-        PopupMenuItem(onTap: () => onCallFrom.call(number), child: Text(l10n.numberActions_callFrom(number))),
-    if (onTransferPressed != null) PopupMenuItem(onTap: onTransferPressed, child: Text(l10n.numberActions_transfer)),
-    if (onChatPressed != null) PopupMenuItem(onTap: onChatPressed, child: Text(l10n.numberActions_chat)),
-    if (onSendSmsPressed != null) PopupMenuItem(onTap: onSendSmsPressed, child: Text(l10n.numberActions_sendSms)),
-    if (onViewContactPressed != null)
-      PopupMenuItem(onTap: onViewContactPressed, child: Text(l10n.numberActions_viewContact)),
-    if (onCallLogPressed != null) PopupMenuItem(onTap: onCallLogPressed, child: Text(l10n.numberActions_callLog)),
-    if (copyNumber != null)
-      PopupMenuItem(
-        onTap: () => Clipboard.setData(ClipboardData(text: copyNumber)),
-        child: Text(l10n.numberActions_copyNumber),
-      ),
-    if (copyCallId != null)
-      PopupMenuItem(
-        onTap: () => Clipboard.setData(ClipboardData(text: copyCallId)),
-        child: Text(l10n.numberActions_copyCallId),
-      ),
-    if (onDelete != null) PopupMenuItem(onTap: onDelete, child: Text(l10n.numberActions_delete)),
-  ];
-}
-
 class CallTileActionsBar extends StatelessWidget {
-  const CallTileActionsBar({
-    super.key,
-    this.onAudioCallPressed,
-    this.onVideoCallPressed,
-    this.onChatPressed,
-    this.onCallLogPressed,
-    this.onViewContactPressed,
-    required this.onMorePressed,
-  });
+  const CallTileActionsBar({super.key, required this.actions, this.onMorePressed});
 
-  final VoidCallback? onAudioCallPressed;
-  final VoidCallback? onVideoCallPressed;
-  final VoidCallback? onChatPressed;
-  final VoidCallback? onCallLogPressed;
-  final VoidCallback? onViewContactPressed;
+  /// Primary actions to render inline (see [NumberAction.primary]).
+  final List<NumberAction> actions;
+
+  /// Opens the overflow menu with the remaining actions; hidden when null.
   final VoidCallback? onMorePressed;
 
   @override
@@ -93,41 +42,9 @@ class CallTileActionsBar extends StatelessWidget {
     final l10n = context.l10n;
     return Row(
       children: [
-        if (onAudioCallPressed != null)
+        for (final action in actions)
           Expanded(
-            child: _CallTileAction(
-              icon: Icons.call_outlined,
-              label: l10n.numberActions_audioCall,
-              onTap: onAudioCallPressed!,
-            ),
-          ),
-        if (onVideoCallPressed != null)
-          Expanded(
-            child: _CallTileAction(
-              icon: Icons.videocam_outlined,
-              label: l10n.numberActions_videoCall,
-              onTap: onVideoCallPressed!,
-            ),
-          ),
-        if (onChatPressed != null)
-          Expanded(
-            child: _CallTileAction(
-              icon: Icons.chat_outlined,
-              label: l10n.callTileActions_message,
-              onTap: onChatPressed!,
-            ),
-          ),
-        if (onCallLogPressed != null)
-          Expanded(
-            child: _CallTileAction(icon: Icons.history, label: l10n.callTileActions_history, onTap: onCallLogPressed!),
-          ),
-        if (onViewContactPressed != null)
-          Expanded(
-            child: _CallTileAction(
-              icon: Icons.person_outline,
-              label: l10n.callTileActions_contact,
-              onTap: onViewContactPressed!,
-            ),
+            child: _CallTileAction(icon: action.icon, label: action.label, onTap: action.onTap),
           ),
         if (onMorePressed != null)
           Expanded(
@@ -239,37 +156,30 @@ class CallTile extends StatefulWidget {
 class _CallTileState extends State<CallTile> {
   late final tileKey = GlobalKey();
 
-  /// Mirrors the gating of [buildNumberActions] so menu affordances (the
-  /// trailing button and the More action) are hidden when the menu is empty.
-  bool get hasMenuActions =>
-      widget.onAudioCallPressed != null ||
-      widget.onVideoCallPressed != null ||
-      (widget.callNumbers.length > 1 && widget.onCallFrom != null) ||
-      widget.onTransferPressed != null ||
-      widget.onChatPressed != null ||
-      widget.onSendSmsPressed != null ||
-      widget.onViewContactPressed != null ||
-      widget.onCallLogPressed != null ||
-      widget.copyNumber != null ||
-      widget.copyCallId != null ||
-      widget.onDelete != null;
+  List<NumberAction> buildActions() => buildNumberActions(
+    context,
+    callNumbers: widget.callNumbers,
+    onAudioCallPressed: widget.onAudioCallPressed,
+    onVideoCallPressed: widget.onVideoCallPressed,
+    onChatPressed: widget.onChatPressed,
+    onCallLogPressed: widget.onCallLogPressed,
+    onViewContactPressed: widget.onViewContactPressed,
+    onTransferPressed: widget.onTransferPressed,
+    onSendSmsPressed: widget.onSendSmsPressed,
+    onCallFrom: widget.onCallFrom,
+    copyNumber: widget.copyNumber,
+    copyCallId: widget.copyCallId,
+    onDelete: widget.onDelete,
+  );
 
-  void showMenuPopup() {
-    final items = buildNumberActions(
-      context,
-      callNumbers: widget.callNumbers,
-      onAudioCallPressed: widget.onAudioCallPressed,
-      onVideoCallPressed: widget.onVideoCallPressed,
-      onTransferPressed: widget.onTransferPressed,
-      onChatPressed: widget.onChatPressed,
-      onSendSmsPressed: widget.onSendSmsPressed,
-      onViewContactPressed: widget.onViewContactPressed,
-      onCallLogPressed: widget.onCallLogPressed,
-      onCallFrom: widget.onCallFrom,
-      copyNumber: widget.copyNumber,
-      copyCallId: widget.copyCallId,
-      onDelete: widget.onDelete,
-    );
+  /// Shows the popup menu. When [overflowOnly] is set, the primary actions that
+  /// already sit in the inline bar are filtered out, so the "More" menu never
+  /// repeats them. The collapsed-row affordances (long press, trailing button)
+  /// pass the full set instead.
+  void showMenuPopup({bool overflowOnly = false}) {
+    var actions = buildActions();
+    if (overflowOnly) actions = actions.where((action) => !action.primary).toList();
+    final items = numberActionsToMenu(actions);
     if (items.isEmpty) return;
 
     showMenu(context: context, position: getPosition(), items: items);
@@ -291,6 +201,10 @@ class _CallTileState extends State<CallTile> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final colorScheme = themeData.colorScheme;
+
+    final actions = buildActions();
+    final primaryActions = actions.where((action) => action.primary).toList();
+    final hasOverflowActions = actions.any((action) => !action.primary);
 
     final nameText = Text(
       widget.name,
@@ -352,7 +266,7 @@ class _CallTileState extends State<CallTile> {
           splashColor: colorScheme.secondary.withAlpha(50),
           key: tileKey,
           onTap: widget.gesturesEnabled ? widget.onTap : null,
-          onLongPress: widget.gesturesEnabled ? showMenuPopup : null,
+          onLongPress: widget.gesturesEnabled ? () => showMenuPopup() : null,
           child: Padding(
             padding: const EdgeInsets.only(left: 8, right: 0, top: 8, bottom: 8),
             child: Column(
@@ -381,8 +295,8 @@ class _CallTileState extends State<CallTile> {
                           onPressed: widget.onDialPressed,
                           icon: Icon(widget.dialIcon ?? Icons.call, color: colorScheme.primary),
                         )
-                      else if (hasMenuActions)
-                        TileMenuButton(onTap: showMenuPopup),
+                      else if (actions.isNotEmpty)
+                        TileMenuButton(onTap: () => showMenuPopup()),
                   ],
                 ),
                 AnimatedSize(
@@ -393,12 +307,8 @@ class _CallTileState extends State<CallTile> {
                       ? Padding(
                           padding: const EdgeInsets.only(top: 4, right: 8),
                           child: CallTileActionsBar(
-                            onAudioCallPressed: widget.onAudioCallPressed,
-                            onVideoCallPressed: widget.onVideoCallPressed,
-                            onChatPressed: widget.onChatPressed,
-                            onCallLogPressed: widget.onCallLogPressed,
-                            onViewContactPressed: widget.onViewContactPressed,
-                            onMorePressed: hasMenuActions ? showMenuPopup : null,
+                            actions: primaryActions,
+                            onMorePressed: hasOverflowActions ? () => showMenuPopup(overflowOnly: true) : null,
                           ),
                         )
                       : const SizedBox(width: double.infinity),

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -203,8 +203,18 @@ class _CallTileState extends State<CallTile> {
     final colorScheme = themeData.colorScheme;
 
     final actions = buildActions();
-    final primaryActions = actions.where((action) => action.primary).toList();
     final hasOverflowActions = actions.any((action) => !action.primary);
+
+    // The trailing dial button is a static call shortcut. When expanded, drop the
+    // inline call action of the same kind (audio/video) so the bar does not
+    // duplicate it; the dial button stays visible and keeps that action.
+    final suppressedInlineIcon = widget.onDialPressed == null
+        ? null
+        : (widget.dialIcon == Icons.videocam ? Icons.videocam_outlined : Icons.call_outlined);
+    final primaryActions = actions
+        .where((action) => action.primary)
+        .where((action) => !(widget.expanded && action.icon == suppressedInlineIcon))
+        .toList();
 
     final nameText = Text(
       widget.name,

--- a/lib/widgets/call/number_actions.dart
+++ b/lib/widgets/call/number_actions.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+/// A single contact/number action.
+///
+/// This is the one source of truth for both the inline actions bar and the
+/// popup menu, so the set, labels, icons and ordering of actions never diverge
+/// between the two surfaces (or between different screens that reuse them).
+class NumberAction {
+  const NumberAction({required this.icon, required this.label, required this.onTap, this.primary = false});
+
+  /// Icon used when the action is rendered in the inline actions bar.
+  final IconData icon;
+
+  /// Single source label, shared by the inline bar and the popup menu.
+  final String label;
+
+  final VoidCallback onTap;
+
+  /// Whether the action belongs to the inline bar. Non-primary actions are kept
+  /// in the overflow menu only, so an action never shows up in both places.
+  final bool primary;
+}
+
+/// Builds the ordered list of available actions from the provided callbacks.
+///
+/// Only the actions whose callback is non-null are included, so each caller
+/// gets exactly the affordances it wires up. Primary actions lead the list.
+List<NumberAction> buildNumberActions(
+  BuildContext context, {
+  required List<String> callNumbers,
+  VoidCallback? onAudioCallPressed,
+  VoidCallback? onVideoCallPressed,
+  VoidCallback? onChatPressed,
+  VoidCallback? onCallLogPressed,
+  VoidCallback? onViewContactPressed,
+  VoidCallback? onTransferPressed,
+  VoidCallback? onSendSmsPressed,
+  void Function(String)? onCallFrom,
+  String? copyNumber,
+  String? copyCallId,
+  VoidCallback? onDelete,
+}) {
+  final l10n = context.l10n;
+  return [
+    // Primary actions: surfaced inline when expanded.
+    if (onAudioCallPressed != null)
+      NumberAction(
+        icon: Icons.call_outlined,
+        label: l10n.numberActions_audioCall,
+        onTap: onAudioCallPressed,
+        primary: true,
+      ),
+    if (onVideoCallPressed != null)
+      NumberAction(
+        icon: Icons.videocam_outlined,
+        label: l10n.numberActions_videoCall,
+        onTap: onVideoCallPressed,
+        primary: true,
+      ),
+    if (onChatPressed != null)
+      NumberAction(icon: Icons.chat_outlined, label: l10n.callTileActions_message, onTap: onChatPressed, primary: true),
+    if (onCallLogPressed != null)
+      NumberAction(icon: Icons.history, label: l10n.callTileActions_history, onTap: onCallLogPressed, primary: true),
+    if (onViewContactPressed != null)
+      NumberAction(
+        icon: Icons.person_outline,
+        label: l10n.callTileActions_contact,
+        onTap: onViewContactPressed,
+        primary: true,
+      ),
+    // Overflow actions: kept in the menu only.
+    if (callNumbers.length > 1 && onCallFrom != null)
+      for (final number in callNumbers)
+        NumberAction(
+          icon: Icons.call_outlined,
+          label: l10n.numberActions_callFrom(number),
+          onTap: () => onCallFrom(number),
+        ),
+    if (onTransferPressed != null)
+      NumberAction(icon: Icons.phone_forwarded_outlined, label: l10n.numberActions_transfer, onTap: onTransferPressed),
+    if (onSendSmsPressed != null)
+      NumberAction(icon: Icons.sms_outlined, label: l10n.numberActions_sendSms, onTap: onSendSmsPressed),
+    if (copyNumber != null)
+      NumberAction(
+        icon: Icons.copy_outlined,
+        label: l10n.numberActions_copyNumber,
+        onTap: () => Clipboard.setData(ClipboardData(text: copyNumber)),
+      ),
+    if (copyCallId != null)
+      NumberAction(
+        icon: Icons.copy_outlined,
+        label: l10n.numberActions_copyCallId,
+        onTap: () => Clipboard.setData(ClipboardData(text: copyCallId)),
+      ),
+    if (onDelete != null) NumberAction(icon: Icons.delete_outline, label: l10n.numberActions_delete, onTap: onDelete),
+  ];
+}
+
+/// Converts actions into popup menu entries (text-only, icons are not shown).
+List<PopupMenuEntry<dynamic>> numberActionsToMenu(List<NumberAction> actions) {
+  return [for (final action in actions) PopupMenuItem(onTap: action.onTap, child: Text(action.label))];
+}

--- a/test/features/contact/widgets/contact_phone_tile_adapter_test.dart
+++ b/test/features/contact/widgets/contact_phone_tile_adapter_test.dart
@@ -311,7 +311,7 @@ void main() {
         await tester.tap(find.byIcon(Icons.more_vert));
         await tester.pumpAndSettle();
 
-        expect(find.text('View call history'), findsOneWidget);
+        expect(find.text('History'), findsOneWidget);
       });
 
       testWidgets('hidden when enableTileCallLog is false', (tester) async {
@@ -320,7 +320,7 @@ void main() {
         await tester.tap(find.byIcon(Icons.more_vert));
         await tester.pumpAndSettle();
 
-        expect(find.text('View call history'), findsNothing);
+        expect(find.text('History'), findsNothing);
       });
 
       testWidgets('tapping call log entry triggers onCallLogPressed', (tester) async {
@@ -331,7 +331,7 @@ void main() {
 
         await tester.tap(find.byIcon(Icons.more_vert));
         await tester.pumpAndSettle();
-        await tester.tap(find.text('View call history'));
+        await tester.tap(find.text('History'));
         await tester.pumpAndSettle();
 
         expect(called, isTrue);

--- a/test/features/contacts/widgets/contact_tile_test.dart
+++ b/test/features/contacts/widgets/contact_tile_test.dart
@@ -29,6 +29,7 @@ void main() {
     VoidCallback? onChatPressed,
     VoidCallback? onCallLogPressed,
     VoidCallback? onViewContactPressed,
+    String? copyNumber,
   }) {
     return ContactTile(
       displayName: 'John Doe',
@@ -39,6 +40,7 @@ void main() {
       onChatPressed: onChatPressed,
       onCallLogPressed: onCallLogPressed,
       onViewContactPressed: onViewContactPressed,
+      copyNumber: copyNumber,
     );
   }
 
@@ -55,7 +57,14 @@ void main() {
     testWidgets('expanded tile shows actions for non-null callbacks', (tester) async {
       await tester.pumpWidget(
         buildTestable(
-          buildTile(expanded: true, onVideoCallPressed: () {}, onCallLogPressed: () {}, onViewContactPressed: () {}),
+          buildTile(
+            expanded: true,
+            onVideoCallPressed: () {},
+            onCallLogPressed: () {},
+            onViewContactPressed: () {},
+            // overflow action so the More affordance is rendered
+            copyNumber: '1001',
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -65,6 +74,20 @@ void main() {
       expect(find.text('Contact'), findsOneWidget);
       expect(find.text('More'), findsOneWidget);
       expect(find.text('Message'), findsNothing);
+    });
+
+    testWidgets('expanded tile hides More when there are no overflow actions', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(
+          buildTile(expanded: true, onVideoCallPressed: () {}, onCallLogPressed: () {}, onViewContactPressed: () {}),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video call'), findsOneWidget);
+      expect(find.text('History'), findsOneWidget);
+      expect(find.text('Contact'), findsOneWidget);
+      expect(find.text('More'), findsNothing);
     });
 
     testWidgets('row tap calls onTap and not onDialPressed', (tester) async {

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -162,6 +162,40 @@ void main() {
       expect(history, isTrue);
     });
 
+    testWidgets('expanded hides the inline audio action when the dial button is audio', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(
+          buildTile(expanded: true, onDialPressed: () {}, onAudioCallPressed: () {}, onVideoCallPressed: () {}),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The static dial button stays and keeps the audio action.
+      expect(find.byIcon(Icons.call), findsOneWidget);
+      // The inline audio action is dropped so it is not duplicated.
+      expect(find.text('Audio call'), findsNothing);
+      expect(find.text('Video call'), findsOneWidget);
+    });
+
+    testWidgets('expanded hides the inline video action when the dial button is video', (tester) async {
+      await tester.pumpWidget(
+        buildTestable(
+          buildTile(
+            expanded: true,
+            onDialPressed: () {},
+            dialIcon: Icons.videocam,
+            onAudioCallPressed: () {},
+            onVideoCallPressed: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.videocam), findsOneWidget);
+      expect(find.text('Video call'), findsNothing);
+      expect(find.text('Audio call'), findsOneWidget);
+    });
+
     testWidgets('disabled gestures hide dial button and actions bar', (tester) async {
       await tester.pumpWidget(
         buildTestable(buildTile(expanded: true, gesturesEnabled: false, onDialPressed: () {}, onCallLogPressed: () {})),

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -191,7 +191,8 @@ void main() {
       expect(find.text('More'), findsNothing);
     });
 
-    testWidgets('More opens the full actions menu', (tester) async {
+    testWidgets('More opens the overflow menu without the inline actions', (tester) async {
+      // Audio call is a primary (inline) action; copyNumber is an overflow action.
       await tester.pumpWidget(buildTestable(buildTile(expanded: true, onAudioCallPressed: () {})));
       await tester.pumpAndSettle();
 
@@ -200,7 +201,20 @@ void main() {
       await tester.tap(find.text('More'));
       await tester.pumpAndSettle();
 
+      // The overflow menu carries the remaining action, not the inline ones.
+      expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Copy number'), findsOneWidget);
+      expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Audio call'), findsNothing);
+    });
+
+    testWidgets('long press opens the full menu including inline actions', (tester) async {
+      await tester.pumpWidget(buildTestable(buildTile(onAudioCallPressed: () {})));
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.text('John Doe'));
+      await tester.pumpAndSettle();
+
       expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Audio call'), findsOneWidget);
+      expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Copy number'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Overview

The contact action surfaces each kept their own hardcoded list of actions, so the same action was offered twice at once with inconsistent wording:

- The inline expandable actions bar and the popup menu both listed audio/video call, history and view-contact. The **More** button reopened the *full* menu, repeating everything already shown in the bar.
- Labels diverged between the two surfaces: "History" vs "View call history", "Contact" vs "View Contact".
- `ContactPhoneTile` (contact details) maintained a third, separate popup builder with the same actions yet again.

## Changes

- Add `NumberAction` plus a single `buildNumberActions` builder (`lib/widgets/call/number_actions.dart`) as the one source of truth for the set, labels, icons and ordering of contact actions. Each action carries a `primary` flag.
- `CallTile` now derives both surfaces from that model:
  - the inline bar renders the **primary** actions;
  - **More** opens an *overflow* menu with only the remaining actions, so it never repeats what is already in the bar (and is hidden when there is no overflow);
  - long press / the collapsed-row menu button still expose the **full** set.
- `ContactPhoneTile` builds its overflow menu from the same builder instead of its own hardcoded entries; inline call/video/message icons and the favorite / initiated-transfer affordances are unchanged.
- Labels consolidated to one key per action ("History", "Contact").

Messaging/chat behavior is intentionally left as-is.

## Testing

- `flutter analyze` clean.
- `flutter test` - full suite green (updated `call_tile`, `contact_tile`, `contact_phone_tile_adapter` tests for the new overflow semantics; added coverage for long-press = full menu and More-hidden-without-overflow).

## Out of scope

- `keypad/widgets/actionpad.dart` still has its own popup builder - a candidate to migrate onto the same model later.