### PR TITLE
feat: play call-waiting tone on second incoming call during active call

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -144,6 +144,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   late final HandshakeProcessor _handshakeProcessor;
   final ConnectivityService _connectivityService;
 
+  // Edge guard for the iOS call-waiting tone (play/stop once per transition).
+  bool _callWaitingTonePlaying = false;
+
   CallBloc({
     required this.callLogsRepository,
     required void Function(String callId, String callerName) onMissedCall,
@@ -304,6 +307,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   @override
   void onChange(Change<CallState> change) {
     super.onChange(change);
+
+    _syncCallWaitingTone(change.nextState);
 
     // Re-notify the reconnect controller when the call-active state flips while
     // the app is backgrounded - covers the gap the lifecycle handler misses
@@ -4410,6 +4415,28 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       hungUpTime: activeCall.hungUpTime,
     );
     callLogsRepository.add(call);
+  }
+
+  // Soft beep over the earpiece when a second call rings in while another call is
+  // connected. The side effect goes through CallMediaManager; playback lives in the
+  // callkeep plugin on both platforms.
+  void _syncCallWaitingTone(CallState state) {
+    const ringingIncoming = {CallProcessingStatus.incomingFromPush, CallProcessingStatus.incomingFromOffer};
+    final hasConnected = state.activeCalls.any((c) => c.processingStatus == CallProcessingStatus.connected);
+    final hasRingingIncoming = state.activeCalls.any((c) => ringingIncoming.contains(c.processingStatus));
+    final shouldPlay = hasConnected && hasRingingIncoming;
+
+    if (shouldPlay && !_callWaitingTonePlaying) {
+      _callWaitingTonePlaying = true;
+      _mediaManager.playCallWaitingTone().catchError(
+        (Object e, StackTrace s) => _logger.warning('playCallWaitingTone failed', e, s),
+      );
+    } else if (!shouldPlay && _callWaitingTonePlaying) {
+      _callWaitingTonePlaying = false;
+      _mediaManager.stopCallWaitingTone().catchError(
+        (Object e, StackTrace s) => _logger.warning('stopCallWaitingTone failed', e, s),
+      );
+    }
   }
 
   Future<void> _releaseLocalStream(MediaStream? stream) async {

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -144,8 +144,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   late final HandshakeProcessor _handshakeProcessor;
   final ConnectivityService _connectivityService;
 
-  final _callkeepSound = WebtritCallkeepSound();
-
   CallBloc({
     required this.callLogsRepository,
     required void Function(String callId, String callerName) onMissedCall,
@@ -281,7 +279,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     await _signalingSubscription.cancel();
 
-    await _stopRingbackSound();
+    await _mediaManager.stopRingbackSound();
 
     for (final activeCall in state.activeCalls) {
       await _releaseLocalStream(activeCall.localStream);
@@ -721,7 +719,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _iceRestartDebounce.cancel(event.callId);
     _slowlinkDebounce.cancel(event.callId);
     _slowlinkHits.remove(event.callId);
-    await _stopRingbackSound();
+    await _mediaManager.stopRingbackSound();
 
     try {
       emit(
@@ -1121,7 +1119,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   // no early media - play ringtone
   Future<void> __onCallSignalingEventRinging(_CallSignalingEventRinging event, Emitter<CallState> emit) async {
-    await _playRingbackSound();
+    await _mediaManager.playRingbackSound();
 
     emit(
       state.copyWithMappedActiveCall(event.callId, (call) {
@@ -1132,7 +1130,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   // early media - set specified session description
   Future<void> __onCallSignalingEventProgress(_CallSignalingEventProgress event, Emitter<CallState> emit) async {
-    await _stopRingbackSound();
+    await _mediaManager.stopRingbackSound();
 
     final jsep = event.jsep;
     if (jsep != null) {
@@ -2007,7 +2005,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // Handles exceptions during the outgoing call perform event, sends a notification, stops the ringtone, and completes the peer connection with an error.
       // The specific error "Error setting ICE locally" indicates an issue with ICE (Interactive Connectivity Establishment) negotiation in the WebRTC signaling process.
       callErrorReporter.handle(e, stackTrace, '__onMutationPerformStart error:');
-      await _stopRingbackSound();
+      await _mediaManager.stopRingbackSound();
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
       add(_ResetStateEvent.completeCall(event.callId));
     }
@@ -2217,7 +2215,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   Future<void> __onMutationPerformEnd(_CallMutationEventPerformEnd event, Emitter<CallState> emit) async {
     try {
-      await _stopRingbackSound();
+      await _mediaManager.stopRingbackSound();
 
       emit(
         state.copyWithMappedActiveCall(event.callId, (activeCall) {
@@ -2893,7 +2891,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       call = call.copyWith(processingStatus: CallProcessingStatus.connected, acceptedTime: clock.now());
 
       if (outgoing) {
-        await _stopRingbackSound();
+        await _mediaManager.stopRingbackSound();
         await callkeep.reportConnectedOutgoingCall(event.callId);
       }
     } else {
@@ -2943,7 +2941,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> __onMutationSignalingHangup(_CallMutationEventSignalingHangup event, Emitter<CallState> emit) async {
-    _stopRingbackSound().ignore();
+    _mediaManager.stopRingbackSound().ignore();
     _signalingModule.cancelRequestsByCallId(event.callId);
 
     ActiveCall? call = state.retrieveActiveCall(event.callId);
@@ -4413,10 +4411,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
     callLogsRepository.add(call);
   }
-
-  Future<void> _playRingbackSound() => _callkeepSound.playRingbackSound();
-
-  Future<void> _stopRingbackSound() => _callkeepSound.stopRingbackSound();
 
   Future<void> _releaseLocalStream(MediaStream? stream) async {
     if (stream == null) return;

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -33,6 +33,7 @@ class CallMediaManager {
   }
 
   final Callkeep _callkeep;
+  final _callkeepSound = WebtritCallkeepSound();
 
   // Audio device priority for voice calls on Android.
   // AudioSwitch selects the first available device from this list on activate().
@@ -66,6 +67,17 @@ class CallMediaManager {
   // ---------------------------------------------------------------------------
   // Call session lifecycle
   // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // Call sounds (callkeep sound surface)
+  // ---------------------------------------------------------------------------
+
+  /// Plays the ringback sound while an outgoing call is progressing
+  /// (e.g. on SIP 180 Ringing).
+  Future<void> playRingbackSound() => _callkeepSound.playRingbackSound();
+
+  /// Stops the ringback sound once the outgoing call is connected or ended.
+  Future<void> stopRingbackSound() => _callkeepSound.stopRingbackSound();
 
   /// Clears the Android communication device after the last call ends (N → 0).
   ///

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -79,6 +79,20 @@ class CallMediaManager {
   /// Stops the ringback sound once the outgoing call is connected or ended.
   Future<void> stopRingbackSound() => _callkeepSound.stopRingbackSound();
 
+  /// Plays a soft, recurrent beep over the active call audio to signal a second
+  /// incoming call. Playback is owned by webtrit_callkeep on both platforms; the
+  /// Android connection service only suppresses the full ringtone in this scenario.
+  Future<void> playCallWaitingTone() async {
+    if (kIsWeb) return; // the tone has no web implementation
+    await _callkeepSound.playCallWaitingTone();
+  }
+
+  /// Stops the call-waiting tone (second call answered, declined or ended).
+  Future<void> stopCallWaitingTone() async {
+    if (kIsWeb) return; // the tone has no web implementation
+    await _callkeepSound.stopCallWaitingTone();
+  }
+
   /// Clears the Android communication device after the last call ends (N → 0).
   ///
   /// Without this, Bluetooth stays in SCO (call profile, mono/low-quality) instead


### PR DESCRIPTION
## Overview

WT-1415. When a second call rings in while another call is connected, the user gets a soft call-waiting beep over the active call audio (previously: silence on iOS; on Android the connection service played it on its own).

`CallBloc` gains `_syncCallWaitingTone`, driven from `onChange`: it detects the connected + ringing-incoming combination over `activeCalls` (`incomingFromPush`/`incomingFromOffer`) and edge-triggers the tone - play when the state appears, stop when it goes away (second call answered, declined or ended, or the active call ends). The side effect goes through `CallMediaManager` (the single owner of the callkeep/webrtc audio surface), which delegates to the callkeep sound API `playCallWaitingTone`/`stopCallWaitingTone` on both platforms.

Stacked on WebTrit/webtrit_phone#1465 (routes the existing ringback through `CallMediaManager`); this PR is tone-only.

## Testing

- iOS device: beep in the earpiece over the active call while the second call rings; silent with a single call; stops on answer/decline/hangup; the remote side does not hear it.
- `flutter analyze` + full test suite green (pre-push).

## Dependencies

Merge order: WebTrit/flutter-webrtc#12 -> WebTrit/webtrit_callkeep#340 -> WebTrit/webtrit_phone#1465 -> this PR.
The flutter_webrtc pin (`main_ext_rebase_06.05.26`) is unchanged - it picks up the fork changes once #12 merges into that branch; callkeep is consumed via the path dependency per the develop convention.