### PR TITLE
fix(login): allow letters in OTP sign-in identifier field (WT-1642)

### DIFF
--- a/lib/features/login/extensions/otp_signin_identifier.dart
+++ b/lib/features/login/extensions/otp_signin_identifier.dart
@@ -18,7 +18,11 @@ extension OtpSigninIdentifiersInput on List<OtpSigninIdentifier> {
     return l10n.login_TextFieldLabelText_otpSigninUserRef;
   }
 
-  TextInputType get userRefKeyboardType => _hasPhone && !_hasEmail ? TextInputType.phone : TextInputType.emailAddress;
+  /// Account references may be alphanumeric (for example `ph123x456`) even when
+  /// the backend advertises phone as the only OTP identifier, so a phone-only
+  /// dial pad would wrongly block letters. Use a text keyboard whenever email is
+  /// not advertised, and the email keyboard otherwise for the handy `@` key.
+  TextInputType get userRefKeyboardType => _hasEmail ? TextInputType.emailAddress : TextInputType.text;
 
   List<String> get userRefAutofillHints {
     if (_hasPhone && !_hasEmail) return const [AutofillHints.telephoneNumber];

--- a/packages/pjsua_companion/bin/server.dart
+++ b/packages/pjsua_companion/bin/server.dart
@@ -237,7 +237,7 @@ Future<Process> _spawnPjsua(
     '--publish',
     '--log-level=1',
     if (autoAnswer) '--auto-answer=200',
-    if (callTarget != null) callTarget,
+    ?callTarget,
   ]);
 
   final pid = process.pid;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.15.4+1
+app_version: 1.15.4+2
 
 environment:
   sdk: ^3.12.0

--- a/test/features/login/otp_signin_identifier_test.dart
+++ b/test/features/login/otp_signin_identifier_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import 'package:pub_semver/pub_semver.dart';
 
 import 'package:webtrit_phone/app/constants.dart';

--- a/test/features/login/otp_signin_identifier_test.dart
+++ b/test/features/login/otp_signin_identifier_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pub_semver/pub_semver.dart';
 
@@ -78,6 +79,24 @@ void main() {
         kOtpLoginIdentifiersCustomKey: ['email'],
       });
       expect(state.otpSigninIdentifiers, [OtpSigninIdentifier.email]);
+    });
+  });
+
+  group('OtpSigninIdentifiersInput.userRefKeyboardType', () {
+    test('allows letters for phone-only identifiers (alphanumeric accounts)', () {
+      expect([OtpSigninIdentifier.phoneNumber].userRefKeyboardType, TextInputType.text);
+    });
+
+    test('uses the email keyboard when email is advertised', () {
+      expect([OtpSigninIdentifier.email].userRefKeyboardType, TextInputType.emailAddress);
+      expect(
+        [OtpSigninIdentifier.phoneNumber, OtpSigninIdentifier.email].userRefKeyboardType,
+        TextInputType.emailAddress,
+      );
+    });
+
+    test('falls back to a text keyboard when nothing is advertised', () {
+      expect(<OtpSigninIdentifier>[].userRefKeyboardType, TextInputType.text);
     });
   });
 }


### PR DESCRIPTION
## Overview

Cherry-pick of the WT-1642 fix (PR #1413, targeting develop) onto the 1.15.4 release line, plus a build bump.

OTP sign-in only accepted digits, so customers with alphanumeric account references (e.g. `ph123x456`) could not log in. The field worked in 1.15.2 but regressed in 1.15.3/1.15.4.

## Changes

- `userRefKeyboardType` now uses `TextInputType.text` whenever email is not an advertised identifier, keeping `TextInputType.emailAddress` only when email is accepted (regression from WT-1433 forcing `TextInputType.phone` for the phone-only case). Labels and autofill hints unchanged.
- Keyboard-type test coverage added.
- `build:` bump `app_version` 1.15.4+1 -> 1.15.4+2.
- `fix:` one-line analyze restore on this branch (`?callTarget` null-aware element in `pjsua_companion` companion server) - identical to the form already on develop (#1361); required so the release branch passes `flutter analyze`. Does not touch shipped app code.

## Tests

Full suite green (pre-push). 

## Linked

Develop PR: #1413.