### PR TITLE
fix: deliver patched callkeep 1.3.0+1 and reword the standalone caption [release/1.16.0]

### DIFF
--- a/lib/features/settings/features/diagnostic/widgets/diagnostic_calling_mode_item.dart
+++ b/lib/features/settings/features/diagnostic/widgets/diagnostic_calling_mode_item.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 
 /// Diagnostic row shown only when the device runs in the limited standalone
-/// call mode (no Android Telecom). Warns the user that incoming-call delivery
-/// may be delayed; tapping opens the details sheet.
+/// call mode (no Android Telecom). Warns the user that ringing presentation
+/// and headset selection may be limited; tapping opens the details sheet.
 class DiagnosticCallingModeItem extends StatelessWidget {
   const DiagnosticCallingModeItem({super.key, required this.onTap});
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1098,7 +1098,7 @@ abstract class AppLocalizations {
   /// No description provided for @diagnostic_callingMode_standalone_caption.
   ///
   /// In en, this message translates to:
-  /// **'Standalone - delivery may be delayed'**
+  /// **'Standalone - ringing and headset selection may be limited'**
   String get diagnostic_callingMode_standalone_caption;
 
   /// No description provided for @diagnostic_callingMode_standalone_description.

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -583,7 +583,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diagnostic_callingMode_standalone_title => 'Limited call mode';
 
   @override
-  String get diagnostic_callingMode_standalone_caption => 'Standalone - delivery may be delayed';
+  String get diagnostic_callingMode_standalone_caption => 'Standalone - ringing and headset selection may be limited';
 
   @override
   String get diagnostic_callingMode_standalone_description =>

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -589,7 +589,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diagnostic_callingMode_standalone_title => 'Modalità chiamate limitata';
 
   @override
-  String get diagnostic_callingMode_standalone_caption => 'Standalone - possibile ritardo nella consegna';
+  String get diagnostic_callingMode_standalone_caption =>
+      'Standalone - squillo e selezione dell\'auricolare possono essere limitati';
 
   @override
   String get diagnostic_callingMode_standalone_description =>

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -594,7 +594,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get diagnostic_callingMode_standalone_title => 'Обмежений режим дзвінків';
 
   @override
-  String get diagnostic_callingMode_standalone_caption => 'Standalone — можлива затримка доставки';
+  String get diagnostic_callingMode_standalone_caption =>
+      'Standalone — можливі обмеження сповіщення про дзвінок і вибору гарнітури';
 
   @override
   String get diagnostic_callingMode_standalone_description =>

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -500,7 +500,7 @@
   "@diagnostic_callingMode_tile_title": {},
   "diagnostic_callingMode_standalone_title": "Limited call mode",
   "@diagnostic_callingMode_standalone_title": {},
-  "diagnostic_callingMode_standalone_caption": "Standalone - delivery may be delayed",
+  "diagnostic_callingMode_standalone_caption": "Standalone - ringing and headset selection may be limited",
   "@diagnostic_callingMode_standalone_caption": {},
   "diagnostic_callingMode_standalone_description": "This device does not support the system call framework (Telecom), so incoming calls use a limited background service. Calls may be delayed or missed when the system restricts background apps. Bluetooth and wired headset selection is not available in this mode.",
   "@diagnostic_callingMode_standalone_description": {},

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -500,7 +500,7 @@
   "@diagnostic_callingMode_tile_title": {},
   "diagnostic_callingMode_standalone_title": "Modalità chiamate limitata",
   "@diagnostic_callingMode_standalone_title": {},
-  "diagnostic_callingMode_standalone_caption": "Standalone - possibile ritardo nella consegna",
+  "diagnostic_callingMode_standalone_caption": "Standalone - squillo e selezione dell'auricolare possono essere limitati",
   "@diagnostic_callingMode_standalone_caption": {},
   "diagnostic_callingMode_standalone_description": "Questo dispositivo non supporta il framework di chiamata di sistema (Telecom), quindi le chiamate in arrivo usano un servizio in background limitato. Le chiamate possono essere ritardate o perse quando il sistema limita le app in background. In questa modalità non è disponibile la selezione dell'auricolare Bluetooth o cablato.",
   "@diagnostic_callingMode_standalone_description": {},

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -500,7 +500,7 @@
   "@diagnostic_callingMode_tile_title": {},
   "diagnostic_callingMode_standalone_title": "Обмежений режим дзвінків",
   "@diagnostic_callingMode_standalone_title": {},
-  "diagnostic_callingMode_standalone_caption": "Standalone — можлива затримка доставки",
+  "diagnostic_callingMode_standalone_caption": "Standalone — можливі обмеження сповіщення про дзвінок і вибору гарнітури",
   "@diagnostic_callingMode_standalone_caption": {},
   "diagnostic_callingMode_standalone_description": "Цей пристрій не підтримує системний механізм дзвінків (Telecom), тому вхідні дзвінки використовують обмежену фонову службу. Дзвінки можуть затримуватися або не надходити, коли система обмежує фонові застосунки. Вибір Bluetooth- чи дротової гарнітури в цьому режимі недоступний.",
   "@diagnostic_callingMode_standalone_description": {},

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2002,16 +2002,16 @@ packages:
     description:
       path: webtrit_callkeep
       ref: "1.3.0"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
-    version: "1.3.0+0"
+    version: "1.3.0+1"
   webtrit_callkeep_android:
     dependency: transitive
     description:
       path: webtrit_callkeep_android
-      ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2019,8 +2019,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_ios
-      ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2028,8 +2028,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_linux
-      ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"
@@ -2037,8 +2037,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_macos
-      ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"
@@ -2046,8 +2046,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_platform_interface
-      ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2055,8 +2055,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_web
-      ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2064,8 +2064,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_windows
-      ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
-      resolved-ref: "11c1b97be8259267689c90e5cd0953a0c0b8d564"
+      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.0+4
+app_version: 1.16.0+5
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Overview

Combined release patch (replaces closed #1468):

- Re-pin `webtrit_callkeep` in `pubspec.lock` to the patched `1.3.0+1` release tip `b7006b6` (standalone fixes webtrit_callkeep#341 + webtrit_callkeep#342 via webtrit_callkeep#343/#344; the temporary `1.3.0` tag was moved onto it). The re-pin from #1467 was lost in a merge race, so `release/1.16.0` still resolved the old `1.3.0+0`.
- Cherry-pick of the standalone calling-mode caption reword from #1469 (`c3593e0e`).
- Build-iteration bump to `app_version 1.16.0+5`.

## Notes

- Thai localization is not part of this release, so the `app_th.arb` / `app_localizations_th.g.dart` changes are dropped, same as in #1467.