### PR TITLE
refactor: reuse the diagnostic standalone-mode strings for the session issue [release/1.16.0]

### DIFF
--- a/lib/extensions/session_issue.dart
+++ b/lib/extensions/session_issue.dart
@@ -22,7 +22,8 @@ extension SessionIssueL10n on SessionIssue {
   String title(BuildContext context) {
     switch (id) {
       case SessionIssueId.limitedStandaloneCallMode:
-        return context.l10n.sessionStatus_issue_limitedStandaloneCallMode_title;
+        // Same warning as the diagnostic calling-mode row - reuse its strings.
+        return context.l10n.diagnostic_callingMode_standalone_title;
     }
   }
 
@@ -30,7 +31,7 @@ extension SessionIssueL10n on SessionIssue {
   String caption(BuildContext context) {
     switch (id) {
       case SessionIssueId.limitedStandaloneCallMode:
-        return context.l10n.sessionStatus_issue_limitedStandaloneCallMode_caption;
+        return context.l10n.diagnostic_callingMode_standalone_caption;
     }
   }
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -3462,18 +3462,6 @@ abstract class AppLocalizations {
   /// **'Problem with configuration push notification service'**
   String get sessionStatus_pushNotificationServiceProblem;
 
-  /// No description provided for @sessionStatus_issue_limitedStandaloneCallMode_title.
-  ///
-  /// In en, this message translates to:
-  /// **'Limited call mode'**
-  String get sessionStatus_issue_limitedStandaloneCallMode_title;
-
-  /// No description provided for @sessionStatus_issue_limitedStandaloneCallMode_caption.
-  ///
-  /// In en, this message translates to:
-  /// **'Standalone - delivery may be delayed'**
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption;
-
   /// Status message displayed while the application is performing cleanup during the logout process.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -853,10 +853,6 @@ extension AppLocalizationsExtension on AppLocalizations {
       'sessionStatus_AppBar_connecting' => sessionStatus_AppBar_connecting,
       'sessionStatus_pushNotificationServiceProblem' =>
         sessionStatus_pushNotificationServiceProblem,
-      'sessionStatus_issue_limitedStandaloneCallMode_title' =>
-        sessionStatus_issue_limitedStandaloneCallMode_title,
-      'sessionStatus_issue_limitedStandaloneCallMode_caption' =>
-        sessionStatus_issue_limitedStandaloneCallMode_caption,
       'session_Teardown_progressText' => session_Teardown_progressText,
       'settings_AboutText_ApplicationEmbeddedLinks' =>
         settings_AboutText_ApplicationEmbeddedLinks,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1878,12 +1878,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'Problem with configuration push notification service';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Limited call mode';
-
-  @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - delivery may be delayed';
-
-  @override
   String get session_Teardown_progressText => 'Signing out...';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1902,12 +1902,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Problema con la configurazione del servizio di notifiche push';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Modalità chiamate limitata';
-
-  @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone - possibile ritardo nella consegna';
-
-  @override
   String get session_Teardown_progressText => 'Disconnessione in corso...';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1903,12 +1903,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get sessionStatus_pushNotificationServiceProblem => 'Проблема з налаштуванням служби пуш-сповіщень';
 
   @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_title => 'Обмежений режим дзвінків';
-
-  @override
-  String get sessionStatus_issue_limitedStandaloneCallMode_caption => 'Standalone — можлива затримка доставки';
-
-  @override
   String get session_Teardown_progressText => 'Вихід із системи...';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1609,10 +1609,6 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Problem with configuration push notification service",
   "@sessionStatus_pushNotificationServiceProblem": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_title": "Limited call mode",
-  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone - delivery may be delayed",
-  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Signing out...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1606,10 +1606,6 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Problema con la configurazione del servizio di notifiche push",
   "@sessionStatus_pushNotificationServiceProblem": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_title": "Modalità chiamate limitata",
-  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone - possibile ritardo nella consegna",
-  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Disconnessione in corso...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1606,10 +1606,6 @@
   },
   "sessionStatus_pushNotificationServiceProblem": "Проблема з налаштуванням служби пуш-сповіщень",
   "@sessionStatus_pushNotificationServiceProblem": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_title": "Обмежений режим дзвінків",
-  "@sessionStatus_issue_limitedStandaloneCallMode_title": {},
-  "sessionStatus_issue_limitedStandaloneCallMode_caption": "Standalone — можлива затримка доставки",
-  "@sessionStatus_issue_limitedStandaloneCallMode_caption": {},
   "session_Teardown_progressText": "Вихід із системи...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.0+5
+app_version: 1.16.0+6
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Overview

Cherry-pick of #1471 (`ae80845b`) onto `release/1.16.0` plus a build-iteration bump to `app_version 1.16.0+6`.

## Notes

- Thai localization is not part of this release, so the `app_th.arb` / `app_localizations_th.g.dart` changes are dropped, same as in #1467/#1470.