### PR TITLE
refactor: route call sounds through CallMediaManager

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -144,8 +144,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   late final HandshakeProcessor _handshakeProcessor;
   final ConnectivityService _connectivityService;
 
-  final _callkeepSound = WebtritCallkeepSound();
-
   CallBloc({
     required this.callLogsRepository,
     required void Function(String callId, String callerName) onMissedCall,
@@ -281,7 +279,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     await _signalingSubscription.cancel();
 
-    await _stopRingbackSound();
+    await _mediaManager.stopRingbackSound();
 
     for (final activeCall in state.activeCalls) {
       await _releaseLocalStream(activeCall.localStream);
@@ -721,7 +719,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     _iceRestartDebounce.cancel(event.callId);
     _slowlinkDebounce.cancel(event.callId);
     _slowlinkHits.remove(event.callId);
-    await _stopRingbackSound();
+    await _mediaManager.stopRingbackSound();
 
     try {
       emit(
@@ -1121,7 +1119,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   // no early media - play ringtone
   Future<void> __onCallSignalingEventRinging(_CallSignalingEventRinging event, Emitter<CallState> emit) async {
-    await _playRingbackSound();
+    await _mediaManager.playRingbackSound();
 
     emit(
       state.copyWithMappedActiveCall(event.callId, (call) {
@@ -1132,7 +1130,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   // early media - set specified session description
   Future<void> __onCallSignalingEventProgress(_CallSignalingEventProgress event, Emitter<CallState> emit) async {
-    await _stopRingbackSound();
+    await _mediaManager.stopRingbackSound();
 
     final jsep = event.jsep;
     if (jsep != null) {
@@ -2007,7 +2005,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       // Handles exceptions during the outgoing call perform event, sends a notification, stops the ringtone, and completes the peer connection with an error.
       // The specific error "Error setting ICE locally" indicates an issue with ICE (Interactive Connectivity Establishment) negotiation in the WebRTC signaling process.
       callErrorReporter.handle(e, stackTrace, '__onMutationPerformStart error:');
-      await _stopRingbackSound();
+      await _mediaManager.stopRingbackSound();
       _peerConnectionManager.completeError(event.callId, e, stackTrace);
       add(_ResetStateEvent.completeCall(event.callId));
     }
@@ -2217,7 +2215,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
   Future<void> __onMutationPerformEnd(_CallMutationEventPerformEnd event, Emitter<CallState> emit) async {
     try {
-      await _stopRingbackSound();
+      await _mediaManager.stopRingbackSound();
 
       emit(
         state.copyWithMappedActiveCall(event.callId, (activeCall) {
@@ -2893,7 +2891,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       call = call.copyWith(processingStatus: CallProcessingStatus.connected, acceptedTime: clock.now());
 
       if (outgoing) {
-        await _stopRingbackSound();
+        await _mediaManager.stopRingbackSound();
         await callkeep.reportConnectedOutgoingCall(event.callId);
       }
     } else {
@@ -2943,7 +2941,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   }
 
   Future<void> __onMutationSignalingHangup(_CallMutationEventSignalingHangup event, Emitter<CallState> emit) async {
-    _stopRingbackSound().ignore();
+    _mediaManager.stopRingbackSound().ignore();
     _signalingModule.cancelRequestsByCallId(event.callId);
 
     ActiveCall? call = state.retrieveActiveCall(event.callId);
@@ -4413,10 +4411,6 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
     callLogsRepository.add(call);
   }
-
-  Future<void> _playRingbackSound() => _callkeepSound.playRingbackSound();
-
-  Future<void> _stopRingbackSound() => _callkeepSound.stopRingbackSound();
 
   Future<void> _releaseLocalStream(MediaStream? stream) async {
     if (stream == null) return;

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -33,6 +33,7 @@ class CallMediaManager {
   }
 
   final Callkeep _callkeep;
+  final _callkeepSound = WebtritCallkeepSound();
 
   // Audio device priority for voice calls on Android.
   // AudioSwitch selects the first available device from this list on activate().
@@ -66,6 +67,17 @@ class CallMediaManager {
   // ---------------------------------------------------------------------------
   // Call session lifecycle
   // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // Call sounds (callkeep sound surface)
+  // ---------------------------------------------------------------------------
+
+  /// Plays the ringback sound while an outgoing call is progressing
+  /// (e.g. on SIP 180 Ringing).
+  Future<void> playRingbackSound() => _callkeepSound.playRingbackSound();
+
+  /// Stops the ringback sound once the outgoing call is connected or ended.
+  Future<void> stopRingbackSound() => _callkeepSound.stopRingbackSound();
 
   /// Clears the Android communication device after the last call ends (N → 0).
   ///


### PR DESCRIPTION
## Overview

`CallMediaManager` is documented as the single owner of the callkeep/webrtc audio surface ("CallBloc has no direct dependency on either plugin's audio surface"), but the ringback sound predates the manager and was still driven from `CallBloc` through a directly constructed `WebtritCallkeepSound`.

Move the ringback delegation into the manager (new "Call sounds" section), inline the trivial private forwarders at the 9 call sites, and drop the `_callkeepSound` field from `CallBloc`. Pure refactor - the delegation chain is identical, no behavior change.

Standalone quality cleanup; no other PRs depend on it.

## Testing

- `flutter analyze` + full test suite green (pre-push).