### PR TITLE
refactor(theme): provide ThemeSettings as an inherited value, out of AppState

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -41,7 +41,6 @@ class _AppState extends State<App> {
       contactsAgreementStatusRepository: context.read<ContactsAgreementStatusRepository>(),
       localeRepository: context.read<LocaleRepository>(),
       themeModeRepository: context.read<ThemeModeRepository>(),
-      appThemes: context.read<AppThemes>(),
       sessionRepository: context.read<SessionRepository>(),
       systemInfoRepository: context.read<SystemInfoRepository>(),
       appCompatibilityResolver: context.read<AppCompatibilityResolver>(),
@@ -117,63 +116,60 @@ class _AppState extends State<App> {
     final isDeepLinkEnabled = EnvironmentConfig.APP_LINK_DOMAIN.isNotEmpty;
 
     final featureAccess = context.watch<FeatureAccess>();
+    final themeSettings = context.watch<ThemeSettings>();
 
-    final materialApp = BlocBuilder<AppBloc, AppState>(
-      buildWhen: (previous, current) => previous.themeSettings != current.themeSettings,
-      builder: (context, state) {
-        return ThemeProvider(
-          settings: state.themeSettings,
-          lightDynamic: null,
-          darkDynamic: null,
-          child: BlocBuilder<AppBloc, AppState>(
-            buildWhen: (previous, current) =>
-                previous.effectiveLocale != current.effectiveLocale ||
-                previous.effectiveThemeMode != current.effectiveThemeMode,
-            builder: (context, state) {
-              final themeProvider = ThemeProvider.of(context);
-              final forcedMode = featureAccess.supportedConfig.themeMode;
-              final finalThemeMode = forcedMode == ThemeMode.system ? state.effectiveThemeMode : forcedMode;
+    final materialApp = ThemeProvider(
+      settings: themeSettings,
+      lightDynamic: null,
+      darkDynamic: null,
+      child: BlocBuilder<AppBloc, AppState>(
+        buildWhen: (previous, current) =>
+            previous.effectiveLocale != current.effectiveLocale || previous.themeMode != current.themeMode,
+        builder: (context, state) {
+          final themeProvider = ThemeProvider.of(context);
+          final forcedMode = featureAccess.supportedConfig.themeMode;
+          final finalThemeMode = forcedMode == ThemeMode.system
+              ? themeSettings.effectiveThemeMode(state.themeMode)
+              : forcedMode;
 
-              return MaterialApp.router(
-                locale: state.effectiveLocale,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                // restorationScopeId: 'App', // TODO: temporary comment to prevent AppShell's AutoRouter placeholder blink - additional investigation necessary
-                title: EnvironmentConfig.APP_NAME,
-                themeMode: finalThemeMode,
-                theme: themeProvider.light(),
-                darkTheme: themeProvider.dark(),
-                routerConfig: appRouter.config(
-                  deepLinkBuilder: isDeepLinkEnabled ? appRouter.deepLinkBuilder : null,
-                  navigatorObservers: () => [
-                    AppRouterObserver(),
-                    context.read<AppAnalyticsRepository>().createObserver(),
-                    AutoRouteObserver(),
-                  ],
-                  reevaluateListenable: ReevaluateListenable.stream(
-                    // Insert and skip the initial state to ensure the distinct buffer if filled
-                    // and ensure the next state change is emitted only if it differ from the initial state.
-                    //
-                    // Please verify next caases if you change this logic:
-                    // - Call drop after theme change or locale change:
-                    appBloc.stream
-                        .mergeAll([
-                          Stream.fromIterable([appBloc.state]),
-                        ])
-                        .distinct((p, n) {
-                          final same = p.compareToReevaluate(n);
-                          _logger.fine('AppState compareToReevaluate: $same');
-                          if (!same) _logger.fine('AppState compareToReevaluate: previous: $p\n  next: $n');
-                          return same;
-                        })
-                        .skip(1),
-                  ),
-                ),
-              );
-            },
-          ),
-        );
-      },
+          return MaterialApp.router(
+            locale: state.effectiveLocale,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            // restorationScopeId: 'App', // TODO: temporary comment to prevent AppShell's AutoRouter placeholder blink - additional investigation necessary
+            title: EnvironmentConfig.APP_NAME,
+            themeMode: finalThemeMode,
+            theme: themeProvider.light(),
+            darkTheme: themeProvider.dark(),
+            routerConfig: appRouter.config(
+              deepLinkBuilder: isDeepLinkEnabled ? appRouter.deepLinkBuilder : null,
+              navigatorObservers: () => [
+                AppRouterObserver(),
+                context.read<AppAnalyticsRepository>().createObserver(),
+                AutoRouteObserver(),
+              ],
+              reevaluateListenable: ReevaluateListenable.stream(
+                // Insert and skip the initial state to ensure the distinct buffer if filled
+                // and ensure the next state change is emitted only if it differ from the initial state.
+                //
+                // Please verify next caases if you change this logic:
+                // - Call drop after theme change or locale change:
+                appBloc.stream
+                    .mergeAll([
+                      Stream.fromIterable([appBloc.state]),
+                    ])
+                    .distinct((p, n) {
+                      final same = p.compareToReevaluate(n);
+                      _logger.fine('AppState compareToReevaluate: $same');
+                      if (!same) _logger.fine('AppState compareToReevaluate: previous: $p\n  next: $n');
+                      return same;
+                    })
+                    .skip(1),
+              ),
+            ),
+          );
+        },
+      ),
     );
 
     return MultiBlocProvider(

--- a/lib/blocs/app/app_bloc.dart
+++ b/lib/blocs/app/app_bloc.dart
@@ -17,7 +17,6 @@ import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/resolvers/resolvers.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 part 'app_bloc.freezed.dart';
@@ -40,14 +39,12 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     required this.systemInfoRepository,
     required this.appCompatibilityResolver,
     required this.packageInfo,
-    required AppThemes appThemes,
   }) : super(
          AppState(
            session: sessionRepository.getCurrent(),
            status: (sessionRepository.getCurrent().isLoggedIn)
                ? AppLifecycleStatus.authenticated
                : AppLifecycleStatus.unauthenticated,
-           themeSettings: appThemes.values.first.settings,
            themeMode: themeModeRepository.getThemeMode(),
            locale: localeRepository.getLocale(),
            userAgreementStatus: userAgreementStatusRepository.getUserAgreementStatus(),
@@ -55,7 +52,6 @@ class AppBloc extends Bloc<AppEvent, AppState> {
          ),
        ) {
     on<AppLoggedIn>(_onLoggedIn);
-    on<AppThemeSettingsChanged>(_onThemeSettingsChanged, transformer: droppable());
     on<AppThemeModeChanged>(_onThemeModeChanged, transformer: droppable());
     on<AppLocaleChanged>(_onLocaleChanged, transformer: droppable());
     on<AppAgreementAccepted>(_onUserAgreementAccepted, transformer: droppable());
@@ -195,10 +191,6 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     await sessionRepository.clean();
 
     emit(state.copyWith(status: AppLifecycleStatus.unauthenticated, session: const Session(), logoutReason: null));
-  }
-
-  void _onThemeSettingsChanged(AppThemeSettingsChanged event, Emitter<AppState> emit) {
-    emit(state.copyWith(themeSettings: event.value));
   }
 
   void _onThemeModeChanged(AppThemeModeChanged event, Emitter<AppState> emit) async {

--- a/lib/blocs/app/app_bloc.freezed.dart
+++ b/lib/blocs/app/app_bloc.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AppState {
 
- AppLifecycleStatus get status; AppLogoutReason? get logoutReason; Session get session; ThemeSettings get themeSettings; ThemeMode get themeMode; Locale get locale; AgreementStatus get userAgreementStatus; AgreementStatus get contactsAgreementStatus; AppCompatibility get appCompatibility;
+ AppLifecycleStatus get status; AppLogoutReason? get logoutReason; Session get session; ThemeMode get themeMode; Locale get locale; AgreementStatus get userAgreementStatus; AgreementStatus get contactsAgreementStatus; AppCompatibility get appCompatibility;
 /// Create a copy of AppState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $AppStateCopyWith<AppState> get copyWith => _$AppStateCopyWithImpl<AppState>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppState&&(identical(other.status, status) || other.status == status)&&(identical(other.logoutReason, logoutReason) || other.logoutReason == logoutReason)&&(identical(other.session, session) || other.session == session)&&(identical(other.themeSettings, themeSettings) || other.themeSettings == themeSettings)&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.userAgreementStatus, userAgreementStatus) || other.userAgreementStatus == userAgreementStatus)&&(identical(other.contactsAgreementStatus, contactsAgreementStatus) || other.contactsAgreementStatus == contactsAgreementStatus)&&(identical(other.appCompatibility, appCompatibility) || other.appCompatibility == appCompatibility));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppState&&(identical(other.status, status) || other.status == status)&&(identical(other.logoutReason, logoutReason) || other.logoutReason == logoutReason)&&(identical(other.session, session) || other.session == session)&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.userAgreementStatus, userAgreementStatus) || other.userAgreementStatus == userAgreementStatus)&&(identical(other.contactsAgreementStatus, contactsAgreementStatus) || other.contactsAgreementStatus == contactsAgreementStatus)&&(identical(other.appCompatibility, appCompatibility) || other.appCompatibility == appCompatibility));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,status,logoutReason,session,themeSettings,themeMode,locale,userAgreementStatus,contactsAgreementStatus,appCompatibility);
+int get hashCode => Object.hash(runtimeType,status,logoutReason,session,themeMode,locale,userAgreementStatus,contactsAgreementStatus,appCompatibility);
 
 @override
 String toString() {
-  return 'AppState(status: $status, logoutReason: $logoutReason, session: $session, themeSettings: $themeSettings, themeMode: $themeMode, locale: $locale, userAgreementStatus: $userAgreementStatus, contactsAgreementStatus: $contactsAgreementStatus, appCompatibility: $appCompatibility)';
+  return 'AppState(status: $status, logoutReason: $logoutReason, session: $session, themeMode: $themeMode, locale: $locale, userAgreementStatus: $userAgreementStatus, contactsAgreementStatus: $contactsAgreementStatus, appCompatibility: $appCompatibility)';
 }
 
 
@@ -45,11 +45,11 @@ abstract mixin class $AppStateCopyWith<$Res>  {
   factory $AppStateCopyWith(AppState value, $Res Function(AppState) _then) = _$AppStateCopyWithImpl;
 @useResult
 $Res call({
- AppLifecycleStatus status, AppLogoutReason? logoutReason, Session session, ThemeSettings themeSettings, ThemeMode themeMode, Locale locale, AgreementStatus userAgreementStatus, AgreementStatus contactsAgreementStatus, AppCompatibility appCompatibility
+ AppLifecycleStatus status, AppLogoutReason? logoutReason, Session session, ThemeMode themeMode, Locale locale, AgreementStatus userAgreementStatus, AgreementStatus contactsAgreementStatus, AppCompatibility appCompatibility
 });
 
 
-$SessionCopyWith<$Res> get session;$ThemeSettingsCopyWith<$Res> get themeSettings;
+$SessionCopyWith<$Res> get session;
 
 }
 /// @nodoc
@@ -62,13 +62,12 @@ class _$AppStateCopyWithImpl<$Res>
 
 /// Create a copy of AppState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? logoutReason = freezed,Object? session = null,Object? themeSettings = null,Object? themeMode = null,Object? locale = null,Object? userAgreementStatus = null,Object? contactsAgreementStatus = null,Object? appCompatibility = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? logoutReason = freezed,Object? session = null,Object? themeMode = null,Object? locale = null,Object? userAgreementStatus = null,Object? contactsAgreementStatus = null,Object? appCompatibility = null,}) {
   return _then(_self.copyWith(
 status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as AppLifecycleStatus,logoutReason: freezed == logoutReason ? _self.logoutReason : logoutReason // ignore: cast_nullable_to_non_nullable
 as AppLogoutReason?,session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
-as Session,themeSettings: null == themeSettings ? _self.themeSettings : themeSettings // ignore: cast_nullable_to_non_nullable
-as ThemeSettings,themeMode: null == themeMode ? _self.themeMode : themeMode // ignore: cast_nullable_to_non_nullable
+as Session,themeMode: null == themeMode ? _self.themeMode : themeMode // ignore: cast_nullable_to_non_nullable
 as ThemeMode,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
 as Locale,userAgreementStatus: null == userAgreementStatus ? _self.userAgreementStatus : userAgreementStatus // ignore: cast_nullable_to_non_nullable
 as AgreementStatus,contactsAgreementStatus: null == contactsAgreementStatus ? _self.contactsAgreementStatus : contactsAgreementStatus // ignore: cast_nullable_to_non_nullable
@@ -84,15 +83,6 @@ $SessionCopyWith<$Res> get session {
   
   return $SessionCopyWith<$Res>(_self.session, (value) {
     return _then(_self.copyWith(session: value));
-  });
-}/// Create a copy of AppState
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$ThemeSettingsCopyWith<$Res> get themeSettings {
-  
-  return $ThemeSettingsCopyWith<$Res>(_self.themeSettings, (value) {
-    return _then(_self.copyWith(themeSettings: value));
   });
 }
 }
@@ -173,10 +163,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AppLifecycleStatus status,  AppLogoutReason? logoutReason,  Session session,  ThemeSettings themeSettings,  ThemeMode themeMode,  Locale locale,  AgreementStatus userAgreementStatus,  AgreementStatus contactsAgreementStatus,  AppCompatibility appCompatibility)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AppLifecycleStatus status,  AppLogoutReason? logoutReason,  Session session,  ThemeMode themeMode,  Locale locale,  AgreementStatus userAgreementStatus,  AgreementStatus contactsAgreementStatus,  AppCompatibility appCompatibility)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AppState() when $default != null:
-return $default(_that.status,_that.logoutReason,_that.session,_that.themeSettings,_that.themeMode,_that.locale,_that.userAgreementStatus,_that.contactsAgreementStatus,_that.appCompatibility);case _:
+return $default(_that.status,_that.logoutReason,_that.session,_that.themeMode,_that.locale,_that.userAgreementStatus,_that.contactsAgreementStatus,_that.appCompatibility);case _:
   return orElse();
 
 }
@@ -194,10 +184,10 @@ return $default(_that.status,_that.logoutReason,_that.session,_that.themeSetting
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AppLifecycleStatus status,  AppLogoutReason? logoutReason,  Session session,  ThemeSettings themeSettings,  ThemeMode themeMode,  Locale locale,  AgreementStatus userAgreementStatus,  AgreementStatus contactsAgreementStatus,  AppCompatibility appCompatibility)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AppLifecycleStatus status,  AppLogoutReason? logoutReason,  Session session,  ThemeMode themeMode,  Locale locale,  AgreementStatus userAgreementStatus,  AgreementStatus contactsAgreementStatus,  AppCompatibility appCompatibility)  $default,) {final _that = this;
 switch (_that) {
 case _AppState():
-return $default(_that.status,_that.logoutReason,_that.session,_that.themeSettings,_that.themeMode,_that.locale,_that.userAgreementStatus,_that.contactsAgreementStatus,_that.appCompatibility);}
+return $default(_that.status,_that.logoutReason,_that.session,_that.themeMode,_that.locale,_that.userAgreementStatus,_that.contactsAgreementStatus,_that.appCompatibility);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -211,10 +201,10 @@ return $default(_that.status,_that.logoutReason,_that.session,_that.themeSetting
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AppLifecycleStatus status,  AppLogoutReason? logoutReason,  Session session,  ThemeSettings themeSettings,  ThemeMode themeMode,  Locale locale,  AgreementStatus userAgreementStatus,  AgreementStatus contactsAgreementStatus,  AppCompatibility appCompatibility)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AppLifecycleStatus status,  AppLogoutReason? logoutReason,  Session session,  ThemeMode themeMode,  Locale locale,  AgreementStatus userAgreementStatus,  AgreementStatus contactsAgreementStatus,  AppCompatibility appCompatibility)?  $default,) {final _that = this;
 switch (_that) {
 case _AppState() when $default != null:
-return $default(_that.status,_that.logoutReason,_that.session,_that.themeSettings,_that.themeMode,_that.locale,_that.userAgreementStatus,_that.contactsAgreementStatus,_that.appCompatibility);case _:
+return $default(_that.status,_that.logoutReason,_that.session,_that.themeMode,_that.locale,_that.userAgreementStatus,_that.contactsAgreementStatus,_that.appCompatibility);case _:
   return null;
 
 }
@@ -226,13 +216,12 @@ return $default(_that.status,_that.logoutReason,_that.session,_that.themeSetting
 
 
 class _AppState extends AppState {
-  const _AppState({this.status = AppLifecycleStatus.unauthenticated, this.logoutReason = null, this.session = const Session(), required this.themeSettings, required this.themeMode, required this.locale, required this.userAgreementStatus, required this.contactsAgreementStatus, this.appCompatibility = const AppCompatible()}): super._();
+  const _AppState({this.status = AppLifecycleStatus.unauthenticated, this.logoutReason = null, this.session = const Session(), required this.themeMode, required this.locale, required this.userAgreementStatus, required this.contactsAgreementStatus, this.appCompatibility = const AppCompatible()}): super._();
   
 
 @override@JsonKey() final  AppLifecycleStatus status;
 @override@JsonKey() final  AppLogoutReason? logoutReason;
 @override@JsonKey() final  Session session;
-@override final  ThemeSettings themeSettings;
 @override final  ThemeMode themeMode;
 @override final  Locale locale;
 @override final  AgreementStatus userAgreementStatus;
@@ -249,16 +238,16 @@ _$AppStateCopyWith<_AppState> get copyWith => __$AppStateCopyWithImpl<_AppState>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AppState&&(identical(other.status, status) || other.status == status)&&(identical(other.logoutReason, logoutReason) || other.logoutReason == logoutReason)&&(identical(other.session, session) || other.session == session)&&(identical(other.themeSettings, themeSettings) || other.themeSettings == themeSettings)&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.userAgreementStatus, userAgreementStatus) || other.userAgreementStatus == userAgreementStatus)&&(identical(other.contactsAgreementStatus, contactsAgreementStatus) || other.contactsAgreementStatus == contactsAgreementStatus)&&(identical(other.appCompatibility, appCompatibility) || other.appCompatibility == appCompatibility));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AppState&&(identical(other.status, status) || other.status == status)&&(identical(other.logoutReason, logoutReason) || other.logoutReason == logoutReason)&&(identical(other.session, session) || other.session == session)&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.userAgreementStatus, userAgreementStatus) || other.userAgreementStatus == userAgreementStatus)&&(identical(other.contactsAgreementStatus, contactsAgreementStatus) || other.contactsAgreementStatus == contactsAgreementStatus)&&(identical(other.appCompatibility, appCompatibility) || other.appCompatibility == appCompatibility));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,status,logoutReason,session,themeSettings,themeMode,locale,userAgreementStatus,contactsAgreementStatus,appCompatibility);
+int get hashCode => Object.hash(runtimeType,status,logoutReason,session,themeMode,locale,userAgreementStatus,contactsAgreementStatus,appCompatibility);
 
 @override
 String toString() {
-  return 'AppState(status: $status, logoutReason: $logoutReason, session: $session, themeSettings: $themeSettings, themeMode: $themeMode, locale: $locale, userAgreementStatus: $userAgreementStatus, contactsAgreementStatus: $contactsAgreementStatus, appCompatibility: $appCompatibility)';
+  return 'AppState(status: $status, logoutReason: $logoutReason, session: $session, themeMode: $themeMode, locale: $locale, userAgreementStatus: $userAgreementStatus, contactsAgreementStatus: $contactsAgreementStatus, appCompatibility: $appCompatibility)';
 }
 
 
