### PR TITLE
fix: stop voicemail playback when the message is deleted (WT-1664)

### DIFF
--- a/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
+++ b/lib/features/settings/features/voicemail/bloc/voicemail_playback_controller.dart
@@ -110,6 +110,19 @@ class VoicemailPlaybackController extends ChangeNotifier with WidgetsBindingObse
     }
   }
 
+  /// Stops playback and clears the active track. Used when the active
+  /// voicemail disappears from the list (deleted locally or remotely) --
+  /// the player is screen-scoped, so nothing else would stop it.
+  Future<void> stop() async {
+    _generation++;
+    _loadingDebounce.cancel();
+    _activeId = null;
+    _error = null;
+    _isLoading = false;
+    notifyListeners();
+    await _player.stop();
+  }
+
   Future<void> pause() => _player.pause();
 
   Future<void> resume() => _player.play();

--- a/lib/features/settings/features/voicemail/view/voicemail_screen.dart
+++ b/lib/features/settings/features/voicemail/view/voicemail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -6,7 +8,7 @@ import 'package:webtrit_phone/l10n/app_localizations.g.mapper.dart';
 import 'package:webtrit_phone/models/voicemail/user_voicemail.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
-import '../bloc/voicemail_cubit.dart';
+import '../bloc/bloc.dart';
 import '../widgets/widgets.dart';
 
 class VoicemailScreen extends StatefulWidget {
@@ -19,7 +21,9 @@ class VoicemailScreen extends StatefulWidget {
 class _VoicemailScreenState extends State<VoicemailScreen> {
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<VoicemailCubit, VoicemailState>(
+    return BlocConsumer<VoicemailCubit, VoicemailState>(
+      listenWhen: (previous, current) => previous.items != current.items,
+      listener: _stopPlaybackOfRemovedVoicemail,
       builder: (context, state) {
         return Scaffold(
           appBar: AppBar(
@@ -75,6 +79,17 @@ class _VoicemailScreenState extends State<VoicemailScreen> {
         );
       },
     );
+  }
+
+  // The player is screen-scoped and not owned by the tiles, so when the
+  // active voicemail leaves the list (deleted on this device or remotely)
+  // nothing else stops the audio.
+  void _stopPlaybackOfRemovedVoicemail(BuildContext context, VoicemailState state) {
+    final controller = context.read<VoicemailPlaybackController>();
+    final activeId = controller.activeId;
+    if (activeId != null && !state.items.any((it) => it.id == activeId)) {
+      unawaited(controller.stop());
+    }
   }
 
   void _onRetryFetch() {

--- a/test/features/settings/features/voicemail/bloc/voicemail_playback_controller_test.dart
+++ b/test/features/settings/features/voicemail/bloc/voicemail_playback_controller_test.dart
@@ -260,6 +260,64 @@ void main() {
       });
     });
 
+    group('stop()', () {
+      test('clears activeId, error and isLoading, stops the player and notifies', () async {
+        when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+        when(() => player.play()).thenAnswer((_) async {});
+        await controller.play(id: 'track1', uri: uri, isLocal: true);
+        expect(controller.activeId, 'track1');
+
+        var notified = false;
+        controller.addListener(() => notified = true);
+        await controller.stop();
+
+        expect(controller.activeId, isNull);
+        expect(controller.error, isNull);
+        expect(controller.isLoading, isFalse);
+        expect(notified, isTrue);
+        verify(() => player.stop()).called(1);
+      });
+
+      test('invalidates an in-flight play() chain', () {
+        fakeAsync((async) {
+          final completer = Completer<Duration?>();
+          when(() => player.setAudioSource(any())).thenAnswer((_) => completer.future);
+          when(() => player.play()).thenAnswer((_) async {});
+
+          unawaited(controller.play(id: 'track1', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          unawaited(controller.stop());
+          async.flushMicrotasks();
+          expect(controller.activeId, isNull);
+
+          // The stale chain resolves -- it must not resurrect the track or start playback.
+          completer.complete(null);
+          async.flushMicrotasks();
+
+          expect(controller.activeId, isNull);
+          verifyNever(() => player.play());
+        });
+      });
+
+      test('cancels a pending loading debounce', () {
+        fakeAsync((async) {
+          final completer = Completer<Duration?>();
+          when(() => player.setAudioSource(any())).thenAnswer((_) => completer.future);
+
+          unawaited(controller.play(id: 'track1', uri: uri, isLocal: true));
+          async.flushMicrotasks();
+
+          unawaited(controller.stop());
+          async.elapse(const Duration(milliseconds: 300));
+
+          expect(controller.isLoading, isFalse);
+
+          completer.complete(null);
+        });
+      });
+    });
+
     group('pause / resume / seek', () {
       test('pause() delegates to player.pause()', () async {
         when(() => player.pause()).thenAnswer((_) async {});

--- a/test/features/settings/features/voicemail/view/voicemail_screen_playback_stop_test.dart
+++ b/test/features/settings/features/voicemail/view/voicemail_screen_playback_stop_test.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+
+import 'package:webtrit_phone/features/settings/features/voicemail/bloc/bloc.dart';
+import 'package:webtrit_phone/features/settings/features/voicemail/models/models.dart';
+import 'package:webtrit_phone/features/settings/features/voicemail/view/voicemail_screen.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/models/voicemail/user_voicemail.dart';
+import 'package:webtrit_phone/utils/view_params/presence_view_params.dart';
+
+class _MockVoicemailCubit extends MockCubit<VoicemailState> implements VoicemailCubit {}
+
+class _MockAudioPlayer extends Mock implements AudioPlayer {}
+
+Voicemail _voicemail(String id) => Voicemail(
+  id,
+  '2026-07-06 10:00:00',
+  10.0,
+  '555001',
+  'User 555001',
+  '555002',
+  ReadStatus.read,
+  1024,
+  'voicemail',
+  'https://example.com/vm/$id.mp3',
+);
+
+VoicemailState _loadedState(List<Voicemail> items) =>
+    const VoicemailState().copyWith(items: items, status: VoicemailStatus.loaded);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(AudioSource.uri(Uri.parse('file:///fallback')));
+  });
+
+  late _MockVoicemailCubit cubit;
+  late _MockAudioPlayer player;
+  late StreamController<PlayerState> playerStateController;
+  late VoicemailPlaybackController controller;
+
+  setUp(() {
+    cubit = _MockVoicemailCubit();
+    player = _MockAudioPlayer();
+    playerStateController = StreamController<PlayerState>.broadcast(sync: true);
+
+    when(() => player.playerStateStream).thenAnswer((_) => playerStateController.stream);
+    when(() => player.playing).thenReturn(true);
+    when(() => player.stop()).thenAnswer((_) async {});
+    when(() => player.dispose()).thenAnswer((_) async {});
+    when(() => player.setAudioSource(any())).thenAnswer((_) async => null);
+    when(() => player.play()).thenAnswer((_) async {});
+    when(() => player.positionStream).thenAnswer((_) => Stream.value(Duration.zero));
+    when(() => player.duration).thenReturn(const Duration(seconds: 10));
+
+    controller = VoicemailPlaybackController(player: player, setupAudioSession: () async {});
+  });
+
+  tearDown(() async {
+    await playerStateController.close();
+  });
+
+  Widget host() {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: MultiProvider(
+        providers: [
+          BlocProvider<VoicemailCubit>.value(value: cubit),
+          Provider<VoicemailScreenContext>(
+            create: (_) => VoicemailScreenContext(
+              mediaCacheBasePath: '/tmp/vm-cache',
+              dateFormat: DateFormat('yyyy-MM-dd HH:mm'),
+              mediaHeaders: const {},
+            ),
+          ),
+          ChangeNotifierProvider<VoicemailPlaybackController>.value(value: controller),
+        ],
+        child: const PresenceViewParams(
+          hybridPresenceSupport: false,
+          blfViaSipSupport: false,
+          presenceViaSipSupport: false,
+          child: VoicemailScreen(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('stops playback when the active voicemail disappears from the list', (tester) async {
+    final vm1 = _voicemail('vm-1');
+    final vm2 = _voicemail('vm-2');
+
+    whenListen(
+      cubit,
+      Stream.fromIterable([
+        _loadedState([vm2]),
+      ]),
+      initialState: _loadedState([vm1, vm2]),
+    );
+
+    await controller.play(id: 'vm-1', uri: Uri.parse(vm1.url!), isLocal: true);
+    expect(controller.activeId, 'vm-1');
+    clearInteractions(player);
+
+    await tester.pumpWidget(host());
+    await tester.pump();
+
+    expect(controller.activeId, isNull);
+    verify(() => player.stop()).called(1);
+  });
+
+  testWidgets('keeps playback when a different voicemail is removed', (tester) async {
+    final vm1 = _voicemail('vm-1');
+    final vm2 = _voicemail('vm-2');
+
+    whenListen(
+      cubit,
+      Stream.fromIterable([
+        _loadedState([vm1]),
+      ]),
+      initialState: _loadedState([vm1, vm2]),
+    );
+
+    await controller.play(id: 'vm-1', uri: Uri.parse(vm1.url!), isLocal: true);
+    clearInteractions(player);
+
+    await tester.pumpWidget(host());
+    await tester.pump();
+
+    expect(controller.activeId, 'vm-1');
+    verifyNever(() => player.stop());
+  });
+}


### PR DESCRIPTION
## Overview

Deleting a voicemail while it is playing removed the tile from the list but the audio kept playing until the user left the screen (WT-1664).

This is a regression of the shared-player rework (#1399): previously each tile owned its own `AudioPlayer`, so removing the tile disposed the player and implicitly stopped the audio. With the screen-scoped `VoicemailPlaybackController` nothing stops playback when the active item leaves the list - the delete flows in `VoicemailCubit` have no link to the controller.

## Changes

- Add `VoicemailPlaybackController.stop()`: bumps the play generation (invalidates any in-flight `play()` chain), cancels the pending loading debounce, clears the active track state, and stops the player.
- `VoicemailScreen`: listen for item-list changes and stop playback when the active voicemail is no longer in the list. This covers single, selected, and delete-all flows, as well as removals arriving from the server via the watch stream.
- Tests: controller `stop()` unit tests (state reset, in-flight play invalidation, debounce cancel) and widget tests for the screen listener (stops for the active item, keeps playing when another item is removed).

## Testing

- `flutter analyze` clean; full test suite 1004/1004 green.
- Voicemail feature tests: 34/34.