### PR TITLE
fix(call): gate peer_message media_state by core version

### DIFF
--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -578,6 +578,7 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         iceFilter: FilterWithAppSettings(iceSettingsRepository),
                         peerConnectionPolicyApplier: pearConnectionPolicyApplier,
                         sendPresenceSettings: featureAccess.sipPresenceConfig.hybridPresenceSupport,
+                        peerMessageSupported: featureAccess.callConfig.capabilities.isPeerMessageEnabled,
                         onCallEnded: () => cdrsSyncWorker?.forceSync(const Duration(seconds: 1)),
                         onDiagnosticReportRequested: (id, error) => diagnosticService.request(
                           DiagnosticType.androidCallkeepOnly,

--- a/lib/app/router/main_shell.dart
+++ b/lib/app/router/main_shell.dart
@@ -577,6 +577,9 @@ class _MainShellState extends State<MainShell> with WidgetsBindingObserver {
                         ),
                         iceFilter: FilterWithAppSettings(iceSettingsRepository),
                         peerConnectionPolicyApplier: pearConnectionPolicyApplier,
+                        // TODO(Serdun): these per-feature capability flags keep growing as
+                        // individual constructor args; inject a single capabilities/config
+                        // struct (e.g. CallCapabilitiesConfig) instead of one bool each.
                         sendPresenceSettings: featureAccess.sipPresenceConfig.hybridPresenceSupport,
                         peerMessageSupported: featureAccess.callConfig.capabilities.isPeerMessageEnabled,
                         onCallEnded: () => cdrsSyncWorker?.forceSync(const Duration(seconds: 1)),

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -110,7 +110,7 @@ class FeatureAccess extends Equatable {
       final loginConfig = LoginMapper.map(appConfig, embeddedConfig.embeddedResources);
       final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig, coreSupport);
       final settingsConfig = SettingsMapper.map(appConfig, embeddedResources, coreSupport, termsConfig);
-      final callConfig = CallMapper.map(appConfig, featureOverrides);
+      final callConfig = CallMapper.map(appConfig, featureOverrides, systemInfo);
       final messagingConfig = MessagingMapper.map(appConfig, coreSupport);
       final contactsConfig = ContactsMapper.map(appConfig);
       final systemNotificationsConfig = SystemNotificationsMapper.map(coreSupport, appConfig, featureOverrides);
@@ -369,7 +369,7 @@ abstract final class SettingsMapper {
 /// and environment settings.
 abstract final class CallMapper {
   /// Maps [AppConfig] to [CallCapabilitiesConfig].
-  static CallConfig map(AppConfig appConfig, FeatureOverrides featureOverrides) {
+  static CallConfig map(AppConfig appConfig, FeatureOverrides featureOverrides, WebtritSystemInfo? systemInfo) {
     final rawCallConfig = appConfig.callConfig;
     final transferConfig = rawCallConfig.transfer;
     final encodingConfig = rawCallConfig.encoding;
@@ -384,11 +384,16 @@ abstract final class CallMapper {
     // Apply remote overrides
     final isVideoEnabled = featureOverrides.isVideoCallEnabled ?? rawCallConfig.videoEnabled;
 
+    // Version-gated: the in-call peer_message side channel is only safe to use
+    // when the remote core understands the request (see CoreInfo.supportsPeerMessage).
+    final isPeerMessageEnabled = systemInfo?.core.supportsPeerMessage ?? false;
+
     return CallConfig(
       capabilities: CallCapabilitiesConfig(
         isVideoCallEnabled: isVideoEnabled,
         isBlindTransferEnabled: transferConfig.enableBlindTransfer,
         isAttendedTransferEnabled: transferConfig.enableAttendedTransfer,
+        isPeerMessageEnabled: isPeerMessageEnabled,
       ),
       triggerConfig: const CallTriggerConfig(
         smsFallback: SmsFallbackTriggerConfig(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -117,6 +117,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   final ContactResolver contactResolver;
   final CallErrorReporter callErrorReporter;
   final bool sendPresenceSettings;
+
+  /// Whether the remote core supports the `peer_message` side channel.
+  ///
+  /// An older core rejects an unknown `peer_message` request by closing the
+  /// signaling socket (code 4600), so [_sendMediaState] is suppressed unless
+  /// this is `true`.
+  final bool peerMessageSupported;
   final VoidCallback? onCallEnded;
   final OnDiagnosticReportRequested onDiagnosticReportRequested;
 
@@ -163,6 +170,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     required this.contactResolver,
     required this.callErrorReporter,
     required this.sendPresenceSettings,
+    required this.peerMessageSupported,
     required this.onDiagnosticReportRequested,
     this.isCameraPermissionGranted,
     this.sdpMunger,
@@ -1135,6 +1143,11 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   /// camera state without SDP renegotiation - the only channel that works
   /// while the call is still ringing.
   void _sendMediaState(ActiveCall call, {required bool video}) {
+    // An older core does not know the peer_message request and would tear down
+    // the whole signaling socket (code 4600) in response, so skip the signal
+    // entirely when the core does not advertise support.
+    if (!peerMessageSupported) return;
+
     final transaction = WebtritSignalingClient.generateTransactionId();
     _signalingModule
         .execute(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -1146,7 +1146,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     // An older core does not know the peer_message request and would tear down
     // the whole signaling socket (code 4600) in response, so skip the signal
     // entirely when the core does not advertise support.
-    if (!peerMessageSupported) return;
+    if (!peerMessageSupported) {
+      _logger.fine('_sendMediaState: skipped (core does not support peer_message) for call ${call.callId}');
+      return;
+    }
 
     final transaction = WebtritSignalingClient.generateTransactionId();
     _signalingModule

--- a/lib/models/feature_access/call_config.dart
+++ b/lib/models/feature_access/call_config.dart
@@ -38,6 +38,7 @@ class CallCapabilitiesConfig extends Equatable {
     this.isAudioToVideoSwitchEnabled = true,
     this.isBlindTransferEnabled = true,
     this.isAttendedTransferEnabled = true,
+    this.isPeerMessageEnabled = false,
   });
 
   /// Whether the UI should show video call functionality.
@@ -60,11 +61,19 @@ class CallCapabilitiesConfig extends Equatable {
   /// If `true`, the user can talk to the recipient before transferring the call.
   final bool isAttendedTransferEnabled;
 
+  /// Whether the remote core supports the `peer_message` app-to-app side channel.
+  ///
+  /// Gated by the core version: an older core rejects an unknown `peer_message`
+  /// request by tearing down the whole signaling socket (code 4600), so the
+  /// in-call media_state signal must only be sent when this is `true`.
+  final bool isPeerMessageEnabled;
+
   @override
   List<Object?> get props => [
     isVideoCallEnabled,
     isAudioToVideoSwitchEnabled,
     isBlindTransferEnabled,
     isAttendedTransferEnabled,
+    isPeerMessageEnabled,
   ];
 }

--- a/lib/models/system_info/components/core_info.dart
+++ b/lib/models/system_info/components/core_info.dart
@@ -37,4 +37,9 @@ class CoreInfo with EquatableMixin {
     // Hybrid presence was was added in 0.28.0-alpha.1
     return verifyVersionStr('>=0.28.0-alpha.1 <2.0.0');
   }
+
+  bool get supportsPeerMessage {
+    // peer_message app-to-app side channel was added in 0.33.0
+    return verifyVersionStr('>=0.33.0 <2.0.0');
+  }
 }

--- a/lib/models/system_info/components/core_info.dart
+++ b/lib/models/system_info/components/core_info.dart
@@ -40,6 +40,6 @@ class CoreInfo with EquatableMixin {
 
   bool get supportsPeerMessage {
     // peer_message app-to-app side channel was added in 0.33.0
-    return verifyVersionStr('>=0.33.0 <2.0.0');
+    return verifyVersionStr('>=0.33.0-alpha <2.0.0');
   }
 }

--- a/test/app/core_version_test.dart
+++ b/test/app/core_version_test.dart
@@ -30,4 +30,12 @@ void main() {
   test('toString', () {
     expect(CoreInfo(version: Version(0, 1, 0)).toString(), equals('CoreInfo(0.1.0)'));
   });
+
+  test('supportsPeerMessage', () {
+    expect(CoreInfo(version: Version(0, 32, 0)).supportsPeerMessage, false);
+    expect(CoreInfo(version: Version(0, 33, 0, pre: 'alpha.1')).supportsPeerMessage, false);
+    expect(CoreInfo(version: Version(0, 33, 0)).supportsPeerMessage, true);
+    expect(CoreInfo(version: Version(0, 34, 5)).supportsPeerMessage, true);
+    expect(CoreInfo(version: Version(2, 0, 0)).supportsPeerMessage, false);
+  });
 }

--- a/test/app/core_version_test.dart
+++ b/test/app/core_version_test.dart
@@ -33,7 +33,8 @@ void main() {
 
   test('supportsPeerMessage', () {
     expect(CoreInfo(version: Version(0, 32, 0)).supportsPeerMessage, false);
-    expect(CoreInfo(version: Version(0, 33, 0, pre: 'alpha.1')).supportsPeerMessage, false);
+    expect(CoreInfo(version: Version(0, 33, 0, pre: 'alpha')).supportsPeerMessage, true);
+    expect(CoreInfo(version: Version(0, 33, 0, pre: 'alpha.1')).supportsPeerMessage, true);
     expect(CoreInfo(version: Version(0, 33, 0)).supportsPeerMessage, true);
     expect(CoreInfo(version: Version(0, 34, 5)).supportsPeerMessage, true);
     expect(CoreInfo(version: Version(2, 0, 0)).supportsPeerMessage, false);


### PR DESCRIPTION
## Overview

When the app talks to an older core that does not understand the `peer_message`
request, the core does not just reject it - it closes the whole signaling socket
with code `4600` ("call request unknown error"), forcing a mid-call reconnect:

```
_addData add: {"request":"peer_message",...,"type":"media_state","data":{"video":false}}
_wsOnDone code: 4600 reason: call request unknown error
_sendMediaState: WebtritSignalingTransactionTerminateByDisconnectException ... code: 4600
```

This gates the in-call `media_state` signal behind a core version check so old
cores keep behaving exactly as before (the signal is simply not sent).

## Changes

- `CoreInfo.supportsPeerMessage` - version getter, single source of the constraint
  (mirrors `hybridPresenceAware` and friends).
- `CallCapabilitiesConfig.isPeerMessageEnabled` - folded in via `CallMapper` from
  `systemInfo.core.supportsPeerMessage` (same path `hybridPresenceAware` already
  uses through `FeatureAccess`).
- `CallBloc.peerMessageSupported` - construct-time bool (mirrors `sendPresenceSettings`);
  `_sendMediaState`, the single send chokepoint, returns early when unsupported.
- Test for the new getter.

## Note

The version constraint is a placeholder `>=0.33.0` for the next core release that
ships the feature (core PR #103). Finalize the number once that PR merges and a
release version is assigned.