### PR TITLE
test(screenshots): give favorites varied presence so the preview shows it

### DIFF
--- a/screenshots/lib/data/favorites.dart
+++ b/screenshots/lib/data/favorites.dart
@@ -1,5 +1,26 @@
 import 'package:webtrit_phone/models/models.dart';
 
+// Fixed timestamp so the presence-driven screenshots stay deterministic.
+final _presenceAt = DateTime.utc(2024, 1, 1);
+
+PresenceInfo _presence(String number, {required bool available, List<PresenceActivity> activities = const []}) {
+  return PresenceInfo(
+    id: number,
+    number: number,
+    available: available,
+    note: '',
+    statusIcon: null,
+    device: null,
+    timeOffsetMin: null,
+    timestamp: _presenceAt,
+    activities: activities,
+    source: PresenceInfoSource.sip,
+    arrivalTime: _presenceAt,
+  );
+}
+
+// Each favorite carries a distinct presence so the preview showcases the
+// available/unavailable colors and the activity icons rendered on top of them.
 final dFavorites = <FavoriteWithContact>[
   (
     favorite: Favorite(number: '1234', sourceType: FavoriteSourceType.device, sourceId: '1', label: 'ext', position: 0),
@@ -10,6 +31,7 @@ final dFavorites = <FavoriteWithContact>[
       sourceId: '1',
       registered: true,
       aliasName: 'Thomas Anderson',
+      presenceInfo: [_presence('1234', available: true)],
     ),
   ),
   (
@@ -21,6 +43,7 @@ final dFavorites = <FavoriteWithContact>[
       sourceId: '2',
       registered: false,
       aliasName: 'Anna Collins',
+      presenceInfo: [_presence('2345', available: false)],
     ),
   ),
   (
@@ -32,6 +55,9 @@ final dFavorites = <FavoriteWithContact>[
       sourceId: '3',
       registered: true,
       aliasName: 'Lawrence Brown',
+      presenceInfo: [
+        _presence('3456', available: true, activities: [PresenceActivity.onThePhone]),
+      ],
     ),
   ),
   (
@@ -41,8 +67,11 @@ final dFavorites = <FavoriteWithContact>[
       sourceType: ContactSourceType.external,
       kind: ContactKind.visible,
       sourceId: '4',
-      registered: false,
+      registered: true,
       aliasName: 'Ruth Jenkins',
+      presenceInfo: [
+        _presence('4567', available: true, activities: [PresenceActivity.doNotDisturb]),
+      ],
     ),
   ),
   (
@@ -54,6 +83,9 @@ final dFavorites = <FavoriteWithContact>[
       sourceId: '5',
       registered: true,
       aliasName: 'Beverly Nelson',
+      presenceInfo: [
+        _presence('5678', available: true, activities: [PresenceActivity.meeting]),
+      ],
     ),
   ),
   (
@@ -65,6 +97,9 @@ final dFavorites = <FavoriteWithContact>[
       sourceId: '6',
       registered: false,
       aliasName: 'Randy Jones',
+      presenceInfo: [
+        _presence('6789', available: false, activities: [PresenceActivity.away]),
+      ],
     ),
   ),
 ];

--- a/screenshots/lib/data/messaging.dart
+++ b/screenshots/lib/data/messaging.dart
@@ -4,6 +4,22 @@ import 'package:webtrit_phone/models/models.dart';
 
 import 'clock.dart';
 
