### PR TITLE
fix: show an error on OTP sign-in when the account has no email (WT-1565)

### DIFF
--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -574,7 +574,13 @@ class LoginCubit extends Cubit<LoginState> {
         'validation_error' => const LoginValidationErrorNotification(),
         'parameters_apply_issue' => const LoginParametersApplyIssueNotification(),
         'empty_email' => const LoginEmptyEmailNotification(),
-        'delivery_channel_unspecified' => const LoginDeliveryChannelUnspecifiedNotification(),
+        // The identifier-specific wording only makes sense for the OTP sign-in
+        // form; a non-empty user reference input is the evidence the error came
+        // from there (the code is declared on otp-create only, but signup
+        // passes adapter 422 bodies through verbatim).
+        'delivery_channel_unspecified' => LoginDeliveryChannelUnspecifiedNotification(
+          state.otpSigninUserRefInput.value.isNotEmpty ? state.otpSigninIdentifiers : const [],
+        ),
         _ => null,
       };
       if (readableNotification != null) {

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -574,6 +574,7 @@ class LoginCubit extends Cubit<LoginState> {
         'validation_error' => const LoginValidationErrorNotification(),
         'parameters_apply_issue' => const LoginParametersApplyIssueNotification(),
         'empty_email' => const LoginEmptyEmailNotification(),
+        'delivery_channel_unspecified' => const LoginDeliveryChannelUnspecifiedNotification(),
         _ => null,
       };
       if (readableNotification != null) {

--- a/lib/features/login/extensions/otp_signin_identifier.dart
+++ b/lib/features/login/extensions/otp_signin_identifier.dart
@@ -18,6 +18,17 @@ extension OtpSigninIdentifiersInput on List<OtpSigninIdentifier> {
     return l10n.login_TextFieldLabelText_otpSigninUserRef;
   }
 
+  /// Error message for `delivery_channel_unspecified` matching the advertised
+  /// OTP identifiers. The backend does not report which delivery channel the
+  /// account lacks, so the message names only what the user entered and stays
+  /// neutral about the missing contact method.
+  String deliveryChannelUnspecifiedMessage(BuildContext context) {
+    final l10n = context.l10n;
+    if (_hasPhone && !_hasEmail) return l10n.login_RequestFailureDeliveryChannelUnspecifiedPhoneError;
+    if (_hasEmail && !_hasPhone) return l10n.login_RequestFailureDeliveryChannelUnspecifiedEmailError;
+    return l10n.login_RequestFailureDeliveryChannelUnspecifiedError;
+  }
+
   /// Account references may be alphanumeric (for example `ph123x456`) even when
   /// the backend advertises phone as the only OTP identifier, so a phone-only
   /// dial pad would wrongly block letters. Use a text keyboard whenever email is

--- a/lib/features/login/models/notifications.dart
+++ b/lib/features/login/models/notifications.dart
@@ -5,6 +5,9 @@ import 'package:webtrit_api/webtrit_api.dart';
 import 'package:webtrit_phone/app/notifications/models/notification.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 
+import '../extensions/otp_signin_identifier.dart';
+import 'otp_signin_identifier.dart';
+
 @Deprecated.instantiate('will be removed, (see [app/notifications/models/notification.dart] for details)')
 final class LoginErrorNotification extends DefaultErrorNotification {
   LoginErrorNotification(super.error);
@@ -153,11 +156,16 @@ final class LoginEmptyEmailNotification extends MessageNotification {
 }
 
 final class LoginDeliveryChannelUnspecifiedNotification extends MessageNotification {
-  const LoginDeliveryChannelUnspecifiedNotification();
+  const LoginDeliveryChannelUnspecifiedNotification([this.identifiers = const []]);
+
+  /// Advertised OTP sign-in identifiers at the moment of the failure; an empty
+  /// list keeps the message generic (e.g. when the error did not come from the
+  /// OTP sign-in form).
+  final List<OtpSigninIdentifier> identifiers;
 
   @override
   String l10n(BuildContext context) {
-    return context.l10n.login_RequestFailureDeliveryChannelUnspecifiedError;
+    return identifiers.deliveryChannelUnspecifiedMessage(context);
   }
 }
 

--- a/lib/features/login/models/notifications.dart
+++ b/lib/features/login/models/notifications.dart
@@ -23,6 +23,8 @@ final class LoginErrorNotification extends DefaultErrorNotification {
           return context.l10n.login_RequestFailurePhoneNotFoundError;
         case 'empty_email':
           return context.l10n.login_RequestFailureEmptyEmailError;
+        case 'delivery_channel_unspecified':
+          return context.l10n.login_RequestFailureDeliveryChannelUnspecifiedError;
         case 'validation_error':
           return context.l10n.login_RequestFailureIdentifierIsNotValid;
         // sessionOtpVerify
@@ -147,6 +149,15 @@ final class LoginEmptyEmailNotification extends MessageNotification {
   @override
   String l10n(BuildContext context) {
     return context.l10n.login_RequestFailureEmptyEmailError;
+  }
+}
+
+final class LoginDeliveryChannelUnspecifiedNotification extends MessageNotification {
+  const LoginDeliveryChannelUnspecifiedNotification();
+
+  @override
+  String l10n(BuildContext context) {
+    return context.l10n.login_RequestFailureDeliveryChannelUnspecifiedError;
   }
 }
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1690,6 +1690,18 @@ abstract class AppLocalizations {
   /// **'This account has no email address or other contact method to receive the verification code'**
   String get login_RequestFailureDeliveryChannelUnspecifiedError;
 
+  /// Shown during OTP sign-in on deployments where users sign in with a phone number, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account.
+  ///
+  /// In en, this message translates to:
+  /// **'The account with this phone number has no contact method configured to receive the verification code'**
+  String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError;
+
+  /// Shown during OTP sign-in on deployments where users sign in with an email address, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account.
+  ///
+  /// In en, this message translates to:
+  /// **'The account with this email address has no contact method configured to receive the verification code'**
+  String get login_RequestFailureDeliveryChannelUnspecifiedEmailError;
+
   /// Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1684,6 +1684,12 @@ abstract class AppLocalizations {
   /// **'Your app version is no longer supported, please update the application to continue (current: {actual}, minimum required: {minSupported})'**
   String login_AppVersionUnsupportedExceptionError(String actual, String minSupported);
 
+  /// Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account.
+  ///
+  /// In en, this message translates to:
+  /// **'This account has no email address or other contact method to receive the verification code'**
+  String get login_RequestFailureDeliveryChannelUnspecifiedError;
+
   /// Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1684,10 +1684,10 @@ abstract class AppLocalizations {
   /// **'Your app version is no longer supported, please update the application to continue (current: {actual}, minimum required: {minSupported})'**
   String login_AppVersionUnsupportedExceptionError(String actual, String minSupported);
 
-  /// Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account.
+  /// Shown during OTP sign-in when the requested account has no configured delivery channel to receive the one-time verification code and the advertised sign-in identifiers do not allow a more specific wording. Condition: the server rejects the OTP request because no delivery channel is set up for the account.
   ///
   /// In en, this message translates to:
-  /// **'This account has no email address or other contact method to receive the verification code'**
+  /// **'This account has no contact method configured to receive the verification code'**
   String get login_RequestFailureDeliveryChannelUnspecifiedError;
 
   /// Shown during OTP sign-in on deployments where users sign in with a phone number, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account.

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -422,6 +422,10 @@ extension AppLocalizationsExtension on AppLocalizations {
         login_ButtonTooltip_signInToYourInstance,
       'login_RequestFailureDeliveryChannelUnspecifiedError' =>
         login_RequestFailureDeliveryChannelUnspecifiedError,
+      'login_RequestFailureDeliveryChannelUnspecifiedPhoneError' =>
+        login_RequestFailureDeliveryChannelUnspecifiedPhoneError,
+      'login_RequestFailureDeliveryChannelUnspecifiedEmailError' =>
+        login_RequestFailureDeliveryChannelUnspecifiedEmailError,
       'login_RequestFailureEmptyEmailError' =>
         login_RequestFailureEmptyEmailError,
       'login_RequestFailureIdentifierIsNotValid' =>

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -420,6 +420,8 @@ extension AppLocalizationsExtension on AppLocalizations {
       'login_Button_signupVerifyRepeat' => login_Button_signupVerifyRepeat,
       'login_ButtonTooltip_signInToYourInstance' =>
         login_ButtonTooltip_signInToYourInstance,
+      'login_RequestFailureDeliveryChannelUnspecifiedError' =>
+        login_RequestFailureDeliveryChannelUnspecifiedError,
       'login_RequestFailureEmptyEmailError' =>
         login_RequestFailureEmptyEmailError,
       'login_RequestFailureIdentifierIsNotValid' =>
@@ -762,6 +764,8 @@ extension AppLocalizationsExtension on AppLocalizations {
         permission_manufacturer_Text_xiaomi_tip1,
       'permission_manufacturer_Text_xiaomi_tip2' =>
         permission_manufacturer_Text_xiaomi_tip2,
+      'permission_manufacturer_Text_xiaomi_tip3' =>
+        permission_manufacturer_Text_xiaomi_tip3,
       'permission_Text_description' => permission_Text_description,
       'persistentConnectionReminderContent' =>
         persistentConnectionReminderContent,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -915,7 +915,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedError =>
-      'This account has no email address or other contact method to receive the verification code';
+      'This account has no contact method configured to receive the verification code';
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -914,6 +914,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedError =>
+      'This account has no email address or other contact method to receive the verification code';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'Cannot send the verification code';
 
   @override

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -918,6 +918,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'This account has no email address or other contact method to receive the verification code';
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>
+      'The account with this phone number has no contact method configured to receive the verification code';
+
+  @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedEmailError =>
+      'The account with this email address has no contact method configured to receive the verification code';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'Cannot send the verification code';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -921,6 +921,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedError =>
+      'Questo account non ha un indirizzo email o un altro metodo di contatto per ricevere il codice di verifica';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'Impossibile inviare il codice di verifica';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -922,7 +922,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedError =>
-      'Questo account non ha un indirizzo email o un altro metodo di contatto per ricevere il codice di verifica';
+      'Questo account non ha alcun metodo di contatto configurato per ricevere il codice di verifica';
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -925,6 +925,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Questo account non ha un indirizzo email o un altro metodo di contatto per ricevere il codice di verifica';
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>
+      'L\'account con questo numero di telefono non ha alcun metodo di contatto configurato per ricevere il codice di verifica';
+
+  @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedEmailError =>
+      'L\'account con questo indirizzo email non ha alcun metodo di contatto configurato per ricevere il codice di verifica';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'Impossibile inviare il codice di verifica';
 
   @override

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -908,7 +908,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedError =>
-      'บัญชีนี้ไม่มีอีเมลหรือช่องทางติดต่ออื่นสำหรับรับรหัสยืนยัน';
+      'บัญชีนี้ไม่มีช่องทางติดต่อที่ตั้งค่าไว้สำหรับรับรหัสยืนยัน';
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -911,6 +911,14 @@ class AppLocalizationsTh extends AppLocalizations {
       'บัญชีนี้ไม่มีอีเมลหรือช่องทางติดต่ออื่นสำหรับรับรหัสยืนยัน';
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>
+      'บัญชีที่ใช้หมายเลขโทรศัพท์นี้ไม่มีช่องทางติดต่อที่ตั้งค่าไว้สำหรับรับรหัสยืนยัน';
+
+  @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedEmailError =>
+      'บัญชีที่ใช้อีเมลนี้ไม่มีช่องทางติดต่อที่ตั้งค่าไว้สำหรับรับรหัสยืนยัน';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'ไม่สามารถส่งรหัสยืนยันได้';
 
   @override

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -907,6 +907,10 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedError =>
+      'บัญชีนี้ไม่มีอีเมลหรือช่องทางติดต่ออื่นสำหรับรับรหัสยืนยัน';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'ไม่สามารถส่งรหัสยืนยันได้';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -930,6 +930,14 @@ class AppLocalizationsUk extends AppLocalizations {
       'До цього облікового запису не прив\'язано адресу електронної пошти чи інший спосіб зв\'язку для отримання коду підтвердження';
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>
+      'Обліковий запис із цим номером телефону не має налаштованого способу зв\'язку для отримання коду підтвердження';
+
+  @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedEmailError =>
+      'Обліковий запис із цією адресою електронної пошти не має налаштованого способу зв\'язку для отримання коду підтвердження';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'Не вдалося відправити код підтвердження';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -926,6 +926,10 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get login_RequestFailureDeliveryChannelUnspecifiedError =>
+      'До цього облікового запису не прив\'язано адресу електронної пошти чи інший спосіб зв\'язку для отримання коду підтвердження';
+
+  @override
   String get login_RequestFailureEmptyEmailError => 'Не вдалося відправити код підтвердження';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -927,7 +927,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedError =>
-      'До цього облікового запису не прив\'язано адресу електронної пошти чи інший спосіб зв\'язку для отримання коду підтвердження';
+      'Цей обліковий запис не має налаштованого способу зв\'язку для отримання коду підтвердження';
 
   @override
   String get login_RequestFailureDeliveryChannelUnspecifiedPhoneError =>

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -776,6 +776,14 @@
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
     "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "The account with this phone number has no contact method configured to receive the verification code",
+  "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with a phone number, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
+  "login_RequestFailureDeliveryChannelUnspecifiedEmailError": "The account with this email address has no contact method configured to receive the verification code",
+  "@login_RequestFailureDeliveryChannelUnspecifiedEmailError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with an email address, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "Cannot send the verification code",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -772,9 +772,9 @@
       }
     }
   },
-  "login_RequestFailureDeliveryChannelUnspecifiedError": "This account has no email address or other contact method to receive the verification code",
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "This account has no contact method configured to receive the verification code",
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
-    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel to receive the one-time verification code and the advertised sign-in identifiers do not allow a more specific wording. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
   "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "The account with this phone number has no contact method configured to receive the verification code",
   "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -772,6 +772,10 @@
       }
     }
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "This account has no email address or other contact method to receive the verification code",
+  "@login_RequestFailureDeliveryChannelUnspecifiedError": {
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "Cannot send the verification code",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -772,6 +772,10 @@
       }
     }
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "Questo account non ha un indirizzo email o un altro metodo di contatto per ricevere il codice di verifica",
+  "@login_RequestFailureDeliveryChannelUnspecifiedError": {
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "Impossibile inviare il codice di verifica",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -772,9 +772,9 @@
       }
     }
   },
-  "login_RequestFailureDeliveryChannelUnspecifiedError": "Questo account non ha un indirizzo email o un altro metodo di contatto per ricevere il codice di verifica",
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "Questo account non ha alcun metodo di contatto configurato per ricevere il codice di verifica",
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
-    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel to receive the one-time verification code and the advertised sign-in identifiers do not allow a more specific wording. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
   "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "L'account con questo numero di telefono non ha alcun metodo di contatto configurato per ricevere il codice di verifica",
   "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -776,6 +776,14 @@
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
     "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "L'account con questo numero di telefono non ha alcun metodo di contatto configurato per ricevere il codice di verifica",
+  "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with a phone number, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
+  "login_RequestFailureDeliveryChannelUnspecifiedEmailError": "L'account con questo indirizzo email non ha alcun metodo di contatto configurato per ricevere il codice di verifica",
+  "@login_RequestFailureDeliveryChannelUnspecifiedEmailError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with an email address, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "Impossibile inviare il codice di verifica",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -774,6 +774,10 @@
       }
     }
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "บัญชีนี้ไม่มีอีเมลหรือช่องทางติดต่ออื่นสำหรับรับรหัสยืนยัน",
+  "@login_RequestFailureDeliveryChannelUnspecifiedError": {
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "ไม่สามารถส่งรหัสยืนยันได้",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -774,9 +774,9 @@
       }
     }
   },
