### PR TITLE
feat(theme): configurable dialog theme and readable dialog background (WT-1631)

### DIFF
--- a/lib/theme/factory/styles/confirm__dialog_style_factory.dart
+++ b/lib/theme/factory/styles/confirm__dialog_style_factory.dart
@@ -8,11 +8,12 @@ import 'package:webtrit_phone/widgets/confirm_dialog.dart';
 import '../theme_style_factory.dart';
 
 class ConfirmDialogStyleFactory implements ThemeStyleFactory<ConfirmDialogStyles> {
-  ConfirmDialogStyleFactory(this.colors, this.styles, this.config);
+  ConfirmDialogStyleFactory(this.colors, this.styles, this.config, this.defaultFontFamily);
 
   final ColorScheme colors;
   final TextButtonStyles styles;
   final ConfirmDialogWidgetConfig? config;
+  final String? defaultFontFamily;
 
   @override
   ConfirmDialogStyles create() {
@@ -24,11 +25,24 @@ class ConfirmDialogStyleFactory implements ThemeStyleFactory<ConfirmDialogStyles
     final activeButtonStyle2 = styles.dangerous?.copyWith(foregroundColor: activeButtonStyle2ForegroundColor);
     final defaultButtonStyle = const ButtonStyle().copyWith(foregroundColor: defaultButtonStyleForegroundColor);
 
+    // Confirm-specific overrides stay null when unset so the dialog inherits
+    // [ThemeData.dialogTheme] instead of forcing a value.
+    final borderRadius = config?.borderRadius;
+    final shape = borderRadius != null
+        ? RoundedRectangleBorder(borderRadius: BorderRadius.circular(borderRadius))
+        : null;
+
     return ConfirmDialogStyles(
       primary: ConfirmDialogStyle(
         activeButtonStyle1: activeButtonStyle1,
         activeButtonStyle2: activeButtonStyle2,
         defaultButtonStyle: defaultButtonStyle,
+        backgroundColor: config?.backgroundColor?.toColor(),
+        surfaceTintColor: config?.surfaceTintColor?.toColor(),
+        elevation: config?.elevation,
+        shape: shape,
+        titleTextStyle: config?.titleTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+        contentTextStyle: config?.contentTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
       ),
     );
   }

--- a/lib/theme/factory/theme_data/dialog_theme_data_factory.dart
+++ b/lib/theme/factory/theme_data/dialog_theme_data_factory.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/theme/theme.dart';
+
+import '../theme_style_factory.dart';
+
+/// Builds [ThemeData.dialogTheme] for every dialog (`showDialog`, `AlertDialog`,
+/// `Dialog`).
+///
+/// Material 3 derives the dialog background from `colorScheme.surfaceContainerHigh`,
+/// which can resolve to an unreadable color in a seeded scheme. To keep all dialogs
+/// legible by default this factory pins the background to a readable surface role and
+/// disables the surface tint overlay, while still allowing a theme to override every
+/// value through [DialogThemeConfig].
+class DialogThemeDataFactory implements ThemeStyleFactory<DialogThemeData> {
+  const DialogThemeDataFactory(this.colors, this.config, this.defaultFontFamily);
+
+  final ColorScheme colors;
+  final DialogThemeConfig config;
+  final String? defaultFontFamily;
+
+  @override
+  DialogThemeData create() {
+    final borderRadius = config.borderRadius;
+
+    return DialogThemeData(
+      backgroundColor: config.backgroundColor?.toColor() ?? colors.surface,
+      surfaceTintColor: config.surfaceTintColor?.toColor() ?? Colors.transparent,
+      shadowColor: config.shadowColor?.toColor(),
+      barrierColor: config.barrierColor?.toColor(),
+      elevation: config.elevation,
+      shape: borderRadius != null ? RoundedRectangleBorder(borderRadius: BorderRadius.circular(borderRadius)) : null,
+      titleTextStyle: config.titleTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+      contentTextStyle: config.contentTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+    );
+  }
+}

--- a/lib/theme/factory/theme_data/theme_data.dart
+++ b/lib/theme/factory/theme_data/theme_data.dart
@@ -1,5 +1,6 @@
 export 'app_bar_theme_data_factory.dart';
 export 'bottom_navigation_bar_theme_data_factory.dart';
+export 'dialog_theme_data_factory.dart';
 export 'elevated_button_theme_data_factory.dart';
 export 'input_decoration_theme_data_factory.dart';
 export 'list_tile_theme_data_factory.dart';

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -70,7 +70,12 @@ class ThemeStyleFactoryProvider {
 
     // Specific widget styles
     final appIconStylesProvider = AppIconStyleFactory(colorScheme, appIconConfig);
-    final confirmDialogStylesProvider = ConfirmDialogStyleFactory(colorScheme, textButtonStyle, confirmDialog);
+    final confirmDialogStylesProvider = ConfirmDialogStyleFactory(
+      colorScheme,
+      textButtonStyle,
+      confirmDialog,
+      defaultFontFamily,
+    );
     final inputDecorationStyleFactory = InputDecorationStyleFactory(colorScheme);
     final callStatusStyleFactory = CallStatusStyleFactory(colorScheme, callStatuses);
     final elevatedButtonStyleFactory = ElevatedButtonStyleFactory(colorScheme, elevatedButton, defaultFontFamily);
@@ -193,6 +198,14 @@ class ThemeStyleFactoryProvider {
 
   SnackBarThemeData createSnackBarThemeData() {
     return SnackBarThemeDataFactory(colorScheme).create();
+  }
+
+  DialogThemeData createDialogThemeData() {
+    return DialogThemeDataFactory(
+      colorScheme,
+      widgetConfig.dialog.theme,
+      defaultTextTheme.bodyMedium?.fontFamily,
+    ).create();
   }
 
   ListTileThemeData createListTileThemeData() {

--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -115,6 +115,7 @@ class ThemeProvider extends InheritedWidget {
       bottomNavigationBarTheme: style.createBottomNavigationBarThemeData(),
       listTileTheme: style.createListTileThemeData(),
       snackBarTheme: style.createSnackBarThemeData(),
+      dialogTheme: style.createDialogThemeData(),
       elevatedButtonTheme: style.createElevatedButtonThemeData(),
       outlinedButtonTheme: style.createOutlinedButtonThemeData(),
       textButtonTheme: style.createTextButtonThemeData(),

--- a/lib/widgets/confirm_dialog.dart
+++ b/lib/widgets/confirm_dialog.dart
@@ -10,6 +10,12 @@ export 'confirm_dialog_style.dart';
 export 'confirm_dialog_styles.dart';
 
 class ConfirmDialog extends StatelessWidget {
+  // Anchor the dialog to the nearest navigator instead of the app-wide root. The
+  // originating theme is preserved by showDialog's InheritedTheme capture, so the
+  // appearance and behavior are unchanged in the app; this only matters when a
+  // screen is hosted inside another navigator (the configurator preview), where the
+  // root navigator belongs to the host and the dialog would otherwise escape its
+  // surface and lose the phone's Localizations.
   static Future<bool?> show(
     BuildContext context, {
     required String title,
@@ -18,6 +24,7 @@ class ConfirmDialog extends StatelessWidget {
   }) {
     return showDialog<bool?>(
       context: context,
+      useRootNavigator: false,
       builder: (context) {
         return ConfirmDialog._(title: title, content: content, style: style);
       },
@@ -32,6 +39,7 @@ class ConfirmDialog extends StatelessWidget {
   }) {
     return showDialog<bool?>(
       context: context,
+      useRootNavigator: false,
       builder: (context) {
         return ConfirmDialog._(dangerous: true, title: title, content: content, style: style);
       },
@@ -51,6 +59,12 @@ class ConfirmDialog extends StatelessWidget {
     final localStyle = ConfirmDialogStyle.merge(style, Theme.of(context).extension<ConfirmDialogStyles>()?.primary);
 
     return AlertDialog(
+      backgroundColor: localStyle.backgroundColor,
+      surfaceTintColor: localStyle.surfaceTintColor,
+      elevation: localStyle.elevation,
+      shape: localStyle.shape,
+      titleTextStyle: localStyle.titleTextStyle,
+      contentTextStyle: localStyle.contentTextStyle,
       title: Text(title),
       content: Text(content),
       actions: [

--- a/lib/widgets/confirm_dialog_style.dart
+++ b/lib/widgets/confirm_dialog_style.dart
@@ -1,18 +1,46 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class ConfirmDialogStyle with Diagnosticable {
-  ConfirmDialogStyle({this.activeButtonStyle1, this.activeButtonStyle2, this.defaultButtonStyle});
+  ConfirmDialogStyle({
+    this.activeButtonStyle1,
+    this.activeButtonStyle2,
+    this.defaultButtonStyle,
+    this.backgroundColor,
+    this.surfaceTintColor,
+    this.elevation,
+    this.shape,
+    this.titleTextStyle,
+    this.contentTextStyle,
+  });
 
   final ButtonStyle? activeButtonStyle1;
   final ButtonStyle? activeButtonStyle2;
   final ButtonStyle? defaultButtonStyle;
+
+  /// Per-confirm-dialog overrides layered on top of [ThemeData.dialogTheme].
+  /// A null value leaves the corresponding [AlertDialog] property unset so it
+  /// inherits the global dialog theme.
+  final Color? backgroundColor;
+  final Color? surfaceTintColor;
+  final double? elevation;
+  final ShapeBorder? shape;
+  final TextStyle? titleTextStyle;
+  final TextStyle? contentTextStyle;
 
   static ConfirmDialogStyle merge(ConfirmDialogStyle? a, ConfirmDialogStyle? b) {
     return ConfirmDialogStyle(
       activeButtonStyle1: _mergeButtonStyles(a?.activeButtonStyle1, b?.activeButtonStyle1),
       activeButtonStyle2: _mergeButtonStyles(a?.activeButtonStyle2, b?.activeButtonStyle2),
       defaultButtonStyle: _mergeButtonStyles(a?.defaultButtonStyle, b?.defaultButtonStyle),
+      backgroundColor: a?.backgroundColor ?? b?.backgroundColor,
+      surfaceTintColor: a?.surfaceTintColor ?? b?.surfaceTintColor,
+      elevation: a?.elevation ?? b?.elevation,
+      shape: a?.shape ?? b?.shape,
+      titleTextStyle: _mergeTextStyles(a?.titleTextStyle, b?.titleTextStyle),
+      contentTextStyle: _mergeTextStyles(a?.contentTextStyle, b?.contentTextStyle),
     );
   }
 
@@ -22,11 +50,23 @@ class ConfirmDialogStyle with Diagnosticable {
     return a.merge(b);
   }
 
+  static TextStyle? _mergeTextStyles(TextStyle? a, TextStyle? b) {
+    if (a == null) return b;
+    if (b == null) return a;
+    return b.merge(a);
+  }
+
   static ConfirmDialogStyle lerp(ConfirmDialogStyle? a, ConfirmDialogStyle? b, double t) {
     return ConfirmDialogStyle(
       activeButtonStyle1: ButtonStyle.lerp(a?.activeButtonStyle1, b?.activeButtonStyle1, t),
       activeButtonStyle2: ButtonStyle.lerp(a?.activeButtonStyle2, b?.activeButtonStyle2, t),
       defaultButtonStyle: ButtonStyle.lerp(a?.defaultButtonStyle, b?.defaultButtonStyle, t),
+      backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
+      surfaceTintColor: Color.lerp(a?.surfaceTintColor, b?.surfaceTintColor, t),
+      elevation: lerpDouble(a?.elevation, b?.elevation, t),
+      shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
+      titleTextStyle: TextStyle.lerp(a?.titleTextStyle, b?.titleTextStyle, t),
+      contentTextStyle: TextStyle.lerp(a?.contentTextStyle, b?.contentTextStyle, t),
     );
   }
 
@@ -36,5 +76,11 @@ class ConfirmDialogStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<ButtonStyle?>('activeButtonStyle1', activeButtonStyle1));
     properties.add(DiagnosticsProperty<ButtonStyle?>('activeButtonStyle2', activeButtonStyle2));
     properties.add(DiagnosticsProperty<ButtonStyle?>('defaultButtonStyle', defaultButtonStyle));
+    properties.add(ColorProperty('backgroundColor', backgroundColor));
+    properties.add(ColorProperty('surfaceTintColor', surfaceTintColor));
+    properties.add(DoubleProperty('elevation', elevation));
+    properties.add(DiagnosticsProperty<ShapeBorder?>('shape', shape));
+    properties.add(DiagnosticsProperty<TextStyle?>('titleTextStyle', titleTextStyle));
+    properties.add(DiagnosticsProperty<TextStyle?>('contentTextStyle', contentTextStyle));
   }
 }

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.dart
@@ -505,9 +505,18 @@ class LinkifyWidgetConfig with _$LinkifyWidgetConfig {
 @JsonSerializable(explicitToJson: true)
 class DialogWidgetConfig with _$DialogWidgetConfig {
   const DialogWidgetConfig({
+    this.theme = const DialogThemeConfig(),
     this.confirmDialog = const ConfirmDialogWidgetConfig(),
     this.snackBar = const SnackBarWidgetConfig(),
   });
+
+  /// Baseline appearance applied to every dialog via [ThemeData.dialogTheme].
+  ///
+  /// Material 3 derives the dialog background from `surfaceContainerHigh`, which
+  /// can resolve to an unreadable color in some color schemes; this config lets a
+  /// theme pin a predictable surface/text/shape for all dialogs.
+  @override
+  final DialogThemeConfig theme;
 
   @override
   final ConfirmDialogWidgetConfig confirmDialog;
@@ -520,10 +529,67 @@ class DialogWidgetConfig with _$DialogWidgetConfig {
   Map<String, Object?> toJson() => _$DialogWidgetConfigToJson(this);
 }
 
+/// Global dialog appearance mapped to [ThemeData.dialogTheme].
+///
+/// All fields are nullable so existing configs keep working; a null field falls
+/// back to a readable color-scheme role (or the Material default) in the bridge.
+@freezed
+@JsonSerializable(explicitToJson: true)
+class DialogThemeConfig with _$DialogThemeConfig {
+  const DialogThemeConfig({
+    this.backgroundColor,
+    this.surfaceTintColor,
+    this.shadowColor,
+    this.barrierColor,
+    this.elevation,
+    this.borderRadius,
+    this.titleTextStyle,
+    this.contentTextStyle,
+  });
+
+  @override
+  final String? backgroundColor;
+
+  @override
+  final String? surfaceTintColor;
+
+  @override
+  final String? shadowColor;
+
+  @override
+  final String? barrierColor;
+
+  @override
+  final double? elevation;
+
+  @override
+  final double? borderRadius;
+
+  @override
+  final TextStyleConfig? titleTextStyle;
+
+  @override
+  final TextStyleConfig? contentTextStyle;
+
+  factory DialogThemeConfig.fromJson(Map<String, Object?> json) => _$DialogThemeConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$DialogThemeConfigToJson(this);
+}
+
 @freezed
 @JsonSerializable(explicitToJson: true)
 class ConfirmDialogWidgetConfig with _$ConfirmDialogWidgetConfig {
-  const ConfirmDialogWidgetConfig({this.activeButtonColor1, this.activeButtonColor2, this.defaultButtonColor});
+  const ConfirmDialogWidgetConfig({
+    this.activeButtonColor1,
+    this.activeButtonColor2,
+    this.defaultButtonColor,
+    this.backgroundColor,
+    this.surfaceTintColor,
+    this.elevation,
+    this.borderRadius,
+    this.titleTextStyle,
+    this.contentTextStyle,
+  });
 
   @override
   final String? activeButtonColor1;
@@ -533,6 +599,26 @@ class ConfirmDialogWidgetConfig with _$ConfirmDialogWidgetConfig {
 
   @override
   final String? defaultButtonColor;
+
+  /// Confirm-dialog-only overrides layered on top of [DialogThemeConfig];
+  /// when null the dialog inherits [ThemeData.dialogTheme].
+  @override
+  final String? backgroundColor;
+
+  @override
+  final String? surfaceTintColor;
+
+  @override
+  final double? elevation;
+
+  @override
+  final double? borderRadius;
+
+  @override
+  final TextStyleConfig? titleTextStyle;
+
+  @override
+  final TextStyleConfig? contentTextStyle;
 
   factory ConfirmDialogWidgetConfig.fromJson(Map<String, Object?> json) => _$ConfirmDialogWidgetConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.freezed.dart
@@ -3786,7 +3786,7 @@ case _:
 /// @nodoc
 mixin _$DialogWidgetConfig {
 
- ConfirmDialogWidgetConfig get confirmDialog; SnackBarWidgetConfig get snackBar;
+ DialogThemeConfig get theme; ConfirmDialogWidgetConfig get confirmDialog; SnackBarWidgetConfig get snackBar;
 /// Create a copy of DialogWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3797,16 +3797,16 @@ $DialogWidgetConfigCopyWith<DialogWidgetConfig> get copyWith => _$DialogWidgetCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DialogWidgetConfig&&(identical(other.confirmDialog, confirmDialog) || other.confirmDialog == confirmDialog)&&(identical(other.snackBar, snackBar) || other.snackBar == snackBar));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DialogWidgetConfig&&(identical(other.theme, theme) || other.theme == theme)&&(identical(other.confirmDialog, confirmDialog) || other.confirmDialog == confirmDialog)&&(identical(other.snackBar, snackBar) || other.snackBar == snackBar));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,confirmDialog,snackBar);
+int get hashCode => Object.hash(runtimeType,theme,confirmDialog,snackBar);
 
 @override
 String toString() {
-  return 'DialogWidgetConfig(confirmDialog: $confirmDialog, snackBar: $snackBar)';
+  return 'DialogWidgetConfig(theme: $theme, confirmDialog: $confirmDialog, snackBar: $snackBar)';
 }
 
 
@@ -3817,7 +3817,7 @@ abstract mixin class $DialogWidgetConfigCopyWith<$Res>  {
   factory $DialogWidgetConfigCopyWith(DialogWidgetConfig value, $Res Function(DialogWidgetConfig) _then) = _$DialogWidgetConfigCopyWithImpl;
 @useResult
 $Res call({
- ConfirmDialogWidgetConfig confirmDialog, SnackBarWidgetConfig snackBar
+ DialogThemeConfig theme, ConfirmDialogWidgetConfig confirmDialog, SnackBarWidgetConfig snackBar
 });
 
 
@@ -3834,9 +3834,10 @@ class _$DialogWidgetConfigCopyWithImpl<$Res>
 
 /// Create a copy of DialogWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? confirmDialog = null,Object? snackBar = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? theme = null,Object? confirmDialog = null,Object? snackBar = null,}) {
   return _then(DialogWidgetConfig(
-confirmDialog: null == confirmDialog ? _self.confirmDialog : confirmDialog // ignore: cast_nullable_to_non_nullable
+theme: null == theme ? _self.theme : theme // ignore: cast_nullable_to_non_nullable
+as DialogThemeConfig,confirmDialog: null == confirmDialog ? _self.confirmDialog : confirmDialog // ignore: cast_nullable_to_non_nullable
 as ConfirmDialogWidgetConfig,snackBar: null == snackBar ? _self.snackBar : snackBar // ignore: cast_nullable_to_non_nullable
 as SnackBarWidgetConfig,
   ));
@@ -3971,9 +3972,202 @@ case _:
 
 
 /// @nodoc
+mixin _$DialogThemeConfig {
+
+ String? get backgroundColor; String? get surfaceTintColor; String? get shadowColor; String? get barrierColor; double? get elevation; double? get borderRadius; TextStyleConfig? get titleTextStyle; TextStyleConfig? get contentTextStyle;
+/// Create a copy of DialogThemeConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DialogThemeConfigCopyWith<DialogThemeConfig> get copyWith => _$DialogThemeConfigCopyWithImpl<DialogThemeConfig>(this as DialogThemeConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DialogThemeConfig&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.surfaceTintColor, surfaceTintColor) || other.surfaceTintColor == surfaceTintColor)&&(identical(other.shadowColor, shadowColor) || other.shadowColor == shadowColor)&&(identical(other.barrierColor, barrierColor) || other.barrierColor == barrierColor)&&(identical(other.elevation, elevation) || other.elevation == elevation)&&(identical(other.borderRadius, borderRadius) || other.borderRadius == borderRadius)&&(identical(other.titleTextStyle, titleTextStyle) || other.titleTextStyle == titleTextStyle)&&(identical(other.contentTextStyle, contentTextStyle) || other.contentTextStyle == contentTextStyle));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,backgroundColor,surfaceTintColor,shadowColor,barrierColor,elevation,borderRadius,titleTextStyle,contentTextStyle);
+
+@override
+String toString() {
+  return 'DialogThemeConfig(backgroundColor: $backgroundColor, surfaceTintColor: $surfaceTintColor, shadowColor: $shadowColor, barrierColor: $barrierColor, elevation: $elevation, borderRadius: $borderRadius, titleTextStyle: $titleTextStyle, contentTextStyle: $contentTextStyle)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DialogThemeConfigCopyWith<$Res>  {
+  factory $DialogThemeConfigCopyWith(DialogThemeConfig value, $Res Function(DialogThemeConfig) _then) = _$DialogThemeConfigCopyWithImpl;
+@useResult
+$Res call({
+ String? backgroundColor, String? surfaceTintColor, String? shadowColor, String? barrierColor, double? elevation, double? borderRadius, TextStyleConfig? titleTextStyle, TextStyleConfig? contentTextStyle
+});
+
+
+
+
+}
+/// @nodoc
+class _$DialogThemeConfigCopyWithImpl<$Res>
+    implements $DialogThemeConfigCopyWith<$Res> {
+  _$DialogThemeConfigCopyWithImpl(this._self, this._then);
+
+  final DialogThemeConfig _self;
+  final $Res Function(DialogThemeConfig) _then;
+
+/// Create a copy of DialogThemeConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? backgroundColor = freezed,Object? surfaceTintColor = freezed,Object? shadowColor = freezed,Object? barrierColor = freezed,Object? elevation = freezed,Object? borderRadius = freezed,Object? titleTextStyle = freezed,Object? contentTextStyle = freezed,}) {
+  return _then(DialogThemeConfig(
+backgroundColor: freezed == backgroundColor ? _self.backgroundColor : backgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,surfaceTintColor: freezed == surfaceTintColor ? _self.surfaceTintColor : surfaceTintColor // ignore: cast_nullable_to_non_nullable
+as String?,shadowColor: freezed == shadowColor ? _self.shadowColor : shadowColor // ignore: cast_nullable_to_non_nullable
+as String?,barrierColor: freezed == barrierColor ? _self.barrierColor : barrierColor // ignore: cast_nullable_to_non_nullable
+as String?,elevation: freezed == elevation ? _self.elevation : elevation // ignore: cast_nullable_to_non_nullable
+as double?,borderRadius: freezed == borderRadius ? _self.borderRadius : borderRadius // ignore: cast_nullable_to_non_nullable
+as double?,titleTextStyle: freezed == titleTextStyle ? _self.titleTextStyle : titleTextStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,contentTextStyle: freezed == contentTextStyle ? _self.contentTextStyle : contentTextStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [DialogThemeConfig].
+extension DialogThemeConfigPatterns on DialogThemeConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
 mixin _$ConfirmDialogWidgetConfig {
 
- String? get activeButtonColor1; String? get activeButtonColor2; String? get defaultButtonColor;
+ String? get activeButtonColor1; String? get activeButtonColor2; String? get defaultButtonColor; String? get backgroundColor; String? get surfaceTintColor; double? get elevation; double? get borderRadius; TextStyleConfig? get titleTextStyle; TextStyleConfig? get contentTextStyle;
 /// Create a copy of ConfirmDialogWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3984,16 +4178,16 @@ $ConfirmDialogWidgetConfigCopyWith<ConfirmDialogWidgetConfig> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConfirmDialogWidgetConfig&&(identical(other.activeButtonColor1, activeButtonColor1) || other.activeButtonColor1 == activeButtonColor1)&&(identical(other.activeButtonColor2, activeButtonColor2) || other.activeButtonColor2 == activeButtonColor2)&&(identical(other.defaultButtonColor, defaultButtonColor) || other.defaultButtonColor == defaultButtonColor));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConfirmDialogWidgetConfig&&(identical(other.activeButtonColor1, activeButtonColor1) || other.activeButtonColor1 == activeButtonColor1)&&(identical(other.activeButtonColor2, activeButtonColor2) || other.activeButtonColor2 == activeButtonColor2)&&(identical(other.defaultButtonColor, defaultButtonColor) || other.defaultButtonColor == defaultButtonColor)&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.surfaceTintColor, surfaceTintColor) || other.surfaceTintColor == surfaceTintColor)&&(identical(other.elevation, elevation) || other.elevation == elevation)&&(identical(other.borderRadius, borderRadius) || other.borderRadius == borderRadius)&&(identical(other.titleTextStyle, titleTextStyle) || other.titleTextStyle == titleTextStyle)&&(identical(other.contentTextStyle, contentTextStyle) || other.contentTextStyle == contentTextStyle));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,activeButtonColor1,activeButtonColor2,defaultButtonColor);
+int get hashCode => Object.hash(runtimeType,activeButtonColor1,activeButtonColor2,defaultButtonColor,backgroundColor,surfaceTintColor,elevation,borderRadius,titleTextStyle,contentTextStyle);
 
 @override
 String toString() {
-  return 'ConfirmDialogWidgetConfig(activeButtonColor1: $activeButtonColor1, activeButtonColor2: $activeButtonColor2, defaultButtonColor: $defaultButtonColor)';
+  return 'ConfirmDialogWidgetConfig(activeButtonColor1: $activeButtonColor1, activeButtonColor2: $activeButtonColor2, defaultButtonColor: $defaultButtonColor, backgroundColor: $backgroundColor, surfaceTintColor: $surfaceTintColor, elevation: $elevation, borderRadius: $borderRadius, titleTextStyle: $titleTextStyle, contentTextStyle: $contentTextStyle)';
 }
 
 
@@ -4004,7 +4198,7 @@ abstract mixin class $ConfirmDialogWidgetConfigCopyWith<$Res>  {
   factory $ConfirmDialogWidgetConfigCopyWith(ConfirmDialogWidgetConfig value, $Res Function(ConfirmDialogWidgetConfig) _then) = _$ConfirmDialogWidgetConfigCopyWithImpl;
 @useResult
 $Res call({
- String? activeButtonColor1, String? activeButtonColor2, String? defaultButtonColor
+ String? activeButtonColor1, String? activeButtonColor2, String? defaultButtonColor, String? backgroundColor, String? surfaceTintColor, double? elevation, double? borderRadius, TextStyleConfig? titleTextStyle, TextStyleConfig? contentTextStyle
 });
 
 
@@ -4021,12 +4215,18 @@ class _$ConfirmDialogWidgetConfigCopyWithImpl<$Res>
 
 /// Create a copy of ConfirmDialogWidgetConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? activeButtonColor1 = freezed,Object? activeButtonColor2 = freezed,Object? defaultButtonColor = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? activeButtonColor1 = freezed,Object? activeButtonColor2 = freezed,Object? defaultButtonColor = freezed,Object? backgroundColor = freezed,Object? surfaceTintColor = freezed,Object? elevation = freezed,Object? borderRadius = freezed,Object? titleTextStyle = freezed,Object? contentTextStyle = freezed,}) {
   return _then(ConfirmDialogWidgetConfig(
 activeButtonColor1: freezed == activeButtonColor1 ? _self.activeButtonColor1 : activeButtonColor1 // ignore: cast_nullable_to_non_nullable
 as String?,activeButtonColor2: freezed == activeButtonColor2 ? _self.activeButtonColor2 : activeButtonColor2 // ignore: cast_nullable_to_non_nullable
 as String?,defaultButtonColor: freezed == defaultButtonColor ? _self.defaultButtonColor : defaultButtonColor // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,backgroundColor: freezed == backgroundColor ? _self.backgroundColor : backgroundColor // ignore: cast_nullable_to_non_nullable
+as String?,surfaceTintColor: freezed == surfaceTintColor ? _self.surfaceTintColor : surfaceTintColor // ignore: cast_nullable_to_non_nullable
+as String?,elevation: freezed == elevation ? _self.elevation : elevation // ignore: cast_nullable_to_non_nullable
+as double?,borderRadius: freezed == borderRadius ? _self.borderRadius : borderRadius // ignore: cast_nullable_to_non_nullable
+as double?,titleTextStyle: freezed == titleTextStyle ? _self.titleTextStyle : titleTextStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,contentTextStyle: freezed == contentTextStyle ? _self.contentTextStyle : contentTextStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_widget_config.g.dart
@@ -397,6 +397,9 @@ Map<String, dynamic> _$LinkifyWidgetConfigToJson(
 
 DialogWidgetConfig _$DialogWidgetConfigFromJson(Map<String, dynamic> json) =>
     DialogWidgetConfig(
+      theme: json['theme'] == null
+          ? const DialogThemeConfig()
+          : DialogThemeConfig.fromJson(json['theme'] as Map<String, dynamic>),
       confirmDialog: json['confirmDialog'] == null
           ? const ConfirmDialogWidgetConfig()
           : ConfirmDialogWidgetConfig.fromJson(
@@ -411,8 +414,41 @@ DialogWidgetConfig _$DialogWidgetConfigFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$DialogWidgetConfigToJson(DialogWidgetConfig instance) =>
     <String, dynamic>{
+      'theme': instance.theme.toJson(),
       'confirmDialog': instance.confirmDialog.toJson(),
       'snackBar': instance.snackBar.toJson(),
+    };
+
+DialogThemeConfig _$DialogThemeConfigFromJson(Map<String, dynamic> json) =>
+    DialogThemeConfig(
+      backgroundColor: json['backgroundColor'] as String?,
+      surfaceTintColor: json['surfaceTintColor'] as String?,
+      shadowColor: json['shadowColor'] as String?,
+      barrierColor: json['barrierColor'] as String?,
+      elevation: (json['elevation'] as num?)?.toDouble(),
+      borderRadius: (json['borderRadius'] as num?)?.toDouble(),
+      titleTextStyle: json['titleTextStyle'] == null
+          ? null
+          : TextStyleConfig.fromJson(
+              json['titleTextStyle'] as Map<String, dynamic>,
+            ),
+      contentTextStyle: json['contentTextStyle'] == null
+          ? null
+          : TextStyleConfig.fromJson(
+              json['contentTextStyle'] as Map<String, dynamic>,
+            ),
+    );
+
+Map<String, dynamic> _$DialogThemeConfigToJson(DialogThemeConfig instance) =>
+    <String, dynamic>{
+      'backgroundColor': instance.backgroundColor,
+      'surfaceTintColor': instance.surfaceTintColor,
+      'shadowColor': instance.shadowColor,
+      'barrierColor': instance.barrierColor,
+      'elevation': instance.elevation,
+      'borderRadius': instance.borderRadius,
+      'titleTextStyle': instance.titleTextStyle?.toJson(),
+      'contentTextStyle': instance.contentTextStyle?.toJson(),
     };
 
 ConfirmDialogWidgetConfig _$ConfirmDialogWidgetConfigFromJson(
@@ -421,6 +457,20 @@ ConfirmDialogWidgetConfig _$ConfirmDialogWidgetConfigFromJson(
   activeButtonColor1: json['activeButtonColor1'] as String?,
   activeButtonColor2: json['activeButtonColor2'] as String?,
   defaultButtonColor: json['defaultButtonColor'] as String?,
+  backgroundColor: json['backgroundColor'] as String?,
+  surfaceTintColor: json['surfaceTintColor'] as String?,
+  elevation: (json['elevation'] as num?)?.toDouble(),
+  borderRadius: (json['borderRadius'] as num?)?.toDouble(),
+  titleTextStyle: json['titleTextStyle'] == null
+      ? null
+      : TextStyleConfig.fromJson(
+          json['titleTextStyle'] as Map<String, dynamic>,
+        ),
+  contentTextStyle: json['contentTextStyle'] == null
+      ? null
+      : TextStyleConfig.fromJson(
+          json['contentTextStyle'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$ConfirmDialogWidgetConfigToJson(
@@ -429,6 +479,12 @@ Map<String, dynamic> _$ConfirmDialogWidgetConfigToJson(
   'activeButtonColor1': instance.activeButtonColor1,
   'activeButtonColor2': instance.activeButtonColor2,
   'defaultButtonColor': instance.defaultButtonColor,
+  'backgroundColor': instance.backgroundColor,
+  'surfaceTintColor': instance.surfaceTintColor,
+  'elevation': instance.elevation,
+  'borderRadius': instance.borderRadius,
+  'titleTextStyle': instance.titleTextStyle?.toJson(),
+  'contentTextStyle': instance.contentTextStyle?.toJson(),
 };
 
 SnackBarWidgetConfig _$SnackBarWidgetConfigFromJson(

--- a/screenshots/integration_test/take_screenshots_test.dart
+++ b/screenshots/integration_test/take_screenshots_test.dart
@@ -114,6 +114,9 @@ void main() {
     takeScreenshotTestWidgets('settings_screen', () {
       return ScreenshotApp(appBloc: appContext.appBloc, child: const SettingScreenScreenshot());
     });
+    takeScreenshotTestWidgets('dialogs_showcase', () {
+      return ScreenshotApp(appBloc: appContext.appBloc, child: const DialogsShowcaseScreenshot());
+    });
   });
 
   group('take call screen screenshots', () {

--- a/screenshots/lib/mocks/mock_signaling_service_platform.dart
+++ b/screenshots/lib/mocks/mock_signaling_service_platform.dart
@@ -1,0 +1,28 @@
+import 'package:mocktail/mocktail.dart';
+// ignore: depend_on_referenced_packages
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+// ignore: depend_on_referenced_packages
+import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';
+
+/// Preview-only no-op signaling platform.
+///
+/// Lets real screens that touch the native signaling service render in the
+/// screenshot harness, where no platform implementation is registered. In
+/// particular `TeardownScreen.initState` calls `stopService()`, which reaches
+/// `SignalingServicePlatform.instance` and throws a `StateError` when unset.
+// ignore: invalid_use_of_visible_for_testing_member
+class MockSignalingServicePlatform extends Mock with MockPlatformInterfaceMixin implements SignalingServicePlatform {}
+
+/// Registers a no-op [SignalingServicePlatform] for the preview, but only when
+/// none is set yet, so a real platform implementation is never overwritten.
+void ensureMockSignalingServicePlatform() {
+  try {
+    SignalingServicePlatform.instance;
+    return;
+  } on StateError catch (_) {
+    // Thrown only when no platform is registered; install the no-op fallback.
+    final platform = MockSignalingServicePlatform();
+    when(() => platform.stopService()).thenAnswer((_) async {});
+    SignalingServicePlatform.instance = platform;
+  }
+}

--- a/screenshots/lib/mocks/mocks.dart
+++ b/screenshots/lib/mocks/mocks.dart
@@ -35,6 +35,7 @@ export 'mock_recents_bloc.dart';
 export 'mock_register_status_cubit.dart';
 export 'mock_session_status_cubit.dart';
 export 'mock_settings_bloc.dart';
+export 'mock_signaling_service_platform.dart';
 export 'mock_sms_conversation_cubit.dart';
 export 'mock_sms_conversations_cubit.dart';
 export 'mock_sms_typing_cubit.dart';

--- a/screenshots/lib/router.dart
+++ b/screenshots/lib/router.dart
@@ -74,6 +74,7 @@ class _IndexInputScreenState extends State<IndexInputScreen> {
         ),
       ),
       ScreenshotApp(appBloc: appBloc, child: const SettingScreenScreenshot()),
+      ScreenshotApp(appBloc: appBloc, child: const DialogsShowcaseScreenshot()),
       ScreenshotApp(appBloc: appBloc, child: MediaSettingsScreenScreenshot(initialOpenSection: 1)),
       ScreenshotApp(appBloc: appBloc, child: const CallScreenScreenshot(false)),
       ScreenshotApp(appBloc: appBloc, child: const CallScreenScreenshot(true)),

--- a/screenshots/lib/screenshots/dialogs_showcase_screenshot.dart
+++ b/screenshots/lib/screenshots/dialogs_showcase_screenshot.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
+
+/// A catalog page rendering every confirm-dialog variant inline so a single
+/// screenshot shows the dialog theme (background, surface tint, shape, text and
+/// button styling) without having to open each dialog modally.
+class DialogsShowcaseScreenshot extends StatelessWidget {
+  const DialogsShowcaseScreenshot({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final style = ConfirmDialogStyle.merge(null, Theme.of(context).extension<ConfirmDialogStyles>()?.primary);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dialogs')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _DialogPreview(
+            label: 'Confirm',
+            child: _confirmDialog(
+              style,
+              title: l10n.settings_LogoutConfirmDialog_title,
+              content: l10n.settings_LogoutConfirmDialog_content,
+              noLabel: l10n.alertDialogActions_no,
+              yesLabel: l10n.alertDialogActions_yes,
+              yesStyle: style.defaultButtonStyle,
+            ),
+          ),
+          _DialogPreview(
+            label: 'Dangerous confirm',
+            child: _confirmDialog(
+              style,
+              title: l10n.settings_AccountDeleteConfirmDialog_title,
+              content: l10n.settings_AccountDeleteConfirmDialog_content,
+              noLabel: l10n.alertDialogActions_no,
+              yesLabel: l10n.alertDialogActions_yes,
+              yesStyle: style.activeButtonStyle2,
+            ),
+          ),
+          _DialogPreview(
+            label: 'Alert',
+            child: AlertDialog(
+              backgroundColor: style.backgroundColor,
+              surfaceTintColor: style.surfaceTintColor,
+              elevation: style.elevation,
+              shape: style.shape,
+              titleTextStyle: style.titleTextStyle,
+              contentTextStyle: style.contentTextStyle,
+              title: Text(l10n.settings_LogoutConfirmDialog_title),
+              content: Text(l10n.settings_LogoutConfirmDialog_content),
+              actions: [
+                TextButton(onPressed: () {}, style: style.activeButtonStyle1, child: Text(l10n.alertDialogActions_yes)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  AlertDialog _confirmDialog(
+    ConfirmDialogStyle style, {
+    required String title,
+    required String content,
+    required String noLabel,
+    required String yesLabel,
+    required ButtonStyle? yesStyle,
+  }) {
+    return AlertDialog(
+      backgroundColor: style.backgroundColor,
+      surfaceTintColor: style.surfaceTintColor,
+      elevation: style.elevation,
+      shape: style.shape,
+      titleTextStyle: style.titleTextStyle,
+      contentTextStyle: style.contentTextStyle,
+      title: Text(title),
+      content: Text(content),
+      actions: [
+        TextButton(onPressed: () {}, style: style.activeButtonStyle1, child: Text(noLabel)),
+        TextButton(onPressed: () {}, style: yesStyle, child: Text(yesLabel)),
+      ],
+    );
+  }
+}
+
+class _DialogPreview extends StatelessWidget {
+  const _DialogPreview({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 8),
+          // AlertDialog renders inside a Dialog whose Align needs bounded
+          // height; constrain it so it lays out in the scrolling catalog.
+          SizedBox(height: 220, child: child),
+        ],
+      ),
+    );
+  }
+}

--- a/screenshots/lib/screenshots/screenshots.dart
+++ b/screenshots/lib/screenshots/screenshots.dart
@@ -6,6 +6,7 @@ export 'chat_conversation_screen_screenshot.dart';
 export 'contact_screen_screenshot.dart';
 export 'contacts_agreement_screen_screenshot.dart';
 export 'diagnostic_screen_screenshot.dart';
+export 'dialogs_showcase_screenshot.dart';
 export 'embedded_error_dialog_screenshot.dart';
 export 'language_screen_screenshot.dart';
 export 'log_records_console_screen_screenshot.dart';

--- a/screenshots/lib/screenshots/teardown_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/teardown_screen_screenshot.dart
@@ -2,8 +2,30 @@ import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/features/session_status/view/teardown_screen.dart';
 
-class TeardownScreenScreenshot extends StatelessWidget {
+import 'package:screenshots/mocks/mocks.dart';
+
+/// Renders the real [TeardownScreen] so the preview stays in sync with the app.
+///
+/// `TeardownScreen.initState` calls `WebtritSignalingService.stopService()`, which
+/// reaches `SignalingServicePlatform.instance` and throws synchronously when the
+/// native platform is not initialized (the configurator preview / web harness).
+/// Register a no-op platform before the real screen mounts instead of copying its
+/// UI, which would drift from the actual screen over time.
+class TeardownScreenScreenshot extends StatefulWidget {
   const TeardownScreenScreenshot({super.key});
+
+  @override
+  State<TeardownScreenScreenshot> createState() => _TeardownScreenScreenshotState();
+}
+
+class _TeardownScreenScreenshotState extends State<TeardownScreenScreenshot> {
+  @override
+  void initState() {
+    super.initState();
+    // Runs before the child TeardownScreen mounts, so its initState side effect
+    // has a platform to call into.
+    ensureMockSignalingServicePlatform();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/screenshots/lib/screenshots/voicemail_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/voicemail_screen_screenshot.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import 'package:webtrit_phone/features/settings/features/voicemail/bloc/voicemail_cubit.dart';
+import 'package:webtrit_phone/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart';
 import 'package:webtrit_phone/features/settings/features/voicemail/models/voicemail_screen_context.dart';
 import 'package:webtrit_phone/features/settings/features/voicemail/view/voicemail_screen.dart';
 
@@ -30,16 +31,22 @@ class _VoicemailScreenScreenshotState extends State<VoicemailScreenScreenshot> {
         context,
         PageRouteBuilder(
           pageBuilder: (context, _, _) {
-            return Provider<VoicemailScreenContext>(
-              create: (_) => VoicemailScreenContext(
-                mediaCacheBasePath: '/tmp/screenshots_cache',
-                dateFormat: DateFormat.yMMMd().add_Hm(),
-                mediaHeaders: const {},
-              ),
-              child: BlocProvider<VoicemailCubit>(
-                create: (_) => MockVoicemailCubit.withItems(),
-                child: const VoicemailScreen(),
-              ),
+            // Mirror VoicemailScreenPage's provider set so VoicemailTile/AudioView
+            // can resolve VoicemailPlaybackController; omitting it throws
+            // ProviderNotFoundException while building the preview.
+            return MultiProvider(
+              providers: [
+                Provider<VoicemailScreenContext>(
+                  create: (_) => VoicemailScreenContext(
+                    mediaCacheBasePath: '/tmp/screenshots_cache',
+                    dateFormat: DateFormat.yMMMd().add_Hm(),
+                    mediaHeaders: const {},
+                  ),
+                ),
+                BlocProvider<VoicemailCubit>(create: (_) => MockVoicemailCubit.withItems()),
+                ChangeNotifierProvider(create: (_) => VoicemailPlaybackController()),
+              ],
+              child: const VoicemailScreen(),
             );
           },
           transitionDuration: Duration.zero,


### PR DESCRIPTION
Backports #1419 onto release/1.16.0.

Cherry-pick of the squashed change. The webtrit_appearance_theme generated code (theme_widget_config.freezed.dart / .g.dart) was re-run with the branch SDK and matches a fresh build, and the version placeholder is left untouched. The new theme fields are nullable with defaults, so existing 1.16.0 themes deserialize unchanged.