### PR TITLE
feat: play call-waiting tone on second incoming call during active call

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -144,6 +144,9 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   late final HandshakeProcessor _handshakeProcessor;
   final ConnectivityService _connectivityService;
 
+  // Edge guard for the iOS call-waiting tone (play/stop once per transition).
+  bool _callWaitingTonePlaying = false;
+
   CallBloc({
     required this.callLogsRepository,
     required void Function(String callId, String callerName) onMissedCall,
@@ -304,6 +307,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
   @override
   void onChange(Change<CallState> change) {
     super.onChange(change);
+
+    _syncCallWaitingTone(change.nextState);
 
     // Re-notify the reconnect controller when the call-active state flips while
     // the app is backgrounded - covers the gap the lifecycle handler misses
@@ -4410,6 +4415,28 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       hungUpTime: activeCall.hungUpTime,
     );
     callLogsRepository.add(call);
+  }
+
+  // Soft beep over the earpiece when a second call rings in while another call is
+  // connected. The side effect goes through CallMediaManager; playback lives in the
+  // callkeep plugin on both platforms.
+  void _syncCallWaitingTone(CallState state) {
+    const ringingIncoming = {CallProcessingStatus.incomingFromPush, CallProcessingStatus.incomingFromOffer};
+    final hasConnected = state.activeCalls.any((c) => c.processingStatus == CallProcessingStatus.connected);
+    final hasRingingIncoming = state.activeCalls.any((c) => ringingIncoming.contains(c.processingStatus));
+    final shouldPlay = hasConnected && hasRingingIncoming;
+
+    if (shouldPlay && !_callWaitingTonePlaying) {
+      _callWaitingTonePlaying = true;
+      _mediaManager.playCallWaitingTone().catchError(
+        (Object e, StackTrace s) => _logger.warning('playCallWaitingTone failed', e, s),
+      );
+    } else if (!shouldPlay && _callWaitingTonePlaying) {
+      _callWaitingTonePlaying = false;
+      _mediaManager.stopCallWaitingTone().catchError(
+        (Object e, StackTrace s) => _logger.warning('stopCallWaitingTone failed', e, s),
+      );
+    }
   }
 
   Future<void> _releaseLocalStream(MediaStream? stream) async {

--- a/lib/features/call/utils/call_media_manager.dart
+++ b/lib/features/call/utils/call_media_manager.dart
@@ -79,6 +79,20 @@ class CallMediaManager {
   /// Stops the ringback sound once the outgoing call is connected or ended.
   Future<void> stopRingbackSound() => _callkeepSound.stopRingbackSound();
 
+  /// Plays a soft, recurrent beep over the active call audio to signal a second
+  /// incoming call. Playback is owned by webtrit_callkeep on both platforms; the
+  /// Android connection service only suppresses the full ringtone in this scenario.
+  Future<void> playCallWaitingTone() async {
+    if (kIsWeb) return; // the tone has no web implementation
+    await _callkeepSound.playCallWaitingTone();
+  }
+
+  /// Stops the call-waiting tone (second call answered, declined or ended).
+  Future<void> stopCallWaitingTone() async {
+    if (kIsWeb) return; // the tone has no web implementation
+    await _callkeepSound.stopCallWaitingTone();
+  }
+
   /// Clears the Android communication device after the last call ends (N → 0).
   ///
   /// Without this, Bluetooth stays in SCO (call profile, mono/low-quality) instead


### PR DESCRIPTION
## Overview

WT-1415. When a second call rings in while another call is connected, the user gets a soft call-waiting beep over the active call audio (previously: silence on iOS; on Android the connection service played it on its own).

`CallBloc` gains `_syncCallWaitingTone`, driven from `onChange`: it detects the connected + ringing-incoming combination over `activeCalls` (`incomingFromPush`/`incomingFromOffer`) and edge-triggers the tone - play when the state appears, stop when it goes away (second call answered, declined or ended, or the active call ends). The side effect goes through `CallMediaManager` (the single owner of the callkeep/webrtc audio surface), which delegates to the callkeep sound API `playCallWaitingTone`/`stopCallWaitingTone` on both platforms.

Stacked on the CallMediaManager sounds refactor PR; this PR is tone-only. No flutter_webrtc changes are required - the tone playback is fully self-contained in webtrit_callkeep.

## Testing

- iOS device: beep in the earpiece over the active call while the second call rings; silent with a single call; stops on answer/decline/hangup.
- `flutter analyze` + full test suite green (pre-push).

## Dependencies

Merge order: WebTrit/webtrit_callkeep#345 -> the CallMediaManager refactor PR -> this PR (callkeep is consumed via the path dependency per the develop convention).