### PR TITLE
feat(web): web implementation of webtrit_signaling_service

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -261,24 +261,23 @@ Future<AppPermissions> _createAppPermissions(
 Future<void> _initCallkeep(FeatureAccess featureAccess) async {
   final logger = Logger('bootstrap');
 
-  if (kIsWeb) {
-    // Callkeep background services and the signaling module factory are not
-    // initialized on web.
-    logger.info('callkeep + signaling init skipped on web');
-    return;
-  }
-
   // Registers the factory used by the signaling service to create a [SignalingModule]
   // instance. Must be a top-level function annotated @pragma('vm:entry-point').
   // iOS: stored in memory, called directly in start(). Android: also persisted to
   // SharedPreferences for deserialization in the background isolate.
+  // Required on every platform - web/iOS run the signaling in the main isolate
+  // (WebtritSignalingServiceDirect) and start() throws without a registered factory.
   try {
     await WebtritSignalingService.setModuleFactory(createSignalingModule);
   } catch (e, s) {
     logger.severe('setModuleFactory failed -- signaling may not work in background isolate', e, s);
   }
 
-  if (!Platform.isAndroid) return;
+  // The remaining callkeep services (Android background push isolate,
+  // persistent-mode call-event handler, SMS triggers) are Android-only; web has
+  // no background isolates and iOS does not use them. kIsWeb short-circuits before
+  // the dart:io Platform check (which is unavailable on web).
+  if (kIsWeb || !Platform.isAndroid) return;
 
   // Registers the top-level callback that the native Android side invokes when a push
   // notification arrives in the background. Bootstraps the push isolate and delegates

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -270,7 +270,7 @@ Future<void> _initCallkeep(FeatureAccess featureAccess) async {
   try {
     await WebtritSignalingService.setModuleFactory(createSignalingModule);
   } catch (e, s) {
-    logger.severe('setModuleFactory failed -- signaling may not work in background isolate', e, s);
+    logger.severe('signaling module factory registration failed -- signaling may not work', e, s);
   }
 
   // The remaining callkeep services (Android background push isolate,

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/pubspec.yaml
@@ -17,6 +17,8 @@ flutter:
         default_package: webtrit_signaling_service_android
       ios:
         default_package: webtrit_signaling_service_ios
+      web:
+        default_package: webtrit_signaling_service_web
 
 dependencies:
   flutter:
@@ -30,6 +32,8 @@ dependencies:
     path: ../webtrit_signaling_service_android
   webtrit_signaling_service_ios:
     path: ../webtrit_signaling_service_ios
+  webtrit_signaling_service_web:
+    path: ../webtrit_signaling_service_web
 
 dev_dependencies:
   flutter_test:

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_web/lib/webtrit_signaling_service_web.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_web/lib/webtrit_signaling_service_web.dart
@@ -10,7 +10,12 @@ import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_s
 class WebtritSignalingServiceWeb extends WebtritSignalingServiceDirect {
   WebtritSignalingServiceWeb._();
 
+  static WebtritSignalingServiceWeb? _instance;
+
   static void registerWith(Registrar registrar) {
-    SignalingServicePlatform.instance = WebtritSignalingServiceWeb._();
+    // Reuse the existing instance on a repeated registration so the registered
+    // module factory and the active events controller are not dropped.
+    _instance ??= WebtritSignalingServiceWeb._();
+    SignalingServicePlatform.instance = _instance!;
   }
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_web/lib/webtrit_signaling_service_web.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_web/lib/webtrit_signaling_service_web.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_web_plugins/flutter_web_plugins.dart' show Registrar;
+
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
+
+/// Web implementation of [SignalingServicePlatform].
+///
+/// Delegates entirely to [WebtritSignalingServiceDirect] - on web there is no
+/// foreground/background service, so the WebSocket always runs in the main
+/// isolate (the same model iOS uses).
+class WebtritSignalingServiceWeb extends WebtritSignalingServiceDirect {
+  WebtritSignalingServiceWeb._();
+
+  static void registerWith(Registrar registrar) {
+    SignalingServicePlatform.instance = WebtritSignalingServiceWeb._();
+  }
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_web/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_web/pubspec.yaml
@@ -1,0 +1,32 @@
+name: webtrit_signaling_service_web
+description: Web implementation of the webtrit_signaling_service plugin.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: ^3.8.0
+  flutter: '>=3.32.0'
+
+flutter:
+  plugin:
+    implements: webtrit_signaling_service
+    platforms:
+      web:
+        pluginClass: WebtritSignalingServiceWeb
+        fileName: webtrit_signaling_service_web.dart
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
+  webtrit_signaling_service_platform_interface:
+    path: ../webtrit_signaling_service_platform_interface
+  webtrit_signaling:
+    path: ../../webtrit_signaling
+  logging: ^1.3.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_web/pubspec.yaml
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_web/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
     path: ../webtrit_signaling_service_platform_interface
   webtrit_signaling:
     path: ../../webtrit_signaling
-  logging: ^1.3.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2113,6 +2113,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  webtrit_signaling_service_web:
+    dependency: transitive
+    description:
+      path: "packages/webtrit_signaling_service/webtrit_signaling_service_web"
+      relative: true
+    source: path
+    version: "0.0.1"
   webview_flutter:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Overview

PR 2 of the decomposed Flutter web series. **Stacked on #1420** (base `feat/web-foundation`); review/merge after it.

The federated `webtrit_signaling_service` plugin shipped only android + ios, so on web `SignalingServicePlatform.instance` was never registered and entering the main shell threw `StateError: No SignalingModuleFactory registered`.

## Scope
- New federated package **`webtrit_signaling_service_web`** that delegates to `WebtritSignalingServiceDirect` (same model as iOS): the WebSocket signaling runs in the main isolate (web has no foreground/background service). Registered as the web `default_package`.
- `bootstrap._initCallkeep` now registers the signaling module factory on **every** platform (web/iOS need it); only Android-only background services stay gated behind `kIsWeb || !Platform.isAndroid`.

Verified: `flutter build web` green (web plugin registrant includes `WebtritSignalingServiceWeb`), `flutter analyze` clean. With this, signaling connects on web (incoming/outgoing calls work end-to-end - verified live earlier in the combined branch).