### PR TITLE
feat: display bundle version on the About screen (WT-1212)

### DIFF
--- a/lib/features/settings/features/about/bloc/about_bloc.dart
+++ b/lib/features/settings/features/about/bloc/about_bloc.dart
@@ -51,10 +51,11 @@ class AboutBloc extends Bloc<AboutEvent, AboutState> {
     try {
       final systemInfo = await infoRepository.getSystemInfo();
       final coreVersion = systemInfo?.core.version;
+      final bundleVersion = systemInfo?.bundleVersion;
 
       if (emit.isDone) return;
 
-      emit(state.copyWith(progress: false, coreVersion: coreVersion));
+      emit(state.copyWith(progress: false, coreVersion: coreVersion, bundleVersion: bundleVersion));
     } catch (e, stackTrace) {
       _logger.warning('_onStarted', e, stackTrace);
 

--- a/lib/features/settings/features/about/bloc/about_bloc.freezed.dart
+++ b/lib/features/settings/features/about/bloc/about_bloc.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AboutState {
 
- bool get progress; List<String> get embeddedLinks; String get packageName; String get appIdentifier; Uri get coreUrl; String get userAgent; String get appInfo; String get deviceInfo; String get callkeepVersion; String? get fcmPushToken; Version? get coreVersion;
+ bool get progress; List<String> get embeddedLinks; String get packageName; String get appIdentifier; Uri get coreUrl; String get userAgent; String get appInfo; String get deviceInfo; String get callkeepVersion; String? get fcmPushToken; Version? get coreVersion; String? get bundleVersion;
 /// Create a copy of AboutState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $AboutStateCopyWith<AboutState> get copyWith => _$AboutStateCopyWithImpl<AboutSt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutState&&(identical(other.progress, progress) || other.progress == progress)&&const DeepCollectionEquality().equals(other.embeddedLinks, embeddedLinks)&&(identical(other.packageName, packageName) || other.packageName == packageName)&&(identical(other.appIdentifier, appIdentifier) || other.appIdentifier == appIdentifier)&&(identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.appInfo, appInfo) || other.appInfo == appInfo)&&(identical(other.deviceInfo, deviceInfo) || other.deviceInfo == deviceInfo)&&(identical(other.callkeepVersion, callkeepVersion) || other.callkeepVersion == callkeepVersion)&&(identical(other.fcmPushToken, fcmPushToken) || other.fcmPushToken == fcmPushToken)&&(identical(other.coreVersion, coreVersion) || other.coreVersion == coreVersion));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AboutState&&(identical(other.progress, progress) || other.progress == progress)&&const DeepCollectionEquality().equals(other.embeddedLinks, embeddedLinks)&&(identical(other.packageName, packageName) || other.packageName == packageName)&&(identical(other.appIdentifier, appIdentifier) || other.appIdentifier == appIdentifier)&&(identical(other.coreUrl, coreUrl) || other.coreUrl == coreUrl)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.appInfo, appInfo) || other.appInfo == appInfo)&&(identical(other.deviceInfo, deviceInfo) || other.deviceInfo == deviceInfo)&&(identical(other.callkeepVersion, callkeepVersion) || other.callkeepVersion == callkeepVersion)&&(identical(other.fcmPushToken, fcmPushToken) || other.fcmPushToken == fcmPushToken)&&(identical(other.coreVersion, coreVersion) || other.coreVersion == coreVersion)&&(identical(other.bundleVersion, bundleVersion) || other.bundleVersion == bundleVersion));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,progress,const DeepCollectionEquality().hash(embeddedLinks),packageName,appIdentifier,coreUrl,userAgent,appInfo,deviceInfo,callkeepVersion,fcmPushToken,coreVersion);
+int get hashCode => Object.hash(runtimeType,progress,const DeepCollectionEquality().hash(embeddedLinks),packageName,appIdentifier,coreUrl,userAgent,appInfo,deviceInfo,callkeepVersion,fcmPushToken,coreVersion,bundleVersion);
 
 @override
 String toString() {
-  return 'AboutState(progress: $progress, embeddedLinks: $embeddedLinks, packageName: $packageName, appIdentifier: $appIdentifier, coreUrl: $coreUrl, userAgent: $userAgent, appInfo: $appInfo, deviceInfo: $deviceInfo, callkeepVersion: $callkeepVersion, fcmPushToken: $fcmPushToken, coreVersion: $coreVersion)';
+  return 'AboutState(progress: $progress, embeddedLinks: $embeddedLinks, packageName: $packageName, appIdentifier: $appIdentifier, coreUrl: $coreUrl, userAgent: $userAgent, appInfo: $appInfo, deviceInfo: $deviceInfo, callkeepVersion: $callkeepVersion, fcmPushToken: $fcmPushToken, coreVersion: $coreVersion, bundleVersion: $bundleVersion)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $AboutStateCopyWith<$Res>  {
   factory $AboutStateCopyWith(AboutState value, $Res Function(AboutState) _then) = _$AboutStateCopyWithImpl;
 @useResult
 $Res call({
- bool progress, List<String> embeddedLinks, String packageName, String appIdentifier, Uri coreUrl, String userAgent, String appInfo, String deviceInfo, String callkeepVersion, String? fcmPushToken, Version? coreVersion
+ bool progress, List<String> embeddedLinks, String packageName, String appIdentifier, Uri coreUrl, String userAgent, String appInfo, String deviceInfo, String callkeepVersion, String? fcmPushToken, Version? coreVersion, String? bundleVersion
 });
 
 
@@ -62,7 +62,7 @@ class _$AboutStateCopyWithImpl<$Res>
 
 /// Create a copy of AboutState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? progress = null,Object? embeddedLinks = null,Object? packageName = null,Object? appIdentifier = null,Object? coreUrl = null,Object? userAgent = null,Object? appInfo = null,Object? deviceInfo = null,Object? callkeepVersion = null,Object? fcmPushToken = freezed,Object? coreVersion = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? progress = null,Object? embeddedLinks = null,Object? packageName = null,Object? appIdentifier = null,Object? coreUrl = null,Object? userAgent = null,Object? appInfo = null,Object? deviceInfo = null,Object? callkeepVersion = null,Object? fcmPushToken = freezed,Object? coreVersion = freezed,Object? bundleVersion = freezed,}) {
   return _then(AboutState(
 progress: null == progress ? _self.progress : progress // ignore: cast_nullable_to_non_nullable
 as bool,embeddedLinks: null == embeddedLinks ? _self.embeddedLinks : embeddedLinks // ignore: cast_nullable_to_non_nullable
@@ -75,7 +75,8 @@ as String,deviceInfo: null == deviceInfo ? _self.deviceInfo : deviceInfo // igno
 as String,callkeepVersion: null == callkeepVersion ? _self.callkeepVersion : callkeepVersion // ignore: cast_nullable_to_non_nullable
 as String,fcmPushToken: freezed == fcmPushToken ? _self.fcmPushToken : fcmPushToken // ignore: cast_nullable_to_non_nullable
 as String?,coreVersion: freezed == coreVersion ? _self.coreVersion : coreVersion // ignore: cast_nullable_to_non_nullable
-as Version?,
+as Version?,bundleVersion: freezed == bundleVersion ? _self.bundleVersion : bundleVersion // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/features/settings/features/about/bloc/about_state.dart
+++ b/lib/features/settings/features/about/bloc/about_state.dart
@@ -14,6 +14,7 @@ class AboutState with _$AboutState {
     required this.callkeepVersion,
     this.fcmPushToken,
     this.coreVersion,
+    this.bundleVersion,
   });
 
   @override
@@ -48,4 +49,9 @@ class AboutState with _$AboutState {
 
   @override
   final Version? coreVersion;
+
+  /// Version of the deployment bundle (e.g. the Add-on Mart package version).
+  /// `null` = the backend does not provide it; the About screen hides the row.
+  @override
+  final String? bundleVersion;
 }

--- a/lib/features/settings/features/about/view/about_screen.dart
+++ b/lib/features/settings/features/about/view/about_screen.dart
@@ -117,6 +117,13 @@ class _AboutScreenState extends State<AboutScreen> {
                                     coreVersion: state.coreVersion,
                                     progress: state.progress,
                                   ),
+                                  if (state.bundleVersion != null) ...[
+                                    SizedBox(height: delimiterHeight / 2),
+                                    InfoTile(
+                                      label: context.l10n.settings_AboutText_BundleVersion,
+                                      value: state.bundleVersion,
+                                    ),
+                                  ],
                                 ],
                               ),
                             ),

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -3499,6 +3499,12 @@ abstract class AppLocalizations {
   /// **'App Version'**
   String get settings_AboutText_AppVersion;
 
+  /// No description provided for @settings_AboutText_BundleVersion.
+  ///
+  /// In en, this message translates to:
+  /// **'Bundle version'**
+  String get settings_AboutText_BundleVersion;
+
   /// No description provided for @settings_AboutText_CallkeepVersion.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -862,6 +862,7 @@ extension AppLocalizationsExtension on AppLocalizations {
       'settings_AboutText_AppSessionIdentifier' =>
         settings_AboutText_AppSessionIdentifier,
       'settings_AboutText_AppVersion' => settings_AboutText_AppVersion,
+      'settings_AboutText_BundleVersion' => settings_AboutText_BundleVersion,
       'settings_AboutText_CallkeepVersion' =>
         settings_AboutText_CallkeepVersion,
       'settings_AboutText_CoreVersion' => settings_AboutText_CoreVersion,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1896,6 +1896,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_AboutText_AppVersion => 'App Version';
 
   @override
+  String get settings_AboutText_BundleVersion => 'Bundle version';
+
+  @override
   String get settings_AboutText_CallkeepVersion => 'CallKeep version';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1920,6 +1920,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_AboutText_AppVersion => 'Versione dell\'app';
 
   @override
+  String get settings_AboutText_BundleVersion => 'Versione bundle';
+
+  @override
   String get settings_AboutText_CallkeepVersion => 'Versione di CallKeep';
 
   @override

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -1895,6 +1895,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settings_AboutText_AppVersion => 'เวอร์ชันแอป';
 
   @override
+  String get settings_AboutText_BundleVersion => 'เวอร์ชันบันเดิล';
+
+  @override
   String get settings_AboutText_CallkeepVersion => 'เวอร์ชัน CallKeep';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1921,6 +1921,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settings_AboutText_AppVersion => 'Версія застосунку';
 
   @override
+  String get settings_AboutText_BundleVersion => 'Версія бандла';
+
+  @override
   String get settings_AboutText_CallkeepVersion => 'Версія CallKeep';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1623,6 +1623,8 @@
   "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AboutText_AppVersion": "App Version",
   "@settings_AboutText_AppVersion": {},
+  "settings_AboutText_BundleVersion": "Bundle version",
+  "@settings_AboutText_BundleVersion": {},
   "settings_AboutText_CallkeepVersion": "CallKeep version",
   "@settings_AboutText_CallkeepVersion": {},
   "settings_AboutText_CoreVersion": "WebTrit Cloud Backend version",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1620,6 +1620,8 @@
   "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AboutText_AppVersion": "Versione dell'app",
   "@settings_AboutText_AppVersion": {},
+  "settings_AboutText_BundleVersion": "Versione bundle",
+  "@settings_AboutText_BundleVersion": {},
   "settings_AboutText_CallkeepVersion": "Versione di CallKeep",
   "@settings_AboutText_CallkeepVersion": {},
   "settings_AboutText_CoreVersion": "Versione WebTrit Cloud Backend",

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -1625,6 +1625,8 @@
   "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AboutText_AppVersion": "เวอร์ชันแอป",
   "@settings_AboutText_AppVersion": {},
+  "settings_AboutText_BundleVersion": "เวอร์ชันบันเดิล",
+  "@settings_AboutText_BundleVersion": {},
   "settings_AboutText_CallkeepVersion": "เวอร์ชัน CallKeep",
   "@settings_AboutText_CallkeepVersion": {},
   "settings_AboutText_CoreVersion": "เวอร์ชัน WebTrit Cloud Backend",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -1620,6 +1620,8 @@
   "@settings_AboutText_AppSessionIdentifier": {},
   "settings_AboutText_AppVersion": "Версія застосунку",
   "@settings_AboutText_AppVersion": {},
+  "settings_AboutText_BundleVersion": "Версія бандла",
+  "@settings_AboutText_BundleVersion": {},
   "settings_AboutText_CallkeepVersion": "Версія CallKeep",
   "@settings_AboutText_CallkeepVersion": {},
   "settings_AboutText_CoreVersion": "Версія WebTrit Cloud Backend",

--- a/lib/mappers/api/system_info_mapper.dart
+++ b/lib/mappers/api/system_info_mapper.dart
@@ -12,6 +12,7 @@ mixin SystemInfoApiMapper {
       janus: systemInfo.janus != null ? janusInfoFromApi(systemInfo.janus!) : null,
       gorush: systemInfo.gorush != null ? gorushInfoFromApi(systemInfo.gorush!) : null,
       minSupportedAppVersion: tryParseVersion(systemInfo.minSupportedAppVersion),
+      bundleVersion: systemInfo.bundleVersion,
     );
   }
 

--- a/lib/mappers/json/system_info_mapper.dart
+++ b/lib/mappers/json/system_info_mapper.dart
@@ -22,6 +22,7 @@ mixin SystemInfoJsonMapper {
       janus: map['janus'] != null ? janusInfoFromMap(map['janus']) : null,
       gorush: map['gorush'] != null ? gorushInfoFromMap(map['gorush']) : null,
       minSupportedAppVersion: tryParseVersion(map['min_supported_app_version']),
+      bundleVersion: map['bundle_version'],
     );
   }
 
@@ -33,6 +34,7 @@ mixin SystemInfoJsonMapper {
       'janus': systemInfo.janus != null ? janusInfoToMap(systemInfo.janus!) : null,
       'gorush': systemInfo.gorush != null ? gorushInfoToMap(systemInfo.gorush!) : null,
       'min_supported_app_version': systemInfo.minSupportedAppVersion?.toString(),
+      'bundle_version': systemInfo.bundleVersion,
     };
   }
 

