### PR TITLE
fix: gate app version against app_version, not the build version

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -45,7 +45,6 @@ class _AppState extends State<App> {
       sessionRepository: context.read<SessionRepository>(),
       systemInfoRepository: context.read<SystemInfoRepository>(),
       appCompatibilityResolver: context.read<AppCompatibilityResolver>(),
-      packageInfo: context.read<PackageInfo>(),
       appInfo: context.read<AppInfo>(),
       userSessionCleanupResolver: RepositoryUserSessionCleanupResolver(
         systemInfoRepository: context.read<SystemInfoRepository>(),

--- a/lib/blocs/app/app_bloc.dart
+++ b/lib/blocs/app/app_bloc.dart
@@ -7,7 +7,6 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
 
@@ -39,7 +38,6 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     required this.userSessionCleanupResolver,
     required this.systemInfoRepository,
     required this.appCompatibilityResolver,
-    required this.packageInfo,
     required AppThemes appThemes,
   }) : super(
          AppState(
@@ -80,7 +78,6 @@ class AppBloc extends Bloc<AppEvent, AppState> {
   final UserSessionCleanupResolver userSessionCleanupResolver;
   final SystemInfoRepository systemInfoRepository;
   final AppCompatibilityResolver appCompatibilityResolver;
-  final PackageInfo packageInfo;
 
   StreamSubscription<WebtritSystemInfo>? _systemInfoSubscription;
 
@@ -107,7 +104,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
   AppCompatibility _resolveAppCompatibility(WebtritSystemInfo systemInfo) {
     return appCompatibilityResolver.resolve(
       systemInfo: systemInfo,
-      appVersion: Version.parse(packageInfo.version),
+      appVersion: appInfo.version,
       coreVersionConstraint: EnvironmentConfig.CORE_VERSION_CONSTRAINT,
     );
   }

--- a/lib/data/app_info.dart
+++ b/lib/data/app_info.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart' as services;
 
 import 'package:logging/logging.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import 'package:webtrit_phone/app/assets.gen.dart';
 import 'package:webtrit_phone/common/common.dart';
@@ -11,20 +12,27 @@ class AppInfo {
   static Future<AppInfo> init(AppIdProvider appIdProvider) async {
     final id = await appIdProvider.getId();
 
-    String? appVersion = await getAppVersion();
+    final appVersion = await getAppVersion();
     final callkeepVersion = await getCallkeepVersion();
 
     return AppInfo._(appIdProvider, id, appVersion, callkeepVersion);
   }
 
-  static Future<String?> getAppVersion() async {
+  /// Parses the custom `app_version` field from the bundled pubspec.yaml as a
+  /// semantic [Version]. This is the version shared across the whole codebase,
+  /// NOT the platform build version (`PackageInfo.version`), which is derived
+  /// from the standard pubspec `version:` (pinned to `0.0.0`) and differs per
+  /// client build. A missing or unparseable value yields [Version.none]
+  /// (`0.0.0`).
+  static Future<Version> getAppVersion() async {
     try {
       final pubspecString = await services.rootBundle.loadString(Assets.pubspec);
       final regExp = RegExp(r'app_version:\s*(\d+\.\d+\.\d+(\+\d+)?)');
-      return regExp.firstMatch(pubspecString)?.group(1);
+      final raw = regExp.firstMatch(pubspecString)?.group(1);
+      return raw == null ? Version.none : Version.parse(raw);
     } catch (e) {
       _logger.warning(e);
-      return null;
+      return Version.none;
     }
   }
 
@@ -63,13 +71,13 @@ class AppInfo {
 
   String _identifier;
 
-  final String? _appVersion;
+  final Version _appVersion;
 
   final String _callkeepVersion;
 
   String get identifier => _identifier;
 
-  String get version => _appVersion ?? '';
+  Version get version => _appVersion;
 
   String get callkeepVersion => _callkeepVersion;
 }

--- a/lib/data/app_metadata_provider.dart
+++ b/lib/data/app_metadata_provider.dart
@@ -64,7 +64,7 @@ class DefaultAppMetadataProvider implements AppMetadataProvider {
 
     return <String, String>{
       'app': _packageInfo.appName,
-      'appVersion': _appInfo.version,
+      'appVersion': _appInfo.version.toString(),
       'appSessionIdentifier': _appInfo.identifier,
       'storeVersion': _packageInfo.version,
       'packageName': _packageInfo.packageName,
@@ -101,7 +101,7 @@ class DefaultAppMetadataProvider implements AppMetadataProvider {
 
     final parts = [
       _packageInfo.appName,
-      _appInfo.version,
+      _appInfo.version.toString(),
       _appInfo.identifier,
       _deviceInfo.model,
       _packageInfo.version,

--- a/lib/features/autoprovision/cubit/autoprovision_cubit.dart
+++ b/lib/features/autoprovision/cubit/autoprovision_cubit.dart
@@ -1,7 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:logging/logging.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
 
@@ -69,7 +68,7 @@ class AutoprovisionCubit extends Cubit<AutoprovisionState> with SystemInfoApiMap
       // priority matches the login and in-app gates.
       final compatibility = appCompatibilityResolver.resolve(
         systemInfo: systemInfo,
-        appVersion: Version.parse(packageInfo.version),
+        appVersion: appInfo.version,
         coreVersionConstraint: config.coreVersionConstraint,
       );
       switch (compatibility) {

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -30,7 +30,7 @@ class LoginCubit extends Cubit<LoginState> {
   LoginCubit({
     required this.authRepository,
     required this.notificationsBloc,
-    required this.packageInfo,
+    required this.appInfo,
     required this.appCompatibilityResolver,
     required this.onLoginSuccess,
     this.signinOrder = const [],
@@ -42,7 +42,7 @@ class LoginCubit extends Cubit<LoginState> {
 
   final NotificationsBloc notificationsBloc;
 
-  final PackageInfo packageInfo;
+  final AppInfo appInfo;
 
   final AppCompatibilityResolver appCompatibilityResolver;
 
@@ -58,7 +58,7 @@ class LoginCubit extends Cubit<LoginState> {
 
   String get coreVersionConstraint => EnvironmentConfig.CORE_VERSION_CONSTRAINT;
 
-  Version get appVersion => Version.parse(packageInfo.version);
+  Version get appVersion => appInfo.version;
 
   String get defaultTenantId => '';
 

--- a/lib/features/login/view/login_router_page.dart
+++ b/lib/features/login/view/login_router_page.dart
@@ -92,7 +92,7 @@ class LoginRouterPage extends StatelessWidget {
     final login = LoginCubit(
       notificationsBloc: context.read<NotificationsBloc>(),
       authRepository: context.read<AuthRepository>(),
-      packageInfo: context.read<PackageInfo>(),
+      appInfo: context.read<AppInfo>(),
       appCompatibilityResolver: context.read<AppCompatibilityResolver>(),
       signinOrder: context.read<FeatureAccess>().loginConfig.signinOrder,
       onLoginSuccess: (session, systemInfo) =>

--- a/lib/features/version_gate/view/compatibility_issue_screen.dart
+++ b/lib/features/version_gate/view/compatibility_issue_screen.dart
@@ -28,10 +28,10 @@ class CompatibilityIssueScreenPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final packageInfo = context.read<PackageInfo>();
+    final appInfo = context.read<AppInfo>();
     final compatibility = context.select<AppBloc, AppCompatibility>((bloc) => bloc.state.appCompatibility);
 
-    final currentVersion = Version.parse(packageInfo.version);
+    final currentVersion = appInfo.version;
     final supportedConstraint = compatibility is CoreVersionUnsupported
         ? compatibility.constraint
         : VersionConstraint.any;

--- a/lib/features/version_gate/view/update_required_screen.dart
+++ b/lib/features/version_gate/view/update_required_screen.dart
@@ -31,10 +31,10 @@ class UpdateRequiredScreenPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final packageInfo = context.read<PackageInfo>();
+    final appInfo = context.read<AppInfo>();
     final compatibility = context.select<AppBloc, AppCompatibility>((bloc) => bloc.state.appCompatibility);
 
-    final currentVersion = Version.parse(packageInfo.version);
+    final currentVersion = appInfo.version;
     final minSupportedVersion = compatibility is AppVersionTooOld ? compatibility.minSupportedVersion : currentVersion;
 
     // The Android back button must not escape the gate.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.0+1
+app_version: 1.16.0+2
 
 environment:
   sdk: ^3.12.0

--- a/test/blocs/app/app_compatibility_gate_test.dart
+++ b/test/blocs/app/app_compatibility_gate_test.dart
@@ -33,22 +33,6 @@ class _MockAppThemes extends Mock implements AppThemes {}
 
 class _FakeThemeSettings extends Fake implements ThemeSettings {}
 
-class _FakePackageInfo implements PackageInfo {
-  _FakePackageInfo(this.version);
-
-  @override
-  final String version;
-
-  @override
-  String get appName => 'WebTrit';
-
-  @override
-  String get packageName => 'com.webtrit.app';
-
-  @override
-  String get buildNumber => '0';
-}
-
 // The default core version constraint is '>=0.7.0-alpha <2.0.0'.
 WebtritSystemInfo _systemInfo({Version? coreVersion, Version? minSupportedAppVersion}) {
   return WebtritSystemInfo(
@@ -105,6 +89,7 @@ void main() {
   });
 
   AppBloc buildBloc(String appVersion) {
+    when(() => appInfo.version).thenReturn(Version.parse(appVersion));
     return AppBloc(
       userAgreementStatusRepository: userAgreementStatusRepository,
       contactsAgreementStatusRepository: contactsAgreementStatusRepository,
@@ -115,7 +100,6 @@ void main() {
       userSessionCleanupResolver: userSessionCleanupResolver,
       appInfo: appInfo,
       appCompatibilityResolver: const DefaultAppCompatibilityResolver(),
-      packageInfo: _FakePackageInfo(appVersion),
       appThemes: appThemes,
     );
   }

--- a/test/features/login/login_cubit_app_version_gate_test.dart
+++ b/test/features/login/login_cubit_app_version_gate_test.dart
@@ -10,21 +10,7 @@ import 'package:webtrit_phone/repositories/repositories.dart';
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
 
-class _FakePackageInfo implements PackageInfo {
-  _FakePackageInfo(this.version);
-
-  @override
-  final String version;
-
-  @override
-  String get appName => 'WebTrit';
-
-  @override
-  String get packageName => 'com.webtrit.app';
-
-  @override
-  String get buildNumber => '0';
-}
+class _MockAppInfo extends Mock implements AppInfo {}
 
 WebtritSystemInfo _systemInfo({Version? minSupportedAppVersion, List<String> supported = const ['passwordSignin']}) {
   return WebtritSystemInfo(
@@ -51,10 +37,12 @@ void main() {
   });
 
   LoginCubit buildCubit(String appVersion) {
+    final appInfo = _MockAppInfo();
+    when(() => appInfo.version).thenReturn(Version.parse(appVersion));
     return LoginCubit(
       authRepository: authRepository,
       notificationsBloc: notificationsBloc,
-      packageInfo: _FakePackageInfo(appVersion),
+      appInfo: appInfo,
       appCompatibilityResolver: const DefaultAppCompatibilityResolver(),
       onLoginSuccess: (session, _) => loginSuccesses.add(session),
     );

--- a/test/features/version_gate/update_required_screen_test.dart
+++ b/test/features/version_gate/update_required_screen_test.dart
@@ -18,6 +18,8 @@ class _MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {}
 
 class _FakeThemeSettings extends Fake implements ThemeSettings {}
 
+class _MockAppInfo extends Mock implements AppInfo {}
+
 class _FakePackageInfo implements PackageInfo {
   _FakePackageInfo(this.version);
 
@@ -45,19 +47,23 @@ AppState _appState(AppCompatibility compatibility) => AppState(
 
 void main() {
   late _MockAppBloc appBloc;
+  late _MockAppInfo appInfo;
 
   setUp(() {
     appBloc = _MockAppBloc();
+    appInfo = _MockAppInfo();
   });
 
   Widget host({required Version current, required Version min}) {
     when(() => appBloc.state).thenReturn(_appState(AppVersionTooOld(appVersion: current, minSupportedVersion: min)));
+    when(() => appInfo.version).thenReturn(current);
 
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: MultiProvider(
         providers: [
+          Provider<AppInfo>.value(value: appInfo),
           Provider<PackageInfo>.value(value: _FakePackageInfo(current.toString())),
           BlocProvider<AppBloc>.value(value: appBloc),
         ],


### PR DESCRIPTION
## Overview

Backport of the WT-1628 fix (#1451, merged to develop) onto `release/1.16.0`, plus an `app_version` build bump.

The force-update / core-compatibility gate compared the backend-declared `min_supported_app_version` against `PackageInfo.version` -- the platform build version (Android `versionName` / iOS `CFBundleShortVersionString`), derived from the standard pubspec `version:` which is pinned to `0.0.0`. The real, codebase-wide release number lives in the custom `app_version`, parsed at runtime by `AppInfo`. Because the build version is always `0.0.0` it matched the `Version.none` debug/sideload exemption, so the gate never fired on real builds and the screens showed `0.0.0`.

## Change

- Cherry-pick of #1451: `AppInfo.getAppVersion()` returns a parsed `Version` (`Version.none` on missing/unparseable); the three gate sites (`LoginCubit`, `AppBloc`, `AutoprovisionCubit`) and the two version-gate screens use `appInfo.version`; `AppBloc`/`LoginCubit` drop the `PackageInfo` dependency; `AppMetadataProvider` stringifies the version for its `String` contexts. Conflicts resolved against this release line (kept the `appThemes`/`ThemeSettings` plumbing that is present on `release/1.16.0` but not on develop).
- `build:` bump `app_version` 1.16.0+1 -> 1.16.0+2.

## Tests

- Gate tests drive `AppInfo.version` (`app_compatibility_gate_test`, `login_cubit_app_version_gate_test`, `update_required_screen_test`).
- `flutter analyze` clean; full suite green via pre-push.