### PR TITLE
feat(app): let a host keep ownership of the browser history

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -39,9 +39,51 @@ class _AppState extends State<App> {
   /// In-memory route-information provider for an embedded instance (when the app
   /// does not own the browser history). Seeds the initial location and swallows
   /// navigations so the browser URL is never touched. Null in a standalone run.
-  late final RouteInformationProvider? _embeddedRouteInformationProvider = widget.ownsBrowserHistory
+  late final _InMemoryRouteInformationProvider? _embeddedRouteInformationProvider = widget.ownsBrowserHistory
       ? null
       : _InMemoryRouteInformationProvider(RouteInformation(uri: Uri.parse('/')));
+
+  /// Inert back-button dispatcher for an embedded instance. A standalone run lets
+  /// [AppRouter.config] install a [RootBackButtonDispatcher], which registers a
+  /// global observer on the platform back button; on the engine the embedded
+  /// preview shares with its host that would swallow the host's back button. The
+  /// inert dispatcher never claims it, so the host keeps full control. Null in a
+  /// standalone run.
+  late final BackButtonDispatcher? _embeddedBackButtonDispatcher = widget.ownsBrowserHistory
+      ? null
+      : _NoopBackButtonDispatcher();
+
+  /// Deep-link builder, resolved once. Null when deep links are disabled.
+  late final _deepLinkBuilder = EnvironmentConfig.APP_LINK_DOMAIN.isNotEmpty ? appRouter.deepLinkBuilder : null;
+
+  /// Drives router guard re-evaluation off [AppBloc]. Built once (not per
+  /// rebuild): the router caches the first listenable it is handed, so rebuilding
+  /// it would leak an [AppBloc] stream subscription on every theme/locale change.
+  /// Disposed in [dispose].
+  late final ReevaluateListenable _reevaluateListenable = ReevaluateListenable.stream(
+    // Insert and skip the initial state to ensure the distinct buffer if filled
+    // and ensure the next state change is emitted only if it differ from the initial state.
+    //
+    // Please verify next caases if you change this logic:
+    // - Call drop after theme change or locale change:
+    appBloc.stream
+        .mergeAll([
+          Stream.fromIterable([appBloc.state]),
+        ])
+        .distinct((p, n) {
+          final same = p.compareToReevaluate(n);
+          _logger.fine('AppState compareToReevaluate: $same');
+          if (!same) _logger.fine('AppState compareToReevaluate: previous: $p\n  next: $n');
+          return same;
+        })
+        .skip(1),
+  );
+
+  List<NavigatorObserver> _navigatorObservers() => [
+    AppRouterObserver(),
+    context.read<AppAnalyticsRepository>().createObserver(),
+    AutoRouteObserver(),
+  ];
 
   @override
   void initState() {
@@ -119,14 +161,14 @@ class _AppState extends State<App> {
 
   @override
   void dispose() {
+    _reevaluateListenable.dispose();
+    _embeddedRouteInformationProvider?.dispose();
     appBloc.close();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final isDeepLinkEnabled = EnvironmentConfig.APP_LINK_DOMAIN.isNotEmpty;
-
     final featureAccess = context.watch<FeatureAccess>();
     final themeSettings = context.watch<ThemeSettings>();
     // Optional read-only override from a host (the configurator's preview);
@@ -154,32 +196,6 @@ class _AppState extends State<App> {
               hostThemeMode ??
               (forcedMode == ThemeMode.system ? themeSettings.effectiveThemeMode(state.themeMode) : forcedMode);
 
-          // Routing inputs shared by both router modes below.
-          final deepLinkBuilder = isDeepLinkEnabled ? appRouter.deepLinkBuilder : null;
-          List<NavigatorObserver> navigatorObservers() => [
-            AppRouterObserver(),
-            context.read<AppAnalyticsRepository>().createObserver(),
-            AutoRouteObserver(),
-          ];
-          final reevaluateListenable = ReevaluateListenable.stream(
-            // Insert and skip the initial state to ensure the distinct buffer if filled
-            // and ensure the next state change is emitted only if it differ from the initial state.
-            //
-            // Please verify next caases if you change this logic:
-            // - Call drop after theme change or locale change:
-            appBloc.stream
-                .mergeAll([
-                  Stream.fromIterable([appBloc.state]),
-                ])
-                .distinct((p, n) {
-                  final same = p.compareToReevaluate(n);
-                  _logger.fine('AppState compareToReevaluate: $same');
-                  if (!same) _logger.fine('AppState compareToReevaluate: previous: $p\n  next: $n');
-                  return same;
-                })
-                .skip(1),
-          );
-
           return MaterialApp.router(
             locale: state.effectiveLocale,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -192,23 +208,31 @@ class _AppState extends State<App> {
             // Standalone owns the browser history: the full config syncs the URL.
             routerConfig: widget.ownsBrowserHistory
                 ? appRouter.config(
-                    deepLinkBuilder: deepLinkBuilder,
-                    navigatorObservers: navigatorObservers,
-                    reevaluateListenable: reevaluateListenable,
+                    deepLinkBuilder: _deepLinkBuilder,
+                    navigatorObservers: _navigatorObservers,
+                    reevaluateListenable: _reevaluateListenable,
                   )
                 : null,
             // Embedded preview: the same parser/delegate (so the initial route
-            // renders normally) but an in-memory route-information provider, so
-            // navigation stays internal and never writes the host's browser URL.
+            // renders normally) but an in-memory route-information provider and an
+            // inert back-button dispatcher, so forward navigation stays internal
+            // and never writes the host's browser URL, and the system back button
+            // is left to the host.
+            //
+            // Known limitation: an in-app back (`context.back()`) routes through
+            // auto_route's own web navigation history, which calls
+            // `window.history.back()` directly and is not injectable without
+            // forking auto_route internals. It is acceptable here because the
+            // preview is forward-oriented (login flow) and the host can recover.
             routeInformationParser: widget.ownsBrowserHistory ? null : appRouter.defaultRouteParser(),
             routeInformationProvider: widget.ownsBrowserHistory ? null : _embeddedRouteInformationProvider,
-            backButtonDispatcher: widget.ownsBrowserHistory ? null : RootBackButtonDispatcher(),
+            backButtonDispatcher: widget.ownsBrowserHistory ? null : _embeddedBackButtonDispatcher,
             routerDelegate: widget.ownsBrowserHistory
                 ? null
                 : appRouter.delegate(
-                    deepLinkBuilder: deepLinkBuilder,
-                    navigatorObservers: navigatorObservers,
-                    reevaluateListenable: reevaluateListenable,
+                    deepLinkBuilder: _deepLinkBuilder,
+                    navigatorObservers: _navigatorObservers,
+                    reevaluateListenable: _reevaluateListenable,
                   ),
           );
         },
@@ -253,3 +277,11 @@ class _InMemoryRouteInformationProvider extends RouteInformationProvider with Ch
     _value = routeInformation;
   }
 }
+
+/// A [BackButtonDispatcher] that never claims the platform back button.
+///
+/// Unlike [RootBackButtonDispatcher], the base dispatcher installs no
+/// `WidgetsBinding` observer, so the platform back button is never routed to it.
+/// An embedded instance uses it to avoid intercepting the back button on the
+/// engine it shares with its host.
+class _NoopBackButtonDispatcher extends BackButtonDispatcher {}

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -21,7 +21,12 @@ import 'package:webtrit_phone/resolvers/resolvers.dart';
 final _logger = Logger('AppWidget');
 
 class App extends StatefulWidget {
-  const App({super.key});
+  const App({super.key, this.ownsBrowserHistory = true});
+
+  /// See `RootApp.ownsBrowserHistory`: when `false` (embedded preview) the app's
+  /// router uses an in-memory route-information provider, so it renders normally
+  /// but never syncs the browser URL.
+  final bool ownsBrowserHistory;
 
   @override
   State<App> createState() => _AppState();
@@ -30,6 +35,13 @@ class App extends StatefulWidget {
 class _AppState extends State<App> {
   late final AppBloc appBloc;
   late final AppRouter appRouter;
+
+  /// In-memory route-information provider for an embedded instance (when the app
+  /// does not own the browser history). Seeds the initial location and swallows
+  /// navigations so the browser URL is never touched. Null in a standalone run.
+  late final RouteInformationProvider? _embeddedRouteInformationProvider = widget.ownsBrowserHistory
+      ? null
+      : _InMemoryRouteInformationProvider(RouteInformation(uri: Uri.parse('/')));
 
   @override
   void initState() {
@@ -142,6 +154,32 @@ class _AppState extends State<App> {
               hostThemeMode ??
               (forcedMode == ThemeMode.system ? themeSettings.effectiveThemeMode(state.themeMode) : forcedMode);
 
+          // Routing inputs shared by both router modes below.
+          final deepLinkBuilder = isDeepLinkEnabled ? appRouter.deepLinkBuilder : null;
+          List<NavigatorObserver> navigatorObservers() => [
+            AppRouterObserver(),
+            context.read<AppAnalyticsRepository>().createObserver(),
+            AutoRouteObserver(),
+          ];
+          final reevaluateListenable = ReevaluateListenable.stream(
+            // Insert and skip the initial state to ensure the distinct buffer if filled
+            // and ensure the next state change is emitted only if it differ from the initial state.
+            //
+            // Please verify next caases if you change this logic:
+            // - Call drop after theme change or locale change:
+            appBloc.stream
+                .mergeAll([
+                  Stream.fromIterable([appBloc.state]),
+                ])
+                .distinct((p, n) {
+                  final same = p.compareToReevaluate(n);
+                  _logger.fine('AppState compareToReevaluate: $same');
+                  if (!same) _logger.fine('AppState compareToReevaluate: previous: $p\n  next: $n');
+                  return same;
+                })
+                .skip(1),
+          );
+
           return MaterialApp.router(
             locale: state.effectiveLocale,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -151,32 +189,27 @@ class _AppState extends State<App> {
             themeMode: finalThemeMode,
             theme: themeProvider.light(),
             darkTheme: themeProvider.dark(),
-            routerConfig: appRouter.config(
-              deepLinkBuilder: isDeepLinkEnabled ? appRouter.deepLinkBuilder : null,
-              navigatorObservers: () => [
-                AppRouterObserver(),
-                context.read<AppAnalyticsRepository>().createObserver(),
-                AutoRouteObserver(),
-              ],
-              reevaluateListenable: ReevaluateListenable.stream(
-                // Insert and skip the initial state to ensure the distinct buffer if filled
-                // and ensure the next state change is emitted only if it differ from the initial state.
-                //
-                // Please verify next caases if you change this logic:
-                // - Call drop after theme change or locale change:
-                appBloc.stream
-                    .mergeAll([
-                      Stream.fromIterable([appBloc.state]),
-                    ])
-                    .distinct((p, n) {
-                      final same = p.compareToReevaluate(n);
-                      _logger.fine('AppState compareToReevaluate: $same');
-                      if (!same) _logger.fine('AppState compareToReevaluate: previous: $p\n  next: $n');
-                      return same;
-                    })
-                    .skip(1),
-              ),
-            ),
+            // Standalone owns the browser history: the full config syncs the URL.
+            routerConfig: widget.ownsBrowserHistory
+                ? appRouter.config(
+                    deepLinkBuilder: deepLinkBuilder,
+                    navigatorObservers: navigatorObservers,
+                    reevaluateListenable: reevaluateListenable,
+                  )
+                : null,
+            // Embedded preview: the same parser/delegate (so the initial route
+            // renders normally) but an in-memory route-information provider, so
+            // navigation stays internal and never writes the host's browser URL.
+            routeInformationParser: widget.ownsBrowserHistory ? null : appRouter.defaultRouteParser(),
+            routeInformationProvider: widget.ownsBrowserHistory ? null : _embeddedRouteInformationProvider,
+            backButtonDispatcher: widget.ownsBrowserHistory ? null : RootBackButtonDispatcher(),
+            routerDelegate: widget.ownsBrowserHistory
+                ? null
+                : appRouter.delegate(
+                    deepLinkBuilder: deepLinkBuilder,
+                    navigatorObservers: navigatorObservers,
+                    reevaluateListenable: reevaluateListenable,
+                  ),
           );
         },
       ),
@@ -195,5 +228,28 @@ class _AppState extends State<App> {
       ],
       child: materialApp,
     );
+  }
+}
+
+/// A [RouteInformationProvider] that keeps routing entirely in memory.
+///
+/// It seeds a fixed initial location and ignores navigations reported by the
+/// router (it never calls into the platform / `window.history`). Used by an
+/// embedded instance that must not own the browser URL, while still driving the
+/// app's parser/delegate so screens render normally.
+class _InMemoryRouteInformationProvider extends RouteInformationProvider with ChangeNotifier {
+  _InMemoryRouteInformationProvider(this._value);
+
+  RouteInformation _value;
+
+  @override
+  RouteInformation get value => _value;
+
+  @override
+  void routerReportsNewRouteInformation(
+    RouteInformation routeInformation, {
+    RouteInformationReportingType type = RouteInformationReportingType.none,
+  }) {
+    _value = routeInformation;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,6 +81,7 @@ class RootApp extends StatelessWidget {
     required this.featureAccess,
     required this.themeSettings,
     this.themeMode,
+    this.ownsBrowserHistory = true,
   });
 
   /// Standalone composition: resolves the config sources from the bootstrap
@@ -113,6 +114,15 @@ class RootApp extends StatelessWidget {
   /// light/dark preview toggle). Null in a standalone run, where the mode comes
   /// from FeatureAccess / AppState; when set it wins, and nothing is persisted.
   final ConfigSource<ThemeMode>? themeMode;
+
+  /// Whether this app instance owns the browser history (the URL / `window.history`).
+  ///
+  /// On the web only one router may sync the URL. When the app is embedded in a
+  /// host that already owns it (the configurator's realtime preview), pass `false`:
+  /// the app then runs a delegate-only router that navigates internally without
+  /// touching the URL, so it can't clobber the host's routing. Default `true` for
+  /// a standalone run, where the app is the sole owner of the URL.
+  final bool ownsBrowserHistory;
 
   @override
   Widget build(BuildContext context) {
@@ -239,7 +249,7 @@ class RootApp extends StatelessWidget {
               RepositoryProvider<UserLocalDatasource>(create: (_) => instanceRegistry.get()),
               RepositoryProvider<AuthRepository>(create: (_) => instanceRegistry.get()),
             ],
-            child: const App(),
+            child: App(ownsBrowserHistory: ownsBrowserHistory),
           );
         },
       ),


### PR DESCRIPTION
## Overview

On the web only one router may sync the URL. The embedded `MaterialApp.router` (auto_route) attaches an `AutoRouteInformationProvider` that reports every navigation to `window.history`, fighting the host's router (e.g. the preview pushed the configurator URL to `/login/login-switch-screen-page-route`).

## Change

- `RootApp.ownsBrowserHistory` (default `true`). Threaded to `App`.
- When `false`, `App` builds a **delegate-only** router — `appRouter.delegate(...)` with no `routeInformationParser` / `routeInformationProvider` — so it navigates internally without touching the URL. Standalone keeps the full `appRouter.config(...)` (URL-syncing).
- It is plain configuration: the app still has no notion of being "embedded", only whether it owns the URL.

The configurator passes `ownsBrowserHistory: false`