### PR TITLE
fix(web): Crashlytics platform-split + tolerant certificate loading

### DIFF
--- a/lib/data/app_certificates.dart
+++ b/lib/data/app_certificates.dart
@@ -2,11 +2,14 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart';
 
 import 'package:ssl_certificates/ssl_certificates.dart';
 
 import 'package:webtrit_phone/app/assets.gen.dart';
+
+final _logger = Logger('AppCertificates');
 
 class AppCertificates {
   AppCertificates._(this._trustedCertificates);
@@ -16,15 +19,26 @@ class AppCertificates {
   /// Returns the list of ssl certificates and their passwords.
   TrustedCertificates get trustedCertificates => _trustedCertificates;
 
-  /// Initialize the AppCerts instance with the certificates
+  /// Initialize the AppCerts instance with the certificates.
+  ///
+  /// Returns [TrustedCertificates.empty] when the certificate assets are not
+  /// bundled — e.g. when the app runs embedded inside another host (the theme
+  /// configurator's realtime preview) whose asset bundle does not include this
+  /// package's `assets/certificates/...`. Custom CA pinning is then unavailable
+  /// and the platform trust store is used instead.
   static Future<AppCertificates> init() async {
-    final certificatePaths = Assets.certificates.values.where((it) => it != Assets.certificates.credentials);
-    final credentialsPath = Assets.certificates.credentials;
+    try {
+      final certificatePaths = Assets.certificates.values.where((it) => it != Assets.certificates.credentials);
+      final credentialsPath = Assets.certificates.credentials;
 
-    final credentials = await _loadCredentials(credentialsPath);
-    final certificates = await Future.wait(certificatePaths.map((it) => _prepareCertificate(it, credentials)));
+      final credentials = await _loadCredentials(credentialsPath);
+      final certificates = await Future.wait(certificatePaths.map((it) => _prepareCertificate(it, credentials)));
 
-    return AppCertificates._(TrustedCertificates(certificates: certificates));
+      return AppCertificates._(TrustedCertificates(certificates: certificates));
+    } catch (e, s) {
+      _logger.warning('Trusted certificate assets unavailable; continuing without custom CA certificates', e, s);
+      return AppCertificates._(TrustedCertificates.empty);
+    }
   }
 
   /// Loads certificate bytes from assets using the provided path and credentials.

--- a/lib/utils/crashlytics_sink/_io.dart
+++ b/lib/utils/crashlytics_sink/_io.dart
@@ -1,0 +1,26 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
+// Native Crashlytics sink: forwards to FirebaseCrashlytics.instance.
+
+Future<void> crashlyticsSetUserIdentifier(String identifier) =>
+    FirebaseCrashlytics.instance.setUserIdentifier(identifier);
+
+Future<void> crashlyticsSetCustomKey(String key, Object value) => FirebaseCrashlytics.instance.setCustomKey(key, value);
+
+void crashlyticsLog(String message) => FirebaseCrashlytics.instance.log(message);
+
+Future<void> crashlyticsRecordError(
+  Object? exception,
+  StackTrace? stack, {
+  Object? reason,
+  Iterable<Object> information = const [],
+  bool fatal = false,
+  bool printDetails = false,
+}) => FirebaseCrashlytics.instance.recordError(
+  exception,
+  stack,
+  reason: reason,
+  information: information,
+  fatal: fatal,
+  printDetails: printDetails,
+);

--- a/lib/utils/crashlytics_sink/_unsupported.dart
+++ b/lib/utils/crashlytics_sink/_unsupported.dart
@@ -1,0 +1,17 @@
+// Fallback Crashlytics sink for platforms with neither dart:io nor dart:js.
+// Telemetry is best-effort, so every operation is a no-op (never throws).
+
+Future<void> crashlyticsSetUserIdentifier(String identifier) => Future.value();
+
+Future<void> crashlyticsSetCustomKey(String key, Object value) => Future.value();
+
+void crashlyticsLog(String message) {}
+
+Future<void> crashlyticsRecordError(
+  Object? exception,
+  StackTrace? stack, {
+  Object? reason,
+  Iterable<Object> information = const [],
+  bool fatal = false,
+  bool printDetails = false,
+}) => Future.value();

--- a/lib/utils/crashlytics_sink/_web.dart
+++ b/lib/utils/crashlytics_sink/_web.dart
@@ -1,0 +1,17 @@
+// Web Crashlytics sink: firebase_crashlytics has no web implementation, so
+// every operation is a no-op. The web bundle never links firebase_crashlytics.
+
+Future<void> crashlyticsSetUserIdentifier(String identifier) => Future.value();
+
+Future<void> crashlyticsSetCustomKey(String key, Object value) => Future.value();
+
+void crashlyticsLog(String message) {}
+
+Future<void> crashlyticsRecordError(
+  Object? exception,
+  StackTrace? stack, {
+  Object? reason,
+  Iterable<Object> information = const [],
+  bool fatal = false,
+  bool printDetails = false,
+}) => Future.value();

--- a/lib/utils/crashlytics_sink/crashlytics_sink.dart
+++ b/lib/utils/crashlytics_sink/crashlytics_sink.dart
@@ -1,0 +1,3 @@
+export '_unsupported.dart' // stub: telemetry is best-effort, never throws
+    if (dart.library.js) '_web.dart' // web: firebase_crashlytics has no web impl -> no-ops
+    if (dart.library.io) '_io.dart'; // native: forwards to FirebaseCrashlytics

--- a/lib/utils/crashlytics_utils.dart
+++ b/lib/utils/crashlytics_utils.dart
@@ -4,9 +4,15 @@ import 'dart:isolate';
 
 import 'package:flutter/foundation.dart';
 
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'crashlytics_sink/crashlytics_sink.dart';
 
 /// Small helper around Firebase Crashlytics for consistent context logging.
+///
+/// The actual Crashlytics calls go through a platform-split sink
+/// (`crashlytics_sink/`): native forwards to `FirebaseCrashlytics.instance`,
+/// web/unsupported are no-ops. This keeps `firebase_crashlytics` (which has no
+/// web implementation) out of the web bundle entirely, instead of guarding each
+/// call at runtime.
 class CrashlyticsUtils {
   CrashlyticsUtils._();
 
@@ -21,17 +27,13 @@ class CrashlyticsUtils {
 
   /// Writes useful isolate/platform context into Crashlytics custom keys.
   static Future<void> logIsolateInfo() async {
-    // firebase_crashlytics has no web implementation; any access to its instance
-    // throws on web (and in embedded previews that skip Firebase init).
-    if (kIsWeb) return;
     final label = currentIsolateLabel();
     final dbg = kIsWeb ? null : Isolate.current.debugName;
     final hash = kIsWeb ? null : Isolate.current.hashCode;
 
-    final crashlytics = FirebaseCrashlytics.instance;
-    unawaited(crashlytics.setCustomKey('isolate_label', label));
-    if (dbg != null) unawaited(crashlytics.setCustomKey('isolate_debugName', dbg));
-    if (hash != null) unawaited(crashlytics.setCustomKey('isolate_hash', hash));
+    unawaited(crashlyticsSetCustomKey('isolate_label', label));
+    if (dbg != null) unawaited(crashlyticsSetCustomKey('isolate_debugName', dbg));
+    if (hash != null) unawaited(crashlyticsSetCustomKey('isolate_hash', hash));
   }
 
   /// Sets Crashlytics user + common session keys.
@@ -42,24 +44,20 @@ class CrashlyticsUtils {
     required String coreUrl,
     required String sessionId,
   }) async {
-    if (kIsWeb) return;
-    final crashlytics = FirebaseCrashlytics.instance;
-    unawaited(crashlytics.setUserIdentifier(userId));
-    unawaited(crashlytics.setCustomKey('tenantId', tenantId));
-    unawaited(crashlytics.setCustomKey('coreUrl', coreUrl));
-    unawaited(crashlytics.setCustomKey('sessionId', sessionId));
+    unawaited(crashlyticsSetUserIdentifier(userId));
+    unawaited(crashlyticsSetCustomKey('tenantId', tenantId));
+    unawaited(crashlyticsSetCustomKey('coreUrl', coreUrl));
+    unawaited(crashlyticsSetCustomKey('sessionId', sessionId));
     await logIsolateInfo();
   }
 
   /// Convenience wrappers
   static void setKey(String key, Object value) {
-    if (kIsWeb) return;
-    unawaited(FirebaseCrashlytics.instance.setCustomKey(key, value));
+    unawaited(crashlyticsSetCustomKey(key, value));
   }
 
   static void log(String message) {
-    if (kIsWeb) return;
-    FirebaseCrashlytics.instance.log(message);
+    crashlyticsLog(message);
   }
 
   /// Records an caught error that is needed to be reported, non fatal by default.
@@ -80,17 +78,10 @@ class CrashlyticsUtils {
     bool skipInDebug = true,
     bool skipNetwork = true,
   }) async {
-    if (kIsWeb) return;
     if (kDebugMode && skipInDebug) return;
     if (skipNetwork && _isTransientNetworkError(exception)) return;
 
-    await FirebaseCrashlytics.instance.recordError(
-      exception,
-      stack,
-      reason: reason,
-      information: information,
-      fatal: fatal,
-    );
+    await crashlyticsRecordError(exception, stack, reason: reason, information: information, fatal: fatal);
   }
 
   static bool _isTransientNetworkError(Object error) =>
@@ -109,16 +100,13 @@ class CrashlyticsUtils {
     String errorGroup = 'UserReport.submit',
     bool isFatal = true,
   }) async {
-    if (kIsWeb) return;
-    final crashlytics = FirebaseCrashlytics.instance;
-
     if (comment.isNotEmpty) {
       _setSafeCustomKey('report_comment', comment);
-      crashlytics.log('Diagnostic Comment: $comment');
+      crashlyticsLog('Diagnostic Comment: $comment');
     }
 
     if (diagnostics.isNotEmpty) {
-      crashlytics.log('Diagnostics: $diagnostics');
+      crashlyticsLog('Diagnostics: $diagnostics');
     }
 
     final allKeys = {...metadata, ...extras, ...diagnostics};
@@ -130,7 +118,7 @@ class CrashlyticsUtils {
     final exception = UserDiagnosticReportException(errorDescription);
     final syntheticStackTrace = StackTrace.fromString('#0      $errorGroup (user_diagnostic_report:1:1)');
 
-    await crashlytics.recordError(
+    await crashlyticsRecordError(
       exception,
       syntheticStackTrace,
       reason: 'Manual User Report via Service',
@@ -142,7 +130,7 @@ class CrashlyticsUtils {
 
   static void _setSafeCustomKey(String key, dynamic value) {
     final safeValue = (value is String || value is num || value is bool) ? value : value.toString();
-    unawaited(FirebaseCrashlytics.instance.setCustomKey(key, safeValue));
+    unawaited(crashlyticsSetCustomKey(key, safeValue));
   }
 }
 

--- a/lib/utils/crashlytics_utils.dart
+++ b/lib/utils/crashlytics_utils.dart
@@ -21,6 +21,9 @@ class CrashlyticsUtils {
 
   /// Writes useful isolate/platform context into Crashlytics custom keys.
   static Future<void> logIsolateInfo() async {
+    // firebase_crashlytics has no web implementation; any access to its instance
+    // throws on web (and in embedded previews that skip Firebase init).
+    if (kIsWeb) return;
     final label = currentIsolateLabel();
     final dbg = kIsWeb ? null : Isolate.current.debugName;
     final hash = kIsWeb ? null : Isolate.current.hashCode;
@@ -39,6 +42,7 @@ class CrashlyticsUtils {
     required String coreUrl,
     required String sessionId,
   }) async {
+    if (kIsWeb) return;
     final crashlytics = FirebaseCrashlytics.instance;
     unawaited(crashlytics.setUserIdentifier(userId));
     unawaited(crashlytics.setCustomKey('tenantId', tenantId));
@@ -49,10 +53,12 @@ class CrashlyticsUtils {
 
   /// Convenience wrappers
   static void setKey(String key, Object value) {
+    if (kIsWeb) return;
     unawaited(FirebaseCrashlytics.instance.setCustomKey(key, value));
   }
 
   static void log(String message) {
+    if (kIsWeb) return;
     FirebaseCrashlytics.instance.log(message);
   }
 
@@ -74,6 +80,7 @@ class CrashlyticsUtils {
     bool skipInDebug = true,
     bool skipNetwork = true,
   }) async {
+    if (kIsWeb) return;
     if (kDebugMode && skipInDebug) return;
     if (skipNetwork && _isTransientNetworkError(exception)) return;
 
@@ -102,6 +109,7 @@ class CrashlyticsUtils {
     String errorGroup = 'UserReport.submit',
     bool isFatal = true,
   }) async {
+    if (kIsWeb) return;
     final crashlytics = FirebaseCrashlytics.instance;
 
     if (comment.isNotEmpty) {


### PR DESCRIPTION
## Overview

Two web/embedded robustness fixes in webtrit_phone, split out of the realtime-preview work as an independent PR.

1. **Crashlytics — platform-split sink.** `firebase_crashlytics` has no web implementation, so any `FirebaseCrashlytics.instance` access throws (`pluginConstants['isCrashlyticsCollectionEnabled'] != null`; on web it fires on login via `CrashlyticsUtils.logSession -> setUserIdentifier`). Instead of guarding each call with `kIsWeb` at runtime, the Crashlytics calls now go through a conditional-import sink (`lib/utils/crashlytics_sink/`), matching the repo's existing pattern (`path_provider`, `native_audio_restart`): native forwards to `FirebaseCrashlytics.instance`; web/unsupported are no-ops. The web bundle no longer links `firebase_crashlytics` at all. `CrashlyticsUtils`' public API is unchanged.
2. **Certificates — tolerant init.** `AppCertificates.init()` throws `Unable to load asset assets/certificates/credentials.json` when the certificate assets are not in the bundle (e.g. embedded in another host). `init()` now falls back to `TrustedCertificates.empty` on any load failure. Kept as a try/catch (not a platform split) on purpose: this is asset availability, not a platform-API gap — a real standalone web build of this app **does** bundle the certs and should still use them; only a host that omits the assets falls back.