### PR TITLE
feat(app): let the caller supply theme and feature config sources

### DIFF
--- a/integration_test/subsequences/pump_root_app.dart
+++ b/integration_test/subsequences/pump_root_app.dart
@@ -4,7 +4,7 @@ import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/main.dart';
 
 Future<void> pumpRootApp(InstanceRegistry instanceRegistry, WidgetTester tester) async {
-  RootApp rootApp = RootApp(instanceRegistry: instanceRegistry);
+  RootApp rootApp = RootApp.standalone(instanceRegistry);
   await tester.pumpWidget(rootApp);
   await tester.pumpAndSettle();
 }

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -117,6 +117,10 @@ class _AppState extends State<App> {
 
     final featureAccess = context.watch<FeatureAccess>();
     final themeSettings = context.watch<ThemeSettings>();
+    // Optional read-only override from a host (the configurator's preview);
+    // null in a standalone run. When set it wins, so the preview reflects the
+    // host's light/dark toggle without persisting anything.
+    final hostThemeMode = context.watch<ThemeMode?>();
 
     final materialApp = ThemeProvider(
       settings: themeSettings,
@@ -128,9 +132,9 @@ class _AppState extends State<App> {
         builder: (context, state) {
           final themeProvider = ThemeProvider.of(context);
           final forcedMode = featureAccess.supportedConfig.themeMode;
-          final finalThemeMode = forcedMode == ThemeMode.system
-              ? themeSettings.effectiveThemeMode(state.themeMode)
-              : forcedMode;
+          final finalThemeMode =
+              hostThemeMode ??
+              (forcedMode == ThemeMode.system ? themeSettings.effectiveThemeMode(state.themeMode) : forcedMode);
 
           return MaterialApp.router(
             locale: state.effectiveLocale,

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -132,6 +132,12 @@ class _AppState extends State<App> {
         builder: (context, state) {
           final themeProvider = ThemeProvider.of(context);
           final forcedMode = featureAccess.supportedConfig.themeMode;
+          // Precedence: a host override wins over the feature-access forced mode
+          // by design. It is only ever set in a preview (the configurator's
+          // light/dark variant toggle), where it must show the chosen variant
+          // even if the previewed config enforces a mode; that override-an-
+          // enforced-mode case cannot happen in a standalone run, where
+          // hostThemeMode is always null and forcedMode governs as before.
           final finalThemeMode =
               hostThemeMode ??
               (forcedMode == ThemeMode.system ? themeSettings.effectiveThemeMode(state.themeMode) : forcedMode);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,19 +45,7 @@ void main() {
 
       Logger.root.onRecord.listen(_onRootLogRecord);
 
-      runApp(
-        RootApp(
-          instanceRegistry: instanceRegistry,
-          featureAccess: (
-            initial: instanceRegistry.get<FeatureAccess>(),
-            updates: instanceRegistry.get<FeatureAccessStreamFactory>().create(),
-          ),
-          themeSettings: (
-            initial: instanceRegistry.get<AppThemes>().values.first.settings,
-            updates: const Stream.empty(),
-          ),
-        ),
-      );
+      runApp(RootApp.standalone(instanceRegistry));
     },
     (error, stackTrace) {
       logger.severe('runZonedGuarded', error, stackTrace);
@@ -89,6 +77,19 @@ class RootApp extends StatelessWidget {
     required this.themeSettings,
     this.themeMode,
   });
+
+  /// Standalone composition: resolves the config sources from the bootstrap
+  /// [instanceRegistry] (the reactive FeatureAccess stream and the first
+  /// bootstrap-built theme, which is static). A host that embeds the app uses
+  /// the default constructor and supplies its own sources instead.
+  factory RootApp.standalone(InstanceRegistry instanceRegistry) => RootApp(
+    instanceRegistry: instanceRegistry,
+    featureAccess: (
+      initial: instanceRegistry.get<FeatureAccess>(),
+      updates: instanceRegistry.get<FeatureAccessStreamFactory>().create(),
+    ),
+    themeSettings: (initial: instanceRegistry.get<AppThemes>().values.first.settings, updates: const Stream.empty()),
+  );
 
   final InstanceRegistry instanceRegistry;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,19 @@ void main() {
 
       Logger.root.onRecord.listen(_onRootLogRecord);
 
-      runApp(RootApp(instanceRegistry: instanceRegistry));
+      runApp(
+        RootApp(
+          instanceRegistry: instanceRegistry,
+          featureAccess: (
+            initial: instanceRegistry.get<FeatureAccess>(),
+            updates: instanceRegistry.get<FeatureAccessStreamFactory>().create(),
+          ),
+          themeSettings: (
+            initial: instanceRegistry.get<AppThemes>().values.first.settings,
+            updates: const Stream.empty(),
+          ),
+        ),
+      );
     },
     (error, stackTrace) {
       logger.severe('runZonedGuarded', error, stackTrace);
@@ -65,10 +77,22 @@ void _onRootLogRecord(LogRecord record) {
   }
 }
 
+/// A reactive config input: the [initial] value for the first frame plus an
+/// [updates] stream that replaces it as it changes.
+typedef ConfigSource<T> = ({T initial, Stream<T> updates});
+
 class RootApp extends StatelessWidget {
-  const RootApp({super.key, required this.instanceRegistry});
+  const RootApp({super.key, required this.instanceRegistry, required this.featureAccess, required this.themeSettings});
 
   final InstanceRegistry instanceRegistry;
+
+  /// Reactive config the app renders, provided down the tree as inherited values.
+  /// The composition root decides the source: standalone (`main`) resolves it
+  /// from the bootstrap registry; a host that embeds this app (the configurator's
+  /// realtime preview) passes its own streams so the preview reflects live edits.
+  /// RootApp itself stays agnostic - it only wires whatever source it is given.
+  final ConfigSource<FeatureAccess> featureAccess;
+  final ConfigSource<ThemeSettings> themeSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -77,21 +101,24 @@ class RootApp extends StatelessWidget {
         Provider<AppInfo>(create: (_) => instanceRegistry.get()),
         // The active theme, provided down the tree as an inherited value so the
         // app consumes it directly (see App.build) instead of holding it in
-        // AppState. A host that embeds this app can override this provider to
-        // drive the theme; standalone it is the first bootstrap-built theme.
-        Provider<ThemeSettings>(create: (_) => instanceRegistry.get<AppThemes>().values.first.settings),
+        // AppState. The source is supplied by the caller (see [themeSettings]).
+        StreamProvider<ThemeSettings>(
+          initialData: themeSettings.initial,
+          create: (_) => themeSettings.updates,
+          updateShouldNotify: (previous, next) => previous != next,
+        ),
         Provider<PackageInfo>(create: (_) => instanceRegistry.get()),
         // Stateless version-compatibility policy shared by the login gate and the
         // in-app force-update gate; const, so no bootstrap registration needed.
         Provider<AppCompatibilityResolver>(create: (_) => const DefaultAppCompatibilityResolver()),
         Provider<DeviceInfo>(create: (_) => instanceRegistry.get()),
         Provider<AppPreferences>(create: (_) => instanceRegistry.get()),
-        // Provides reactive [FeatureAccess] configuration synchronized with [SystemInfoRepository] and [RemoteConfigService].
-        //
-        // Initializes with bootstrap data and updates whenever system information or remote configuration changes.
+        // Reactive [FeatureAccess]; the source is supplied by the caller (see
+        // [featureAccess]). Standalone it is the bootstrap stream synchronized
+        // with SystemInfoRepository and RemoteConfigService.
         StreamProvider<FeatureAccess>(
-          initialData: instanceRegistry.get<FeatureAccess>(),
-          create: (_) => instanceRegistry.get<FeatureAccessStreamFactory>().create(),
+          initialData: featureAccess.initial,
+          create: (_) => featureAccess.updates,
           updateShouldNotify: (previous, next) => previous != next,
         ),
         Provider<SecureStorage>(create: (_) => instanceRegistry.get()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,8 +66,13 @@ void _onRootLogRecord(LogRecord record) {
 }
 
 /// A reactive config input: the [initial] value for the first frame plus an
-/// [updates] stream that replaces it as it changes.
-typedef ConfigSource<T> = ({T initial, Stream<T> updates});
+/// [updates] factory that creates the stream replacing it as it changes.
+///
+/// [updates] is a factory (not a ready stream) so every provider subscription
+/// gets a fresh stream - the bootstrap FeatureAccess stream is single-subscription
+/// and reactive (it follows runtime system-info / remote-config changes), so a
+/// re-created provider must be able to listen again without throwing or going stale.
+typedef ConfigSource<T> = ({T initial, Stream<T> Function() updates});
 
 class RootApp extends StatelessWidget {
   const RootApp({
@@ -86,9 +91,12 @@ class RootApp extends StatelessWidget {
     instanceRegistry: instanceRegistry,
     featureAccess: (
       initial: instanceRegistry.get<FeatureAccess>(),
-      updates: instanceRegistry.get<FeatureAccessStreamFactory>().create(),
+      updates: () => instanceRegistry.get<FeatureAccessStreamFactory>().create(),
     ),
-    themeSettings: (initial: instanceRegistry.get<AppThemes>().values.first.settings, updates: const Stream.empty()),
+    themeSettings: (
+      initial: instanceRegistry.get<AppThemes>().values.first.settings,
+      updates: () => const Stream.empty(),
+    ),
   );
 
   final InstanceRegistry instanceRegistry;
@@ -116,7 +124,7 @@ class RootApp extends StatelessWidget {
         // AppState. The source is supplied by the caller (see [themeSettings]).
         StreamProvider<ThemeSettings>(
           initialData: themeSettings.initial,
-          create: (_) => themeSettings.updates,
+          create: (_) => themeSettings.updates(),
           updateShouldNotify: (previous, next) => previous != next,
         ),
         // Optional host theme-mode override (see [themeMode]); always provided as
@@ -124,7 +132,7 @@ class RootApp extends StatelessWidget {
         if (themeMode case final source?)
           StreamProvider<ThemeMode?>(
             initialData: source.initial,
-            create: (_) => source.updates,
+            create: (_) => source.updates(),
             updateShouldNotify: (previous, next) => previous != next,
           )
         else
@@ -140,7 +148,7 @@ class RootApp extends StatelessWidget {
         // with SystemInfoRepository and RemoteConfigService.
         StreamProvider<FeatureAccess>(
           initialData: featureAccess.initial,
-          create: (_) => featureAccess.updates,
+          create: (_) => featureAccess.updates(),
           updateShouldNotify: (previous, next) => previous != next,
         ),
         Provider<SecureStorage>(create: (_) => instanceRegistry.get()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,7 +82,13 @@ void _onRootLogRecord(LogRecord record) {
 typedef ConfigSource<T> = ({T initial, Stream<T> updates});
 
 class RootApp extends StatelessWidget {
-  const RootApp({super.key, required this.instanceRegistry, required this.featureAccess, required this.themeSettings});
+  const RootApp({
+    super.key,
+    required this.instanceRegistry,
+    required this.featureAccess,
+    required this.themeSettings,
+    this.themeMode,
+  });
 
   final InstanceRegistry instanceRegistry;
 
@@ -93,6 +99,11 @@ class RootApp extends StatelessWidget {
   /// RootApp itself stays agnostic - it only wires whatever source it is given.
   final ConfigSource<FeatureAccess> featureAccess;
   final ConfigSource<ThemeSettings> themeSettings;
+
+  /// Optional read-only override for the displayed theme mode (the configurator's
+  /// light/dark preview toggle). Null in a standalone run, where the mode comes
+  /// from FeatureAccess / AppState; when set it wins, and nothing is persisted.
+  final ConfigSource<ThemeMode>? themeMode;
 
   @override
   Widget build(BuildContext context) {
@@ -107,6 +118,16 @@ class RootApp extends StatelessWidget {
           create: (_) => themeSettings.updates,
           updateShouldNotify: (previous, next) => previous != next,
         ),
+        // Optional host theme-mode override (see [themeMode]); always provided as
+        // a nullable value so App can read it, null in a standalone run.
+        if (themeMode case final source?)
+          StreamProvider<ThemeMode?>(
+            initialData: source.initial,
+            create: (_) => source.updates,
+            updateShouldNotify: (previous, next) => previous != next,
+          )
+        else
+          Provider<ThemeMode?>.value(value: null),
         Provider<PackageInfo>(create: (_) => instanceRegistry.get()),
         // Stateless version-compatibility policy shared by the login gate and the
         // in-app force-update gate; const, so no bootstrap registration needed.

--- a/patrol_test/subsequences/pump_root_and_wait_until_visible.dart
+++ b/patrol_test/subsequences/pump_root_and_wait_until_visible.dart
@@ -6,6 +6,6 @@ import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/main.dart';
 
 Future<void> pumpRootAndWaitUntilVisible(InstanceRegistry instanceRegistry, PatrolIntegrationTester $) async {
-  await $.pumpWidgetAndSettle(RootApp(instanceRegistry: instanceRegistry));
+  await $.pumpWidgetAndSettle(RootApp.standalone(instanceRegistry));
   await $.waitUntilVisible($(AppShell));
 }

--- a/screenshots/lib/bootstrap.dart
+++ b/screenshots/lib/bootstrap.dart
@@ -12,6 +12,7 @@ import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/services/services.dart';
+import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 
 import 'package:screenshots/mocks/mocks.dart';
@@ -49,13 +50,10 @@ Future<AppContext> bootstrap() async {
     featureAccess,
   );
 
-  final appBloc = MockAppBloc.allScreen(
-    themeSettings: appThemes.values.first.settings,
-    themeMode: ThemeMode.light,
-    locale: const Locale('en'),
-  );
+  final appBloc = MockAppBloc.allScreen(themeMode: ThemeMode.light, locale: const Locale('en'));
 
   final providers = [
+    Provider<ThemeSettings>.value(value: appThemes.values.first.settings),
     Provider<FeatureAccess>.value(value: featureAccess),
     Provider<PackageInfo>.value(value: packageInfo),
     Provider<DeviceInfo>.value(value: deviceInfo),

--- a/screenshots/lib/mocks/mock_app_bloc.dart
+++ b/screenshots/lib/mocks/mock_app_bloc.dart
@@ -4,22 +4,16 @@ import 'package:bloc_test/bloc_test.dart';
 
 import 'package:webtrit_phone/blocs/blocs.dart';
 import 'package:webtrit_phone/models/agreement_status.dart';
-import 'package:webtrit_phone/theme/theme.dart';
 
 class MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {
   MockAppBloc();
 
-  factory MockAppBloc.allScreen({
-    required ThemeSettings themeSettings,
-    required ThemeMode themeMode,
-    required Locale locale,
-  }) {
+  factory MockAppBloc.allScreen({required ThemeMode themeMode, required Locale locale}) {
     final mock = MockAppBloc();
     whenListen(
       mock,
       const Stream<AppState>.empty(),
       initialState: AppState(
-        themeSettings: themeSettings,
         themeMode: themeMode,
         locale: locale,
         userAgreementStatus: AgreementStatus.pending,

--- a/screenshots/lib/widgets/screenshot_app.dart
+++ b/screenshots/lib/widgets/screenshot_app.dart
@@ -8,6 +8,7 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:webtrit_phone/blocs/app/app_bloc.dart';
 import 'package:webtrit_phone/environment_config.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 
@@ -20,46 +21,41 @@ class ScreenshotApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget widgetsApp = BlocBuilder<AppBloc, AppState>(
-      buildWhen: (previous, current) => previous.themeSettings != current.themeSettings,
-      builder: (context, state) {
-        return ThemeProvider(
-          settings: state.themeSettings,
-          lightDynamic: null,
-          darkDynamic: null,
-          child: BlocBuilder<AppBloc, AppState>(
-            buildWhen: (previous, current) =>
-                previous.effectiveLocale != current.effectiveLocale ||
-                previous.effectiveThemeMode != current.effectiveThemeMode,
-            builder: (context, state) {
-              final themeProvider = ThemeProvider.of(context);
+    final themeSettings = context.watch<ThemeSettings>();
+    Widget widgetsApp = ThemeProvider(
+      settings: themeSettings,
+      lightDynamic: null,
+      darkDynamic: null,
+      child: BlocBuilder<AppBloc, AppState>(
+        buildWhen: (previous, current) =>
+            previous.effectiveLocale != current.effectiveLocale || previous.themeMode != current.themeMode,
+        builder: (context, state) {
+          final themeProvider = ThemeProvider.of(context);
 
-              final effectiveThemeMode = state.effectiveThemeMode;
-              final ThemeData themeData;
+          final effectiveThemeMode = themeSettings.effectiveThemeMode(state.themeMode);
+          final ThemeData themeData;
 
-              if (effectiveThemeMode == ThemeMode.dark) {
-                themeData = themeProvider.dark();
-              } else {
-                themeData = themeProvider.light();
-              }
+          if (effectiveThemeMode == ThemeMode.dark) {
+            themeData = themeProvider.dark();
+          } else {
+            themeData = themeProvider.light();
+          }
 
-              return WidgetsApp.router(
-                locale: state.effectiveLocale,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                title: EnvironmentConfig.APP_NAME,
-                color: themeData.primaryColor,
-                debugShowCheckedModeBanner: false,
-                routerDelegate: ScreenshotRouterDelegate(child),
-                routeInformationParser: const _NoOpRouteInformationParser(),
-                builder: (context, child) {
-                  return Theme(data: themeData, child: child!);
-                },
-              );
+          return WidgetsApp.router(
+            locale: state.effectiveLocale,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            title: EnvironmentConfig.APP_NAME,
+            color: themeData.primaryColor,
+            debugShowCheckedModeBanner: false,
+            routerDelegate: ScreenshotRouterDelegate(child),
+            routeInformationParser: const _NoOpRouteInformationParser(),
+            builder: (context, child) {
+              return Theme(data: themeData, child: child!);
             },
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
 
     if (ignorePointer) {


### PR DESCRIPTION
## Overview

Makes `RootApp` agnostic about **where** its theme and feature config come from. It takes a `ConfigSource` (an `{initial, updates}` record) for each and wires it into the inherited `StreamProvider` — without reaching into the registry or branching on a host flag. The **composition root decides the source**.

This is the phone-side half of the embedding work (the configurator side comes next). It builds on the inherited-config groundwork already on develop, so the host only supplies a different **source**; consumers (`App.build`, `ThemeModeScreen`) stay agnostic.

## Changes

```dart
typedef ConfigSource<T> = ({T initial, Stream<T> updates});

const RootApp({required this.instanceRegistry, required this.featureAccess, required this.themeSettings});
final ConfigSource<FeatureAccess> featureAccess;
final ConfigSource<ThemeSettings> themeSettings;
```

- `RootApp.build` wires each `ConfigSource` straight into a `StreamProvider` (`initialData: source.initial`, `create: source.updates`) — no registry access, no `host ?? default` branch.
- **Standalone (`main`)** resolves the sources from the bootstrap registry: the `FeatureAccessStreamFactory` stream, and the first `AppThemes` theme (static, so `updates: const Stream.empty()`).
- **A host** (the configurator's realtime preview) passes its own streams + `bootstrap(firebase: const FirebaseIntegrationDisabled())` — live edits flow through the same inherited values.

It's a **record**, not a wrapper class; no imperative relay.

## Verification

- `flutter analyze` — clean.
- Standalone behaviour is unchanged (registry-resolved sources; theme `updates` is empty).