-  "login_RequestFailureDeliveryChannelUnspecifiedError": "บัญชีนี้ไม่มีอีเมลหรือช่องทางติดต่ออื่นสำหรับรับรหัสยืนยัน",
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "บัญชีนี้ไม่มีช่องทางติดต่อที่ตั้งค่าไว้สำหรับรับรหัสยืนยัน",
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
-    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel to receive the one-time verification code and the advertised sign-in identifiers do not allow a more specific wording. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
   "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "บัญชีที่ใช้หมายเลขโทรศัพท์นี้ไม่มีช่องทางติดต่อที่ตั้งค่าไว้สำหรับรับรหัสยืนยัน",
   "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -778,6 +778,14 @@
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
     "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "บัญชีที่ใช้หมายเลขโทรศัพท์นี้ไม่มีช่องทางติดต่อที่ตั้งค่าไว้สำหรับรับรหัสยืนยัน",
+  "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with a phone number, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
+  "login_RequestFailureDeliveryChannelUnspecifiedEmailError": "บัญชีที่ใช้อีเมลนี้ไม่มีช่องทางติดต่อที่ตั้งค่าไว้สำหรับรับรหัสยืนยัน",
+  "@login_RequestFailureDeliveryChannelUnspecifiedEmailError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with an email address, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "ไม่สามารถส่งรหัสยืนยันได้",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -772,9 +772,9 @@
       }
     }
   },