+PresenceInfo _presence(String number, {required bool available, List<PresenceActivity> activities = const []}) {
+  return PresenceInfo(
+    id: number,
+    number: number,
+    available: available,
+    note: '',
+    statusIcon: null,
+    device: null,
+    timeOffsetMin: null,
+    timestamp: dFixedTime,
+    activities: activities,
+    source: PresenceInfoSource.sip,
+    arrivalTime: dFixedTime,
+  );
+}
+
 /// Mock chats for `MockChatsRepository`
 final dChatsMockChatsRepository = [
   Chat(
@@ -72,6 +88,9 @@ final dContactsRepository = [
     sourceId: 'user_1',
     firstName: 'Alice',
     lastName: 'Johnson',
+    presenceInfo: [
+      _presence('1001', available: true, activities: [PresenceActivity.meeting]),
+    ],
     aliasName: 'AJ',
     registered: true,
     userRegistered: true,
@@ -91,6 +110,7 @@ final dContactsRepository = [
     sourceId: 'user_2',
     firstName: 'Bob',
     lastName: 'Smith',
+    presenceInfo: [_presence('+1987654321', available: false)],
     aliasName: null,
     registered: false,
     userRegistered: false,

--- a/screenshots/lib/data/recents.dart
+++ b/screenshots/lib/data/recents.dart
@@ -3,6 +3,25 @@ import 'package:clock/clock.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/models/models.dart';
 
+// Fixed timestamp so the presence-driven screenshots stay deterministic.
+final _presenceAt = DateTime.utc(2024, 1, 1);
+
+PresenceInfo _presence(String number, {required bool available, List<PresenceActivity> activities = const []}) {
+  return PresenceInfo(
+    id: number,
+    number: number,
+    available: available,
+    note: '',
+    statusIcon: null,
+    device: null,
+    timeOffsetMin: null,
+    timestamp: _presenceAt,
+    activities: activities,
+    source: PresenceInfoSource.sip,
+    arrivalTime: _presenceAt,
+  );
+}
+
 /// 🔹 Mock recent call history data for testing call logs & contact integration
 final dMockRecentCallHistory = [
   Recent(
@@ -20,6 +39,7 @@ final dMockRecentCallHistory = [
       sourceId: '1',
       firstName: 'Thomas',
       lastName: 'Anderson',
+      presenceInfo: [_presence('1234', available: true)],
     ),
   ),
   Recent(
@@ -39,6 +59,9 @@ final dMockRecentCallHistory = [
       sourceId: '2',
       firstName: 'Thomas',
       lastName: 'Anderson',
+      presenceInfo: [
+        _presence('1234', available: true, activities: [PresenceActivity.onThePhone]),
+      ],
     ),
   ),
   Recent(
@@ -58,6 +81,9 @@ final dMockRecentCallHistory = [
       sourceId: '3',
       firstName: 'Dion',
       lastName: 'Dames',
+      presenceInfo: [
+        _presence('3344', available: true, activities: [PresenceActivity.meeting]),
+      ],
     ),
   ),
   Recent(
@@ -77,6 +103,7 @@ final dMockRecentCallHistory = [
       sourceId: '4',
       firstName: 'Stuart',
       lastName: 'Peterson',
+      presenceInfo: [_presence('1234', available: false)],
     ),
   ),
   Recent(
@@ -96,6 +123,9 @@ final dMockRecentCallHistory = [
       sourceId: '5',
       firstName: 'Alex',
       lastName: 'Bloom',
+      presenceInfo: [
+        _presence('1234', available: false, activities: [PresenceActivity.away]),
+      ],
     ),
   ),
 ];


### PR DESCRIPTION
The favorites mock contacts in the screenshot/preview harness only carried a SIP `registered` flag and no presence. Once the configurator preview reports a hybrid-presence-aware core, the avatar indicator switches from the registration badge to the presence dot, and with empty presence every avatar collapsed to a single "unavailable" dot.

Each favorite now carries distinct presence so the preview demonstrates the full range: available, unavailable, and available/unavailable combined with on-the-phone, do-not-disturb, meeting and away activities. This exercises both the available/unavailable colors (including the configurable Presence Badge) and the activity icons drawn on top.

Mock data only, scoped to `screenshots/lib/data/favorites.dart`; timestamps are fixed so the generated screenshots stay deterministic. `dart analyze` is clean.