--- a/lib/models/system_info/system_info.dart
+++ b/lib/models/system_info/system_info.dart
@@ -25,6 +25,7 @@ class WebtritSystemInfo with EquatableMixin {
     this.janus,
     this.gorush,
     this.minSupportedAppVersion,
+    this.bundleVersion,
   });
 
   final CoreInfo core;
@@ -36,6 +37,11 @@ class WebtritSystemInfo with EquatableMixin {
   /// Minimum app version the backend declares it supports. `null` = the
   /// backend does not enforce a minimum.
   final Version? minSupportedAppVersion;
+
+  /// Version of the deployment bundle (e.g. the Add-on Mart package version).
+  /// `null` = not configured on the backend. Raw string: the bundle version
+  /// format is not guaranteed to be semver.
+  final String? bundleVersion;
 
   /// Whether [appVersion] satisfies the backend-declared minimum supported app
   /// version. This is the inverse of the core-compatibility check: here the
@@ -54,7 +60,7 @@ class WebtritSystemInfo with EquatableMixin {
   }
 
   @override
-  List<Object?> get props => [core, postgres, adapter, janus, gorush, minSupportedAppVersion];
+  List<Object?> get props => [core, postgres, adapter, janus, gorush, minSupportedAppVersion, bundleVersion];
 
   @override
   bool get stringify => true;

--- a/packages/webtrit_api/lib/src/models/system_info.dart
+++ b/packages/webtrit_api/lib/src/models/system_info.dart
@@ -17,6 +17,7 @@ class SystemInfo with _$SystemInfo {
     this.janus,
     this.gorush,
     this.minSupportedAppVersion,
+    this.bundleVersion,
   });
 
   @override