-  "login_RequestFailureDeliveryChannelUnspecifiedError": "До цього облікового запису не прив'язано адресу електронної пошти чи інший спосіб зв'язку для отримання коду підтвердження",
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "Цей обліковий запис не має налаштованого способу зв'язку для отримання коду підтвердження",
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
-    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel to receive the one-time verification code and the advertised sign-in identifiers do not allow a more specific wording. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
   "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "Обліковий запис із цим номером телефону не має налаштованого способу зв'язку для отримання коду підтвердження",
   "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -776,6 +776,14 @@
   "@login_RequestFailureDeliveryChannelUnspecifiedError": {
     "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedPhoneError": "Обліковий запис із цим номером телефону не має налаштованого способу зв'язку для отримання коду підтвердження",
+  "@login_RequestFailureDeliveryChannelUnspecifiedPhoneError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with a phone number, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
+  "login_RequestFailureDeliveryChannelUnspecifiedEmailError": "Обліковий запис із цією адресою електронної пошти не має налаштованого способу зв'язку для отримання коду підтвердження",
+  "@login_RequestFailureDeliveryChannelUnspecifiedEmailError": {
+    "description": "Shown during OTP sign-in on deployments where users sign in with an email address, when the matched account has no configured delivery channel to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "Не вдалося відправити код підтвердження",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -772,6 +772,10 @@
       }
     }
   },
