### PR TITLE
refactor: reuse the diagnostic standalone-mode strings for the session issue

### DIFF
--- a/lib/extensions/session_issue.dart
+++ b/lib/extensions/session_issue.dart
@@ -22,7 +22,8 @@ extension SessionIssueL10n on SessionIssue {
   String title(BuildContext context) {
     switch (id) {
       case SessionIssueId.limitedStandaloneCallMode:
-        return context.l10n.sessionStatus_issue_limitedStandaloneCallMode_title;
+        // Same warning as the diagnostic calling-mode row - reuse its strings.
+        return context.l10n.diagnostic_callingMode_standalone_title;
     }
   }
 
@@ -30,7 +31,7 @@ extension SessionIssueL10n on SessionIssue {
   String caption(BuildContext context) {
     switch (id) {
       case SessionIssueId.limitedStandaloneCallMode:
-        return context.l10n.sessionStatus_issue_limitedStandaloneCallMode_caption;
+        return context.l10n.diagnostic_callingMode_standalone_caption;
     }
   }
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -3469,18 +3469,6 @@ abstract class AppLocalizations {
   /// **'Problem with configuration push notification service'**
   String get sessionStatus_pushNotificationServiceProblem;
 
-  /// No description provided for @sessionStatus_issue_limitedStandaloneCallMode_title.
-  ///
-  /// In en, this message translates to:
-  /// **'Limited call mode'**
-  String get sessionStatus_issue_limitedStandaloneCallMode_title;
-
-  /// No description provided for @sessionStatus_issue_limitedStandaloneCallMode_caption.
-  ///
-  /// In en, this message translates to:
-  /// **'Standalone - delivery may be delayed'**
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption;
-
   /// Status message displayed while the application is performing cleanup during the logout process.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -854,10 +854,6 @@ extension AppLocalizationsExtension on AppLocalizations {
       'sessionStatus_AppBar_connecting' => sessionStatus_AppBar_connecting,
       'sessionStatus_pushNotificationServiceProblem' =>
         sessionStatus_pushNotificationServiceProblem,
-      'sessionStatus_issue_limitedStandaloneCallMode_title' =>
-        sessionStatus_issue_limitedStandaloneCallMode_title,
-      'sessionStatus_issue_limitedStandaloneCallMode_caption' =>
-        sessionStatus_issue_limitedStandaloneCallMode_caption,
       'session_Teardown_progressText' => session_Teardown_progressText,
       'settings_AboutText_ApplicationEmbeddedLinks' =>
         settings_AboutText_ApplicationEmbeddedLinks,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1881,12 +1881,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'Problem with configuration push notification service';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Limited call mode';
-
-  @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - delivery may be delayed';
-
-  @override
   String get session_Teardown_progressText => 'Signing out...';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1905,12 +1905,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Problema con la configurazione del servizio di notifiche push';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Modalità chiamate limitata';
-
-  @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - possibile ritardo nella consegna';
-
-  @override
   String get session_Teardown_progressText => 'Disconnessione in corso...';
 
   @override

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -1880,12 +1880,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'เกิดปัญหากับการตั้งค่าบริการ push notification';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'โหมดการโทรแบบจำกัด';
-
-  @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'โหมดสแตนด์อโลน - การส่งอาจล่าช้า';
-
-  @override
   String get session_Teardown_progressText => 'กำลังออกจากระบบ...';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1906,12 +1906,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'Проблема з налаштуванням служби пуш-сповіщень';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Обмежений режим дзвінків';
-
-  @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone — можлива затримка доставки';
-
-  @override
   String get session_Teardown_progressText => 'Вихід із системи...';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1611,10 +1611,6 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Problem with configuration push notification service",
   "@sessionStatus_pushNotificationServiceProblem": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_title": "Limited call mode",
-  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone - delivery may be delayed",
-  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Signing out...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1608,10 +1608,6 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Problema con la configurazione del servizio di notifiche push",
   "@sessionStatus_pushNotificationServiceProblem": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_title": "Modalità chiamate limitata",
-  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone - possibile ritardo nella consegna",
-  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Disconnessione in corso...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -1613,10 +1613,6 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "เกิดปัญหากับการตั้งค่าบริการ push notification",
   "@sessionStatus_pushNotificationServiceProblem": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_title": "โหมดการโทรแบบจำกัด",
-  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_caption": "โหมดสแตนด์อโลน - การส่งอาจล่าช้า",
-  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "กำลังออกจากระบบ...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1608,10 +1608,6 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Проблема з налаштуванням служби пуш-сповіщень",
   "@sessionStatus_pushNotificationServiceProblem": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_title": "Обмежений режим дзвінків",
-  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone — можлива затримка доставки",
-  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Вихід із системи...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."


### PR DESCRIPTION
## Overview

The session-status issue banner (limited standalone call mode) duplicated the diagnostic calling-mode row's title and caption under its own l10n keys, and the two copies had already drifted: the session-issue caption still carried the misleading "delivery may be delayed" text that #1469 removes from the diagnostic copy. Since both surfaces show the same warning about the same mode, this drops the duplicate:

- `SessionIssueL10n` now returns `diagnostic_callingMode_standalone_title` / `_caption` for `SessionIssueId.limitedStandaloneCallMode`.
- `sessionStatus_issue_limitedStandaloneCallMode_title` / `_caption` removed from all 4 arb files + regenerated localizations and the l10n mapper.

Once #1469 merges, the banner automatically picks up the corrected caption. No visual changes otherwise.

## Localizely

The two removed keys still exist in Localizely and the upload API cannot delete keys, so the next `l10n:pull` would re-add them to the arb files until `sessionStatus_issue_limitedStandaloneCallMode_title` and `sessionStatus_issue_limitedStandaloneCallMode_caption` are deleted in the Localizely console (needs a maintainer with console access).