### PR TITLE
feat: configurable UI language allowlist

### DIFF
--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -295,6 +295,10 @@
         "showVideoButtonAction": true
       }
     }
+  },
+  "localization": {
+    "__enabledLanguages": "Allowlist of language codes (ISO 639-1) exposed by the app. Intersected with the languages the app bundles, so only ones present in both are selectable and used for auto-resolution. Defaults to every bundled language; remove entries to restrict a build (e.g. keep only [\"en\"] to ship English). An empty list also means no restriction (all bundled languages).",
+    "enabledLanguages": ["en", "it", "th", "uk"]
   }
 }
 

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -198,7 +198,7 @@ class _AppState extends State<App> {
           return MaterialApp.router(
             locale: state.effectiveLocale,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
+            supportedLocales: featureAccess.localizationConfig.supportedLocales,
             // restorationScopeId: 'App', // TODO: temporary comment to prevent AppShell's AutoRouter placeholder blink - additional investigation necessary
             title: EnvironmentConfig.APP_NAME,
             themeMode: finalThemeMode,

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -650,10 +650,39 @@ abstract final class SupportedMapper {
 /// actually bundles ([AppLocalizations.supportedLocales]).
 abstract final class LocalizationMapper {
   static LocalizationConfig map(AppConfig appConfig) {
-    final supportedLocales = LocalizationConfig.resolve(
-      AppLocalizations.supportedLocales,
-      appConfig.localization.enabledLanguages,
-    );
+    final enabledLanguages = appConfig.localization.enabledLanguages;
+    final bundled = AppLocalizations.supportedLocales;
+
+    // Diagnose misconfiguration without throwing: a bad code in a per-brand
+    // config must never brick the app (this feeds MaterialApp.supportedLocales),
+    // so unknown codes are logged and ignored, and resolve() keeps at least the
+    // full bundled set.
+    if (enabledLanguages.isNotEmpty) {
+      final bundledCodes = bundled.map((l) => l.languageCode.toLowerCase()).toSet();
+      final unknown = enabledLanguages
+          .map((code) => code.trim().toLowerCase())
+          .where((code) => code.isNotEmpty && !bundledCodes.contains(code))
+          .toList(growable: false);
+      if (unknown.isNotEmpty) {
+        _logger.warning(
+          'localization.enabledLanguages contains code(s) not bundled in the app '
+          '$unknown; ignoring them. Bundled: ${bundledCodes.toList()}',
+        );
+      }
+    }
+
+    final supportedLocales = LocalizationConfig.resolve(bundled, enabledLanguages);
+    if (enabledLanguages.isNotEmpty && supportedLocales.length == bundled.length) {
+      final requested = enabledLanguages.map((c) => c.trim().toLowerCase()).where((c) => c.isNotEmpty).toSet();
+      final anyValid = bundled.any((l) => requested.contains(l.languageCode.toLowerCase()));
+      if (!anyValid) {
+        _logger.warning(
+          'localization.enabledLanguages ($enabledLanguages) matched no bundled '
+          'language; falling back to all bundled languages.',
+        );
+      }
+    }
+
     return LocalizationConfig(supportedLocales: supportedLocales);
   }
 }

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -8,6 +8,7 @@ import 'package:logging/logging.dart';
 
 import 'package:webtrit_phone/environment_config.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/l10n/app_localizations.g.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/utils/utils.dart';
@@ -60,6 +61,7 @@ class FeatureAccess extends Equatable {
     this.systemNotificationsConfig,
     this.sipPresenceConfig,
     this.supportedConfig,
+    this.localizationConfig,
     this.coreSupport,
     this.overrides,
     this.loggingConfig,
@@ -76,6 +78,10 @@ class FeatureAccess extends Equatable {
   final SystemNotificationsConfig systemNotificationsConfig;
   final SipPresenceConfig sipPresenceConfig;
   final LoggingConfig loggingConfig;
+
+  /// Locales the app exposes for selection and auto-resolution, resolved from
+  /// the app config's language allowlist intersected with the bundled locales.
+  final LocalizationConfig localizationConfig;
 
   /// Represents the set of features explicitly supported and configured within the application's static [AppConfig].
   /// This includes features like theme mode and video call capabilities as defined in the application's build-time configuration.
@@ -118,6 +124,7 @@ class FeatureAccess extends Equatable {
       final loggingConfig = LoggingMapper.map(appConfig, featureOverrides);
 
       final supportedConfig = SupportedMapper.map(appConfig.supported);
+      final localizationConfig = LocalizationMapper.map(appConfig);
 
       return FeatureAccess._(
         embeddedConfig,
@@ -131,6 +138,7 @@ class FeatureAccess extends Equatable {
         systemNotificationsConfig,
         sipPresenceConfig,
         supportedConfig,
+        localizationConfig,
         coreSupport,
         featureOverrides,
         loggingConfig,
@@ -155,6 +163,7 @@ class FeatureAccess extends Equatable {
     sipPresenceConfig,
     loggingConfig,
     supportedConfig,
+    localizationConfig,
     coreSupport,
     overrides,
   ];
@@ -633,6 +642,19 @@ abstract final class SupportedMapper {
     };
 
     return SupportedConfig(themeMode: configThemeMode, isVideoCallEnabled: videoCallFeature.enabled);
+  }
+}
+
+/// Mapper responsible for resolving the app's selectable locales from the
+/// language allowlist in [AppConfig], intersected with the locales the app
+/// actually bundles ([AppLocalizations.supportedLocales]).
+abstract final class LocalizationMapper {
+  static LocalizationConfig map(AppConfig appConfig) {
+    final supportedLocales = LocalizationConfig.resolve(
+      AppLocalizations.supportedLocales,
+      appConfig.localization.enabledLanguages,
+    );
+    return LocalizationConfig(supportedLocales: supportedLocales);
   }
 }
 

--- a/lib/features/call/services/background_isolate_callbacks.dart
+++ b/lib/features/call/services/background_isolate_callbacks.dart
@@ -1,10 +1,15 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
 
+import 'package:webtrit_appearance_theme/webtrit_appearance_theme.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
+import 'package:webtrit_phone/app/assets.gen.dart';
 import 'package:webtrit_phone/common/common.dart';
 import 'package:webtrit_phone/l10n/app_localizations.g.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -37,10 +42,26 @@ PushNotificationIsolateManager? _manager;
 // Resolves an arbitrary persisted locale to a locale that lookupAppLocalizations
 // can handle. Falls back to the first supported locale (EN) when the stored value
 // is the 'und' sentinel (no locale ever selected) or any other unsupported tag.
-Locale _effectiveLocale(Locale locale) {
-  if (AppLocalizations.supportedLocales.contains(locale)) return locale;
-  final byLanguage = AppLocalizations.supportedLocales.where((s) => s.languageCode == locale.languageCode).firstOrNull;
-  return byLanguage ?? AppLocalizations.supportedLocales.first;
+// [supported] is the app's configured locale allowlist (see [_resolveSupportedLocales]).
+Locale _effectiveLocale(Locale locale, List<Locale> supported) {
+  if (supported.contains(locale)) return locale;
+  final byLanguage = supported.where((s) => s.languageCode == locale.languageCode).firstOrNull;
+  return byLanguage ?? supported.first;
+}
+
+// The push isolate is a separate Dart VM without a FeatureAccess instance, so it
+// reads the language allowlist straight from the bundled app config asset and
+// intersects it with the locales the app ships. Any failure falls back to the
+// full bundled set, matching the pre-config behavior.
+Future<List<Locale>> _resolveSupportedLocales() async {
+  try {
+    final raw = await rootBundle.loadString(Assets.themes.appConfig);
+    final appConfig = AppConfig.fromJson(jsonDecode(raw) as Map<String, Object?>);
+    return LocalizationConfig.resolve(AppLocalizations.supportedLocales, appConfig.localization.enabledLanguages);
+  } catch (e, st) {
+    _logger.warning('Failed to resolve supported locales from app config; using all bundled locales', e, st);
+    return AppLocalizations.supportedLocales;
+  }
 }
 
 /// Returns the isolate-level manager, reusing an existing instance if already
@@ -60,7 +81,8 @@ Future<PushNotificationIsolateManager> _getOrInit(PushIsolateContext context) as
   WebtritSignalingService.setHandoffCallback(() => _manager?.notifyActivityTookOver());
   _logger.info('_getOrInit: module factory and handoff callback registered');
 
-  final l10n = lookupAppLocalizations(_effectiveLocale(context.locale));
+  final supportedLocales = await _resolveSupportedLocales();
+  final l10n = lookupAppLocalizations(_effectiveLocale(context.locale, supportedLocales));
   final localPushRepository = context.localPushRepository;
   _manager = PushNotificationIsolateManager(
     callLogsRepository: context.callLogsRepository,

--- a/lib/features/settings/features/language/view/language_screen.dart
+++ b/lib/features/settings/features/language/view/language_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/blocs/blocs.dart';
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
@@ -14,7 +15,8 @@ class LanguageScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final locales = [LocaleExtension.defaultNull, ...AppLocalizations.supportedLocales];
+    final supportedLocales = context.read<FeatureAccess>().localizationConfig.supportedLocales;
+    final locales = [LocaleExtension.defaultNull, ...supportedLocales];
 
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.settings_ListViewTileTitle_language), leading: const ExtBackButton()),

--- a/lib/models/feature_access/feature_access.dart
+++ b/lib/models/feature_access/feature_access.dart
@@ -8,6 +8,7 @@ export 'embedded_config.dart';
 export 'encoding_config.dart';
 export 'feature_flag.dart';
 export 'feature_overrides.dart';
+export 'localization_config.dart';
 export 'login_config.dart';
 export 'login_mode_action.dart';
 export 'messaging_config.dart';

--- a/lib/models/feature_access/localization_config.dart
+++ b/lib/models/feature_access/localization_config.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/widgets.dart';
+
+/// Resolved set of locales the app exposes for selection and auto-resolution.
+///
+/// Built by intersecting the locales the app actually bundles with the
+/// `enabledLanguages` allowlist from the app config. When the allowlist is empty
+/// (or would filter everything out) the full bundled set is kept, so builds that
+/// do not configure a restriction behave exactly as before.
+class LocalizationConfig extends Equatable {
+  const LocalizationConfig({required this.supportedLocales});
+
+  final List<Locale> supportedLocales;
+
+  /// Filters [all] by [enabledLanguages] (matched on `languageCode`), preserving
+  /// the order of [all]. An empty [enabledLanguages] - or a filter that removes
+  /// every locale - falls back to the full [all] list to avoid an app with no
+  /// selectable language.
+  static List<Locale> resolve(List<Locale> all, List<String> enabledLanguages) {
+    if (enabledLanguages.isEmpty) return all;
+    final wanted = enabledLanguages.map((code) => code.trim().toLowerCase()).where((code) => code.isNotEmpty).toSet();
+    if (wanted.isEmpty) return all;
+    final filtered = all.where((locale) => wanted.contains(locale.languageCode.toLowerCase())).toList(growable: false);
+    return filtered.isEmpty ? all : filtered;
+  }
+
+  @override
+  List<Object?> get props => [supportedLocales];
+}

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -18,6 +18,7 @@ class AppConfig with _$AppConfig {
     this.callConfig = const AppConfigCall(),
     this.contacts = const AppConfigContacts(),
     this.messaging = const AppConfigMessaging(),
+    this.localization = const AppConfigLocalization(),
 
     /// List of enabled features and global app configurations.
     this.supported = const [],
@@ -40,6 +41,9 @@ class AppConfig with _$AppConfig {
 
   @override
   final AppConfigMessaging messaging;
+
+  @override
+  final AppConfigLocalization localization;
 
   @override
   final List<SupportedFeature> supported;
@@ -667,4 +671,22 @@ class ChatContactInfo with _$ChatContactInfo {
   factory ChatContactInfo.fromJson(Map<String, Object?> json) => _$ChatContactInfoFromJson(json);
 
   Map<String, Object?> toJson() => _$ChatContactInfoToJson(this);
+}
+
+@freezed
+@JsonSerializable(explicitToJson: true)
+class AppConfigLocalization with _$AppConfigLocalization {
+  const AppConfigLocalization({this.enabledLanguages = const []});
+
+  /// Allowlist of language codes (ISO 639-1, e.g. 'en', 'it') the app exposes.
+  /// The app intersects this with the locales it actually bundles, so only
+  /// languages present in both are selectable and used for auto-resolution.
+  /// An empty list (the default) means "no restriction" - all bundled locales
+  /// are available, preserving the previous behavior.
+  @override
+  final List<String> enabledLanguages;
+
+  factory AppConfigLocalization.fromJson(Map<String, Object?> json) => _$AppConfigLocalizationFromJson(json);
+
+  Map<String, Object?> toJson() => _$AppConfigLocalizationToJson(this);
 }

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AppConfig {
 
- AppConfigLogin get loginConfig; AppConfigMain get mainConfig; AppConfigSettings get settingsConfig; AppConfigCall get callConfig; AppConfigContacts get contacts; AppConfigMessaging get messaging; List<SupportedFeature> get supported;
+ AppConfigLogin get loginConfig; AppConfigMain get mainConfig; AppConfigSettings get settingsConfig; AppConfigCall get callConfig; AppConfigContacts get contacts; AppConfigMessaging get messaging; AppConfigLocalization get localization; List<SupportedFeature> get supported;
 /// Create a copy of AppConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $AppConfigCopyWith<AppConfig> get copyWith => _$AppConfigCopyWithImpl<AppConfig>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfig&&(identical(other.loginConfig, loginConfig) || other.loginConfig == loginConfig)&&(identical(other.mainConfig, mainConfig) || other.mainConfig == mainConfig)&&(identical(other.settingsConfig, settingsConfig) || other.settingsConfig == settingsConfig)&&(identical(other.callConfig, callConfig) || other.callConfig == callConfig)&&(identical(other.contacts, contacts) || other.contacts == contacts)&&(identical(other.messaging, messaging) || other.messaging == messaging)&&const DeepCollectionEquality().equals(other.supported, supported));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfig&&(identical(other.loginConfig, loginConfig) || other.loginConfig == loginConfig)&&(identical(other.mainConfig, mainConfig) || other.mainConfig == mainConfig)&&(identical(other.settingsConfig, settingsConfig) || other.settingsConfig == settingsConfig)&&(identical(other.callConfig, callConfig) || other.callConfig == callConfig)&&(identical(other.contacts, contacts) || other.contacts == contacts)&&(identical(other.messaging, messaging) || other.messaging == messaging)&&(identical(other.localization, localization) || other.localization == localization)&&const DeepCollectionEquality().equals(other.supported, supported));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,loginConfig,mainConfig,settingsConfig,callConfig,contacts,messaging,const DeepCollectionEquality().hash(supported));
+int get hashCode => Object.hash(runtimeType,loginConfig,mainConfig,settingsConfig,callConfig,contacts,messaging,localization,const DeepCollectionEquality().hash(supported));
 
 @override
 String toString() {
-  return 'AppConfig(loginConfig: $loginConfig, mainConfig: $mainConfig, settingsConfig: $settingsConfig, callConfig: $callConfig, contacts: $contacts, messaging: $messaging, supported: $supported)';
+  return 'AppConfig(loginConfig: $loginConfig, mainConfig: $mainConfig, settingsConfig: $settingsConfig, callConfig: $callConfig, contacts: $contacts, messaging: $messaging, localization: $localization, supported: $supported)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $AppConfigCopyWith<$Res>  {
   factory $AppConfigCopyWith(AppConfig value, $Res Function(AppConfig) _then) = _$AppConfigCopyWithImpl;
 @useResult
 $Res call({
- AppConfigLogin loginConfig, AppConfigMain mainConfig, AppConfigSettings settingsConfig, AppConfigCall callConfig, AppConfigContacts contacts, AppConfigMessaging messaging, List<SupportedFeature> supported
+ AppConfigLogin loginConfig, AppConfigMain mainConfig, AppConfigSettings settingsConfig, AppConfigCall callConfig, AppConfigContacts contacts, AppConfigMessaging messaging, AppConfigLocalization localization, List<SupportedFeature> supported
 });
 
 
@@ -63,7 +63,7 @@ class _$AppConfigCopyWithImpl<$Res>
 
 /// Create a copy of AppConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? loginConfig = null,Object? mainConfig = null,Object? settingsConfig = null,Object? callConfig = null,Object? contacts = null,Object? messaging = null,Object? supported = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? loginConfig = null,Object? mainConfig = null,Object? settingsConfig = null,Object? callConfig = null,Object? contacts = null,Object? messaging = null,Object? localization = null,Object? supported = null,}) {
   return _then(AppConfig(
 loginConfig: null == loginConfig ? _self.loginConfig : loginConfig // ignore: cast_nullable_to_non_nullable
 as AppConfigLogin,mainConfig: null == mainConfig ? _self.mainConfig : mainConfig // ignore: cast_nullable_to_non_nullable
@@ -71,7 +71,8 @@ as AppConfigMain,settingsConfig: null == settingsConfig ? _self.settingsConfig :
 as AppConfigSettings,callConfig: null == callConfig ? _self.callConfig : callConfig // ignore: cast_nullable_to_non_nullable
 as AppConfigCall,contacts: null == contacts ? _self.contacts : contacts // ignore: cast_nullable_to_non_nullable
 as AppConfigContacts,messaging: null == messaging ? _self.messaging : messaging // ignore: cast_nullable_to_non_nullable
-as AppConfigMessaging,supported: null == supported ? _self.supported : supported // ignore: cast_nullable_to_non_nullable
+as AppConfigMessaging,localization: null == localization ? _self.localization : localization // ignore: cast_nullable_to_non_nullable
+as AppConfigLocalization,supported: null == supported ? _self.supported : supported // ignore: cast_nullable_to_non_nullable
 as List<SupportedFeature>,
   ));
 }
@@ -5084,6 +5085,192 @@ as bool,
 
 /// Adds pattern-matching-related methods to [ChatContactInfo].
 extension ChatContactInfoPatterns on ChatContactInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$AppConfigLocalization {
+
+ List<String> get enabledLanguages;
+/// Create a copy of AppConfigLocalization
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AppConfigLocalizationCopyWith<AppConfigLocalization> get copyWith => _$AppConfigLocalizationCopyWithImpl<AppConfigLocalization>(this as AppConfigLocalization, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigLocalization&&const DeepCollectionEquality().equals(other.enabledLanguages, enabledLanguages));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(enabledLanguages));
+
+@override
+String toString() {
+  return 'AppConfigLocalization(enabledLanguages: $enabledLanguages)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AppConfigLocalizationCopyWith<$Res>  {
+  factory $AppConfigLocalizationCopyWith(AppConfigLocalization value, $Res Function(AppConfigLocalization) _then) = _$AppConfigLocalizationCopyWithImpl;
+@useResult
+$Res call({
+ List<String> enabledLanguages
+});
+
+
+
+
+}
+/// @nodoc
+class _$AppConfigLocalizationCopyWithImpl<$Res>
+    implements $AppConfigLocalizationCopyWith<$Res> {
+  _$AppConfigLocalizationCopyWithImpl(this._self, this._then);
+
+  final AppConfigLocalization _self;
+  final $Res Function(AppConfigLocalization) _then;
+
+/// Create a copy of AppConfigLocalization
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabledLanguages = null,}) {
+  return _then(AppConfigLocalization(
+enabledLanguages: null == enabledLanguages ? _self.enabledLanguages : enabledLanguages // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AppConfigLocalization].
+extension AppConfigLocalizationPatterns on AppConfigLocalization {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
@@ -27,6 +27,11 @@ AppConfig _$AppConfigFromJson(Map<String, dynamic> json) => AppConfig(
   messaging: json['messaging'] == null
       ? const AppConfigMessaging()
       : AppConfigMessaging.fromJson(json['messaging'] as Map<String, dynamic>),
+  localization: json['localization'] == null
+      ? const AppConfigLocalization()
+      : AppConfigLocalization.fromJson(
+          json['localization'] as Map<String, dynamic>,
+        ),
   supported:
       (json['supported'] as List<dynamic>?)
           ?.map((e) => SupportedFeature.fromJson(e as Map<String, dynamic>))
@@ -41,6 +46,7 @@ Map<String, dynamic> _$AppConfigToJson(AppConfig instance) => <String, dynamic>{
   'callConfig': instance.callConfig.toJson(),
   'contacts': instance.contacts.toJson(),
   'messaging': instance.messaging.toJson(),
+  'localization': instance.localization.toJson(),
   'supported': instance.supported.map((e) => e.toJson()).toList(),
 };
 
@@ -544,6 +550,20 @@ ChatContactInfo _$ChatContactInfoFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$ChatContactInfoToJson(ChatContactInfo instance) =>
     <String, dynamic>{'showVideoButtonAction': instance.showVideoButtonAction};
+
+AppConfigLocalization _$AppConfigLocalizationFromJson(
+  Map<String, dynamic> json,
+) => AppConfigLocalization(
+  enabledLanguages:
+      (json['enabledLanguages'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+);
+
+Map<String, dynamic> _$AppConfigLocalizationToJson(
+  AppConfigLocalization instance,
+) => <String, dynamic>{'enabledLanguages': instance.enabledLanguages};
 
 FavoritesTabScheme _$FavoritesTabSchemeFromJson(Map<String, dynamic> json) =>
     FavoritesTabScheme(

--- a/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
+++ b/packages/webtrit_appearance_theme/test/app_config_main_parsing_test.dart
@@ -160,6 +160,28 @@ void main() {
     });
   });
 
+  group('AppConfig.localization parsing', () {
+    test('the bundled config lists every supported language by default', () async {
+      final json = await loadFixtureJson('../../assets/themes/app.config.json');
+      final config = AppConfig.fromJson(json);
+      expect(config.localization.enabledLanguages, ['en', 'it', 'th', 'uk']);
+    });
+
+    test('parses an explicit allowlist', () {
+      final config = AppConfig.fromJson({
+        'localization': {
+          'enabledLanguages': ['en', 'it'],
+        },
+      });
+      expect(config.localization.enabledLanguages, ['en', 'it']);
+    });
+
+    test('defaults to an empty allowlist when the block is absent', () {
+      final config = AppConfig.fromJson(const {});
+      expect(config.localization.enabledLanguages, isEmpty);
+    });
+  });
+
   group('RecentsTabScheme.supportsCallHistory parsing & useCdrs migration', () {
     bool recentsSupportsCallHistory(Map<String, Object?> extra) {
       final scheme = BottomMenuTabScheme.fromJson({

--- a/test/helpers/feature_access_factories.dart
+++ b/test/helpers/feature_access_factories.dart
@@ -98,6 +98,7 @@ AppConfig createMockAppConfig() {
   when(() => appConfig.callConfig).thenReturn(call);
   when(() => appConfig.contacts).thenReturn(contacts);
   when(() => appConfig.messaging).thenReturn(messaging);
+  when(() => appConfig.localization).thenReturn(const AppConfigLocalization());
   when(() => appConfig.supported).thenReturn([]);
 
   return appConfig;

--- a/test/models/feature_access/localization_config_test.dart
+++ b/test/models/feature_access/localization_config_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/models/models.dart';
+
+void main() {
+  const bundled = [Locale('en'), Locale('it'), Locale('th'), Locale('uk')];
+
+  List<String> codes(List<Locale> locales) => locales.map((l) => l.languageCode).toList();
+
+  group('LocalizationConfig.resolve', () {
+    test('empty allowlist keeps all bundled locales', () {
+      expect(LocalizationConfig.resolve(bundled, const []), bundled);
+    });
+
+    test('filters to the requested subset, preserving bundle order', () {
+      expect(codes(LocalizationConfig.resolve(bundled, const ['it', 'en'])), ['en', 'it']);
+    });
+
+    test('single valid code restricts to that language', () {
+      expect(codes(LocalizationConfig.resolve(bundled, const ['en'])), ['en']);
+    });
+
+    test('unknown codes are ignored, valid ones kept', () {
+      expect(codes(LocalizationConfig.resolve(bundled, const ['en', 'fr', 'de'])), ['en']);
+    });
+
+    test('all-unknown allowlist falls back to the full bundled set', () {
+      expect(LocalizationConfig.resolve(bundled, const ['fr', 'de']), bundled);
+    });
+
+    test('codes are matched case-insensitively and trimmed', () {
+      expect(codes(LocalizationConfig.resolve(bundled, const [' EN ', 'IT'])), ['en', 'it']);
+    });
+
+    test('blank/whitespace-only codes are ignored (treated as no restriction)', () {
+      expect(LocalizationConfig.resolve(bundled, const ['   ', '']), bundled);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Adds per-brand control over which UI languages the app exposes, driven by the configurator-owned `app.config.json` (no dart-define, no rebuild of the config layer).

New field `AppConfig.localization.enabledLanguages` (in `webtrit_appearance_theme`). The app intersects the allowlist with the locales it actually bundles (`en`, `it`, `th`, `uk`); an empty list - or a filter that removes everything - keeps all languages, so existing configs behave exactly as before.

## Changes

- `webtrit_appearance_theme`: new `AppConfigLocalization` DTO + `localization` field on `AppConfig` (+ regen, tests).
- `LocalizationConfig` (`lib/models/feature_access/`) with `resolve(all, enabledLanguages)`; exposed via `FeatureAccess.localizationConfig` (`LocalizationMapper`).
- Consumers switched off `AppLocalizations.supportedLocales`:
  - `MaterialApp.supportedLocales` (`app/view/app.dart`),
  - the settings language picker (`language_screen.dart`),
  - the background push isolate (`background_isolate_callbacks.dart`), which has no `FeatureAccess` and so reads `app.config.json` from the bundle directly, applying the same resolve (fallback to all bundled locales on any failure).
- `assets/themes/app.config.json`: `localization` block listing every bundled language by default; remove entries to restrict a build (e.g. `["en"]` = English only).

## Notes

Configurator UI support ships in a companion PR (`webtrit_phone_configurator`).

## Testing

- `webtrit_appearance_theme`: parsing tests pass.
- `flutter analyze lib`: clean.
- `flutter test`: green (added stub for the new `AppConfig.localization` getter in the feature-access test helper).