### PR TITLE
feat(web): request only web-supported permissions on web

### DIFF
--- a/lib/data/app_permissions.dart
+++ b/lib/data/app_permissions.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:logging/logging.dart';
 import 'package:permission_handler/permission_handler.dart';
 
@@ -17,6 +19,12 @@ class AppPermissions {
 
   /// The list of all possible permissions that the app may request.
   static const _fullPermissions = [..._requiredPermissions, Permission.camera, Permission.contacts, Permission.sms];
+
+  /// Permissions supported by permission_handler's web implementation. Requesting
+  /// or querying any other permission on web throws UnsupportedError, so on web
+  /// the requested set is restricted to these. (contacts/sms are not available on
+  /// web; camera + microphone cover the call use case.)
+  static const _webSupportedPermissions = [Permission.microphone, Permission.camera];
 
   /// A list of special permissions that are absolutely required for the app to function correctly.
   static const _requiredSpecialPermissions = [CallkeepSpecialPermissions.fullScreenIntent];
@@ -51,10 +59,17 @@ class AppPermissions {
   }
 
   AppPermissions._(this._excludePermissions, this._webtritCallkeepPermissions) {
-    _permissionsCache = ExpiringCache(
-      ttl: _cacheTTL,
-      compute: () => _fullPermissions.where((p) => !_excludePermissions().contains(p)).toList(),
-    );
+    _permissionsCache = ExpiringCache(ttl: _cacheTTL, compute: _computePermissions);
+  }
+
+  /// The non-excluded permissions to request. On web, permissions the platform
+  /// cannot handle are dropped - otherwise request()/status throw UnsupportedError.
+  List<Permission> _computePermissions() {
+    final excluded = _excludePermissions();
+    return _fullPermissions
+        .where((p) => !excluded.contains(p))
+        .where((p) => !kIsWeb || _webSupportedPermissions.contains(p))
+        .toList();
   }
 
   /// Manages permissions related to `webtrit_callkeep` plugin.
@@ -196,10 +211,12 @@ class AppPermissions {
   }
 
   Future<bool> isContactPermissionGranted() async {
+    if (kIsWeb) return false; // contacts permission is not supported on web
     return isPermissionGranted(Permission.contacts);
   }
 
   Future<bool> requestContactPermission() async {
+    if (kIsWeb) return false; // contacts permission is not supported on web
     final status = await Permission.contacts.request();
     return status.isGranted;
   }

--- a/lib/data/app_permissions.dart
+++ b/lib/data/app_permissions.dart
@@ -62,14 +62,16 @@ class AppPermissions {
     _permissionsCache = ExpiringCache(ttl: _cacheTTL, compute: _computePermissions);
   }
 
+  /// Whether [permission] can be queried or requested on the current platform.
+  /// On web, permission_handler only implements [_webSupportedPermissions];
+  /// querying or requesting anything else throws UnsupportedError.
+  static bool _isPermissionSupported(Permission permission) => !kIsWeb || _webSupportedPermissions.contains(permission);
+
   /// The non-excluded permissions to request. On web, permissions the platform
   /// cannot handle are dropped - otherwise request()/status throw UnsupportedError.
   List<Permission> _computePermissions() {
     final excluded = _excludePermissions();
-    return _fullPermissions
-        .where((p) => !excluded.contains(p))
-        .where((p) => !kIsWeb || _webSupportedPermissions.contains(p))
-        .toList();
+    return _fullPermissions.where((p) => !excluded.contains(p)).where(_isPermissionSupported).toList();
   }
 
   /// Manages permissions related to `webtrit_callkeep` plugin.
@@ -211,12 +213,12 @@ class AppPermissions {
   }
 
   Future<bool> isContactPermissionGranted() async {
-    if (kIsWeb) return false; // contacts permission is not supported on web
+    if (!_isPermissionSupported(Permission.contacts)) return false;
     return isPermissionGranted(Permission.contacts);
   }
 
   Future<bool> requestContactPermission() async {
-    if (kIsWeb) return false; // contacts permission is not supported on web
+    if (!_isPermissionSupported(Permission.contacts)) return false;
     final status = await Permission.contacts.request();
     return status.isGranted;
   }


### PR DESCRIPTION
## Overview

PR 3 of the decomposed web series. **Stacked on #1421** (base `feat/web-signaling`).

`permission_handler`'s web implementation supports only a subset of permissions; requesting/querying the others (contacts, sms) throws `UnsupportedError`, which crashed the permissions screen on web.

## Scope
- Restrict the requested set to web-supported permissions (microphone, camera) on web.
- Short-circuit the direct contacts helpers (`isContactPermissionGranted` / `requestContactPermission`) to "not granted" on web.
- Native keeps requesting the full set (behavior byte-identical when `!kIsWeb`).

Verified: `flutter analyze` clean. (Special callkeep permissions like fullScreenIntent are already stubbed by `webtrit_callkeep_web` -> granted, so the permissions route guard does not throw.)