@@ -269,11 +258,11 @@ abstract mixin class _$AppStateCopyWith<$Res> implements $AppStateCopyWith<$Res>
   factory _$AppStateCopyWith(_AppState value, $Res Function(_AppState) _then) = __$AppStateCopyWithImpl;
 @override @useResult
 $Res call({
- AppLifecycleStatus status, AppLogoutReason? logoutReason, Session session, ThemeSettings themeSettings, ThemeMode themeMode, Locale locale, AgreementStatus userAgreementStatus, AgreementStatus contactsAgreementStatus, AppCompatibility appCompatibility
+ AppLifecycleStatus status, AppLogoutReason? logoutReason, Session session, ThemeMode themeMode, Locale locale, AgreementStatus userAgreementStatus, AgreementStatus contactsAgreementStatus, AppCompatibility appCompatibility
 });
 
 
-@override $SessionCopyWith<$Res> get session;@override $ThemeSettingsCopyWith<$Res> get themeSettings;
+@override $SessionCopyWith<$Res> get session;
 
 }
 /// @nodoc
@@ -286,13 +275,12 @@ class __$AppStateCopyWithImpl<$Res>
 
 /// Create a copy of AppState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? logoutReason = freezed,Object? session = null,Object? themeSettings = null,Object? themeMode = null,Object? locale = null,Object? userAgreementStatus = null,Object? contactsAgreementStatus = null,Object? appCompatibility = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? logoutReason = freezed,Object? session = null,Object? themeMode = null,Object? locale = null,Object? userAgreementStatus = null,Object? contactsAgreementStatus = null,Object? appCompatibility = null,}) {
   return _then(_AppState(
 status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as AppLifecycleStatus,logoutReason: freezed == logoutReason ? _self.logoutReason : logoutReason // ignore: cast_nullable_to_non_nullable
 as AppLogoutReason?,session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
-as Session,themeSettings: null == themeSettings ? _self.themeSettings : themeSettings // ignore: cast_nullable_to_non_nullable
-as ThemeSettings,themeMode: null == themeMode ? _self.themeMode : themeMode // ignore: cast_nullable_to_non_nullable
+as Session,themeMode: null == themeMode ? _self.themeMode : themeMode // ignore: cast_nullable_to_non_nullable
 as ThemeMode,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
 as Locale,userAgreementStatus: null == userAgreementStatus ? _self.userAgreementStatus : userAgreementStatus // ignore: cast_nullable_to_non_nullable
 as AgreementStatus,contactsAgreementStatus: null == contactsAgreementStatus ? _self.contactsAgreementStatus : contactsAgreementStatus // ignore: cast_nullable_to_non_nullable
@@ -309,15 +297,6 @@ $SessionCopyWith<$Res> get session {
   
   return $SessionCopyWith<$Res>(_self.session, (value) {
     return _then(_self.copyWith(session: value));
-  });
-}/// Create a copy of AppState
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$ThemeSettingsCopyWith<$Res> get themeSettings {
-  
-  return $ThemeSettingsCopyWith<$Res>(_self.themeSettings, (value) {
-    return _then(_self.copyWith(themeSettings: value));
   });
 }
 }

--- a/lib/blocs/app/app_event.dart
+++ b/lib/blocs/app/app_event.dart
@@ -45,15 +45,6 @@ class AppLoggedIn extends AppEvent {
   List<Object?> get props => [session, systemInfo];
 }
 
-class AppThemeSettingsChanged extends AppEvent {
-  const AppThemeSettingsChanged(this.value);
-
-  final ThemeSettings value;
-
-  @override
-  List<Object?> get props => [value];
-}
-
 class AppThemeModeChanged extends AppEvent {
   const AppThemeModeChanged(this.value);
 

--- a/lib/blocs/app/app_state.dart
+++ b/lib/blocs/app/app_state.dart
@@ -8,7 +8,6 @@ sealed class AppState with _$AppState {
     @Default(AppLifecycleStatus.unauthenticated) AppLifecycleStatus status,
     @Default(null) AppLogoutReason? logoutReason,
     @Default(Session()) Session session,
-    required ThemeSettings themeSettings,
     required ThemeMode themeMode,
     required Locale locale,
     required AgreementStatus userAgreementStatus,
@@ -17,10 +16,6 @@ sealed class AppState with _$AppState {
   }) = _AppState;
 
   const AppState._();
-
-  bool get isThemeModeSupported => themeSettings.lightColorSchemeConfig != themeSettings.darkColorSchemeConfig;
-
-  ThemeMode get effectiveThemeMode => isThemeModeSupported ? themeMode : ThemeMode.light;
 
   Locale? get effectiveLocale => locale == LocaleExtension.defaultNull ? null : locale;
 

--- a/lib/extensions/extensions.dart
+++ b/lib/extensions/extensions.dart
@@ -32,6 +32,7 @@ export 'signaling_hangup_failure.dart';
 export 'socket_exception.dart';
 export 'string.dart';
 export 'theme_mode.dart';
+export 'theme_settings.dart';
 export 'uri_extension.dart';
 export 'user_info.dart';
 export 'web_resource_error.dart';

--- a/lib/extensions/theme_settings.dart
+++ b/lib/extensions/theme_settings.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/theme/theme.dart';
+
+/// Theme-mode support derived purely from [ThemeSettings].
+///
+/// Lives on [ThemeSettings] (not [AppState]) so the theme can be provided down
+/// the tree as an inherited value and consumed directly, without routing it
+/// through the app bloc.
+extension ThemeSettingsModeX on ThemeSettings {
+  /// Whether the theme can switch between light and dark. False when the two
+  /// color scheme configs are identical, in which case the single scheme is
+  /// always rendered as light.
+  bool get isThemeModeSupported => lightColorSchemeConfig != darkColorSchemeConfig;
+
+  /// The mode actually applied for [mode]: the requested mode when the theme
+  /// supports switching, otherwise [ThemeMode.light].
+  ThemeMode effectiveThemeMode(ThemeMode mode) => isThemeModeSupported ? mode : ThemeMode.light;
+}

--- a/lib/features/settings/features/theme_mode/view/theme_mode_screen.dart
+++ b/lib/features/settings/features/theme_mode/view/theme_mode_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../../../widgets/widgets.dart';
@@ -15,15 +16,16 @@ class ThemeModeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const themeModes = ThemeMode.values;
+    final themeSettings = context.watch<ThemeSettings>();
 
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.settings_ListViewTileTitle_themeMode), leading: const ExtBackButton()),
       body: BlocBuilder<AppBloc, AppState>(
         builder: (context, state) {
           return RadioGroup<ThemeMode>(
-            groupValue: state.effectiveThemeMode,
+            groupValue: themeSettings.effectiveThemeMode(state.themeMode),
             onChanged: (ThemeMode? value) {
-              if (!state.isThemeModeSupported || value == null) return;
+              if (!themeSettings.isThemeModeSupported || value == null) return;
               context.read<AppBloc>().add(AppThemeModeChanged(value));
             },
             child: ListView.separated(
@@ -34,7 +36,7 @@ class ThemeModeScreen extends StatelessWidget {
                 return RadioListTile<ThemeMode>(
                   value: themeMode,
                   title: Text(themeMode.l10n(context)),
-                  enabled: state.isThemeModeSupported,
+                  enabled: themeSettings.isThemeModeSupported,
                 );
               },
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/services/services.dart';
+import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 void main() {
@@ -74,7 +75,11 @@ class RootApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         Provider<AppInfo>(create: (_) => instanceRegistry.get()),
-        Provider<AppThemes>(create: (_) => instanceRegistry.get()),
+        // The active theme, provided down the tree as an inherited value so the
+        // app consumes it directly (see App.build) instead of holding it in
+        // AppState. A host that embeds this app can override this provider to
+        // drive the theme; standalone it is the first bootstrap-built theme.
+        Provider<ThemeSettings>(create: (_) => instanceRegistry.get<AppThemes>().values.first.settings),
         Provider<PackageInfo>(create: (_) => instanceRegistry.get()),
         // Stateless version-compatibility policy shared by the login gate and the
         // in-app force-update gate; const, so no bootstrap registration needed.

--- a/test/blocs/app/app_compatibility_gate_test.dart
+++ b/test/blocs/app/app_compatibility_gate_test.dart
@@ -11,7 +11,6 @@ import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/resolvers/resolvers.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 
 class _MockUserAgreementStatusRepository extends Mock implements UserAgreementStatusRepository {}
 
@@ -28,10 +27,6 @@ class _MockSystemInfoRepository extends Mock implements SystemInfoRepository {}
 class _MockUserSessionCleanupResolver extends Mock implements UserSessionCleanupResolver {}
 
 class _MockAppInfo extends Mock implements AppInfo {}
-
-class _MockAppThemes extends Mock implements AppThemes {}
-
-class _FakeThemeSettings extends Fake implements ThemeSettings {}
 
 class _FakePackageInfo implements PackageInfo {
   _FakePackageInfo(this.version);
@@ -68,7 +63,6 @@ void main() {
   late _MockUserSessionCleanupResolver userSessionCleanupResolver;
   late _MockAppInfo appInfo;
   late StreamController<WebtritSystemInfo> infoStreamController;
-  late _MockAppThemes appThemes;
 
   setUpAll(() {
     registerFallbackValue(FetchPolicy.cacheFirst);
@@ -84,9 +78,6 @@ void main() {
     userSessionCleanupResolver = _MockUserSessionCleanupResolver();
     appInfo = _MockAppInfo();
     infoStreamController = StreamController<WebtritSystemInfo>.broadcast();
-
-    appThemes = _MockAppThemes();
-    when(() => appThemes.values).thenReturn([AppTheme(settings: _FakeThemeSettings())]);
 
     when(() => sessionRepository.getCurrent()).thenReturn(const Session());
     when(() => themeModeRepository.getThemeMode()).thenReturn(ThemeMode.system);
@@ -116,7 +107,6 @@ void main() {
       appInfo: appInfo,
       appCompatibilityResolver: const DefaultAppCompatibilityResolver(),
       packageInfo: _FakePackageInfo(appVersion),
-      appThemes: appThemes,
     );
   }
 

--- a/test/features/session_status/view/teardown_screen_test.dart
+++ b/test/features/session_status/view/teardown_screen_test.dart
@@ -15,7 +15,6 @@ import 'package:webtrit_phone/blocs/app/app_bloc.dart';
 import 'package:webtrit_phone/features/session_status/view/teardown_screen.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 
 // ---------------------------------------------------------------------------
 // Fakes / Mocks
@@ -23,13 +22,8 @@ import 'package:webtrit_phone/theme/theme.dart';
 
 class _MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {}
 
-/// [AppState] requires a [ThemeSettings], but [TeardownScreen.build] never reads
-/// it (only [AppState.logoutReason]), so a fake placeholder is enough.
-class _FakeThemeSettings extends Fake implements ThemeSettings {}
-
 AppState _appState({AppLogoutReason? logoutReason}) => AppState(
   logoutReason: logoutReason,
-  themeSettings: _FakeThemeSettings(),
   themeMode: ThemeMode.system,
   locale: const Locale('en'),
   userAgreementStatus: AgreementStatus.accepted,

--- a/test/features/version_gate/update_required_screen_test.dart
+++ b/test/features/version_gate/update_required_screen_test.dart
@@ -12,11 +12,8 @@ import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/version_gate/version_gate.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 
 class _MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {}
-
-class _FakeThemeSettings extends Fake implements ThemeSettings {}
 
 class _FakePackageInfo implements PackageInfo {
   _FakePackageInfo(this.version);
@@ -35,7 +32,6 @@ class _FakePackageInfo implements PackageInfo {
 }
 
 AppState _appState(AppCompatibility compatibility) => AppState(
-  themeSettings: _FakeThemeSettings(),
   themeMode: ThemeMode.system,
   locale: const Locale('en'),
   userAgreementStatus: AgreementStatus.accepted,


### PR DESCRIPTION
## Overview

Moves the active `ThemeSettings` out of `AppState` and provides it as an **inherited value** at the composition root, so the app consumes it directly through the widget tree — the same pattern already used for `FeatureAccess`.

The theme settings were static for a whole run (seeded once from `AppThemes`, never changed at runtime), yet lived in `AppState`; the only code that ever emitted `AppThemeSettingsChanged` was external. This refactor makes `RootApp` the single injection boundary for the theme and keeps everything below it consuming via providers — no bloc relay.

This is groundwork for host-driven theming (an embedder overriding the provider); **standalone behaviour is unchanged**.

## Changes

- `RootApp` provides `Provider<ThemeSettings>` (standalone: `AppThemes.values.first.settings`). An embedder can override this provider to drive the theme.
- `App.build` and `ThemeModeScreen` read `context.watch<ThemeSettings>()` instead of `AppState.themeSettings`.
- `isThemeModeSupported` / `effectiveThemeMode` move from `AppState` getters to a `ThemeSettings` extension (they depend only on the settings plus the mode).
- `AppState` keeps only `themeMode` (still user-switchable and persisted). Dropped: the `themeSettings` field, the `AppThemeSettingsChanged` event + handler, and the now-unused `AppThemes` dependency of `AppBloc`.

## Verification

- `flutter analyze` — clean.
- Full test suite — 940 pass (theme-mode screen, teardown, version-gate and app-compatibility-gate tests updated to the new shape).
- `ThemeProvider.of` consumers (e.g. `themed_scaffold`) unaffected — the `ThemeProvider` widget still wraps `MaterialApp`.