### PR TITLE
refactor: optimize video frame checker (WT-1489)

### DIFF
--- a/lib/features/call/utils/frame_analysis_worker.dart
+++ b/lib/features/call/utils/frame_analysis_worker.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+const int _maxSamples = 1200;
+const int _blackLumaThreshold = 16;
+const double _blackFrameRatioThreshold = 0.98;
+
+bool _analyzeFrameInIsolate(Uint8List frameBytes) {
+  if (frameBytes.isEmpty) return true;
+
+  final decoded = img.decodeImage(frameBytes);
+  if (decoded == null) return true;
+
+  final totalPixels = decoded.width * decoded.height;
+  if (totalPixels == 0) return true;
+
+  final step = math.max(1, totalPixels ~/ _maxSamples);
+  var sampledPixels = 0;
+  var opaquePixels = 0;
+  var blackPixels = 0;
+
+  for (var i = 0; i < totalPixels; i += step) {
+    final pixel = decoded.getPixel(i % decoded.width, i ~/ decoded.width);
+    sampledPixels++;
+    if (pixel.a == 0) continue;
+    opaquePixels++;
+    final luma = (pixel.r * 299 + pixel.g * 587 + pixel.b * 114) ~/ 1000;
+    if (luma <= _blackLumaThreshold) blackPixels++;
+  }
+
+  if (sampledPixels == 0 || opaquePixels == 0) return true;
+  return blackPixels / opaquePixels >= _blackFrameRatioThreshold;
+}
+
+void _isolateEntry(SendPort mainSendPort) {
+  final receivePort = ReceivePort();
+  mainSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) {
+    if (message is Uint8List) {
+      try {
+        mainSendPort.send(_analyzeFrameInIsolate(message));
+      } catch (_) {
+        mainSendPort.send(false); // optimistically renderable on analysis error
+      }
+    } else {
+      receivePort.close();
+    }
+  });
+}
+
+/// Long-lived isolate worker that analyses video frames off the main thread.
+///
+/// Call [start] once, [analyzeFrame] for each probe, [dispose] on teardown.
+/// Sequential use only — one outstanding [analyzeFrame] call at a time.
+class FrameAnalysisWorker {
+  Isolate? _isolate;
+  ReceivePort? _receivePort;
+  SendPort? _sendPort;
+  Completer<bool>? _pendingAnalysis;
+  late final Future<void> _ready;
+
+  void start() {
+    _ready = _init();
+  }
+
+  Future<void> _init() async {
+    final receivePort = ReceivePort();
+    _receivePort = receivePort;
+    final handshake = Completer<SendPort>();
+    receivePort.listen((message) {
+      if (!handshake.isCompleted) {
+        handshake.complete(message as SendPort);
+      } else if (message is bool) {
+        _pendingAnalysis?.complete(message);
+        _pendingAnalysis = null;
+      }
+    });
+    _isolate = await Isolate.spawn(_isolateEntry, receivePort.sendPort, debugName: 'FrameAnalysisWorker');
+    _sendPort = await handshake.future;
+  }
+
+  void dispose() {
+    _pendingAnalysis?.completeError(StateError('disposed'));
+    _pendingAnalysis = null;
+    _sendPort?.send(null);
+    _isolate?.kill(priority: Isolate.immediate);
+    _receivePort?.close();
+    _isolate = null;
+    _sendPort = null;
+    _receivePort = null;
+  }
+
+  /// Returns `true` when the frame is black or empty, `false` when it has
+  /// visible content. Awaits isolate startup if [start] hasn't finished yet.
+  Future<bool> analyzeFrame(Uint8List frameBytes) async {
+    await _ready;
+    final completer = Completer<bool>();
+    _pendingAnalysis = completer;
+    _sendPort!.send(frameBytes);
+    return completer.future;
+  }
+}

--- a/lib/features/call/utils/frame_analysis_worker.dart
+++ b/lib/features/call/utils/frame_analysis_worker.dart
@@ -1,18 +1,23 @@
 import 'dart:async';
 import 'dart:isolate';
 import 'dart:math' as math;
-import 'dart:typed_data';
-
+import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
 
 const int _maxSamples = 1200;
 const int _blackLumaThreshold = 16;
 const double _blackFrameRatioThreshold = 0.98;
 
