### PR TITLE
build: bump app_version to 1.15.4+3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.15.4+2
+app_version: 1.15.4+3
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Bumps the app_version build iteration from 1.15.4+2 to 1.15.4+3 so the dialog-theme backport (#1428) ships as a new build. Only app_version changes; the version: placeholder is untouched.