### PR TITLE
fix: require a backend-produced rejection to confirm a missed session (WT-1557)

### DIFF
--- a/lib/app/session/session_verifier.dart
+++ b/lib/app/session/session_verifier.dart
@@ -44,11 +44,12 @@ class SessionUnverifiable extends SessionVerdict {
 
 /// Verifies over the REST API whether the account session is still valid.
 ///
-/// A logout requires positive evidence: transport failures and 5xx responses
-/// carry no verdict about the session and resolve to [SessionUnverifiable],
-/// so a backend outage never logs the user out. If the session is really
-/// gone, the signaling layer keeps reporting it and a later verification gets the
-/// definitive answer once the backend recovers.
+/// A logout requires positive evidence: transport failures, 5xx responses
+/// and 4xx responses produced by intermediaries (load balancers, proxies,
+/// WAFs) carry no verdict about the session and resolve to
+/// [SessionUnverifiable], so a backend outage never logs the user out. If
+/// the session is really gone, the signaling layer keeps reporting it and a
+/// later verification gets the definitive answer once the backend recovers.
 class SessionVerifier {
   SessionVerifier(this._userRepository);
 
@@ -71,12 +72,16 @@ class SessionVerifier {
       _logger.info('verify: session missing - verdict delegated to the session guard');
       return const SessionVerdictDelegated();
     } on RequestFailure catch (e) {
-      final statusCode = e.statusCode;
-      if (statusCode != null && statusCode >= 400 && statusCode < 500) {
-        _logger.warning('verify: session rejected with status $statusCode, code: ${e.error?.code}');
+      // A rejection counts as a verdict only when the backend itself produced
+      // it: a non-transient client error carrying a backend error code.
+      // Status-only responses come from intermediaries and say nothing about
+      // the session.
+      final isVerdict = e.isClientError && !e.isTransient && e.errorCode != null;
+      if (isVerdict) {
+        _logger.warning('verify: session rejected with status ${e.statusCode}, code: ${e.errorCode}');
         return const SessionMissed();
       }
-      _logger.warning('verify: backend failure with status $statusCode, code: ${e.error?.code} - no verdict');
+      _logger.warning('verify: no verdict from status ${e.statusCode}, code: ${e.errorCode}');
       return const SessionUnverifiable();
     } catch (e, st) {
       _logger.warning('verify: transport failure - no verdict', e, st);

--- a/packages/webtrit_api/lib/src/exceptions.dart
+++ b/packages/webtrit_api/lib/src/exceptions.dart
@@ -3,11 +3,37 @@ import 'models/error.dart';
 class RequestFailure implements Exception {
   RequestFailure({required this.url, this.statusCode, required this.requestId, this.token, this.error});
 
+  /// Status codes defined as transient by HTTP semantics (408 Request
+  /// Timeout, 425 Too Early, 429 Too Many Requests): the server explicitly
+  /// asks to retry, so such a response carries no lasting verdict.
+  static const _transientStatusCodes = {408, 425, 429};
+
   final Uri url;
   final int? statusCode;
   final String requestId;
   final String? token;
   final ErrorResponse? error;
+
+  /// Whether the response is a client error (4xx).
+  bool get isClientError {
+    final statusCode = this.statusCode;
+    return statusCode != null && statusCode >= 400 && statusCode < 500;
+  }
+
+  /// Whether the response is a server error (5xx).
+  bool get isServerError {
+    final statusCode = this.statusCode;
+    return statusCode != null && statusCode >= 500 && statusCode < 600;
+  }
+
+  /// Whether the status is transient by HTTP semantics, i.e. the server
+  /// explicitly asks to retry the request later.
+  bool get isTransient => _transientStatusCodes.contains(statusCode);
+
+  /// The backend-produced error code from the response body, if any.
+  /// A response without one was likely produced by an intermediary
+  /// (load balancer, proxy, WAF) rather than the backend itself.
+  String? get errorCode => error?.code;
 
   @override
   String toString() {

--- a/packages/webtrit_api/test/request_failure_test.dart
+++ b/packages/webtrit_api/test/request_failure_test.dart
@@ -92,5 +92,43 @@ void main() {
       expect(logString, contains(reason));
       expect(logString, contains(requestId));
     });
+
+    group('classification getters', () {
+      RequestFailure failure({int? statusCode, String? code}) => RequestFailure(
+        url: Uri.parse('$baseUri/user'),
+        statusCode: statusCode,
+        requestId: 'req-classification',
+        error: code != null ? ErrorResponse(code: code) : null,
+      );
+
+      test('isClientError is true only for 4xx', () {
+        expect(failure(statusCode: 400).isClientError, isTrue);
+        expect(failure(statusCode: 499).isClientError, isTrue);
+        expect(failure(statusCode: 399).isClientError, isFalse);
+        expect(failure(statusCode: 500).isClientError, isFalse);
+        expect(failure(statusCode: null).isClientError, isFalse);
+      });
+
+      test('isServerError is true only for 5xx', () {
+        expect(failure(statusCode: 500).isServerError, isTrue);
+        expect(failure(statusCode: 599).isServerError, isTrue);
+        expect(failure(statusCode: 499).isServerError, isFalse);
+        expect(failure(statusCode: null).isServerError, isFalse);
+      });
+
+      test('isTransient is true only for 408, 425 and 429', () {
+        expect(failure(statusCode: 408).isTransient, isTrue);
+        expect(failure(statusCode: 425).isTransient, isTrue);
+        expect(failure(statusCode: 429).isTransient, isTrue);
+        expect(failure(statusCode: 422).isTransient, isFalse);
+        expect(failure(statusCode: 503).isTransient, isFalse);
+        expect(failure(statusCode: null).isTransient, isFalse);
+      });
+
+      test('errorCode exposes the backend error code when present', () {
+        expect(failure(statusCode: 422, code: 'some_code').errorCode, 'some_code');
+        expect(failure(statusCode: 422).errorCode, isNull);
+      });
+    });
   });
 }

--- a/test/app/session/session_verifier_test.dart
+++ b/test/app/session/session_verifier_test.dart
@@ -63,7 +63,7 @@ void main() {
       expect(await verifier.verify(), isA<SessionVerdictDelegated>());
     });
 
-    test('resolves missed on an unmapped 4xx response', () async {
+    test('resolves missed on an unmapped 4xx response with a backend error code', () async {
       stubVerifyError(
         RequestFailure(
           url: _url,
@@ -74,6 +74,37 @@ void main() {
       );
 
       expect(await verifier.verify(), isA<SessionMissed>());
+    });
+
+    test('resolves unverifiable on a rate-limited 4xx even with a backend error code', () async {
+      stubVerifyError(
+        RequestFailure(
+          url: _url,
+          requestId: 'r1',
+          statusCode: 429,
+          error: const ErrorResponse(code: 'rate_limited'),
+        ),
+      );
+
+      expect(await verifier.verify(), isA<SessionUnverifiable>());
+    });
+
+    test('resolves unverifiable on a request-timeout 4xx', () async {
+      stubVerifyError(RequestFailure(url: _url, requestId: 'r1', statusCode: 408));
+
+      expect(await verifier.verify(), isA<SessionUnverifiable>());
+    });
+
+    test('resolves unverifiable on a too-early 4xx', () async {
+      stubVerifyError(RequestFailure(url: _url, requestId: 'r1', statusCode: 425));
+
+      expect(await verifier.verify(), isA<SessionUnverifiable>());
+    });
+
+    test('resolves unverifiable on a 4xx without a backend error code', () async {
+      stubVerifyError(RequestFailure(url: _url, requestId: 'r1', statusCode: 403));
+
+      expect(await verifier.verify(), isA<SessionUnverifiable>());
     });
 
     test('resolves unverifiable on a 5xx response', () async {


### PR DESCRIPTION
## Overview

Stacked on #1483. Code-review follow-up: the parent PR still treated ANY unmapped 4xx on the verification request as positive evidence of a dead session. That bucket is populated mostly by intermediaries, not by the backend: a rate-limiting load balancer answering 429 during an outage-recovery reconnect storm, a proxy 408, a WAF 403 with no backend error body. One such response was enough to force-logout a perfectly valid session - during exactly the kind of outage the parent PR is meant to survive (no retry at the API-client level for status responses, no debounce on the logout dispatch).

This PR narrows the verdict: a 4xx confirms a missed session only when the backend itself produced the rejection.

- status must not be transient by HTTP semantics (408 Request Timeout, 425 Too Early, 429 Too Many Requests - the server explicitly asks to retry)
- the response body must carry a backend error code (`errorCode`); status-only responses come from intermediaries

Everything else resolves to `SessionUnverifiable` (keep the session, the signaling layer keeps re-reporting and a later verification gets the definitive answer). Real backend verdicts are unaffected: the known session-death rejections arrive as typed exceptions handled earlier, and any future backend rejection code still confirms the logout under the new rule.

The HTTP semantics live in `webtrit_api` as classification getters on `RequestFailure` (`isClientError`, `isServerError`, `isTransient`, `errorCode`), so the session layer composes only the product policy and no raw status-code ranges leak outside the API package.

## Changes

- `webtrit_api`: classification getters on `RequestFailure` + 4 unit tests
- `SessionVerifier`: verdict condition narrowed to `isClientError && !isTransient && errorCode != null`; class doc updated
- `test/app/session/session_verifier_test.dart`: 4 new cases (429 with a code, 408, 425, status-only 403 -> all `SessionUnverifiable`)

## Testing

- `flutter analyze` clean
- `webtrit_api` package tests green (8), full app suite green, including 14 `SessionVerifier` tests