### PR TITLE
fix: escape contacts search input instead of blocking non-Latin scripts

### DIFF
--- a/lib/features/contacts/widgets/cleared_text_field.dart
+++ b/lib/features/contacts/widgets/cleared_text_field.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/theme/theme.dart';
-import 'package:webtrit_phone/utils/regexes.dart';
 
 class ClearedTextField extends StatefulWidget {
   const ClearedTextField({super.key, this.initialValue, this.onChanged, this.onSubmitted, this.iconConstraints});
@@ -74,7 +72,6 @@ class ClearedTextFieldState extends State<ClearedTextField> {
           widget.onChanged?.call(value);
         },
         onSubmitted: (value) => widget.onSubmitted,
-        inputFormatters: [FilteringTextInputFormatter.deny(RegExp(symbolsRegex))],
       ),
     );
   }

--- a/lib/utils/regexes.dart
+++ b/lib/utils/regexes.dart
@@ -6,9 +6,6 @@ const linkRegex =
 const linkWoFilesRegex =
     r'((http|ftp|https):\/\/)?([\w_-]+(?:(?:\.[\w_-]*[a-zA-Z_][\w_-]*)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?[^\.\s]';
 
-/// Matches any symbols except letters, digits, spaces, and Cyrillic characters
-const symbolsRegex = r'[^a-zA-Z\d\s\u0400-\u04FF]+';
-
 const numbersExtractRegex = r'\d+';
 
 const numberSanitizeRegex = r'\D';

--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -210,7 +210,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
 
   Future<FullContactData?> getContactByPhoneMatchedEnding(String number) {
     final query = _joinFullData(select(contactsTable));
-    query.where(contactPhonesTable.number.regexp('.*$number', caseSensitive: false));
+    query.where(contactPhonesTable.number.regexp('.*${_escapeRegExp(number)}', caseSensitive: false));
     query.orderBy(contactsTable.sourcePriorityOrder());
     query.limit(1);
 
@@ -219,7 +219,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
 
   Stream<FullContactData?> watchContactByPhoneMatchedEnding(String number) {
     final query = _joinFullData(select(contactsTable));
-    query.where(contactPhonesTable.number.regexp('.*$number', caseSensitive: false));
+    query.where(contactPhonesTable.number.regexp('.*${_escapeRegExp(number)}', caseSensitive: false));
     query.orderBy(contactsTable.sourcePriorityOrder());
     query.limit(1);
 

--- a/packages/data/app_database/lib/src/daos/contacts_dao.dart
+++ b/packages/data/app_database/lib/src/daos/contacts_dao.dart
@@ -252,7 +252,7 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
                 contactsTable.aliasName,
                 contactPhonesTable.number,
                 contactEmailsTable.address,
-              ].map((c) => c.regexp('.*$searchBit.*', caseSensitive: false)).reduce((v, e) => v | e);
+              ].map((c) => c.regexp('.*${_escapeRegExp(searchBit)}.*', caseSensitive: false)).reduce((v, e) => v | e);
             })
             .reduce((v, e) => v | e),
       );
@@ -330,3 +330,11 @@ class ContactsDao extends DatabaseAccessor<AppDatabase> with _$ContactsDaoMixin 
         .go();
   }
 }
+
+final _regExpMetaChars = RegExp(r'[\\^$.|?*+()[\]{}]');
+
+/// Escapes regular-expression metacharacters so a raw, user-typed search string
+/// can be safely interpolated into the pattern passed to the SQL `REGEXP`
+/// operator (backed by Dart's [RegExp]). Without this, characters such as
+/// `( [ * +` would produce an invalid pattern and break the contacts search.
+String _escapeRegExp(String input) => input.replaceAllMapped(_regExpMetaChars, (match) => '\\${match[0]}');

--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -257,6 +257,23 @@ void main() {
     });
   });
 