+  "login_RequestFailureDeliveryChannelUnspecifiedError": "До цього облікового запису не прив'язано адресу електронної пошти чи інший спосіб зв'язку для отримання коду підтвердження",
+  "@login_RequestFailureDeliveryChannelUnspecifiedError": {
+    "description": "Shown during OTP sign-in when the requested account has no configured delivery channel (such as an email address) to receive the one-time verification code. Condition: the server rejects the OTP request because no delivery channel is set up for the account."
+  },
   "login_RequestFailureEmptyEmailError": "Не вдалося відправити код підтвердження",
   "@login_RequestFailureEmptyEmailError": {
     "description": "Shown during login or signup when the user tries to request a verification code but has not entered an email address. Condition: email field is empty."

--- a/test/features/login/login_cubit_error_notifications_test.dart
+++ b/test/features/login/login_cubit_error_notifications_test.dart
@@ -60,7 +60,23 @@ void main() {
     cubit.handleError(_requestFailure('delivery_channel_unspecified'), StackTrace.current, 'test');
     await pumpEventQueue();
 
-    expect(notificationsBloc.state.lastNotification, isA<LoginDeliveryChannelUnspecifiedNotification>());
+    final notification = notificationsBloc.state.lastNotification;
+    expect(notification, isA<LoginDeliveryChannelUnspecifiedNotification>());
+    // The OTP user reference input is untouched, so the error cannot be
+    // attributed to the OTP sign-in form and the message stays generic.
+    expect((notification as LoginDeliveryChannelUnspecifiedNotification).identifiers, isEmpty);
+  });
+
+  test('delivery_channel_unspecified carries the advertised identifiers when the OTP form was used', () async {
+    final cubit = buildCubit();
+    cubit.otpSigninUserRefInputChanged('380441234567');
+
+    cubit.handleError(_requestFailure('delivery_channel_unspecified'), StackTrace.current, 'test');
+    await pumpEventQueue();
+
+    final notification = notificationsBloc.state.lastNotification;
+    expect(notification, isA<LoginDeliveryChannelUnspecifiedNotification>());
+    expect((notification as LoginDeliveryChannelUnspecifiedNotification).identifiers, cubit.state.otpSigninIdentifiers);
   });
 
   test('maps empty_email to a visible notification', () async {

--- a/test/features/login/login_cubit_error_notifications_test.dart
+++ b/test/features/login/login_cubit_error_notifications_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import 'package:webtrit_api/webtrit_api.dart';
+
+import 'package:webtrit_phone/app/notifications/notifications.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/features/login/login.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+class _MockAppInfo extends Mock implements AppInfo {}
+
+class _MockPackageInfo extends Mock implements PackageInfo {}
+
+RequestFailure _requestFailure(String code, {int statusCode = 422}) {
+  return RequestFailure(
+    url: Uri.parse('https://demo.example.com/api/v1/session/otp-create'),
+    statusCode: statusCode,
+    requestId: 'test-request-id',
+    error: ErrorResponse(code: code),
+  );
+}
+
+void main() {
+  late _MockAuthRepository authRepository;
+  late NotificationsBloc notificationsBloc;
+
+  setUp(() {
+    authRepository = _MockAuthRepository();
+    notificationsBloc = NotificationsBloc();
+  });
+
+  tearDown(() {
+    notificationsBloc.close();
+  });
+
+  LoginCubit buildCubit() {
+    final appInfo = _MockAppInfo();
+    when(() => appInfo.version).thenReturn(Version.parse('1.0.0'));
+    final packageInfo = _MockPackageInfo();
+    when(() => packageInfo.version).thenReturn('0.0.0');
+    when(() => packageInfo.buildNumber).thenReturn('0');
+    return LoginCubit(
+      authRepository: authRepository,
+      notificationsBloc: notificationsBloc,
+      appInfo: appInfo,
+      packageInfo: packageInfo,
+      appCompatibilityResolver: const DefaultAppCompatibilityResolver(),
+      onLoginSuccess: (_, _) {},
+    );
+  }
+
+  test('maps delivery_channel_unspecified to a visible notification', () async {
+    final cubit = buildCubit();
+
+    cubit.handleError(_requestFailure('delivery_channel_unspecified'), StackTrace.current, 'test');
+    await pumpEventQueue();
+
+    expect(notificationsBloc.state.lastNotification, isA<LoginDeliveryChannelUnspecifiedNotification>());
+  });
+
+  test('maps empty_email to a visible notification', () async {
+    final cubit = buildCubit();
+
+    cubit.handleError(_requestFailure('empty_email'), StackTrace.current, 'test');
+    await pumpEventQueue();
+
+    expect(notificationsBloc.state.lastNotification, isA<LoginEmptyEmailNotification>());
+  });
+}

--- a/test/features/login/otp_signin_identifier_test.dart
+++ b/test/features/login/otp_signin_identifier_test.dart
@@ -1,10 +1,11 @@
-import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:pub_semver/pub_semver.dart';
 
 import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/features/login/login.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
 
 LoginState _stateWithCustom(Map<String, dynamic>? custom) {
@@ -98,6 +99,48 @@ void main() {
 
     test('falls back to a text keyboard when nothing is advertised', () {
       expect(<OtpSigninIdentifier>[].userRefKeyboardType, TextInputType.text);
+    });
+  });
+
+  group('OtpSigninIdentifiersInput.deliveryChannelUnspecifiedMessage', () {
+    Future<BuildContext> pumpL10nContext(WidgetTester tester) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      return capturedContext;
+    }
+
+    testWidgets('names the phone number when phone is the only identifier', (tester) async {
+      final context = await pumpL10nContext(tester);
+      expect(
+        [OtpSigninIdentifier.phoneNumber].deliveryChannelUnspecifiedMessage(context),
+        context.l10n.login_RequestFailureDeliveryChannelUnspecifiedPhoneError,
+      );
+    });
+
+    testWidgets('names the email address when email is the only identifier', (tester) async {
+      final context = await pumpL10nContext(tester);
+      expect(
+        [OtpSigninIdentifier.email].deliveryChannelUnspecifiedMessage(context),
+        context.l10n.login_RequestFailureDeliveryChannelUnspecifiedEmailError,
+      );
+    });
+
+    testWidgets('stays generic when both or no identifiers are advertised', (tester) async {
+      final context = await pumpL10nContext(tester);
+      final generic = context.l10n.login_RequestFailureDeliveryChannelUnspecifiedError;
+      expect(OtpSigninIdentifier.values.deliveryChannelUnspecifiedMessage(context), generic);
+      expect(<OtpSigninIdentifier>[].deliveryChannelUnspecifiedMessage(context), generic);
     });
   });
 }


