### PR TITLE
fix: exclude patrol (XCTest) from iOS release builds [release/1.16.0]

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,6 +13,10 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "build/**"
+    # patrol is not a committed dependency (see pubspec.yaml), so the integration
+    # tests that import it are excluded from analysis. They are provisioned and run
+    # only via tool/scripts/* (which add patrol first).
+    - "patrol_test/**"
   errors:
     deprecated_subclass: ignore
     # TODO: remove this suppression and refactor lib/extensions/string.dart

--- a/docs/integration_test_commands.md
+++ b/docs/integration_test_commands.md
@@ -1,5 +1,22 @@
 # Integration Test Commands
 
+## Prerequisite: provision patrol
+
+`patrol` is intentionally NOT a committed dependency. It weak-links `XCTest`, and
+Flutter does not strip dev dependencies from iOS release builds
+([flutter/flutter#163874](https://github.com/flutter/flutter/issues/163874)), so
+shipping it makes the app reference `XCTest` and Apple rejects it (guideline 2.5.1).
+
+Add it before running the commands below (the `tool/scripts/*` helpers do this
+automatically):
+
+```bash
+flutter pub add 'dev:patrol:^4.6.1'
+```
+
+Do not commit the resulting `pubspec.yaml` / `pubspec.lock` change; restore them
+when done (`git checkout pubspec.yaml pubspec.lock`).
+
 ## Run integration tests in dev mode
 
 ```bash

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,10 @@
 PODS:
-  - CocoaAsyncSocket (7.6.5)
   - device_region (0.0.1):
     - Flutter
   - Flutter (1.0.0)
   - flutter_webrtc (1.4.0):
     - Flutter
     - WebRTC-SDK (= 144.7559.04)
-  - patrol (0.0.1):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flutter
-    - FlutterMacOS
   - WebRTC-SDK (144.7559.04)
   - workmanager_apple (0.0.1):
     - Flutter
@@ -18,12 +13,10 @@ DEPENDENCIES:
   - device_region (from `.symlinks/plugins/device_region/ios`)
   - Flutter (from `Flutter`)
   - flutter_webrtc (from `.symlinks/plugins/flutter_webrtc/ios`)
-  - patrol (from `.symlinks/plugins/patrol/darwin`)
   - workmanager_apple (from `.symlinks/plugins/workmanager_apple/ios`)
 
 SPEC REPOS:
   trunk:
-    - CocoaAsyncSocket
     - WebRTC-SDK
 
 EXTERNAL SOURCES:
@@ -33,17 +26,13 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_webrtc:
     :path: ".symlinks/plugins/flutter_webrtc/ios"
-  patrol:
-    :path: ".symlinks/plugins/patrol/darwin"
   workmanager_apple:
     :path: ".symlinks/plugins/workmanager_apple/ios"
 
 SPEC CHECKSUMS:
-  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   device_region: ba5fcd31baab2323f50b73a33850490df4d082a8
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_webrtc: 3cea548ace6c8cdefc98a898fe0c177d680080b7
-  patrol: cea8074f183a2a4232d0ebd10569ae05149ada42
   WebRTC-SDK: ac5965a3cc2c258973466e3b1739ab0308bab0d0
   workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -409,14 +409,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.1"
-  dispose_scope:
-    dependency: transitive
-    description:
-      name: dispose_scope
-      sha256: "48ec38ca2631c53c4f8fa96b294c801e55c335db5e3fb9f82cede150cfe5a2af"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   dlibphonenumber:
     dependency: "direct main"
     description:
@@ -1343,30 +1335,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  patrol:
-    dependency: "direct dev"
-    description:
-      name: patrol
-      sha256: f43fda9425e90c0e69d2dac9e495e3a3036a22a550466365b4720fa4dd53d6ae
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.6.1"
-  patrol_finders:
-    dependency: transitive
-    description:
-      name: patrol_finders
-      sha256: "915da1e63fe7fd024418ab30b2394b1c8d6e812ce25be7d0b11634202521f0a9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.0"
-  patrol_log:
-    dependency: transitive
-    description:
-      name: patrol_log
-      sha256: "16ab747b28621640115d9493138eae82a1d410a613857cb0caf9000ce62fc546"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.0"
   permission_handler:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.0+2
+app_version: 1.16.0+3
 
 environment:
   sdk: ^3.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -178,7 +178,11 @@ dev_dependencies:
       path: l10n_mapper_generator
   melos: ^7.8.0
   mocktail: ^1.0.5
-  patrol: ^4.6.1
+  # patrol is provisioned only for integration-test builds (see tool/scripts/*),
+  # NOT committed here: patrol.podspec weak-links XCTest and Flutter does not strip
+  # dev dependencies from iOS release builds (flutter/flutter#163874), so shipping it
+  # makes the app reference XCTest and Apple rejects it (guideline 2.5.1). Provision
+  # for tests with: flutter pub add dev:patrol:^4.6.1
 
 flutter:
   generate: true

--- a/tool/scripts/patrol_e2e_run_local_android.sh
+++ b/tool/scripts/patrol_e2e_run_local_android.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# patrol is not a committed dependency (it links XCTest into the app, which Apple
+# rejects). Provision it just for this test run.
+grep -qE '^  patrol:' pubspec.yaml || flutter pub add 'dev:patrol:^4.6.1'
+
 target_file="${1:-patrol_test/just_run_test.dart}"
 
 dart run packages/pjsua_companion/bin/server.dart &

--- a/tool/scripts/testlab_assemble_android.sh
+++ b/tool/scripts/testlab_assemble_android.sh
@@ -1,3 +1,7 @@
+# patrol is not a committed dependency (it links XCTest into the app, which Apple
+# rejects). Provision it just for this test build.
+grep -qE '^  patrol:' pubspec.yaml || flutter pub add 'dev:patrol:^4.6.1'
+
 flutter clean
 
 testfile=$1

--- a/tool/scripts/testlab_assemble_ios.sh
+++ b/tool/scripts/testlab_assemble_ios.sh
@@ -1,3 +1,7 @@
+# patrol is not a committed dependency (it links XCTest into the app, which Apple
+# rejects). Provision it just for this test build.
+grep -qE '^  patrol:' pubspec.yaml || flutter pub add 'dev:patrol:^4.6.1'
+
 flutter clean
 
 testfile=$1


### PR DESCRIPTION
## Overview

Cherry-pick of #1455 onto `release/1.16.0` plus a build-iteration bump to `app_version 1.16.0+3`.

patrol is a dev_dependency, but Flutter does not strip dev dependencies from iOS release builds (flutter/flutter#163874), so the patrol pod - which weak-links XCTest via its podspec - was linked into the shipped app. Apple rejects any app that references XCTest (guideline 2.5.1), which blocked the App Store submission.

Removes patrol from the committed pubspec so it is absent from release builds, excludes patrol_test/ from analysis, and has the integration-test entry points (tool/scripts/*) provision patrol on demand. Verified on a clean release build: otool -L Runner no longer links XCTest and patrol.framework is no longer embedded. Shared base, so it covers all white-label apps.

WT-1671

DRAFT until the ~2-week QA window closes.