+  group('getContactByPhoneMatchedEnding regex escaping', () {
+    // Both seed contacts share phone "1234567890".
+    test('a metacharacter-bearing number does not throw and matches nothing', () async {
+      // Unescaped, "+99" makes the pattern '.*+99' which Dart RegExp rejects.
+      final contact = await database.contactsDao.getContactByPhoneMatchedEnding('+99');
+
+      expect(contact, isNull);
+    });
+
+    test('a plain ending still matches', () async {
+      final contact = await database.contactsDao.getContactByPhoneMatchedEnding('7890');
+
+      expect(contact, isNotNull);
+      expect(contact!.phones.first.number, '1234567890');
+    });
+  });
+
   group('getContactByPhoneNumber', () {
     test('should return contact for existing phone number', () async {
       final fetchedContact = await database.contactsDao.getContactByPhoneNumber('1234567890');

--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -222,6 +222,41 @@ void main() {
     });
   });
 
+  group('watchAllContacts regex injection is neutralized', () {
+    // The seed data has two contacts ("Тарас Шевченко", "Шевченко Кобзар"),
+    // both sharing phone number "1234567890". A crafted search must be treated
+    // as a literal string, never as an active pattern that over-matches.
+
+    test('".*" does not act as a wildcard and matches nothing', () async {
+      // Unescaped, ".*" makes REGEXP match every row (full contact-list leak).
+      final contacts = await database.contactsDao.watchAllContacts(['.*']).first;
+
+      expect(contacts, isEmpty);
+    });
+
+    test('alternation "Тарас|Кобзар" is literal and matches nothing', () async {
+      // Unescaped, "|" would match either alternative and return both contacts.
+      final contacts = await database.contactsDao.watchAllContacts(['Тарас|Кобзар']).first;
+
+      expect(contacts, isEmpty);
+    });
+
+    test('"\\d" does not match digits in the phone number', () async {
+      // Unescaped, "\d" would match the "1234567890" phone of both contacts.
+      final contacts = await database.contactsDao.watchAllContacts([r'\d']).first;
+
+      expect(contacts, isEmpty);
+    });
+
+    test('".*" still works as a plain prefix on a real query', () async {
+      // Sanity: escaping the injection must not break normal substring search.
+      final contacts = await database.contactsDao.watchAllContacts(['Тарас']).first;
+
+      expect(contacts.length, 1);
+      expect(contacts.single.contact.lastName, 'Тарас Шевченко');
+    });
+  });
+
   group('getContactByPhoneNumber', () {
     test('should return contact for existing phone number', () async {
       final fetchedContact = await database.contactsDao.getContactByPhoneNumber('1234567890');

--- a/packages/data/app_database/test/contacts_dao_test.dart
+++ b/packages/data/app_database/test/contacts_dao_test.dart
@@ -120,6 +120,108 @@ void main() {
     });
   });
 
+  group('watchAllContacts search with regex metacharacters', () {
+    // Regression for the "contacts search invalid regex" bug: the raw search
+    // string is interpolated into the SQL REGEXP pattern, so metacharacters
+    // must be escaped or the query throws / matches the wrong rows.
+    setUp(() async {
+      await database.contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.local),
+          sourceId: Value('source-meta-1'),
+          firstName: Value(''),
+          lastName: Value('Acme (HQ)'),
+          aliasName: Value(''),
+        ),
+      );
+      await database.contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.local),
+          sourceId: Value('source-meta-2'),
+          firstName: Value(''),
+          lastName: Value('C++ Developer'),
+          aliasName: Value(''),
+        ),
+      );
+      await database.contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.local),
+          sourceId: Value('source-meta-3'),
+          firstName: Value(''),
+          lastName: Value('Cxx Developer'),
+          aliasName: Value(''),
+        ),
+      );
+    });
+
+    test('unbalanced "(" does not throw and matches literally', () async {
+      // Before the fix, RegExp('.*(.*') is an invalid pattern and the query throws.
+      final contacts = await database.contactsDao.watchAllContacts(['(']).first;
+
+      expect(contacts.length, 1);
+      expect(contacts.single.contact.lastName, 'Acme (HQ)');
+    });
+
+    test('"(HQ)" matches the literal parentheses', () async {
+      final contacts = await database.contactsDao.watchAllContacts(['(HQ)']).first;
+
+      expect(contacts.length, 1);
+      expect(contacts.single.contact.lastName, 'Acme (HQ)');
+    });
+
+    test('"+" is treated as a literal, not a quantifier', () async {
+      // Escaped "C\+\+" matches "C++ Developer" but not "Cxx Developer".
+      final contacts = await database.contactsDao.watchAllContacts(['C++']).first;
+
+      expect(contacts.length, 1);
+      expect(contacts.single.contact.lastName, 'C++ Developer');
+    });
+  });
+
+  group('watchAllContacts CJK and Thai search', () {
+    setUp(() async {
+      await database.contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.local),
+          sourceId: Value('source-cjk'),
+          firstName: Value(''),
+          lastName: Value('王小明'),
+          aliasName: Value(''),
+        ),
+      );
+      await database.contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.local),
+          sourceId: Value('source-thai'),
+          firstName: Value(''),
+          lastName: Value('สมชาย'),
+          aliasName: Value(''),
+        ),
+      );
+    });
+
+    test('matches a CJK (Chinese/Taiwanese) substring', () async {
+      final contacts = await database.contactsDao.watchAllContacts(['小明']).first;
+
+      expect(contacts.length, 1);
+      expect(contacts.single.contact.lastName, '王小明');
+    });
+
+    test('matches a full CJK name', () async {
+      final contacts = await database.contactsDao.watchAllContacts(['王小明']).first;
+
+      expect(contacts.length, 1);
+      expect(contacts.single.contact.lastName, '王小明');
+    });
+
+    test('matches a Thai substring', () async {
+      final contacts = await database.contactsDao.watchAllContacts(['ชาย']).first;
+
+      expect(contacts.length, 1);
+      expect(contacts.single.contact.lastName, 'สมชาย');
+    });
+  });
+
   group('getContactByPhoneNumber', () {
     test('should return contact for existing phone number', () async {
       final fetchedContact = await database.contactsDao.getContactByPhoneNumber('1234567890');


### PR DESCRIPTION
## Overview

The contacts search box could not accept CJK (Chinese/Taiwanese), Arabic, Thai or any
non-Latin/non-Cyrillic script. Typed characters were stripped on every keystroke, so IME
composition never committed.

## Root cause

`ClearedTextField` (the contacts search input) applied
`FilteringTextInputFormatter.deny(RegExp(symbolsRegex))`, where
`symbolsRegex = r'[^a-zA-Z\d\sЀ-ӿ]+'` -- an allowlist of only Latin, digits,
whitespace and Cyrillic. Everything else (CJK, Arabic, Thai, emoji, ...) fell into the
denied class and was removed.

That formatter was added (PR #629, "fix: contacts search invalid regex") only to keep
regex metacharacters out of the raw search string. The search text is interpolated
directly into the SQL `REGEXP` pattern in `ContactsDao.watchAllContacts`
(`'.*$searchBit.*'`), so a `(`, `[`, `*` etc. produced an invalid pattern and broke the
query. The input filter was a blunt fix that also blocked entire scripts.

## Change

- Escape regex metacharacters at the interpolation site in
  `ContactsDao.watchAllContacts` (new `_escapeRegExp` helper). This removes the actual
  cause of the invalid-pattern bug.
- Apply the same `_escapeRegExp` to the sibling `getContactByPhoneMatchedEnding` /
  `watchContactByPhoneMatchedEnding`, which interpolated a raw `number` into `'.*$number'`
  and would throw on a metacharacter-bearing argument (latent: the live caller passes a
  digits-only national number, so escaping is a no-op there but hardens future callers).
- Drop the now-unneeded `inputFormatters` from `ClearedTextField`, so any script can be
  typed into the search box.
- Remove the orphaned `symbolsRegex` constant (no other usages).

## Testing

- New `contacts_dao_test.dart` groups: regex metacharacters (`(`, `(HQ)`, `C++`),
  CJK/Thai input (`王小明`, `สมชาย`), regex-injection inputs (`.*`, `Тарас|Кобзар`, `\d`
  must match literally / nothing), and matched-ending escaping. Full DAO test suite green.
- `flutter analyze` clean on the changed files; `dart analyze` clean on `contacts_dao.dart`.
- Manual: typing CJK / Arabic into the contacts search now stays in the field; searching
  with `(`, `[`, `*` no longer breaks the query.