-bool _analyzeFrameInIsolate(Uint8List frameBytes) {
+@visibleForTesting
+bool analyzeFrameInIsolate(Uint8List frameBytes) {
   if (frameBytes.isEmpty) return true;
 
-  final decoded = img.decodeImage(frameBytes);
+  final img.Image? decoded;
+  try {
+    decoded = img.decodeImage(frameBytes);
+  } catch (_) {
+    return true;
+  }
   if (decoded == null) return true;
 
   final totalPixels = decoded.width * decoded.height;
@@ -42,7 +47,7 @@ void _isolateEntry(SendPort mainSendPort) {
   receivePort.listen((message) {
     if (message is Uint8List) {
       try {
-        mainSendPort.send(_analyzeFrameInIsolate(message));
+        mainSendPort.send(analyzeFrameInIsolate(message));
       } catch (_) {
         mainSendPort.send(false); // optimistically renderable on analysis error
       }

--- a/lib/features/call/utils/utils.dart
+++ b/lib/features/call/utils/utils.dart
@@ -1,4 +1,5 @@
 export 'audio_constraints_builder.dart';
+export 'frame_analysis_worker.dart';
 export 'call_media_manager.dart';
 export 'handshake_processor.dart';
 export 'pc_exceptions.dart';

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -48,7 +48,7 @@ class CallActiveScaffold extends StatefulWidget {
 }
 
 class CallActiveScaffoldState extends State<CallActiveScaffold> {
-  static const Duration _remoteFrameProbeInterval = Duration(seconds: 1);
+  static const Duration _remoteFrameProbeNoTrackInterval = Duration(seconds: 1);
   static const int _remoteFrameMaxSamples = 1200;
   static const int _blackLumaThreshold = 16;
   static const double _blackFrameRatioThreshold = 0.98;
@@ -72,7 +72,6 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   VideoBackgroundMode _backgroundMode = VideoBackgroundMode.blur;
 
   Timer? _remoteFrameWatcher;
-  bool _remoteFrameProbeInProgress = false;
   bool _hasRenderableRemoteFrame = false;
 
   static const Duration _debounceDuration = Duration(seconds: 2);
@@ -88,7 +87,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     // Synchronize the auto-hide logic with the initial call list configuration.
     _compactController = CompactAutoResetController(initiallyActive: widget.activeCalls.shouldAutoCompact);
-    _remoteFrameWatcher = Timer.periodic(_remoteFrameProbeInterval, (_) => _probeRemoteFrame());
+    _scheduleNextProbe(Duration.zero);
 
     // Dispatch interaction debounce whenever any call is in updating state
     // to prevent user race conditions e.g hold or upgrade to video when the call is updating from remote side.
@@ -498,13 +497,20 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     return tracks.first;
   }
 
+  void _scheduleNextProbe(Duration delay) {
+    if (!mounted) return;
+    _remoteFrameWatcher = Timer(delay, _probeRemoteFrame);
+  }
+
   Future<void> _probeRemoteFrame() async {
-    if (_remoteFrameProbeInProgress || mounted == false) return;
+    if (!mounted) return;
 
     final track = _currentRemoteVideoTrack;
-    if (track == null) return;
+    if (track == null) {
+      _scheduleNextProbe(_remoteFrameProbeNoTrackInterval);
+      return;
+    }
 
-    _remoteFrameProbeInProgress = true;
     final startTime = DateTime.now();
     try {
       final isBlackOrEmpty = await _isTrackFrameBlackOrEmpty(track).timeout(const Duration(seconds: 5));
@@ -513,9 +519,9 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
       // In case of any errors during frame capture or analysis, we optimistically assume that the remote frame is renderable.
       _setHasRenderableRemoteFrame(true);
     } finally {
-      _remoteFrameProbeInProgress = false;
       final elapsed = DateTime.now().difference(startTime);
       _logger.fine('Remote frame probe completed in ${elapsed.inMilliseconds}ms, $_hasRenderableRemoteFrame');
+      _scheduleNextProbe(elapsed * 4);
     }
   }
 

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
+import 'dart:isolate';
 import 'dart:math' as math;
 import 'dart:typed_data';
-import 'dart:ui' as ui;
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:image/image.dart' as img;
 import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/data/data.dart';
@@ -17,6 +18,58 @@ import 'package:webtrit_phone/widgets/widgets.dart';
 import '../call.dart';
 
 final _logger = Logger('CallActiveScaffold');
+
+const int _remoteFrameMaxSamples = 1200;
+const int _blackLumaThreshold = 16;
+const double _blackFrameRatioThreshold = 0.98;
+
+// Decodes PNG bytes and determines whether the frame is black or empty.
+// Runs entirely in the worker isolate — no dart:ui dependency.
+bool _analyzeFrameInIsolate(Uint8List pngBytes) {
+  if (pngBytes.isEmpty) return true;
+
+  final decoded = img.decodeImage(pngBytes);
+  if (decoded == null) return true;
+
+  final totalPixels = decoded.width * decoded.height;
+  if (totalPixels == 0) return true;
+
+  final step = math.max(1, totalPixels ~/ _remoteFrameMaxSamples);
+  var sampledPixels = 0;
+  var opaquePixels = 0;
+  var blackPixels = 0;
+
+  for (var i = 0; i < totalPixels; i += step) {
+    final pixel = decoded.getPixel(i % decoded.width, i ~/ decoded.width);
+    sampledPixels++;
+    if (pixel.a == 0) continue;
+    opaquePixels++;
+    final luma = (pixel.r * 299 + pixel.g * 587 + pixel.b * 114) ~/ 1000;
+    if (luma <= _blackLumaThreshold) blackPixels++;
+  }
+
+  if (sampledPixels == 0 || opaquePixels == 0) return true;
+  return blackPixels / opaquePixels >= _blackFrameRatioThreshold;
+}
+
+// Entry point for the long-lived frame-analysis isolate.
+// Sends back its own SendPort on startup, then processes PNG Uint8List messages
+// and replies with a bool. Any non-Uint8List message (null) shuts it down.
+void _frameAnalysisIsolateEntry(SendPort mainSendPort) {
+  final receivePort = ReceivePort();
+  mainSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) {
+    if (message is Uint8List) {
+      try {
+        mainSendPort.send(_analyzeFrameInIsolate(message));
+      } catch (_) {
+        mainSendPort.send(false); // optimistically renderable on analysis error
+      }
+    } else {
+      receivePort.close();
+    }
+  });
+}
 
 class CallActiveScaffold extends StatefulWidget {
   const CallActiveScaffold({
@@ -48,10 +101,7 @@ class CallActiveScaffold extends StatefulWidget {
 }
 
 class CallActiveScaffoldState extends State<CallActiveScaffold> {
-  static const Duration _remoteFrameProbeNoTrackInterval = Duration(seconds: 1);
-  static const int _remoteFrameMaxSamples = 1200;
-  static const int _blackLumaThreshold = 16;
-  static const double _blackFrameRatioThreshold = 0.98;
+  static const Duration _remoteFrameProbeThrottle = Duration(seconds: 1);
 
   /// Cached `CallBloc` obtained in `initState`.
   /// Avoids unsafe `context.read` during widget deactivation (e.g., navigation pop).
@@ -74,6 +124,12 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   Timer? _remoteFrameWatcher;
   bool _hasRenderableRemoteFrame = false;
 
+  Isolate? _frameAnalysisIsolate;
+  ReceivePort? _frameAnalysisReceivePort;
+  SendPort? _frameAnalysisSendPort;
+  Completer<bool>? _pendingFrameAnalysis;
+  late Future<void> _frameAnalysisIsolateReady;
+
   static const Duration _debounceDuration = Duration(seconds: 2);
   DateTime? _debounceReleaseTime;
   Timer? _debounceTimer;
@@ -87,6 +143,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     // Synchronize the auto-hide logic with the initial call list configuration.
     _compactController = CompactAutoResetController(initiallyActive: widget.activeCalls.shouldAutoCompact);
+    _frameAnalysisIsolateReady = _initFrameAnalysisIsolate();
     _scheduleNextProbe(Duration.zero);
 
     // Dispatch interaction debounce whenever any call is in updating state
@@ -110,6 +167,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   @override
   void dispose() {
     _disposeRemoteFrameWatcher();
+    _disposeFrameAnalysisIsolate();
     _compactController.removeListener(_onCompactChanged);
     _compactController.dispose();
     _debounceByStateSubscription?.cancel();
@@ -507,7 +565,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     final track = _currentRemoteVideoTrack;
     if (track == null) {
-      _scheduleNextProbe(_remoteFrameProbeNoTrackInterval);
+      _scheduleNextProbe(_remoteFrameProbeThrottle * 2);
       return;
     }
 
@@ -521,78 +579,48 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     } finally {
       final elapsed = DateTime.now().difference(startTime);
       _logger.fine('Remote frame probe completed in ${elapsed.inMilliseconds}ms, $_hasRenderableRemoteFrame');
-      _scheduleNextProbe(elapsed * 4);
+      _scheduleNextProbe(_remoteFrameProbeThrottle);
     }
   }
 
   Future<bool> _isTrackFrameBlackOrEmpty(MediaStreamTrack track) async {
     final capturedFrame = await track.captureFrame();
-    final framePngBytes = capturedFrame.asUint8List();
-
-    if (framePngBytes.isEmpty) {
-      return true;
-    }
-
-    final codec = await ui.instantiateImageCodec(framePngBytes);
-    try {
-      final nextFrame = await codec.getNextFrame();
-      final image = nextFrame.image;
-      try {
-        final frameRgbaBytes = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
-
-        if (frameRgbaBytes == null || frameRgbaBytes.lengthInBytes == 0) {
-          return true;
-        }
-
-        final rgbaBytes = frameRgbaBytes.buffer.asUint8List(frameRgbaBytes.offsetInBytes, frameRgbaBytes.lengthInBytes);
-
-        return _isMostlyBlackRgbaFrame(rgbaBytes);
-      } finally {
-        image.dispose();
-      }
-    } finally {
-      codec.dispose();
-    }
+    return _analyzeFrame(capturedFrame.asUint8List());
   }
 
-  bool _isMostlyBlackRgbaFrame(Uint8List rgbaBytes) {
-    final totalPixels = rgbaBytes.length ~/ 4;
-
-    if (totalPixels == 0) {
-      return true;
-    }
-
-    final step = math.max(1, totalPixels ~/ _remoteFrameMaxSamples);
-    var sampledPixels = 0;
-    var opaquePixels = 0;
-    var blackPixels = 0;
-
-    for (var pixelIndex = 0; pixelIndex < totalPixels; pixelIndex += step) {
-      final offset = pixelIndex * 4;
-      final red = rgbaBytes[offset];
-      final green = rgbaBytes[offset + 1];
-      final blue = rgbaBytes[offset + 2];
-      final alpha = rgbaBytes[offset + 3];
-
-      sampledPixels++;
-
-      if (alpha == 0) {
-        continue;
+  Future<void> _initFrameAnalysisIsolate() async {
+    final receivePort = ReceivePort();
+    _frameAnalysisReceivePort = receivePort;
+    final handshake = Completer<SendPort>();
+    receivePort.listen((message) {
+      if (!handshake.isCompleted) {
+        handshake.complete(message as SendPort);
+      } else if (message is bool) {
+        _pendingFrameAnalysis?.complete(message);
+        _pendingFrameAnalysis = null;
       }
+    });
+    _frameAnalysisIsolate = await Isolate.spawn(_frameAnalysisIsolateEntry, receivePort.sendPort);
+    _frameAnalysisSendPort = await handshake.future;
+  }
 
-      opaquePixels++;
+  void _disposeFrameAnalysisIsolate() {
+    _pendingFrameAnalysis?.completeError(StateError('disposed'));
+    _pendingFrameAnalysis = null;
+    _frameAnalysisSendPort?.send(null);
+    _frameAnalysisIsolate?.kill(priority: Isolate.immediate);
+    _frameAnalysisReceivePort?.close();
+    _frameAnalysisIsolate = null;
+    _frameAnalysisSendPort = null;
+    _frameAnalysisReceivePort = null;
+  }
 
-      final luma = ((red * 299) + (green * 587) + (blue * 114)) ~/ 1000;
-      if (luma <= _blackLumaThreshold) {
-        blackPixels++;
-      }
-    }
-
-    if (sampledPixels == 0 || opaquePixels == 0) {
-      return true;
-    }
-
-    return blackPixels / opaquePixels >= _blackFrameRatioThreshold;
+  Future<bool> _analyzeFrame(Uint8List pngBytes) async {
+    await _frameAnalysisIsolateReady;
+    final completer = Completer<bool>();
+    _pendingFrameAnalysis = completer;
+    _frameAnalysisSendPort!.send(pngBytes);
+    return completer.future;
   }
 
   void _setHasRenderableRemoteFrame(bool value) {

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -1,14 +1,10 @@
 import 'dart:async';
-import 'dart:isolate';
-import 'dart:math' as math;
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
-import 'package:image/image.dart' as img;
 import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/data/data.dart';
@@ -18,58 +14,6 @@ import 'package:webtrit_phone/widgets/widgets.dart';
 import '../call.dart';
 
 final _logger = Logger('CallActiveScaffold');
-
-const int _remoteFrameMaxSamples = 1200;
-const int _blackLumaThreshold = 16;
-const double _blackFrameRatioThreshold = 0.98;
-
-// Decodes PNG bytes and determines whether the frame is black or empty.
-// Runs entirely in the worker isolate — no dart:ui dependency.
-bool _analyzeFrameInIsolate(Uint8List pngBytes) {
-  if (pngBytes.isEmpty) return true;
-
-  final decoded = img.decodeImage(pngBytes);
-  if (decoded == null) return true;
-
-  final totalPixels = decoded.width * decoded.height;
-  if (totalPixels == 0) return true;
-
-  final step = math.max(1, totalPixels ~/ _remoteFrameMaxSamples);
-  var sampledPixels = 0;
-  var opaquePixels = 0;
-  var blackPixels = 0;
-
-  for (var i = 0; i < totalPixels; i += step) {
-    final pixel = decoded.getPixel(i % decoded.width, i ~/ decoded.width);
-    sampledPixels++;
-    if (pixel.a == 0) continue;
-    opaquePixels++;
-    final luma = (pixel.r * 299 + pixel.g * 587 + pixel.b * 114) ~/ 1000;
-    if (luma <= _blackLumaThreshold) blackPixels++;
-  }
-
-  if (sampledPixels == 0 || opaquePixels == 0) return true;
-  return blackPixels / opaquePixels >= _blackFrameRatioThreshold;
-}
-
-// Entry point for the long-lived frame-analysis isolate.
-// Sends back its own SendPort on startup, then processes PNG Uint8List messages
-// and replies with a bool. Any non-Uint8List message (null) shuts it down.
-void _frameAnalysisIsolateEntry(SendPort mainSendPort) {
-  final receivePort = ReceivePort();
-  mainSendPort.send(receivePort.sendPort);
-  receivePort.listen((message) {
-    if (message is Uint8List) {
-      try {
-        mainSendPort.send(_analyzeFrameInIsolate(message));
-      } catch (_) {
-        mainSendPort.send(false); // optimistically renderable on analysis error
-      }
-    } else {
-      receivePort.close();
-    }
-  });
-}
 
 class CallActiveScaffold extends StatefulWidget {
   const CallActiveScaffold({
@@ -101,7 +45,7 @@ class CallActiveScaffold extends StatefulWidget {
 }
 
 class CallActiveScaffoldState extends State<CallActiveScaffold> {
-  static const Duration _remoteFrameProbeThrottle = Duration(seconds: 1);
+  static const Duration _remoteFrameProbeDelay = Duration(seconds: 1);
 
   /// Cached `CallBloc` obtained in `initState`.
   /// Avoids unsafe `context.read` during widget deactivation (e.g., navigation pop).
@@ -123,12 +67,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
   Timer? _remoteFrameWatcher;
   bool _hasRenderableRemoteFrame = false;
-
-  Isolate? _frameAnalysisIsolate;
-  ReceivePort? _frameAnalysisReceivePort;
-  SendPort? _frameAnalysisSendPort;
-  Completer<bool>? _pendingFrameAnalysis;
-  late Future<void> _frameAnalysisIsolateReady;
+  late final FrameAnalysisWorker _frameAnalysisWorker;
 
   static const Duration _debounceDuration = Duration(seconds: 2);
   DateTime? _debounceReleaseTime;
@@ -143,7 +82,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     // Synchronize the auto-hide logic with the initial call list configuration.
     _compactController = CompactAutoResetController(initiallyActive: widget.activeCalls.shouldAutoCompact);
-    _frameAnalysisIsolateReady = _initFrameAnalysisIsolate();
+    _frameAnalysisWorker = FrameAnalysisWorker()..start();
     _scheduleNextProbe(Duration.zero);
 
     // Dispatch interaction debounce whenever any call is in updating state
@@ -167,7 +106,7 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   @override
   void dispose() {
     _disposeRemoteFrameWatcher();
-    _disposeFrameAnalysisIsolate();
+    _frameAnalysisWorker.dispose();
     _compactController.removeListener(_onCompactChanged);
     _compactController.dispose();
     _debounceByStateSubscription?.cancel();
@@ -565,13 +504,13 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
 
     final track = _currentRemoteVideoTrack;
     if (track == null) {
-      _scheduleNextProbe(_remoteFrameProbeThrottle * 2);
+      _scheduleNextProbe(_remoteFrameProbeDelay);
       return;
     }
 
     final startTime = DateTime.now();
     try {
-      final isBlackOrEmpty = await _isTrackFrameBlackOrEmpty(track).timeout(const Duration(seconds: 5));
+      final isBlackOrEmpty = await _isTrackFrameBlackOrEmpty(track).timeout(const Duration(seconds: 10));
       _setHasRenderableRemoteFrame(!isBlackOrEmpty);
     } catch (_) {
       // In case of any errors during frame capture or analysis, we optimistically assume that the remote frame is renderable.
@@ -579,48 +518,13 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     } finally {
       final elapsed = DateTime.now().difference(startTime);
       _logger.fine('Remote frame probe completed in ${elapsed.inMilliseconds}ms, $_hasRenderableRemoteFrame');
-      _scheduleNextProbe(_remoteFrameProbeThrottle);
+      _scheduleNextProbe(_remoteFrameProbeDelay);
     }
   }
 
   Future<bool> _isTrackFrameBlackOrEmpty(MediaStreamTrack track) async {
     final capturedFrame = await track.captureFrame();
-    return _analyzeFrame(capturedFrame.asUint8List());
-  }
-
-  Future<void> _initFrameAnalysisIsolate() async {
-    final receivePort = ReceivePort();
-    _frameAnalysisReceivePort = receivePort;
-    final handshake = Completer<SendPort>();
-    receivePort.listen((message) {
-      if (!handshake.isCompleted) {
-        handshake.complete(message as SendPort);
-      } else if (message is bool) {
-        _pendingFrameAnalysis?.complete(message);
-        _pendingFrameAnalysis = null;
-      }
-    });
-    _frameAnalysisIsolate = await Isolate.spawn(_frameAnalysisIsolateEntry, receivePort.sendPort);
-    _frameAnalysisSendPort = await handshake.future;
-  }
-
-  void _disposeFrameAnalysisIsolate() {
-    _pendingFrameAnalysis?.completeError(StateError('disposed'));
-    _pendingFrameAnalysis = null;
-    _frameAnalysisSendPort?.send(null);
-    _frameAnalysisIsolate?.kill(priority: Isolate.immediate);
-    _frameAnalysisReceivePort?.close();
-    _frameAnalysisIsolate = null;
-    _frameAnalysisSendPort = null;
-    _frameAnalysisReceivePort = null;
-  }
-
-  Future<bool> _analyzeFrame(Uint8List pngBytes) async {
-    await _frameAnalysisIsolateReady;
-    final completer = Completer<bool>();
-    _pendingFrameAnalysis = completer;
-    _frameAnalysisSendPort!.send(pngBytes);
-    return completer.future;
+    return _frameAnalysisWorker.analyzeFrame(capturedFrame.asUint8List());
   }
 
   void _setHasRenderableRemoteFrame(bool value) {

--- a/lib/features/call/widgets/call_active_thumbnail.dart
+++ b/lib/features/call/widgets/call_active_thumbnail.dart
@@ -1,4 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
@@ -7,7 +12,9 @@ import '../bloc/call_bloc.dart';
 import '../utils/utils.dart';
 import 'stream_thumbnail.dart';
 
-class CallActiveThumbnail extends StatelessWidget {
+final _logger = Logger('CallActiveThumbnail');
+
+class CallActiveThumbnail extends StatefulWidget {
   const CallActiveThumbnail({
     required this.activeCall,
     required this.orientation,
@@ -24,17 +31,87 @@ class CallActiveThumbnail extends StatelessWidget {
   final double smallerSide;
 
   @override
-  Widget build(BuildContext context) {
-    final frameSize = ThumbnailLayout.calcFrameSize(orientation: orientation, smallerSide: smallerSide);
-    final hasRemoteVideo = activeCall.remoteStream?.getVideoTracks().isNotEmpty ?? false;
+  State<CallActiveThumbnail> createState() => _CallActiveThumbnailState();
+}
 
-    // Its important to hide video if held to avoid showing frozen/last frames when held,
-    // and especially for case when both sides turn on hold and after one side unholds video started to show for another 'holded' side.
-    final displayStream = hasRemoteVideo && activeCall.held == false;
+class _CallActiveThumbnailState extends State<CallActiveThumbnail> {
+  static const Duration _remoteFrameProbeDelay = Duration(seconds: 1);
+
+  Timer? _remoteFrameWatcher;
+  bool _hasRenderableRemoteFrame = false;
+  late final FrameAnalysisWorker _frameAnalysisWorker;
+
+  @override
+  void initState() {
+    super.initState();
+    _frameAnalysisWorker = FrameAnalysisWorker()..start();
+    _scheduleNextProbe(Duration.zero);
+  }
+
+  @override
+  void didUpdateWidget(CallActiveThumbnail oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Reset when the remote stream changes so we don't flash stale content.
+    if (oldWidget.activeCall.remoteStream != widget.activeCall.remoteStream) {
+      _setHasRenderableRemoteFrame(false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _remoteFrameWatcher?.cancel();
+    _frameAnalysisWorker.dispose();
+    super.dispose();
+  }
+
+  MediaStreamTrack? get _remoteVideoTrack {
+    final tracks = widget.activeCall.remoteStream?.getVideoTracks();
+    return (tracks != null && tracks.isNotEmpty) ? tracks.first : null;
+  }
+
+  void _scheduleNextProbe(Duration delay) {
+    if (!mounted) return;
+    _remoteFrameWatcher = Timer(delay, _probeRemoteFrame);
+  }
+
+  Future<void> _probeRemoteFrame() async {
+    if (!mounted) return;
+
+    final track = _remoteVideoTrack;
+    if (track == null) {
+      _scheduleNextProbe(_remoteFrameProbeDelay);
+      return;
+    }
+
+    try {
+      final capturedFrame = await track.captureFrame().timeout(const Duration(seconds: 10));
+      final isBlackOrEmpty = await _frameAnalysisWorker.analyzeFrame(capturedFrame.asUint8List());
+      _setHasRenderableRemoteFrame(!isBlackOrEmpty);
+    } catch (_) {
+      _setHasRenderableRemoteFrame(true);
+    } finally {
+      _logger.fine('Thumbnail frame probe done, hasRenderableFrame=$_hasRenderableRemoteFrame');
+      _scheduleNextProbe(_remoteFrameProbeDelay);
+    }
+  }
+
+  void _setHasRenderableRemoteFrame(bool value) {
+    if (_hasRenderableRemoteFrame == value || !mounted) return;
+    setState(() => _hasRenderableRemoteFrame = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final frameSize = ThumbnailLayout.calcFrameSize(orientation: widget.orientation, smallerSide: widget.smallerSide);
+    final hasRemoteVideo = widget.activeCall.remoteStream?.getVideoTracks().isNotEmpty ?? false;
+
+    // Hide video when held to avoid showing frozen/last frames, and also when the
+    // frame analyser hasn't confirmed renderable content yet (black/empty guard).
+    final displayStream = hasRemoteVideo && widget.activeCall.held == false && _hasRenderableRemoteFrame;
 
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final isAccepted = activeCall.wasAccepted;
+    final isAccepted = widget.activeCall.wasAccepted;
 
     final duration = isAccepted ? const Duration(milliseconds: 2500) : const Duration(milliseconds: 1500);
 
@@ -53,7 +130,7 @@ class CallActiveThumbnail extends StatelessWidget {
       child: SizedBox.fromSize(
         size: frameSize,
         child: GestureDetector(
-          onTap: onTap,
+          onTap: widget.onTap,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
             child: Stack(
@@ -61,9 +138,9 @@ class CallActiveThumbnail extends StatelessWidget {
               children: [
                 Shimmer(duration: duration, baseColor: baseColor, highlightColor: highlightColor),
                 if (displayStream)
-                  StreamThumbnail(stream: activeCall.remoteStream)
+                  StreamThumbnail(stream: widget.activeCall.remoteStream)
                 else
-                  _AvatarOverlay(activeCall: activeCall, contactResolver: contactResolver),
+                  _AvatarOverlay(activeCall: widget.activeCall, contactResolver: widget.contactResolver),
               ],
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -978,7 +978,7 @@ packages:
     source: hosted
     version: "2.1.0"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: "492bd52f6c4fbb6ee41f781ff27765ce5f627910e1e0cbecfa3d9add5562604c"
@@ -2036,7 +2036,7 @@ packages:
       path: "../webtrit_callkeep/webtrit_callkeep"
       relative: true
     source: path
-    version: "1.3.0+0"
+    version: "1.2.0+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ dependencies:
   gravatar_utils: ^1.0.0
   html: ^0.15.6
   http: ^1.6.0
+  image: ^4.0.0
   icon_decoration: ^2.1.0
   in_app_update: ^4.2.5
   intl: any

--- a/test/features/call/utils/frame_analysis_worker_test.dart
+++ b/test/features/call/utils/frame_analysis_worker_test.dart
@@ -1,0 +1,128 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+import 'package:webtrit_phone/features/call/utils/frame_analysis_worker.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Creates a solid-colour RGBA PNG of the given dimensions.
+Uint8List _solidPng(int width, int height, {required int r, required int g, required int b, int a = 255}) {
+  final image = img.Image(width: width, height: height, numChannels: 4);
+  img.fill(image, color: img.ColorRgba8(r, g, b, a));
+  return img.encodePng(image);
+}
+
+/// Returns the expected luma for a uniform r/g/b value (same formula as the
+/// production code) so tests stay in sync with the threshold constant.
+int _luma(int r, int g, int b) => (r * 299 + g * 587 + b * 114) ~/ 1000;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('analyzeFrameInIsolate', () {
+    // --- empty / invalid input -----------------------------------------------
+
+    test('returns true for empty bytes', () {
+      expect(analyzeFrameInIsolate(Uint8List(0)), isTrue);
+    });
+
+    test('returns true for bytes that are not a valid image', () {
+      expect(analyzeFrameInIsolate(Uint8List.fromList([0x00, 0x01, 0x02, 0x03])), isTrue);
+    });
+
+    // --- solid colour frames -------------------------------------------------
+
+    test('returns true for a solid black frame', () {
+      expect(_luma(0, 0, 0), lessThanOrEqualTo(16)); // sanity-check the threshold
+      final png = _solidPng(64, 64, r: 0, g: 0, b: 0);
+      expect(analyzeFrameInIsolate(png), isTrue);
+    });
+
+    test('returns true for a near-black frame whose luma equals the threshold', () {
+      // r=g=b=16 → luma = (16*299 + 16*587 + 16*114) / 1000 = 16 ≤ 16
+      expect(_luma(16, 16, 16), equals(16));
+      final png = _solidPng(64, 64, r: 16, g: 16, b: 16);
+      expect(analyzeFrameInIsolate(png), isTrue);
+    });
+
+    test('returns false for a frame whose luma is just above the threshold', () {
+      // r=g=b=17 → luma = 17 > 16
+      expect(_luma(17, 17, 17), equals(17));
+      final png = _solidPng(64, 64, r: 17, g: 17, b: 17);
+      expect(analyzeFrameInIsolate(png), isFalse);
+    });
+
+    test('returns false for a solid white frame', () {
+      final png = _solidPng(64, 64, r: 255, g: 255, b: 255);
+      expect(analyzeFrameInIsolate(png), isFalse);
+    });
+
+    test('returns false for a solid red frame', () {
+      final png = _solidPng(64, 64, r: 255, g: 0, b: 0);
+      expect(analyzeFrameInIsolate(png), isFalse);
+    });
+
+    test('returns false for a solid green frame', () {
+      final png = _solidPng(64, 64, r: 0, g: 255, b: 0);
+      expect(analyzeFrameInIsolate(png), isFalse);
+    });
+
+    // --- alpha ---------------------------------------------------------------
+
+    test('returns true for a fully transparent frame (no opaque pixels)', () {
+      final png = _solidPng(64, 64, r: 255, g: 255, b: 255, a: 0);
+      expect(analyzeFrameInIsolate(png), isTrue);
+    });
+
+    // --- black-pixel ratio boundary ------------------------------------------
+    //
+    // Use a 100×1 image so step = max(1, 100÷1200) = 1 and every pixel is
+    // sampled, giving exact control over the ratio.
+
+    test('returns true when exactly 98% of opaque pixels are black (at threshold)', () {
+      final image = img.Image(width: 100, height: 1, numChannels: 4);
+      for (var x = 0; x < 98; x++) {
+        image.setPixel(x, 0, img.ColorRgba8(0, 0, 0, 255)); // black
+      }
+      for (var x = 98; x < 100; x++) {
+        image.setPixel(x, 0, img.ColorRgba8(255, 255, 255, 255)); // white
+      }
+      expect(analyzeFrameInIsolate(img.encodePng(image)), isTrue);
+    });
+
+    test('returns false when 97% of opaque pixels are black (below threshold)', () {
+      final image = img.Image(width: 100, height: 1, numChannels: 4);
+      for (var x = 0; x < 97; x++) {
+        image.setPixel(x, 0, img.ColorRgba8(0, 0, 0, 255)); // black
+      }
+      for (var x = 97; x < 100; x++) {
+        image.setPixel(x, 0, img.ColorRgba8(255, 255, 255, 255)); // white
+      }
+      expect(analyzeFrameInIsolate(img.encodePng(image)), isFalse);
+    });
+
+    // --- degenerate geometry -------------------------------------------------
+
+    test('returns true for a 0×0 image (no pixels)', () {
+      // img.Image(0,0) encodes to a valid PNG with empty pixel data.
+      final png = img.encodePng(img.Image(width: 0, height: 0));
+      expect(analyzeFrameInIsolate(png), isTrue);
+    });
+
+    test('returns true for a 1×1 black pixel', () {
+      final png = _solidPng(1, 1, r: 0, g: 0, b: 0);
+      expect(analyzeFrameInIsolate(png), isTrue);
+    });
+
+    test('returns false for a 1×1 white pixel', () {
+      final png = _solidPng(1, 1, r: 255, g: 255, b: 255);
+      expect(analyzeFrameInIsolate(png), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Summary

  Refactors a frame-analysis mechanism that detects black/empty remote video frames and hides the video renderer until real content arrives, preventing black flicker at the start of video calls. The analyser runs on a dedicated background isolate so pixel-level work never touches the main thread.

  - FrameAnalysisWorker (lib/features/call/utils/frame_analysis_worker.dart) — persistent isolate worker that accepts raw frame bytes, decodes them with package:image
  (format-agnostic: PNG, JPEG, etc.), samples up to 1 200 pixels for luma, and returns true when ≥ 98 % of opaque pixels are below the black threshold (luma ≤ 16).  Isolate is spawned once per widget lifecycle, not per probe.
  - CallActiveScaffold — replaced Timer.periodic with recursive one-shot scheduling; frame capture happens on the main isolate (platform-channel constraint), pixel analysis is offloaded to FrameAnalysisWorker; remote video is suppressed until the first renderable frame is confirmed.
  - CallActiveThumbnail — converted from StatelessWidget to StatefulWidget; applies the same probing loop to the minimized call overlay so the avatar placeholder is  shown instead of a black thumbnail until video content is confirmed.
  - Tests (test/features/call/utils/frame_analysis_worker_test.dart) — 14 unit tests covering empty input, decoder exceptions (corrupt bytes), solid colours, luma boundary, alpha-only frames, ratio boundary (97 % / 98 %), degenerate 0 × 0 geometry, and 1 × 1 pixels.
  - Added image: ^4.0.0 as an explicit direct dependency (was already a transitive dependency at 4.7.2).