@@ -40,6 +41,13 @@ class SystemInfo with _$SystemInfo {
   /// transport; the domain mapper parses it into a [Version].
   @override
   final String? minSupportedAppVersion;
+
+  /// Optional version of the deployment bundle (JSON key `bundle_version`),
+  /// e.g. the Add-on Mart package version. `null` = not configured on the
+  /// backend. Kept as a raw string: the bundle version format is not
+  /// guaranteed to be semver.
+  @override
+  final String? bundleVersion;
 
   factory SystemInfo.fromJson(Map<String, Object?> json) => _$SystemInfoFromJson(json);
 

--- a/packages/webtrit_api/lib/src/models/system_info.freezed.dart
+++ b/packages/webtrit_api/lib/src/models/system_info.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SystemInfo {
 
- CoreInfo get core; PostgresInfo get postgres; AdapterInfo? get adapter; JanusInfo? get janus; GorushInfo? get gorush; String? get minSupportedAppVersion;
+ CoreInfo get core; PostgresInfo get postgres; AdapterInfo? get adapter; JanusInfo? get janus; GorushInfo? get gorush; String? get minSupportedAppVersion; String? get bundleVersion;
 /// Create a copy of SystemInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $SystemInfoCopyWith<SystemInfo> get copyWith => _$SystemInfoCopyWithImpl<SystemI
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SystemInfo&&(identical(other.core, core) || other.core == core)&&(identical(other.postgres, postgres) || other.postgres == postgres)&&(identical(other.adapter, adapter) || other.adapter == adapter)&&(identical(other.janus, janus) || other.janus == janus)&&(identical(other.gorush, gorush) || other.gorush == gorush)&&(identical(other.minSupportedAppVersion, minSupportedAppVersion) || other.minSupportedAppVersion == minSupportedAppVersion));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SystemInfo&&(identical(other.core, core) || other.core == core)&&(identical(other.postgres, postgres) || other.postgres == postgres)&&(identical(other.adapter, adapter) || other.adapter == adapter)&&(identical(other.janus, janus) || other.janus == janus)&&(identical(other.gorush, gorush) || other.gorush == gorush)&&(identical(other.minSupportedAppVersion, minSupportedAppVersion) || other.minSupportedAppVersion == minSupportedAppVersion)&&(identical(other.bundleVersion, bundleVersion) || other.bundleVersion == bundleVersion));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,core,postgres,adapter,janus,gorush,minSupportedAppVersion);
+int get hashCode => Object.hash(runtimeType,core,postgres,adapter,janus,gorush,minSupportedAppVersion,bundleVersion);
 
 @override
 String toString() {
-  return 'SystemInfo(core: $core, postgres: $postgres, adapter: $adapter, janus: $janus, gorush: $gorush, minSupportedAppVersion: $minSupportedAppVersion)';
+  return 'SystemInfo(core: $core, postgres: $postgres, adapter: $adapter, janus: $janus, gorush: $gorush, minSupportedAppVersion: $minSupportedAppVersion, bundleVersion: $bundleVersion)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $SystemInfoCopyWith<$Res>  {
   factory $SystemInfoCopyWith(SystemInfo value, $Res Function(SystemInfo) _then) = _$SystemInfoCopyWithImpl;
 @useResult
 $Res call({
- CoreInfo core, PostgresInfo postgres, AdapterInfo? adapter, JanusInfo? janus, GorushInfo? gorush, String? minSupportedAppVersion
+ CoreInfo core, PostgresInfo postgres, AdapterInfo? adapter, JanusInfo? janus, GorushInfo? gorush, String? minSupportedAppVersion, String? bundleVersion
 });
 
 
@@ -63,7 +63,7 @@ class _$SystemInfoCopyWithImpl<$Res>
 
 /// Create a copy of SystemInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? core = null,Object? postgres = null,Object? adapter = freezed,Object? janus = freezed,Object? gorush = freezed,Object? minSupportedAppVersion = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? core = null,Object? postgres = null,Object? adapter = freezed,Object? janus = freezed,Object? gorush = freezed,Object? minSupportedAppVersion = freezed,Object? bundleVersion = freezed,}) {
   return _then(SystemInfo(
 core: null == core ? _self.core : core // ignore: cast_nullable_to_non_nullable
 as CoreInfo,postgres: null == postgres ? _self.postgres : postgres // ignore: cast_nullable_to_non_nullable
@@ -71,6 +71,7 @@ as PostgresInfo,adapter: freezed == adapter ? _self.adapter : adapter // ignore:
 as AdapterInfo?,janus: freezed == janus ? _self.janus : janus // ignore: cast_nullable_to_non_nullable
 as JanusInfo?,gorush: freezed == gorush ? _self.gorush : gorush // ignore: cast_nullable_to_non_nullable
 as GorushInfo?,minSupportedAppVersion: freezed == minSupportedAppVersion ? _self.minSupportedAppVersion : minSupportedAppVersion // ignore: cast_nullable_to_non_nullable
+as String?,bundleVersion: freezed == bundleVersion ? _self.bundleVersion : bundleVersion // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/packages/webtrit_api/lib/src/models/system_info.g.dart
+++ b/packages/webtrit_api/lib/src/models/system_info.g.dart
@@ -19,6 +19,7 @@ SystemInfo _$SystemInfoFromJson(Map<String, dynamic> json) => SystemInfo(
       ? null
       : GorushInfo.fromJson(json['gorush'] as Map<String, dynamic>),
   minSupportedAppVersion: json['min_supported_app_version'] as String?,
+  bundleVersion: json['bundle_version'] as String?,
 );
 
 Map<String, dynamic> _$SystemInfoToJson(SystemInfo instance) =>
@@ -29,6 +30,7 @@ Map<String, dynamic> _$SystemInfoToJson(SystemInfo instance) =>
       'janus': instance.janus?.toJson(),
       'gorush': instance.gorush?.toJson(),
       'min_supported_app_version': instance.minSupportedAppVersion,
+      'bundle_version': instance.bundleVersion,
     };
 
 CoreInfo _$CoreInfoFromJson(Map<String, dynamic> json) => CoreInfo(

--- a/packages/webtrit_api/test/webtrit_api_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_test.dart
@@ -85,6 +85,7 @@ void main() {
               'custom': {'abc': 'qwe'},
             },
             'min_supported_app_version': '1.5.0',
+            'bundle_version': '0.14.7',
           }),
           200,
           request: request,
@@ -108,13 +109,14 @@ void main() {
               ),
               postgres: PostgresInfo(version: '1.0.0'),
               minSupportedAppVersion: '1.5.0',
+              bundleVersion: '0.14.7',
             ),
           ),
         ),
       );
     });
 
