### PR TITLE
feat(cdrs): gate call history by local flag, Firebase override and server capability (WT-727)

### DIFF
--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -56,7 +56,8 @@
           "initial": false,
           "type": "recents",
           "titleL10n": "main_BottomNavigationBarItemLabel_recents",
-          "icon": "0xe03a"
+          "icon": "0xe03a",
+          "supportsCallHistory": true
         },
         {
           "enabled": true,

--- a/docs/application_config.md
+++ b/docs/application_config.md
@@ -182,13 +182,19 @@ Recent calls or history screen.
   "type": "recents",
   "enabled": true,
   "titleL10n": "main_BottomNavigationBarItemLabel_recents",
-  "icon": "0xe03a"
+  "icon": "0xe03a",
+  "supportsCallHistory": true
 }
 ```
 
-Remote call history (CDRs) is no longer configured here. It is enabled automatically when the
-server advertises the `callHistory` adapter capability in system-info; otherwise the recents tab
-falls back to the local device call log.
+| Field                 | Type      | Default | Description |
+| --------------------- | --------- | ------- | ----------- |
+| `supportsCallHistory` | `boolean` | `true`  | Local opt-in for remote call history (CDRs). |
+
+Remote call history (CDRs) is shown only when both signals agree: the local `supportsCallHistory`
+flag is `true` AND the server advertises the `callHistory` adapter capability in system-info. When
+either is false the recents tab falls back to the local device call log. The legacy `useCdrs` key is
+still accepted on read and migrated to `supportsCallHistory`.
 
 ### **ContactsTabScheme**
 

--- a/docs/application_config.md
+++ b/docs/application_config.md
@@ -191,10 +191,16 @@ Recent calls or history screen.
 | --------------------- | --------- | ------- | ----------- |
 | `supportsCallHistory` | `boolean` | `true`  | Local opt-in for remote call history (CDRs). |
 
-Remote call history (CDRs) is shown only when both signals agree: the local `supportsCallHistory`
-flag is `true` AND the server advertises the `callHistory` adapter capability in system-info. When
-either is false the recents tab falls back to the local device call log. The legacy `useCdrs` key is
-still accepted on read and migrated to `supportsCallHistory`.
+Remote call history (CDRs) is shown only when both signals agree: the resolved local flag is `true`
+AND the server advertises the `callHistory` adapter capability in system-info. When either is false
+the recents tab falls back to the local device call log. The legacy `useCdrs` key is still accepted
+on read and migrated to `supportsCallHistory`.
+
+The local flag can be overridden remotely via the Firebase Remote Config boolean
+`feature_call_history_enabled`: when set, it takes precedence over the config `supportsCallHistory`
+value; when unset it falls back to the config value. The remote override can flip the local opt-in
+either way, but it never bypasses the server `callHistory` capability - the capability gate always
+applies. Resolution: `(feature_call_history_enabled ?? supportsCallHistory) && callHistory`.
 
 ### **ContactsTabScheme**
 

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -237,8 +237,8 @@ abstract final class BottomMenuMapper {
         titleL10n: tab.titleL10n,
         icon: tab.icon.toIconData(),
       ),
-      recents: (enabled, initial, titleL10n, icon) => RecentsBottomMenuTab(
-        supportsCallHistory: coreSupport.supportsCallHistory,
+      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) => RecentsBottomMenuTab(
+        supportsCallHistory: supportsCallHistory && coreSupport.supportsCallHistory,
         enabled: tab.enabled,
         initial: tab.initial,
         titleL10n: tab.titleL10n,

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -108,7 +108,7 @@ class FeatureAccess extends Equatable {
       final termsConfig = TermsMapper.map(embeddedResources);
 
       final loginConfig = LoginMapper.map(appConfig, embeddedConfig.embeddedResources);
-      final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig, coreSupport);
+      final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig, coreSupport, featureOverrides);
       final settingsConfig = SettingsMapper.map(appConfig, embeddedResources, coreSupport, termsConfig);
       final callConfig = CallMapper.map(appConfig, featureOverrides);
       final messagingConfig = MessagingMapper.map(appConfig, coreSupport);
@@ -205,7 +205,15 @@ abstract final class BottomMenuMapper {
   /// [coreSupport] resolves capability-gated tab options - e.g. the recents tab uses server CDRs only
   /// when the adapter advertises call history, and the contacts tab keeps the `external` source only
   /// when it advertises the `extensions` capability.
-  static BottomMenuConfig map(AppConfig appConfig, EmbeddedConfig embeddedConfig, CoreSupport coreSupport) {
+  ///
+  /// [overrides] carries remote (Firebase Remote Config) overrides; when defined they take precedence
+  /// over the local config flag but never over a missing core capability.
+  static BottomMenuConfig map(
+    AppConfig appConfig,
+    EmbeddedConfig embeddedConfig,
+    CoreSupport coreSupport,
+    FeatureOverrides overrides,
+  ) {
     final bottomMenu = appConfig.mainConfig.bottomMenu;
 
     if (bottomMenu.tabs.isEmpty) {
@@ -214,7 +222,7 @@ abstract final class BottomMenuMapper {
 
     final bottomMenuTabs = bottomMenu.tabs
         .where((tab) => tab.enabled)
-        .map((tab) => _createBottomMenuTab(tab, embeddedConfig, coreSupport))
+        .map((tab) => _createBottomMenuTab(tab, embeddedConfig, coreSupport, overrides))
         .where((tab) => !(tab is ContactsBottomMenuTab && tab.contactSourceTypes.isEmpty))
         .toList();
 
@@ -229,6 +237,7 @@ abstract final class BottomMenuMapper {
     BottomMenuTabScheme tab,
     EmbeddedConfig embeddedConfig,
     CoreSupport coreSupport,
+    FeatureOverrides overrides,
   ) {
     return tab.when(
       favorites: (enabled, initial, titleL10n, icon) => FavoritesBottomMenuTab(
@@ -237,13 +246,19 @@ abstract final class BottomMenuMapper {
         titleL10n: tab.titleL10n,
         icon: tab.icon.toIconData(),
       ),
-      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) => RecentsBottomMenuTab(
-        supportsCallHistory: supportsCallHistory && coreSupport.supportsCallHistory,
-        enabled: tab.enabled,
-        initial: tab.initial,
-        titleL10n: tab.titleL10n,
-        icon: tab.icon.toIconData(),
-      ),
+      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) {
+        // Local flag (config) can be overridden by Firebase Remote Config, then gated by the core
+        // capability: call history is shown only when the resolved local flag AND the server
+        // callHistory capability are both true.
+        final localFlag = overrides.isCallHistoryEnabled ?? supportsCallHistory;
+        return RecentsBottomMenuTab(
+          supportsCallHistory: localFlag && coreSupport.supportsCallHistory,
+          enabled: tab.enabled,
+          initial: tab.initial,
+          titleL10n: tab.titleL10n,
+          icon: tab.icon.toIconData(),
+        );
+      },
       contacts: (enabled, initial, titleL10n, icon, contactSourceTypes) => ContactsBottomMenuTab(
         enabled: tab.enabled,
         initial: tab.initial,

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -246,19 +246,16 @@ abstract final class BottomMenuMapper {
         titleL10n: tab.titleL10n,
         icon: tab.icon.toIconData(),
       ),
-      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) {
-        // Local flag (config) can be overridden by Firebase Remote Config, then gated by the core
-        // capability: call history is shown only when the resolved local flag AND the server
-        // callHistory capability are both true.
-        final localFlag = overrides.isCallHistoryEnabled ?? supportsCallHistory;
-        return RecentsBottomMenuTab(
-          supportsCallHistory: localFlag && coreSupport.supportsCallHistory,
-          enabled: tab.enabled,
-          initial: tab.initial,
-          titleL10n: tab.titleL10n,
-          icon: tab.icon.toIconData(),
-        );
-      },
+      // Local flag (config) can be overridden by Firebase Remote Config, then gated by the core
+      // capability: call history is shown only when the resolved local flag AND the server
+      // callHistory capability are both true.
+      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) => RecentsBottomMenuTab(
+        supportsCallHistory: (overrides.isCallHistoryEnabled ?? supportsCallHistory) && coreSupport.supportsCallHistory,
+        enabled: tab.enabled,
+        initial: tab.initial,
+        titleL10n: tab.titleL10n,
+        icon: tab.icon.toIconData(),
+      ),
       contacts: (enabled, initial, titleL10n, icon, contactSourceTypes) => ContactsBottomMenuTab(
         enabled: tab.enabled,
         initial: tab.initial,

--- a/lib/models/feature_access/feature_overrides.dart
+++ b/lib/models/feature_access/feature_overrides.dart
@@ -9,6 +9,7 @@ class FeatureOverrides extends Equatable {
     this.isSystemNotificationsEnabled,
     this.hybridPresenceSupport,
     this.isVoicemailEnabled,
+    this.isCallHistoryEnabled,
     this.monitorCheckInterval,
     this.logLevel,
     this.remoteLoggingEnabled,
@@ -19,6 +20,7 @@ class FeatureOverrides extends Equatable {
   final bool? isSystemNotificationsEnabled;
   final bool? hybridPresenceSupport;
   final bool? isVoicemailEnabled;
+  final bool? isCallHistoryEnabled;
   final Duration? monitorCheckInterval;
   final Level? logLevel;
   final bool? remoteLoggingEnabled;
@@ -30,6 +32,7 @@ class FeatureOverrides extends Equatable {
     isSystemNotificationsEnabled,
     hybridPresenceSupport,
     isVoicemailEnabled,
+    isCallHistoryEnabled,
     monitorCheckInterval,
     logLevel,
     remoteLoggingEnabled,
@@ -41,6 +44,7 @@ abstract final class FeatureOverridesFactory {
   static const _kSystemNotificationsEnabledKey = 'feature_system_notifications_enabled';
   static const _kHybridPresenceEnabledKey = 'feature_hybrid_presence_enabled';
   static const _kVoicemailEnabledKey = 'feature_voicemail_enabled';
+  static const _kCallHistoryEnabledKey = 'feature_call_history_enabled';
   static const _kMonitorCheckIntervalKey = 'feature_monitor_check_interval_sec';
   static const _kLogLevelKey = 'feature_log_level';
   static const _kRemoteLoggingEnabledKey = 'firebaseRemoteLogging';
@@ -61,6 +65,7 @@ abstract final class FeatureOverridesFactory {
       isSystemNotificationsEnabled: snapshot.getBool(_kSystemNotificationsEnabledKey),
       hybridPresenceSupport: snapshot.getBool(_kHybridPresenceEnabledKey),
       isVoicemailEnabled: snapshot.getBool(_kVoicemailEnabledKey),
+      isCallHistoryEnabled: snapshot.getBool(_kCallHistoryEnabledKey),
       monitorCheckInterval: monitorCheckInterval,
       logLevel: logLevel,
       remoteLoggingEnabled: snapshot.getBool(_kRemoteLoggingEnabledKey),

--- a/lib/models/feature_access/feature_overrides.dart
+++ b/lib/models/feature_access/feature_overrides.dart
@@ -36,6 +36,7 @@ class FeatureOverrides extends Equatable {
     monitorCheckInterval,
     logLevel,
     remoteLoggingEnabled,
+    isLogAnonymizationEnabled,
   ];
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -363,9 +363,9 @@ class EncodingDefaultPresetOverride with _$EncodingDefaultPresetOverride {
 }
 
 // Migration shim for the recents tab call-history flag: prefer the current
-// `supportsCallHistory` key, fall back to the legacy `useCdrs` key, then let the
-// field default apply when neither is present.
-Object? _readRecentsSupportsCallHistory(Map json, String key) => json[key] ?? json['useCdrs'];
+// `supportsCallHistory` key (when present, even if null), fall back to the
+// legacy `useCdrs` key, then let the field default apply when neither is present.
+Object? _readRecentsSupportsCallHistory(Map json, String key) => json.containsKey(key) ? json[key] : json['useCdrs'];
 
 @Freezed(unionKey: 'type')
 sealed class BottomMenuTabScheme with _$BottomMenuTabScheme {

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -155,6 +155,7 @@ class AppConfigMain with _$AppConfigMain {
           initial: false,
           titleL10n: 'main_BottomNavigationBarItemLabel_recents',
           icon: '0xe03a',
+          supportsCallHistory: true,
         ),
         ContactsTabScheme(
           enabled: true,
@@ -361,6 +362,11 @@ class EncodingDefaultPresetOverride with _$EncodingDefaultPresetOverride {
   Map<String, Object?> toJson() => _$EncodingDefaultPresetOverrideToJson(this);
 }
 
+// Migration shim for the recents tab call-history flag: prefer the current
+// `supportsCallHistory` key, fall back to the legacy `useCdrs` key, then let the
+// field default apply when neither is present.
+Object? _readRecentsSupportsCallHistory(Map json, String key) => json[key] ?? json['useCdrs'];
+
 @Freezed(unionKey: 'type')
 sealed class BottomMenuTabScheme with _$BottomMenuTabScheme {
   const BottomMenuTabScheme._();
@@ -379,6 +385,11 @@ sealed class BottomMenuTabScheme with _$BottomMenuTabScheme {
     @Default(false) bool initial,
     required String titleL10n,
     required String icon,
+    // Local opt-in for remote call history (CDRs). Resolved against the server
+    // `callHistory` adapter capability in feature_access (both must be true).
+    // Reads the `supportsCallHistory` key and falls back to the legacy `useCdrs`
+    // key so existing configs keep their value.
+    @JsonKey(readValue: _readRecentsSupportsCallHistory) @Default(true) bool supportsCallHistory,
   }) = RecentsTabScheme;
 
   @JsonSerializable(explicitToJson: true)

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
@@ -2656,11 +2656,11 @@ return embedded(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  recents,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @JsonKey(readValue: _readRecentsSupportsCallHistory)  bool supportsCallHistory)?  recents,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case FavoritesTabScheme() when favorites != null:
 return favorites(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case RecentsTabScheme() when recents != null:
-return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case ContactsTabScheme() when contacts != null:
+return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.supportsCallHistory);case ContactsTabScheme() when contacts != null:
 return contacts(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.contactSourceTypes);case KeypadTabScheme() when keypad != null:
 return keypad(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case MessagingTabScheme() when messaging != null:
 return messaging(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case EmbeddedTabScheme() when embedded != null:
@@ -2682,11 +2682,11 @@ return embedded(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.emb
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  favorites,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  recents,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)  contacts,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  keypad,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  messaging,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)  embedded,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  favorites,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @JsonKey(readValue: _readRecentsSupportsCallHistory)  bool supportsCallHistory)  recents,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)  contacts,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  keypad,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon)  messaging,required TResult Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)  embedded,}) {final _that = this;
 switch (_that) {
 case FavoritesTabScheme():
 return favorites(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case RecentsTabScheme():
-return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case ContactsTabScheme():
+return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.supportsCallHistory);case ContactsTabScheme():
 return contacts(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.contactSourceTypes);case KeypadTabScheme():
 return keypad(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case MessagingTabScheme():
 return messaging(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case EmbeddedTabScheme():
@@ -2704,11 +2704,11 @@ return embedded(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.emb
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  recents,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  favorites,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon, @JsonKey(readValue: _readRecentsSupportsCallHistory)  bool supportsCallHistory)?  recents,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon,  List<String> contactSourceTypes)?  contacts,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  keypad,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon)?  messaging,TResult? Function( bool enabled,  bool initial,  String titleL10n,  String icon, @IntToStringConverter()  String embeddedResourceId)?  embedded,}) {final _that = this;
 switch (_that) {
 case FavoritesTabScheme() when favorites != null:
 return favorites(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case RecentsTabScheme() when recents != null:
-return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case ContactsTabScheme() when contacts != null:
+return recents(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.supportsCallHistory);case ContactsTabScheme() when contacts != null:
 return contacts(_that.enabled,_that.initial,_that.titleL10n,_that.icon,_that.contactSourceTypes);case KeypadTabScheme() when keypad != null:
 return keypad(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case MessagingTabScheme() when messaging != null:
 return messaging(_that.enabled,_that.initial,_that.titleL10n,_that.icon);case EmbeddedTabScheme() when embedded != null:
@@ -2803,13 +2803,18 @@ as String,
 
 @JsonSerializable(explicitToJson: true)
 class RecentsTabScheme extends BottomMenuTabScheme {
-  const RecentsTabScheme({this.enabled = true, this.initial = false, required this.titleL10n, required this.icon, final  String? $type}): $type = $type ?? 'recents',super._();
+  const RecentsTabScheme({this.enabled = true, this.initial = false, required this.titleL10n, required this.icon, @JsonKey(readValue: _readRecentsSupportsCallHistory) this.supportsCallHistory = true, final  String? $type}): $type = $type ?? 'recents',super._();
   factory RecentsTabScheme.fromJson(Map<String, dynamic> json) => _$RecentsTabSchemeFromJson(json);
 
 @override@JsonKey() final  bool enabled;
 @override@JsonKey() final  bool initial;
 @override final  String titleL10n;
 @override final  String icon;
+// Local opt-in for remote call history (CDRs). Resolved against the server
+// `callHistory` adapter capability in feature_access (both must be true).
+// Reads the `supportsCallHistory` key and falls back to the legacy `useCdrs`
+// key so existing configs keep their value.
+@JsonKey(readValue: _readRecentsSupportsCallHistory) final  bool supportsCallHistory;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -2828,16 +2833,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsTabScheme&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.initial, initial) || other.initial == initial)&&(identical(other.titleL10n, titleL10n) || other.titleL10n == titleL10n)&&(identical(other.icon, icon) || other.icon == icon));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecentsTabScheme&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.initial, initial) || other.initial == initial)&&(identical(other.titleL10n, titleL10n) || other.titleL10n == titleL10n)&&(identical(other.icon, icon) || other.icon == icon)&&(identical(other.supportsCallHistory, supportsCallHistory) || other.supportsCallHistory == supportsCallHistory));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enabled,initial,titleL10n,icon);
+int get hashCode => Object.hash(runtimeType,enabled,initial,titleL10n,icon,supportsCallHistory);
 
 @override
 String toString() {
-  return 'BottomMenuTabScheme.recents(enabled: $enabled, initial: $initial, titleL10n: $titleL10n, icon: $icon)';
+  return 'BottomMenuTabScheme.recents(enabled: $enabled, initial: $initial, titleL10n: $titleL10n, icon: $icon, supportsCallHistory: $supportsCallHistory)';
 }
 
 
@@ -2848,7 +2853,7 @@ abstract mixin class $RecentsTabSchemeCopyWith<$Res> implements $BottomMenuTabSc
   factory $RecentsTabSchemeCopyWith(RecentsTabScheme value, $Res Function(RecentsTabScheme) _then) = _$RecentsTabSchemeCopyWithImpl;
 @override @useResult
 $Res call({
- bool enabled, bool initial, String titleL10n, String icon
+ bool enabled, bool initial, String titleL10n, String icon,@JsonKey(readValue: _readRecentsSupportsCallHistory) bool supportsCallHistory
 });
 
 
@@ -2865,13 +2870,14 @@ class _$RecentsTabSchemeCopyWithImpl<$Res>
 
 /// Create a copy of BottomMenuTabScheme
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? initial = null,Object? titleL10n = null,Object? icon = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? initial = null,Object? titleL10n = null,Object? icon = null,Object? supportsCallHistory = null,}) {
   return _then(RecentsTabScheme(
 enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool,initial: null == initial ? _self.initial : initial // ignore: cast_nullable_to_non_nullable
 as bool,titleL10n: null == titleL10n ? _self.titleL10n : titleL10n // ignore: cast_nullable_to_non_nullable
 as String,icon: null == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
-as String,
+as String,supportsCallHistory: null == supportsCallHistory ? _self.supportsCallHistory : supportsCallHistory // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
@@ -146,6 +146,7 @@ AppConfigMain _$AppConfigMainFromJson(Map<String, dynamic> json) =>
                   initial: false,
                   titleL10n: 'main_BottomNavigationBarItemLabel_recents',
                   icon: '0xe03a',
+                  supportsCallHistory: true,
                 ),
                 ContactsTabScheme(
                   enabled: true,
@@ -568,6 +569,10 @@ RecentsTabScheme _$RecentsTabSchemeFromJson(Map<String, dynamic> json) =>
       initial: json['initial'] as bool? ?? false,
       titleL10n: json['titleL10n'] as String,
       icon: json['icon'] as String,
+      supportsCallHistory:
+          _readRecentsSupportsCallHistory(json, 'supportsCallHistory')
+              as bool? ??
+          true,
       $type: json['type'] as String?,
     );
 
@@ -577,6 +582,7 @@ Map<String, dynamic> _$RecentsTabSchemeToJson(RecentsTabScheme instance) =>
       'initial': instance.initial,
       'titleL10n': instance.titleL10n,
       'icon': instance.icon,
+      'supportsCallHistory': instance.supportsCallHistory,
       'type': instance.$type,
     };
 

--- a/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
+++ b/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
@@ -187,6 +187,10 @@ void main() {
       expect(recentsSupportsCallHistory({'supportsCallHistory': false, 'useCdrs': true}), isFalse);
     });
 
+    test('explicit null new key does not fall back to legacy useCdrs (default applies)', () {
+      expect(recentsSupportsCallHistory({'supportsCallHistory': null, 'useCdrs': false}), isTrue);
+    });
+
     test('defaults to true when neither key is present', () {
       expect(recentsSupportsCallHistory(const {}), isTrue);
     });

--- a/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
+++ b/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
@@ -51,11 +51,12 @@ void main() {
       // Recents
       tabs[1].when(
         favorites: unexpectedFavorites,
-        recents: (enabled, initial, titleL10n, icon) {
-          expect(enabled, isFalse);
+        recents: (enabled, initial, titleL10n, icon, supportsCallHistory) {
+          expect(enabled, isTrue);
           expect(initial, isFalse);
           expect(titleL10n, 'main_BottomNavigationBarItemLabel_recents');
           expect(icon, '0xe03a');
+          expect(supportsCallHistory, isTrue);
         },
         contacts: unexpectedContacts,
         keypad: unexpectedKeypad,
@@ -101,7 +102,7 @@ void main() {
         contacts: unexpectedContacts,
         keypad: unexpectedKeypad,
         messaging: (enabled, initial, titleL10n, icon) {
-          expect(enabled, isFalse);
+          expect(enabled, isTrue);
           expect(initial, isFalse);
           expect(titleL10n, 'main_BottomNavigationBarItemLabel_chats');
           expect(icon, '0xe155');
@@ -156,6 +157,38 @@ void main() {
       final settingsSection = sections.firstWhere((s) => s.titleL10n == 'settings_ListViewTileTitle_settings');
       expect(settingsSection.enabled, isTrue);
       expect(settingsSection.items.any((i) => i.type == 'terms'), isTrue);
+    });
+  });
+
+  group('RecentsTabScheme.supportsCallHistory parsing & useCdrs migration', () {
+    bool recentsSupportsCallHistory(Map<String, Object?> extra) {
+      final scheme = BottomMenuTabScheme.fromJson({
+        'type': 'recents',
+        'enabled': true,
+        'titleL10n': 'recents',
+        'icon': '0xe03a',
+        ...extra,
+      });
+      return (scheme as RecentsTabScheme).supportsCallHistory;
+    }
+
+    test('new key is honoured', () {
+      expect(recentsSupportsCallHistory({'supportsCallHistory': false}), isFalse);
+      expect(recentsSupportsCallHistory({'supportsCallHistory': true}), isTrue);
+    });
+
+    test('legacy useCdrs key migrates when new key is absent', () {
+      expect(recentsSupportsCallHistory({'useCdrs': false}), isFalse);
+      expect(recentsSupportsCallHistory({'useCdrs': true}), isTrue);
+    });
+
+    test('new key wins over legacy useCdrs when both present', () {
+      expect(recentsSupportsCallHistory({'supportsCallHistory': true, 'useCdrs': false}), isTrue);
+      expect(recentsSupportsCallHistory({'supportsCallHistory': false, 'useCdrs': true}), isFalse);
+    });
+
+    test('defaults to true when neither key is present', () {
+      expect(recentsSupportsCallHistory(const {}), isTrue);
     });
   });
 }

--- a/packages/webtrit_appearance_theme/test/helpers/freezed_unexpected.dart
+++ b/packages/webtrit_appearance_theme/test/helpers/freezed_unexpected.dart
@@ -6,7 +6,8 @@ Never unexpectedKeypad(bool a, bool b, String c, String d) => throw TestFailure(
 
 Never unexpectedMessaging(bool a, bool b, String c, String d) => throw TestFailure('Unexpected messaging variant hit');
 
-Never unexpectedRecents(bool a, bool b, String c, String d) => throw TestFailure('Unexpected recents variant hit');
+Never unexpectedRecents(bool a, bool b, String c, String d, bool e) =>
+    throw TestFailure('Unexpected recents variant hit');
 
 Never unexpectedContacts(bool a, bool b, String c, String d, List<String> e) =>
     throw TestFailure('Unexpected contacts variant hit');

--- a/test/data/bottom_menu_mapper_test.dart
+++ b/test/data/bottom_menu_mapper_test.dart
@@ -10,13 +10,18 @@ import 'package:webtrit_phone/utils/core_support.dart';
 void main() {
   final emptyEmbedded = EmbeddedMapper.map(const []);
 
-  group('BottomMenuMapper recents useCdrs gating by the callHistory capability', () {
-    AppConfig appConfigWithRecents() {
+  group('BottomMenuMapper recents call history gated by local flag AND callHistory capability', () {
+    AppConfig appConfigWithRecents({required bool supportsCallHistory}) {
       return AppConfig(
         mainConfig: AppConfigMain(
           bottomMenu: AppConfigBottomMenu(
             tabs: [
-              const BottomMenuTabScheme.recents(enabled: true, titleL10n: 'recents', icon: '0xe03a'),
+              BottomMenuTabScheme.recents(
+                enabled: true,
+                titleL10n: 'recents',
+                icon: '0xe03a',
+                supportsCallHistory: supportsCallHistory,
+              ),
               const BottomMenuTabScheme.keypad(enabled: true, titleL10n: 'keypad', icon: '0xe1ce'),
             ],
           ),
@@ -24,17 +29,29 @@ void main() {
       );
     }
 
-    bool? recentsUseCdrs(AppConfig appConfig, List<String> flags) {
-      final config = BottomMenuMapper.map(appConfig, emptyEmbedded, CoreSupportImpl(flags));
+    bool? recentsUseCdrs({required bool localFlag, required List<String> flags}) {
+      final config = BottomMenuMapper.map(
+        appConfigWithRecents(supportsCallHistory: localFlag),
+        emptyEmbedded,
+        CoreSupportImpl(flags),
+      );
       return config.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory;
     }
 
-    test('callHistory advertised -> true', () {
-      expect(recentsUseCdrs(appConfigWithRecents(), [kCallHistoryFeatureFlag]), isTrue);
+    test('local flag true AND callHistory advertised -> true', () {
+      expect(recentsUseCdrs(localFlag: true, flags: [kCallHistoryFeatureFlag]), isTrue);
     });
 
-    test('callHistory NOT advertised -> false (local call log fallback)', () {
-      expect(recentsUseCdrs(appConfigWithRecents(), const []), isFalse);
+    test('local flag true but callHistory NOT advertised -> false (local call log fallback)', () {
+      expect(recentsUseCdrs(localFlag: true, flags: const []), isFalse);
+    });
+
+    test('local flag false even when callHistory advertised -> false', () {
+      expect(recentsUseCdrs(localFlag: false, flags: [kCallHistoryFeatureFlag]), isFalse);
+    });
+
+    test('local flag false and callHistory NOT advertised -> false', () {
+      expect(recentsUseCdrs(localFlag: false, flags: const []), isFalse);
     });
   });
 

--- a/test/data/bottom_menu_mapper_test.dart
+++ b/test/data/bottom_menu_mapper_test.dart
@@ -29,7 +29,7 @@ void main() {
       );
     }
 
-    bool? recentsUseCdrs({required bool localFlag, required List<String> flags}) {
+    bool? resolvedSupportsCallHistory({required bool localFlag, required List<String> flags}) {
       final config = BottomMenuMapper.map(
         appConfigWithRecents(supportsCallHistory: localFlag),
         emptyEmbedded,
@@ -39,19 +39,19 @@ void main() {
     }
 
     test('local flag true AND callHistory advertised -> true', () {
-      expect(recentsUseCdrs(localFlag: true, flags: [kCallHistoryFeatureFlag]), isTrue);
+      expect(resolvedSupportsCallHistory(localFlag: true, flags: [kCallHistoryFeatureFlag]), isTrue);
     });
 
     test('local flag true but callHistory NOT advertised -> false (local call log fallback)', () {
-      expect(recentsUseCdrs(localFlag: true, flags: const []), isFalse);
+      expect(resolvedSupportsCallHistory(localFlag: true, flags: const []), isFalse);
     });
 
     test('local flag false even when callHistory advertised -> false', () {
-      expect(recentsUseCdrs(localFlag: false, flags: [kCallHistoryFeatureFlag]), isFalse);
+      expect(resolvedSupportsCallHistory(localFlag: false, flags: [kCallHistoryFeatureFlag]), isFalse);
     });
 
     test('local flag false and callHistory NOT advertised -> false', () {
-      expect(recentsUseCdrs(localFlag: false, flags: const []), isFalse);
+      expect(resolvedSupportsCallHistory(localFlag: false, flags: const []), isFalse);
     });
   });
 

--- a/test/data/bottom_menu_mapper_test.dart
+++ b/test/data/bottom_menu_mapper_test.dart
@@ -29,11 +29,12 @@ void main() {
       );
     }
 
-    bool? resolvedSupportsCallHistory({required bool localFlag, required List<String> flags}) {
+    bool? resolvedSupportsCallHistory({required bool localFlag, required List<String> flags, bool? firebaseOverride}) {
       final config = BottomMenuMapper.map(
         appConfigWithRecents(supportsCallHistory: localFlag),
         emptyEmbedded,
         CoreSupportImpl(flags),
+        FeatureOverrides(isCallHistoryEnabled: firebaseOverride),
       );
       return config.getTabEnabled<RecentsBottomMenuTab>()?.supportsCallHistory;
     }
@@ -52,6 +53,31 @@ void main() {
 
     test('local flag false and callHistory NOT advertised -> false', () {
       expect(resolvedSupportsCallHistory(localFlag: false, flags: const []), isFalse);
+    });
+
+    test('firebase override true lifts a false local flag when callHistory advertised -> true', () {
+      expect(
+        resolvedSupportsCallHistory(localFlag: false, flags: [kCallHistoryFeatureFlag], firebaseOverride: true),
+        isTrue,
+      );
+    });
+
+    test('firebase override false suppresses a true local flag even when callHistory advertised -> false', () {
+      expect(
+        resolvedSupportsCallHistory(localFlag: true, flags: [kCallHistoryFeatureFlag], firebaseOverride: false),
+        isFalse,
+      );
+    });
+
+    test('firebase override true cannot bypass a missing callHistory capability -> false', () {
+      expect(resolvedSupportsCallHistory(localFlag: false, flags: const [], firebaseOverride: true), isFalse);
+    });
+
+    test('null firebase override falls back to the local flag', () {
+      expect(
+        resolvedSupportsCallHistory(localFlag: true, flags: [kCallHistoryFeatureFlag], firebaseOverride: null),
+        isTrue,
+      );
     });
   });
 
@@ -75,7 +101,7 @@ void main() {
     }
 
     ContactsBottomMenuTab? contactsTab(AppConfig appConfig, List<String> flags) {
-      final config = BottomMenuMapper.map(appConfig, emptyEmbedded, CoreSupportImpl(flags));
+      final config = BottomMenuMapper.map(appConfig, emptyEmbedded, CoreSupportImpl(flags), const FeatureOverrides());
       return config.getTabEnabled<ContactsBottomMenuTab>();
     }
 

--- a/test/data/bottom_menu_mapper_test.dart
+++ b/test/data/bottom_menu_mapper_test.dart
@@ -55,14 +55,14 @@ void main() {
       expect(resolvedSupportsCallHistory(localFlag: false, flags: const []), isFalse);
     });
 
-    test('firebase override true lifts a false local flag when callHistory advertised -> true', () {
+    test('firebase override true lifts a false local flag when callHistory is advertised -> true', () {
       expect(
         resolvedSupportsCallHistory(localFlag: false, flags: [kCallHistoryFeatureFlag], firebaseOverride: true),
         isTrue,
       );
     });
 
-    test('firebase override false suppresses a true local flag even when callHistory advertised -> false', () {
+    test('firebase override false suppresses a true local flag even when callHistory is advertised -> false', () {
       expect(
         resolvedSupportsCallHistory(localFlag: true, flags: [kCallHistoryFeatureFlag], firebaseOverride: false),
         isFalse,


### PR DESCRIPTION
## Overview

Partially reverts #1327. That change made the server `callHistory` adapter capability the sole source of truth for remote call history (CDRs) and dropped the local config flag. This restores a local opt-in and adds a remote (Firebase) override on top, while keeping the server capability as a hard gate.

Remote call history (CDRs) is resolved from three sources:

```
(feature_call_history_enabled ?? supportsCallHistory) && callHistory
```

- `supportsCallHistory` - local config flag on the recents tab (`RecentsTabScheme`).
- `feature_call_history_enabled` - Firebase Remote Config boolean; when set it overrides the local flag, when unset it falls back to it.
- `callHistory` - server adapter capability from system-info; a hard gate the remote override can NOT bypass.

When the resolved value is false the recents tab falls back to the local device call log.

## How

- `webtrit_appearance_theme`: re-add `supportsCallHistory` to `RecentsTabScheme` (default `true`), regenerate freezed/json. The JSON read shim uses `containsKey` so an explicitly present key (even null) wins, and falls back to the legacy `useCdrs` key otherwise - existing configs keep their value with no migration step.
- `FeatureOverrides`: add `isCallHistoryEnabled`, read from the `feature_call_history_enabled` Remote Config key (same pattern as the other remote overrides).
- `BottomMenuMapper`: takes `FeatureOverrides` and resolves `(override ?? localFlag) && coreSupport.supportsCallHistory` when building `RecentsBottomMenuTab`. The runtime field name `RecentsBottomMenuTab.supportsCallHistory` is unchanged, so router/shell/screens are untouched. Reactive rebuilds already combine the core stream and Remote Config updates via `FeatureAccessStreamFactory`.
- `assets/themes/app.config.json`: recents tab carries `"supportsCallHistory": true`.
- `docs/application_config.md`: document the local flag, the legacy alias, and the remote override + resolution order.

## Tests

- `app_config_main_parsing_test.dart`: parsing/migration cases - new key honoured, legacy `useCdrs` migrated, new key wins over legacy, explicit-null does not fall back to legacy, default `true`.
- `bottom_menu_mapper_test.dart`: full matrix of local flag x server capability x Firebase override (override lifts/suppresses the local flag; override can never bypass a missing capability; null override falls back to the local flag).
- Also aligned two stale `enabled` expectations in the parsing test with the committed `app.config.json` fixture (recents and messaging) - pre-existing mismatch, unrelated to this feature.

## Follow-ups

- Pairs with webtrit_phone_configurator#151, which restores the Use CDRs toggle. It resolves `webtrit_appearance_theme` through its local path dependency on webtrit_phone, so merge this PR first.
- Register the boolean key `feature_call_history_enabled` in the Firebase Remote Config console; until set, behavior is unchanged (falls back to the config flag).