### PR TITLE
fix: track release after hangup (WT-1489)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2977,12 +2977,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       }
     }
 
-    await _peerConnectionManager.disposePeerConnection(event.callId).catchError((e) {
-      _logger.warning('__onMutationSignalingHangup: disposePeerConnection error $e');
-    });
-
+    // Invoke _releaseLocalStream before disposePeerConnection to ensure that the local media tracks are stopped and released properly.
+    // or there might be a record indicator stuck after call
     await _releaseLocalStream(call.localStream).catchError((e) {
       _logger.warning('__onMutationSignalingHangup: _releaseLocalStream error $e');
+    });
+    await _peerConnectionManager.disposePeerConnection(event.callId).catchError((e) {
+      _logger.warning('__onMutationSignalingHangup: disposePeerConnection error $e');
     });
 
     emit(state.copyWithPopActiveCall(event.callId));


### PR DESCRIPTION
This pull request makes a targeted improvement to the call teardown process in `call_bloc.dart`. The main change is to ensure that local media tracks are stopped and released before disposing of the peer connection, which prevents issues like a stuck record indicator after a call ends.

Call teardown reliability:

* Changed the order of operations in the call hangup handler to call `_releaseLocalStream` before `disposePeerConnection`, ensuring local media tracks are properly stopped and released before the peer connection is disposed. This prevents UI issues such as a stuck record indicator after a call.