### PR TITLE
chore: fix sdp log cutoff on accept call

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2922,10 +2922,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
         return;
       }
 
-      _logger.info(
-        '__onMutationSignalingAccepted answer SDP (callId=${event.callId}, initialAccept=$initialAccept):\n'
-        '${remoteDescription.sdp}',
-      );
+      _logger.info('__onMutationSignalingAccepted answer SDP (callId=${event.callId}, initialAccept=$initialAccept)');
+      _logger.infoPretty(remoteDescription.sdp, tag: '__onMutationSignalingAccepted answer SDP');
 
       try {
         await peerConnection.setRemoteDescription(remoteDescription);


### PR DESCRIPTION
This pull request makes a small logging improvement in the `CallBloc` class. The main change is to split the logging of the answer SDP into two separate log statements, improving readability and structure.

Logging improvements:

* In `lib/features/call/bloc/call_bloc.dart`, the answer SDP log in the `__onMutationSignalingAccepted` handler is now split: a summary message is logged with `_logger.info`, and the actual SDP content is logged with `_logger.infoPretty` for better formatting.