### PR TITLE
feat: show the build version alongside the app version on version-gate surfaces (WT-1676)

### DIFF
--- a/lib/data/package_info.dart
+++ b/lib/data/package_info.dart
@@ -10,6 +10,13 @@ abstract class PackageInfo {
   String get buildNumber;
 }
 
+extension PackageInfoFullVersion on PackageInfo {
+  /// Full build version as shipped to the store: versionName plus versionCode
+  /// (e.g. "4.4.9+449000002"). Same composition the diagnostic appInfo string
+  /// uses in the app metadata provider.
+  String get fullVersion => '$version+$buildNumber';
+}
+
 class PackageInfoFactory {
   static Future<PackageInfo> init() async {
     return PackageInfoImpl(await plugin.PackageInfo.fromPlatform());

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -31,6 +31,7 @@ class LoginCubit extends Cubit<LoginState> {
     required this.authRepository,
     required this.notificationsBloc,
     required this.appInfo,
+    required this.packageInfo,
     required this.appCompatibilityResolver,
     required this.onLoginSuccess,
     this.signinOrder = const [],
@@ -43,6 +44,8 @@ class LoginCubit extends Cubit<LoginState> {
   final NotificationsBloc notificationsBloc;
 
   final AppInfo appInfo;
+
+  final PackageInfo packageInfo;
 
   final AppCompatibilityResolver appCompatibilityResolver;
 
@@ -158,8 +161,9 @@ class LoginCubit extends Cubit<LoginState> {
         return null;
       case AppVersionTooOld(:final appVersion, :final minSupportedVersion):
         final notification = AppVersionUnsupportedErrorNotification(
-          appVersion.toString(),
-          minSupportedVersion.toString(),
+          appVersion: appVersion.toString(),
+          minSupported: minSupportedVersion.toString(),
+          storeVersion: packageInfo.fullVersion,
         );
         notificationsBloc.add(NotificationsSubmitted(notification));
         return null;

--- a/lib/features/login/models/notifications.dart
+++ b/lib/features/login/models/notifications.dart
@@ -172,13 +172,25 @@ final class CoreVersionUnsupportedErrorNotification extends MessageNotification 
 }
 
 final class AppVersionUnsupportedErrorNotification extends MessageNotification {
-  const AppVersionUnsupportedErrorNotification(this.actual, this.minSupported);
+  const AppVersionUnsupportedErrorNotification({
+    required this.appVersion,
+    required this.minSupported,
+    required this.storeVersion,
+  });
 
-  final String actual;
+  /// Internal app_version the gate compared against [minSupported].
+  final String appVersion;
   final String minSupported;
+
+  /// Per-client build version+code of the installed build (versionName +
+  /// versionCode, e.g. "4.4.9+449000002"); shown in parentheses so users and
+  /// support can match the numbers from the store console (debug/sideload
+  /// builds carry the literal 0.0.0+0 placeholder).
+  final String storeVersion;
 
   @override
   String l10n(BuildContext context) {
+    final actual = context.l10n.main_AppUpdateRequiredDialog_currentVersionValue(storeVersion, appVersion);
     return context.l10n.login_AppVersionUnsupportedExceptionError(actual, minSupported);
   }
 }

--- a/lib/features/login/view/login_router_page.dart
+++ b/lib/features/login/view/login_router_page.dart
@@ -93,6 +93,7 @@ class LoginRouterPage extends StatelessWidget {
       notificationsBloc: context.read<NotificationsBloc>(),
       authRepository: context.read<AuthRepository>(),
       appInfo: context.read<AppInfo>(),
+      packageInfo: context.read<PackageInfo>(),
       appCompatibilityResolver: context.read<AppCompatibilityResolver>(),
       signinOrder: context.read<FeatureAccess>().loginConfig.signinOrder,
       onLoginSuccess: (session, systemInfo) =>

--- a/lib/features/version_gate/view/update_required_screen.dart
+++ b/lib/features/version_gate/view/update_required_screen.dart
@@ -32,15 +32,26 @@ class UpdateRequiredScreenPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appInfo = context.read<AppInfo>();
+    final packageInfo = context.read<PackageInfo>();
     final compatibility = context.select<AppBloc, AppCompatibility>((bloc) => bloc.state.appCompatibility);
 
     final currentVersion = appInfo.version;
+    // The per-client build version+code (native versionName+versionCode, what
+    // the store console lists) rides along as a muted sub-line so users and
+    // support can match the numbers they see in Play Store / App Store.
+    // Debug/sideload builds show their literal 0.0.0+0 placeholder - only
+    // developers ever see those builds.
+    final storeVersion = packageInfo.fullVersion;
     final minSupportedVersion = compatibility is AppVersionTooOld ? compatibility.minSupportedVersion : currentVersion;
 
     // The Android back button must not escape the gate.
     return PopScope(
       canPop: false,
-      child: _UpdateRequiredView(currentVersion: currentVersion, minSupportedVersion: minSupportedVersion),
+      child: _UpdateRequiredView(
+        currentVersion: currentVersion,
+        storeVersion: storeVersion,
+        minSupportedVersion: minSupportedVersion,
+      ),
     );
   }
 }
@@ -50,9 +61,14 @@ class UpdateRequiredScreenPage extends StatelessWidget {
 /// the former MainBloc behaviour). Resolution failures are swallowed and the
 /// Update button is simply omitted.
 class _UpdateRequiredView extends StatefulWidget {
-  const _UpdateRequiredView({required this.currentVersion, required this.minSupportedVersion});
+  const _UpdateRequiredView({
+    required this.currentVersion,
+    required this.storeVersion,
+    required this.minSupportedVersion,
+  });
 
   final Version currentVersion;
+  final String storeVersion;
   final Version minSupportedVersion;
 
   @override
@@ -134,6 +150,7 @@ class _UpdateRequiredViewState extends State<_UpdateRequiredView> {
                         const SizedBox(height: kInset * 1.5),
                         _VersionCard(
                           currentVersion: widget.currentVersion,
+                          storeVersion: widget.storeVersion,
                           minSupportedVersion: widget.minSupportedVersion,
                         ),
                         const Spacer(flex: 2),
@@ -198,10 +215,17 @@ class _UpdateHero extends StatelessWidget {
 }
 
 /// Bordered card contrasting the running version with the required minimum.
+///
+/// The running build is described by two explicitly labeled values: the
+/// internal app_version (the headline, what the minimum is compared against)
+/// and the per-client build version+code (native versionName+versionCode, the
+/// numbers visible in the store console). The required minimum exists only in
+/// internal app_version terms, so it is rendered as a secondary line.
 class _VersionCard extends StatelessWidget {
-  const _VersionCard({required this.currentVersion, required this.minSupportedVersion});
+  const _VersionCard({required this.currentVersion, required this.storeVersion, required this.minSupportedVersion});
 
   final Version currentVersion;
+  final String storeVersion;
   final Version minSupportedVersion;
 
   @override
@@ -218,14 +242,22 @@ class _VersionCard extends StatelessWidget {
         children: [
           _VersionRow(
             label: context.l10n.main_AppUpdateRequiredDialog_currentVersionLabel,
-            version: currentVersion,
+            value: currentVersion.toString(),
             valueColor: colorScheme.onSurface,
+          ),
+          const SizedBox(height: kInset / 2),
+          _VersionRow(
+            label: context.l10n.main_AppUpdateRequiredDialog_buildVersionLabel,
+            value: storeVersion,
+            valueColor: colorScheme.onSurfaceVariant,
+            emphasized: false,
           ),
           Divider(height: kInset, color: colorScheme.outlineVariant),
           _VersionRow(
             label: context.l10n.main_AppUpdateRequiredDialog_minimumVersionLabel,
-            version: minSupportedVersion,
+            value: minSupportedVersion.toString(),
             valueColor: colorScheme.primary,
+            emphasized: false,
           ),
         ],
       ),
@@ -234,15 +266,17 @@ class _VersionCard extends StatelessWidget {
 }
 
 class _VersionRow extends StatelessWidget {
-  const _VersionRow({required this.label, required this.version, required this.valueColor});
+  const _VersionRow({required this.label, required this.value, required this.valueColor, this.emphasized = true});
 
   final String label;
-  final Version version;
+  final String value;
   final Color valueColor;
+  final bool emphasized;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final valueStyle = emphasized ? theme.textTheme.titleLarge : theme.textTheme.titleMedium;
     return Column(
       children: [
         Text(
@@ -251,13 +285,18 @@ class _VersionRow extends StatelessWidget {
           style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
         ),
         const SizedBox(height: kInset / 6),
-        Text(
-          version.toString(),
-          textAlign: TextAlign.center,
-          style: theme.textTheme.titleLarge?.copyWith(
-            color: valueColor,
-            fontWeight: FontWeight.bold,
-            fontFeatures: const [FontFeature.tabularFigures()],
+        // Versions/build codes can be long: keep each line whole and shrink it
+        // to fit instead of wrapping mid-number.
+        FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Text(
+            value,
+            textAlign: TextAlign.center,
+            style: valueStyle?.copyWith(
+              color: valueColor,
+              fontWeight: FontWeight.bold,
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
           ),
         ),
       ],

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2011,11 +2011,23 @@ abstract class AppLocalizations {
   /// **'Your app version is no longer supported. Please update the application to continue.'**
   String get main_AppUpdateRequiredDialog_description;
 
-  /// Label above the running app version on the update-required prompt.
+  /// Label above the running app's internal app_version on the update-required prompt.
   ///
   /// In en, this message translates to:
-  /// **'Current version'**
+  /// **'App version'**
   String get main_AppUpdateRequiredDialog_currentVersionLabel;
+
+  /// Label above the per-client build version+code (native versionName+versionCode) on the update-required prompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Build version'**
+  String get main_AppUpdateRequiredDialog_buildVersionLabel;
+
+  /// Composed current-version value on version-gate surfaces: the internal app_version leads, the per-client build (store distribution) version follows in parentheses.
+  ///
+  /// In en, this message translates to:
+  /// **'{appVersion} (build {storeVersion})'**
+  String main_AppUpdateRequiredDialog_currentVersionValue(String storeVersion, String appVersion);
 
   /// Label above the minimum supported app version on the update-required prompt.
   ///

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -508,6 +508,8 @@ extension AppLocalizationsExtension on AppLocalizations {
         main_AppUpdateRequiredDialog_description,
       'main_AppUpdateRequiredDialog_currentVersionLabel' =>
         main_AppUpdateRequiredDialog_currentVersionLabel,
+      'main_AppUpdateRequiredDialog_buildVersionLabel' =>
+        main_AppUpdateRequiredDialog_buildVersionLabel,
       'main_AppUpdateRequiredDialog_minimumVersionLabel' =>
         main_AppUpdateRequiredDialog_minimumVersionLabel,
       'messaging_ActionBtn_retry' => messaging_ActionBtn_retry,
@@ -1661,6 +1663,16 @@ extension AppLocalizationsExtension on AppLocalizations {
             'main_CompatibilityIssueDialog_contentCoreVersionUnsupportedExceptionError requires 2 arguments',
           ),
         },
+      'main_AppUpdateRequiredDialog_currentVersionValue' => switch (args) {
+        [final String storeVersion, final String appVersion] =>
+          main_AppUpdateRequiredDialog_currentVersionValue(
+            storeVersion,
+            appVersion,
+          ),
+        _ => throw ArgumentError(
+          'main_AppUpdateRequiredDialog_currentVersionValue requires 2 arguments',
+        ),
+      },
       'messaging_ConversationBuilders_contactExtension' => switch (args) {
         [final String extension] =>
           messaging_ConversationBuilders_contactExtension(extension),

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1097,7 +1097,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your app version is no longer supported. Please update the application to continue.';
 
   @override
-  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'Current version';
+  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'App version';
+
+  @override
+  String get main_AppUpdateRequiredDialog_buildVersionLabel => 'Build version';
+
+  @override
+  String main_AppUpdateRequiredDialog_currentVersionValue(String storeVersion, String appVersion) {
+    return '$appVersion (build $storeVersion)';
+  }
 
   @override
   String get main_AppUpdateRequiredDialog_minimumVersionLabel => 'Minimum required version';

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1110,7 +1110,15 @@ class AppLocalizationsIt extends AppLocalizations {
       'La versione della tua app non è più supportata. Aggiorna l\'applicazione per continuare.';
 
   @override
-  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'Versione attuale';
+  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'Versione app';
+
+  @override
+  String get main_AppUpdateRequiredDialog_buildVersionLabel => 'Versione build';
+
+  @override
+  String main_AppUpdateRequiredDialog_currentVersionValue(String storeVersion, String appVersion) {
+    return '$appVersion (build $storeVersion)';
+  }
 
   @override
   String get main_AppUpdateRequiredDialog_minimumVersionLabel => 'Versione minima richiesta';

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -1095,7 +1095,15 @@ class AppLocalizationsTh extends AppLocalizations {
       'เวอร์ชันแอปของคุณไม่ได้รับการสนับสนุนอีกต่อไป กรุณาอัปเดตแอปพลิเคชันเพื่อใช้งานต่อ';
 
   @override
-  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'เวอร์ชันปัจจุบัน';
+  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'เวอร์ชันแอป';
+
+  @override
+  String get main_AppUpdateRequiredDialog_buildVersionLabel => 'เวอร์ชันบิลด์';
+
+  @override
+  String main_AppUpdateRequiredDialog_currentVersionValue(String storeVersion, String appVersion) {
+    return '$appVersion (บิลด์ $storeVersion)';
+  }
 
   @override
   String get main_AppUpdateRequiredDialog_minimumVersionLabel => 'เวอร์ชันขั้นต่ำที่ต้องการ';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1117,7 +1117,15 @@ class AppLocalizationsUk extends AppLocalizations {
       'Версія вашого застосунку більше не підтримується. Будь ласка, оновіть застосунок, щоб продовжити.';
 
   @override
-  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'Поточна версія';
+  String get main_AppUpdateRequiredDialog_currentVersionLabel => 'Версія застосунку';
+
+  @override
+  String get main_AppUpdateRequiredDialog_buildVersionLabel => 'Версія збірки';
+
+  @override
+  String main_AppUpdateRequiredDialog_currentVersionValue(String storeVersion, String appVersion) {
+    return '$appVersion (збірка $storeVersion)';
+  }
 
   @override
   String get main_AppUpdateRequiredDialog_minimumVersionLabel => 'Мінімальна потрібна версія';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -959,9 +959,25 @@
   "@main_AppUpdateRequiredDialog_description": {
     "description": "Body text of the full-screen update-required prompt, shown when the running app is older than the backend-declared minimum supported app version."
   },
-  "main_AppUpdateRequiredDialog_currentVersionLabel": "Current version",
+  "main_AppUpdateRequiredDialog_currentVersionLabel": "App version",
   "@main_AppUpdateRequiredDialog_currentVersionLabel": {
-    "description": "Label above the running app version on the update-required prompt."
+    "description": "Label above the running app's internal app_version on the update-required prompt."
+  },
+  "main_AppUpdateRequiredDialog_buildVersionLabel": "Build version",
+  "@main_AppUpdateRequiredDialog_buildVersionLabel": {
+    "description": "Label above the per-client build version+code (native versionName+versionCode) on the update-required prompt."
+  },
+  "main_AppUpdateRequiredDialog_currentVersionValue": "{appVersion} (build {storeVersion})",
+  "@main_AppUpdateRequiredDialog_currentVersionValue": {
+    "description": "Composed current-version value on version-gate surfaces: the internal app_version leads, the per-client build (store distribution) version follows in parentheses.",
+    "placeholders": {
+      "storeVersion": {
+        "type": "String"
+      },
+      "appVersion": {
+        "type": "String"
+      }
+    }
   },
   "main_AppUpdateRequiredDialog_minimumVersionLabel": "Minimum required version",
   "@main_AppUpdateRequiredDialog_minimumVersionLabel": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -959,10 +959,14 @@
   "@main_AppUpdateRequiredDialog_description": {
     "description": "Body text of the full-screen update-required prompt, shown when the running app is older than the backend-declared minimum supported app version."
   },
-  "main_AppUpdateRequiredDialog_currentVersionLabel": "Versione attuale",
+  "main_AppUpdateRequiredDialog_currentVersionLabel": "Versione app",
   "@main_AppUpdateRequiredDialog_currentVersionLabel": {
     "description": "Label above the running app version on the update-required prompt."
   },
+  "main_AppUpdateRequiredDialog_buildVersionLabel": "Versione build",
+  "@main_AppUpdateRequiredDialog_buildVersionLabel": {},
+  "main_AppUpdateRequiredDialog_currentVersionValue": "{appVersion} (build {storeVersion})",
+  "@main_AppUpdateRequiredDialog_currentVersionValue": {},
   "main_AppUpdateRequiredDialog_minimumVersionLabel": "Versione minima richiesta",
   "@main_AppUpdateRequiredDialog_minimumVersionLabel": {
     "description": "Label above the minimum supported app version on the update-required prompt."

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -961,10 +961,14 @@
   "@main_AppUpdateRequiredDialog_description": {
     "description": "Body text of the full-screen update-required prompt, shown when the running app is older than the backend-declared minimum supported app version."
   },
-  "main_AppUpdateRequiredDialog_currentVersionLabel": "เวอร์ชันปัจจุบัน",
+  "main_AppUpdateRequiredDialog_currentVersionLabel": "เวอร์ชันแอป",
   "@main_AppUpdateRequiredDialog_currentVersionLabel": {
     "description": "Label above the running app version on the update-required prompt."
   },
+  "main_AppUpdateRequiredDialog_buildVersionLabel": "เวอร์ชันบิลด์",
+  "@main_AppUpdateRequiredDialog_buildVersionLabel": {},
+  "main_AppUpdateRequiredDialog_currentVersionValue": "{appVersion} (บิลด์ {storeVersion})",
+  "@main_AppUpdateRequiredDialog_currentVersionValue": {},
   "main_AppUpdateRequiredDialog_minimumVersionLabel": "เวอร์ชันขั้นต่ำที่ต้องการ",
   "@main_AppUpdateRequiredDialog_minimumVersionLabel": {
     "description": "Label above the minimum supported app version on the update-required prompt."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -959,10 +959,14 @@
   "@main_AppUpdateRequiredDialog_description": {
     "description": "Body text of the full-screen update-required prompt, shown when the running app is older than the backend-declared minimum supported app version."
   },
-  "main_AppUpdateRequiredDialog_currentVersionLabel": "Поточна версія",
+  "main_AppUpdateRequiredDialog_currentVersionLabel": "Версія застосунку",
   "@main_AppUpdateRequiredDialog_currentVersionLabel": {
     "description": "Label above the running app version on the update-required prompt."
   },
+  "main_AppUpdateRequiredDialog_buildVersionLabel": "Версія збірки",
+  "@main_AppUpdateRequiredDialog_buildVersionLabel": {},
+  "main_AppUpdateRequiredDialog_currentVersionValue": "{appVersion} (збірка {storeVersion})",
+  "@main_AppUpdateRequiredDialog_currentVersionValue": {},
   "main_AppUpdateRequiredDialog_minimumVersionLabel": "Мінімальна потрібна версія",
   "@main_AppUpdateRequiredDialog_minimumVersionLabel": {
     "description": "Label above the minimum supported app version on the update-required prompt."

--- a/test/features/login/login_cubit_app_version_gate_test.dart
+++ b/test/features/login/login_cubit_app_version_gate_test.dart
@@ -12,6 +12,8 @@ class _MockAuthRepository extends Mock implements AuthRepository {}
 
 class _MockAppInfo extends Mock implements AppInfo {}
 
+class _MockPackageInfo extends Mock implements PackageInfo {}
+
 WebtritSystemInfo _systemInfo({Version? minSupportedAppVersion, List<String> supported = const ['passwordSignin']}) {
   return WebtritSystemInfo(
     core: CoreInfo(version: Version(1, 0, 0)),
@@ -36,13 +38,17 @@ void main() {
     notificationsBloc.close();
   });
 
-  LoginCubit buildCubit(String appVersion) {
+  LoginCubit buildCubit(String appVersion, {String storeVersion = '0.0.0', String storeBuildNumber = '0'}) {
     final appInfo = _MockAppInfo();
     when(() => appInfo.version).thenReturn(Version.parse(appVersion));
+    final packageInfo = _MockPackageInfo();
+    when(() => packageInfo.version).thenReturn(storeVersion);
+    when(() => packageInfo.buildNumber).thenReturn(storeBuildNumber);
     return LoginCubit(
       authRepository: authRepository,
       notificationsBloc: notificationsBloc,
       appInfo: appInfo,
+      packageInfo: packageInfo,
       appCompatibilityResolver: const DefaultAppCompatibilityResolver(),
       onLoginSuccess: (session, _) => loginSuccesses.add(session),
     );
@@ -59,10 +65,15 @@ void main() {
       () => authRepository.getSystemInfo(any(), any()),
     ).thenAnswer((_) async => _systemInfo(minSupportedAppVersion: Version(2, 0, 0)));
 
-    final cubit = buildCubit('1.15.3');
+    final cubit = buildCubit('1.15.3', storeVersion: '4.4.9', storeBuildNumber: '449000002');
     await submitCoreUrl(cubit);
 
-    expect(notificationsBloc.state.lastNotification, isA<AppVersionUnsupportedErrorNotification>());
+    final notification = notificationsBloc.state.lastNotification;
+    expect(notification, isA<AppVersionUnsupportedErrorNotification>());
+    // The internal app_version leads the message; the build version+code
+    // rides along in parentheses.
+    expect((notification as AppVersionUnsupportedErrorNotification).storeVersion, '4.4.9+449000002');
+    expect(notification.appVersion, '1.15.3');
     expect(cubit.state.systemInfo, isNull);
     expect(cubit.state.supportedLoginTypes, isNull);
     expect(loginSuccesses, isEmpty);

--- a/test/features/version_gate/update_required_screen_test.dart
+++ b/test/features/version_gate/update_required_screen_test.dart
@@ -18,19 +18,19 @@ class _MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {}
 class _MockAppInfo extends Mock implements AppInfo {}
 
 class _FakePackageInfo implements PackageInfo {
-  _FakePackageInfo(this.version);
+  _FakePackageInfo(this.version, [this.buildNumber = '0']);
 
   @override
   final String version;
+
+  @override
+  final String buildNumber;
 
   @override
   String get appName => 'WebTrit';
 
   @override
   String get packageName => 'com.webtrit.app';
-
-  @override
-  String get buildNumber => '0';
 }
 
 AppState _appState(AppCompatibility compatibility) => AppState(
@@ -50,7 +50,12 @@ void main() {
     appInfo = _MockAppInfo();
   });
 
-  Widget host({required Version current, required Version min}) {
+  Widget host({
+    required Version current,
+    required Version min,
+    String storeVersion = '0.0.0',
+    String storeBuildNumber = '0',
+  }) {
     when(() => appBloc.state).thenReturn(_appState(AppVersionTooOld(appVersion: current, minSupportedVersion: min)));
     when(() => appInfo.version).thenReturn(current);
 
@@ -60,7 +65,7 @@ void main() {
       home: MultiProvider(
         providers: [
           Provider<AppInfo>.value(value: appInfo),
-          Provider<PackageInfo>.value(value: _FakePackageInfo(current.toString())),
+          Provider<PackageInfo>.value(value: _FakePackageInfo(storeVersion, storeBuildNumber)),
           BlocProvider<AppBloc>.value(value: appBloc),
         ],
         child: const UpdateRequiredScreenPage(),
@@ -69,7 +74,7 @@ void main() {
   }
 
   testWidgets('renders title, description, both versions and the logout action', (tester) async {
-    await tester.pumpWidget(host(current: Version(1, 14, 0), min: Version(1, 15, 0)));
+    await tester.pumpWidget(host(current: Version(1, 14, 0), min: Version(1, 15, 0), storeVersion: '4.4.9'));
     await tester.pumpAndSettle();
 
     final context = tester.element(find.byType(UpdateRequiredScreenPage));
@@ -77,9 +82,36 @@ void main() {
     expect(find.text(context.l10n.main_AppUpdateRequiredDialog_description), findsOneWidget);
     expect(find.text(context.l10n.main_AppUpdateRequiredDialog_currentVersionLabel), findsOneWidget);
     expect(find.text(context.l10n.main_AppUpdateRequiredDialog_minimumVersionLabel), findsOneWidget);
+    // The internal app_version and the build version+code render as two
+    // explicitly labeled values.
+    expect(find.text(context.l10n.main_AppUpdateRequiredDialog_buildVersionLabel), findsOneWidget);
     expect(find.text('1.14.0'), findsOneWidget);
+    expect(find.text('4.4.9+0'), findsOneWidget);
     expect(find.text('1.15.0'), findsOneWidget);
     expect(find.text(context.l10n.main_CompatibilityIssueDialogActions_logout), findsOneWidget);
+  });
+
+  testWidgets('fits long build versions on one line without overflow', (tester) async {
+    await tester.pumpWidget(
+      host(
+        current: Version.parse('1.16.0+6'),
+        min: Version(99, 0, 0),
+        storeVersion: '4.4.9',
+        storeBuildNumber: '449000002',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('1.16.0+6'), findsOneWidget);
+    expect(find.text('4.4.9+449000002'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('shows the literal 0.0.0 placeholder for builds without a store version', (tester) async {
+    await tester.pumpWidget(host(current: Version(1, 14, 0), min: Version(1, 15, 0)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('0.0.0+0'), findsOneWidget);
   });
 
   testWidgets('hides the Update action when no newer store build is available', (tester) async {


### PR DESCRIPTION
## Overview

The force-update screen and the login version-gate notification showed only the bare internal `app_version` (e.g. `1.16.0`) as the current version. Users and support checking Play Store / App Store (or the store consoles) see the per-client build version and code instead (e.g. `4.4.9` / `449000002`) and cannot match the numbers.

The version card now presents the running build as two explicitly labeled values: "App version" (the internal `app_version`, the headline and what the minimum is compared against) and "Build version" (the per-client `versionName+versionCode` from `PackageInfo`, e.g. `4.4.9+449000002` - the numbers visible in the store console). The login notification composes the same values into its text: `1.16.0 (build 4.4.9+449000002)`. Debug/sideload builds are compiled without `--build-name`/`--build-number` and simply show their literal `0.0.0+0` placeholder - only developers ever see those builds, so no special-casing. Long values stay on one line: version rows shrink to fit (`FittedBox`) instead of wrapping mid-number.

The gate comparison logic is untouched: `min_supported_app_version` is still evaluated against the internal `app_version`, and the required minimum is still rendered in those terms (visually secondary on the card).

- `PackageInfo.fullVersion` extension: `versionName+versionCode`
- update-required screen: labeled "App version" + "Build version" sections, minimum row de-emphasized, one-line fit for long values
- `AppVersionUnsupportedErrorNotification` carries `storeVersion`/`appVersion` separately and composes the message in `l10n()`; `LoginCubit` gets `PackageInfo` injected to supply it
- l10n (en/it/uk/th): `main_AppUpdateRequiredDialog_currentVersionLabel` reworded to "App version", new `main_AppUpdateRequiredDialog_buildVersionLabel`, new parameterized `main_AppUpdateRequiredDialog_currentVersionValue` (notification text)

## Testing

- widget tests: both labeled values render separately; long build codes fit on one line without overflow; 0.0.0 builds show the literal placeholder
- login gate tests: notification carries the build version+code and the internal version separately