### PR TITLE
fix(login): allow letters in OTP sign-in identifier field (WT-1642)

### DIFF
--- a/lib/features/login/extensions/otp_signin_identifier.dart
+++ b/lib/features/login/extensions/otp_signin_identifier.dart
@@ -18,7 +18,11 @@ extension OtpSigninIdentifiersInput on List<OtpSigninIdentifier> {
     return l10n.login_TextFieldLabelText_otpSigninUserRef;
   }
 
-  TextInputType get userRefKeyboardType => _hasPhone && !_hasEmail ? TextInputType.phone : TextInputType.emailAddress;
+  /// Account references may be alphanumeric (for example `ph123x456`) even when
+  /// the backend advertises phone as the only OTP identifier, so a phone-only
+  /// dial pad would wrongly block letters. Use a text keyboard whenever email is
+  /// not advertised, and the email keyboard otherwise for the handy `@` key.
+  TextInputType get userRefKeyboardType => _hasEmail ? TextInputType.emailAddress : TextInputType.text;
 
   List<String> get userRefAutofillHints {
     if (_hasPhone && !_hasEmail) return const [AutofillHints.telephoneNumber];

--- a/test/features/login/otp_signin_identifier_test.dart
+++ b/test/features/login/otp_signin_identifier_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import 'package:pub_semver/pub_semver.dart';
 
 import 'package:webtrit_phone/app/constants.dart';

--- a/test/features/login/otp_signin_identifier_test.dart
+++ b/test/features/login/otp_signin_identifier_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pub_semver/pub_semver.dart';
 
@@ -78,6 +79,24 @@ void main() {
         kOtpLoginIdentifiersCustomKey: ['email'],
       });
       expect(state.otpSigninIdentifiers, [OtpSigninIdentifier.email]);
+    });
+  });
+
+  group('OtpSigninIdentifiersInput.userRefKeyboardType', () {
+    test('allows letters for phone-only identifiers (alphanumeric accounts)', () {
+      expect([OtpSigninIdentifier.phoneNumber].userRefKeyboardType, TextInputType.text);
+    });
+
+    test('uses the email keyboard when email is advertised', () {
+      expect([OtpSigninIdentifier.email].userRefKeyboardType, TextInputType.emailAddress);
+      expect(
+        [OtpSigninIdentifier.phoneNumber, OtpSigninIdentifier.email].userRefKeyboardType,
+        TextInputType.emailAddress,
+      );
+    });
+
+    test('falls back to a text keyboard when nothing is advertised', () {
+      expect(<OtpSigninIdentifier>[].userRefKeyboardType, TextInputType.text);
     });
   });
 }


### PR DESCRIPTION
## Overview

OTP sign-in only accepted digits, so customers with alphanumeric account references (e.g. `ph123x456`) could not log in. The field worked in 1.15.2 but regressed in 1.15.3/1.15.4.

## Root cause

WT-1433 aligned the identifier keyboard with the backend's advertised `otp_login_identifiers`. For the phone-only case it selected `TextInputType.phone`, which renders a numeric dial pad and blocks letters. PortaOne account ids advertised as `phone_number` can still be alphanumeric, so the dial pad is wrong.

## Fix

`userRefKeyboardType` now uses `TextInputType.text` whenever email is not an advertised identifier, and keeps `TextInputType.emailAddress` only when email is accepted. The input validator already permits letters, so no other change is needed. Labels and autofill hints from WT-1433 are unchanged.

## Tests

Added keyboard-type coverage to `otp_signin_identifier_test.dart` (phone-only -> text, email/mixed -> email, empty -> text). Full suite green.

## Affected versions

1.15.3, 1.15.4. To be cherry-picked onto `release/1.15.4`.