### PR DESCRIPTION
## Overview

On OTP sign-in, when the requested account has no delivery channel assigned to receive the verification code, the BSS rejects the OTP request with 422 `delivery_channel_unspecified`. The app did not map this error code to a user-visible notification, so tapping Proceed silently did nothing: the error went only to the log and Crashlytics while the UI stayed silent.

The error body does not say which delivery channel the account lacks (the channel is only reported on success), so the message is built around the one fact the client does know: what the user entered. On deployments that advertise a single OTP identifier (`otp_login_identifiers`), the message names it ("The account with this phone number / email address has no contact method configured to receive the verification code"); otherwise it stays generic.

## Changes

- Map `delivery_channel_unspecified` to the new `LoginDeliveryChannelUnspecifiedNotification` in `LoginCubit.handleError`, following the existing `empty_email` pattern.
- Select the message by the advertised OTP identifiers (`deliveryChannelUnspecifiedMessage`, mirroring the existing `userRefLabel`): phone-only and email-only deployments get identifier-specific wording, mixed/unknown get the generic one. The identifier-specific wording is applied only when the OTP user reference input is non-empty, since the code is declared on `otp-create` only, but the signup endpoint passes adapter 422 bodies through verbatim.
- Add the `login_RequestFailureDeliveryChannelUnspecifiedError` key plus its `...PhoneError`/`...EmailError` variants to all four locales (en, it, uk, th) and regenerate the localization files.
- Cover the error-code-to-notification mapping, the identifier guard, and the message selection with tests.

## Testing

- `flutter analyze` clean; full test suite green (pre-push hook).
- Reproduced end-to-end on a local stack (app -> Core -> adapter returning 422 `delivery_channel_unspecified`): before this change the UI stays silent while the log records `Unexpected error during login process`.

## Notes

- The new l10n keys (3) are not yet pushed to Localizely; they must be pushed before the next `l10n:pull`, otherwise the pull will drop them.
