### PR TITLE
feat(app): inject external theme and feature config into the embedded app

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -21,7 +23,17 @@ import 'package:webtrit_phone/resolvers/resolvers.dart';
 final _logger = Logger('AppWidget');
 
 class App extends StatefulWidget {
-  const App({super.key, this.embeddedPreview = false});
+  const App({super.key, this.externalThemeSettings, this.externalThemeMode, this.embeddedPreview = false});
+
+  /// Optional external [ThemeSettings] stream used by embedders such as the
+  /// theme configurator's realtime preview to drive the running app's
+  /// appearance live. Emissions are applied via [AppThemeSettingsChanged] and
+  /// are not persisted to local preferences.
+  final Stream<ThemeSettings>? externalThemeSettings;
+
+  /// Optional external [ThemeMode] stream paired with [externalThemeSettings];
+  /// emissions are applied via [AppThemeModeChanged].
+  final Stream<ThemeMode>? externalThemeMode;
 
   /// Whether the app runs embedded inside another Flutter host (realtime
   /// preview). When true, Firebase-backed integrations such as the analytics
@@ -36,6 +48,9 @@ class App extends StatefulWidget {
 class _AppState extends State<App> {
   late final AppBloc appBloc;
   late final AppRouter appRouter;
+
+  StreamSubscription<ThemeSettings>? _externalThemeSettingsSubscription;
+  StreamSubscription<ThemeMode>? _externalThemeModeSubscription;
 
   @override
   void initState() {
@@ -89,6 +104,13 @@ class _AppState extends State<App> {
       initialTabResolver,
       featureAccess.checker,
     );
+
+    _externalThemeSettingsSubscription = widget.externalThemeSettings?.listen(
+      (settings) => appBloc.add(AppThemeSettingsChanged(settings)),
+    );
+    _externalThemeModeSubscription = widget.externalThemeMode?.listen(
+      (themeMode) => appBloc.add(AppThemeModeChanged(themeMode)),
+    );
   }
 
   @override
@@ -114,6 +136,8 @@ class _AppState extends State<App> {
 
   @override
   void dispose() {
+    _externalThemeSettingsSubscription?.cancel();
+    _externalThemeModeSubscription?.cancel();
     appBloc.close();
     super.dispose();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/services/services.dart';
+import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 void main() {
@@ -66,7 +67,15 @@ void _onRootLogRecord(LogRecord record) {
 }
 
 class RootApp extends StatelessWidget {
-  const RootApp({super.key, required this.instanceRegistry, this.embeddedPreview = false});
+  const RootApp({
+    super.key,
+    required this.instanceRegistry,
+    this.externalThemeSettings,
+    this.externalThemeMode,
+    this.externalFeatureAccess,
+    this.externalFeatureAccessInitial,
+    this.embeddedPreview = false,
+  });
 
   final InstanceRegistry instanceRegistry;
 
@@ -74,6 +83,24 @@ class RootApp extends StatelessWidget {
   /// configurator's realtime preview). Forwarded to [App] so Firebase-backed
   /// integrations such as the analytics navigator observer are skipped.
   final bool embeddedPreview;
+
+  /// Optional external [ThemeSettings] stream forwarded to [App] so embedders
+  /// such as the theme configurator's realtime preview can drive the running
+  /// app's appearance live.
+  final Stream<ThemeSettings>? externalThemeSettings;
+
+  /// Optional external [ThemeMode] stream forwarded to [App], paired with
+  /// [externalThemeSettings].
+  final Stream<ThemeMode>? externalThemeMode;
+
+  /// Optional external [FeatureAccess] stream that replaces the bootstrap-built
+  /// reactive configuration, letting embedders (the configurator's realtime
+  /// preview) drive the live app/login/feature config being edited.
+  final Stream<FeatureAccess>? externalFeatureAccess;
+
+  /// Initial [FeatureAccess] paired with [externalFeatureAccess]; used as the
+  /// `StreamProvider` seed so the first frame already reflects the edited config.
+  final FeatureAccess? externalFeatureAccessInitial;
 
   @override
   Widget build(BuildContext context) {
@@ -91,8 +118,8 @@ class RootApp extends StatelessWidget {
         //
         // Initializes with bootstrap data and updates whenever system information or remote configuration changes.
         StreamProvider<FeatureAccess>(
-          initialData: instanceRegistry.get<FeatureAccess>(),
-          create: (_) => instanceRegistry.get<FeatureAccessStreamFactory>().create(),
+          initialData: externalFeatureAccessInitial ?? instanceRegistry.get<FeatureAccess>(),
+          create: (_) => externalFeatureAccess ?? instanceRegistry.get<FeatureAccessStreamFactory>().create(),
           updateShouldNotify: (previous, next) => previous != next,
         ),
         Provider<SecureStorage>(create: (_) => instanceRegistry.get()),
@@ -186,7 +213,11 @@ class RootApp extends StatelessWidget {
               RepositoryProvider<UserLocalDatasource>(create: (_) => instanceRegistry.get()),
               RepositoryProvider<AuthRepository>(create: (_) => instanceRegistry.get()),
             ],
-            child: App(embeddedPreview: embeddedPreview),
+            child: App(
+              externalThemeSettings: externalThemeSettings,
+              externalThemeMode: externalThemeMode,
+              embeddedPreview: embeddedPreview,
+            ),
           );
         },
       ),


### PR DESCRIPTION
## Overview

Stacked on #1438 (Firebase-free `embeddedPreview` bootstrap). Lets an embedder — the configurator's realtime preview — drive the **live appearance and feature/login/tab config** of the embedded app.

- `RootApp`/`App` accept external `ThemeSettings` / `ThemeMode` / `FeatureAccess` streams (+ initial seeds).
- `App` subscribes to the theme streams and applies them via `AppThemeSettingsChanged` / `AppThemeModeChanged` (no prefs write); subscriptions are cancelled on dispose.
- `RootApp`'s `FeatureAccess` `StreamProvider` source is swapped to the external stream, with the external initial as the first-frame seed.

## Why

Second half of the embedded-host support for the realtime-preview epic (split from #1437). Depends on #1438 for the `embeddedPreview` flag / Firebase-free bootstrap.

> Stacked on #1438 — review/merge that first; this PR's base is `feat/embedded-preview-firebase-free` and will retarget to `develop` once #1438 lands.

## Notes

- Standalone behaviour unchanged: all external streams default to `null`.
- `flutter analyze lib` green.