-    test('get info without min_supported_app_version yields null', () {
+    test('get info without min_supported_app_version and bundle_version yields nulls', () {
       Future<Response> handler(Request request) async {
         return Response(
           jsonEncode({

--- a/test/mappers/system_info_mapper_test.dart
+++ b/test/mappers/system_info_mapper_test.dart
@@ -11,19 +11,21 @@ class _Mapper with SystemInfoApiMapper, SystemInfoJsonMapper {}
 void main() {
   final mapper = _Mapper();
 
-  api.SystemInfo apiInfo({String? minSupportedAppVersion}) {
+  api.SystemInfo apiInfo({String? minSupportedAppVersion, String? bundleVersion}) {
     return api.SystemInfo(
       core: api.CoreInfo(version: Version(1, 0, 0)),
       postgres: api.PostgresInfo(version: '15.0'),
       minSupportedAppVersion: minSupportedAppVersion,
+      bundleVersion: bundleVersion,
     );
   }
 
-  WebtritSystemInfo domainInfo({Version? minSupportedAppVersion}) {
+  WebtritSystemInfo domainInfo({Version? minSupportedAppVersion, String? bundleVersion}) {
     return WebtritSystemInfo(
       core: CoreInfo(version: Version(1, 0, 0)),
       postgres: PostgresInfo(version: '15.0'),
       minSupportedAppVersion: minSupportedAppVersion,
+      bundleVersion: bundleVersion,
     );
   }
 
@@ -60,6 +62,35 @@ void main() {
     test('reads a malformed cached value as null instead of throwing', () {
       final map = mapper.systemInfoToMap(domainInfo())..['min_supported_app_version'] = 'garbage';
       expect(mapper.systemInfoFromMap(map).minSupportedAppVersion, isNull);
+    });
+  });
+
+  group('SystemInfoApiMapper.systemInfoFromApi bundleVersion', () {
+    test('passes the raw string through', () {
+      expect(mapper.systemInfoFromApi(apiInfo(bundleVersion: '0.14.7')).bundleVersion, '0.14.7');
+    });
+
+    test('maps null to null', () {
+      expect(mapper.systemInfoFromApi(apiInfo(bundleVersion: null)).bundleVersion, isNull);
+    });
+  });
+
+  group('SystemInfoJsonMapper bundleVersion round-trip', () {
+    test('round-trips a non-null value through to/from map', () {
+      final map = mapper.systemInfoToMap(domainInfo(bundleVersion: '0.14.7'));
+      expect(map['bundle_version'], '0.14.7');
+      expect(mapper.systemInfoFromMap(map).bundleVersion, '0.14.7');
+    });
+
+    test('round-trips null', () {
+      final map = mapper.systemInfoToMap(domainInfo(bundleVersion: null));
+      expect(map['bundle_version'], isNull);
+      expect(mapper.systemInfoFromMap(map).bundleVersion, isNull);
+    });
+
+    test('reads a cached map without the key as null', () {
+      final map = mapper.systemInfoToMap(domainInfo())..remove('bundle_version');
+      expect(mapper.systemInfoFromMap(map).bundleVersion, isNull);
     });
   });
 }


### PR DESCRIPTION
## Overview

The About screen shows only the Core version (e.g. 0.33.0), while Add-on Mart lists the bundle version (e.g. 0.14.7), so users and support cannot match the two. The backend (WT-1211, Core bundle 0.14.0+) now exposes a top-level `bundle_version` field in the `/api/v1/system-info` response: a raw string configured at deployment time, `null` when not configured.

This change reads the new field and displays it on the About screen below the Core version. When the backend returns `null` (e.g. non-PortaOne deployments or older Core), the row is hidden entirely.

- `webtrit_api`: `SystemInfo.bundleVersion` (`String?`, JSON key `bundle_version`)
- domain `WebtritSystemInfo.bundleVersion` kept as a raw string (bundle version format is not guaranteed to be semver) + API and JSON/cache mappers
- `AboutBloc`/`AboutState` emit the value alongside the Core version
- About screen renders an `InfoTile` labeled "Bundle version" (l10n key added to en/it/uk/th), hidden when the value is absent

## Testing

- `webtrit_api` client test: `bundle_version` parsed from the response, absent field yields `null`
- mapper tests: API->domain pass-through and JSON cache round-trip (value, `null`, missing key)
- verified against a live backend: `https://testenv-domain-12.portaone.com/api/v1/system-info` returns `"bundle_version": "0.14.7"`