### PR TITLE
fix: reword the standalone calling-mode caption to the actual limitations

### DIFF
--- a/lib/features/settings/features/diagnostic/widgets/diagnostic_calling_mode_item.dart
+++ b/lib/features/settings/features/diagnostic/widgets/diagnostic_calling_mode_item.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 
 /// Diagnostic row shown only when the device runs in the limited standalone
-/// call mode (no Android Telecom). Warns the user that incoming-call delivery
-/// may be delayed; tapping opens the details sheet.
+/// call mode (no Android Telecom). Warns the user that ringing presentation
+/// and headset selection may be limited; tapping opens the details sheet.
 class DiagnosticCallingModeItem extends StatelessWidget {
   const DiagnosticCallingModeItem({super.key, required this.onTap});
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1099,7 +1099,7 @@ abstract class AppLocalizations {
   /// No description provided for @diagnostic_callingMode_standalone_caption.
   ///
   /// In en, this message translates to:
-  /// **'Standalone - delivery may be delayed'**
+  /// **'Standalone - ringing and headset selection may be limited'**
   String get diagnostic_callingMode_standalone_caption;
 
   /// No description provided for @diagnostic_callingMode_standalone_description.

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -583,7 +583,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diagnostic_callingMode_standalone_title => 'Limited call mode';
 
   @override
-  String get diagnostic_callingMode_standalone_caption => 'Standalone - delivery may be delayed';
+  String get diagnostic_callingMode_standalone_caption => 'Standalone - ringing and headset selection may be limited';
 
   @override
   String get diagnostic_callingMode_standalone_description =>

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -589,7 +589,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diagnostic_callingMode_standalone_title => 'Modalità chiamate limitata';
 
   @override
-  String get diagnostic_callingMode_standalone_caption => 'Standalone - possibile ritardo nella consegna';
+  String get diagnostic_callingMode_standalone_caption =>
+      'Standalone - squillo e selezione dell\'auricolare possono essere limitati';
 
   @override
   String get diagnostic_callingMode_standalone_description =>

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -580,7 +580,8 @@ class AppLocalizationsTh extends AppLocalizations {
   String get diagnostic_callingMode_standalone_title => 'โหมดโทรแบบจำกัด';
 
   @override
-  String get diagnostic_callingMode_standalone_caption => 'แบบสแตนด์อโลน - การส่งอาจล่าช้า';
+  String get diagnostic_callingMode_standalone_caption =>
+      'แบบสแตนด์อโลน - การแจ้งสายเรียกเข้าและการเลือกหูฟังอาจถูกจำกัด';
 
   @override
   String get diagnostic_callingMode_standalone_description =>

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -594,7 +594,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get diagnostic_callingMode_standalone_title => 'Обмежений режим дзвінків';
 
   @override
-  String get diagnostic_callingMode_standalone_caption => 'Standalone — можлива затримка доставки';
+  String get diagnostic_callingMode_standalone_caption =>
+      'Standalone — можливі обмеження сповіщення про дзвінок і вибору гарнітури';
 
   @override
   String get diagnostic_callingMode_standalone_description =>

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -500,7 +500,7 @@
   "@diagnostic_callingMode_tile_title": {},
   "diagnostic_callingMode_standalone_title": "Limited call mode",
   "@diagnostic_callingMode_standalone_title": {},
-  "diagnostic_callingMode_standalone_caption": "Standalone - delivery may be delayed",
+  "diagnostic_callingMode_standalone_caption": "Standalone - ringing and headset selection may be limited",
   "@diagnostic_callingMode_standalone_caption": {},
   "diagnostic_callingMode_standalone_description": "This device does not support the system call framework (Telecom), so incoming calls use a limited background service. Calls may be delayed or missed when the system restricts background apps. Bluetooth and wired headset selection is not available in this mode.",
   "@diagnostic_callingMode_standalone_description": {},

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -500,7 +500,7 @@
   "@diagnostic_callingMode_tile_title": {},
   "diagnostic_callingMode_standalone_title": "Modalità chiamate limitata",
   "@diagnostic_callingMode_standalone_title": {},
-  "diagnostic_callingMode_standalone_caption": "Standalone - possibile ritardo nella consegna",
+  "diagnostic_callingMode_standalone_caption": "Standalone - squillo e selezione dell'auricolare possono essere limitati",
   "@diagnostic_callingMode_standalone_caption": {},
   "diagnostic_callingMode_standalone_description": "Questo dispositivo non supporta il framework di chiamata di sistema (Telecom), quindi le chiamate in arrivo usano un servizio in background limitato. Le chiamate possono essere ritardate o perse quando il sistema limita le app in background. In questa modalità non è disponibile la selezione dell'auricolare Bluetooth o cablato.",
   "@diagnostic_callingMode_standalone_description": {},

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -500,7 +500,7 @@
   "@diagnostic_callingMode_tile_title": {},
   "diagnostic_callingMode_standalone_title": "โหมดโทรแบบจำกัด",
   "@diagnostic_callingMode_standalone_title": {},
-  "diagnostic_callingMode_standalone_caption": "แบบสแตนด์อโลน - การส่งอาจล่าช้า",
+  "diagnostic_callingMode_standalone_caption": "แบบสแตนด์อโลน - การแจ้งสายเรียกเข้าและการเลือกหูฟังอาจถูกจำกัด",
   "@diagnostic_callingMode_standalone_caption": {},
   "diagnostic_callingMode_standalone_description": "อุปกรณ์นี้ไม่รองรับเฟรมเวิร์กการโทรของระบบ (Telecom) ดังนั้นสายเรียกเข้าจะใช้บริการเบื้องหลังแบบจำกัด สายอาจล่าช้าหรือพลาดเมื่อระบบจำกัดแอปที่ทำงานเบื้องหลัง การเลือกหูฟังบลูทูธหรือแบบมีสายไม่สามารถใช้งานได้ในโหมดนี้",
   "@diagnostic_callingMode_standalone_description": {},

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -500,7 +500,7 @@
   "@diagnostic_callingMode_tile_title": {},
   "diagnostic_callingMode_standalone_title": "Обмежений режим дзвінків",
   "@diagnostic_callingMode_standalone_title": {},
-  "diagnostic_callingMode_standalone_caption": "Standalone — можлива затримка доставки",
+  "diagnostic_callingMode_standalone_caption": "Standalone — можливі обмеження сповіщення про дзвінок і вибору гарнітури",
   "@diagnostic_callingMode_standalone_caption": {},
   "diagnostic_callingMode_standalone_description": "Цей пристрій не підтримує системний механізм дзвінків (Telecom), тому вхідні дзвінки використовують обмежену фонову службу. Дзвінки можуть затримуватися або не надходити, коли система обмежує фонові застосунки. Вибір Bluetooth- чи дротової гарнітури в цьому режимі недоступний.",
   "@diagnostic_callingMode_standalone_description": {},


### PR DESCRIPTION
## Overview

The standalone calling-mode row on the diagnostic screen captioned the mode with "Standalone - delivery may be delayed". Call delivery is a high-priority push property and its timing does not depend on the calling mode, so the claim was misleading. The caption now names the limitations the user can actually notice in this mode: ringing presentation (the incoming call may surface as a notification instead of the full-screen ring, depending on notification and full-screen-intent permissions) and headset selection (Bluetooth and wired headset selection is unavailable).

- `diagnostic_callingMode_standalone_caption` reworded in en, uk, it, th + regenerated localizations.
- The widget doc comment repeated the same delivery-delay claim and is updated to match.

Follow-up to #1466, which fixed the description text of the same diagnostic row.

## Localizely

The key is already synced to Localizely for all 4 locales via `tool/scripts/localizely_push_key.sh diagnostic_callingMode_standalone_caption` (per-key overwrite), and a round-trip pull confirmed the new texts - a later `l10n:fetch` will not revert this change.