### PR TITLE
fix: gather all contact numbers for matched by number contact (WT-1535 hotfix)

### DIFF
--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:drift/drift.dart';
 import 'package:app_database/src/app_database.dart';
 
@@ -62,6 +60,17 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
     ContactSourceTypeEnum sourceType,
     String sourceId,
   ) => (select(contactsTable)..where((t) => t.sourceType.equalsValue(sourceType) & t.sourceId.equals(sourceId)));
+
+  // Returns a subquery that resolves a phone number to a single winning contact ID,
+  // respecting external-over-local source priority.
+  BaseSelectStatement _contactIdSubqueryByPhone(String number) {
+    return selectOnly(contactsTable)
+      ..addColumns([contactsTable.id])
+      ..join([innerJoin(contactPhonesTable, contactPhonesTable.contactId.equalsExp(contactsTable.id))])
+      ..where(contactPhonesTable.number.equals(number))
+      ..orderBy(contactsTable.sourcePriorityOrder())
+      ..limit(1);
+  }
 
   FullContactData? _gatherSingleContact(List<TypedResult> rows) {
     if (rows.isEmpty) return null;
@@ -171,12 +180,9 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
     ]);
   }
 
-  Future<FullContactData?> getContactByPhoneNumber(String number) async {
+  Future<FullContactData?> getContactByPhoneNumber(String number) {
     final query = _joinFullData(select(contactsTable))
-      ..where(contactPhonesTable.number.equals(number))
-      ..orderBy(contactsTable.sourcePriorityOrder())
-      ..limit(1);
-
+      ..where(contactsTable.id.isInQuery(_contactIdSubqueryByPhone(number)));
     return query.get().then(_gatherSingleContact);
   }
 
@@ -198,10 +204,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
 
   Stream<FullContactData?> watchContactByPhoneNumber(String number) {
     final query = _joinFullData(select(contactsTable))
-      ..where(contactPhonesTable.number.equals(number))
-      ..orderBy(contactsTable.sourcePriorityOrder())
-      ..limit(1);
-
+      ..where(contactsTable.id.isInQuery(_contactIdSubqueryByPhone(number)));
     return query.watch().map(_gatherSingleContact);
   }
 


### PR DESCRIPTION
This pull request refactors the logic for resolving contacts by phone number in the `ContactsDao` class. The main improvement is the introduction of a subquery to consistently select the "winning" contact when multiple contacts share the same phone number, prioritizing external sources over local ones. This change centralizes and clarifies the selection logic, reducing duplication and potential inconsistencies.

**Refactoring contact resolution by phone number:**

* Added a private helper method `_contactIdSubqueryByPhone` that builds a subquery to select the single contact ID matching a given phone number, respecting source priority order.
* Updated both `getContactByPhoneNumber` and `watchContactByPhoneNumber` to use the new subquery for consistent contact selection, replacing the previous in-method filtering and ordering logic. [[1]](diffhunk://#diff-d9e32021e11a999aee4536b82103b51b143683ded48881dbd89e77288b04231fL174-R185) [[2]](diffhunk://#diff-d9e32021e11a999aee4536b82103b51b143683ded48881dbd89e77288b04231fL201-R207)
