### PR TITLE
feat: add response classification getters to RequestFailure (part of WT-1557)

### DIFF
--- a/packages/webtrit_api/lib/src/exceptions.dart
+++ b/packages/webtrit_api/lib/src/exceptions.dart
@@ -3,11 +3,37 @@ import 'models/error.dart';
 class RequestFailure implements Exception {
   RequestFailure({required this.url, this.statusCode, required this.requestId, this.token, this.error});
 
+  // package:http exposes no status-code constants; dart:io is not web-safe.
+  static const _requestTimeout = 408;
+  static const _tooEarly = 425;
+  static const _tooManyRequests = 429;
+
+  static const _transientStatusCodes = {_requestTimeout, _tooEarly, _tooManyRequests};
+
   final Uri url;
   final int? statusCode;
   final String requestId;
   final String? token;
   final ErrorResponse? error;
+
+  /// Whether the response is a client error (4xx).
+  bool get isClientError {
+    final statusCode = this.statusCode;
+    return statusCode != null && statusCode >= 400 && statusCode < 500;
+  }
+
+  /// Whether the response is a server error (5xx).
+  bool get isServerError {
+    final statusCode = this.statusCode;
+    return statusCode != null && statusCode >= 500 && statusCode < 600;
+  }
+
+  /// Whether the status is transient by HTTP semantics: the server asks to
+  /// retry the request.
+  bool get isTransient => _transientStatusCodes.contains(statusCode);
+
+  /// The backend-produced error code from the response body, if any.
+  String? get errorCode => error?.code;
 
   @override
   String toString() {

--- a/packages/webtrit_api/test/request_failure_test.dart
+++ b/packages/webtrit_api/test/request_failure_test.dart
@@ -92,5 +92,43 @@ void main() {
       expect(logString, contains(reason));
       expect(logString, contains(requestId));
     });
+
+    group('classification getters', () {
+      RequestFailure failure({int? statusCode, String? code}) => RequestFailure(
+        url: Uri.parse('$baseUri/user'),
+        statusCode: statusCode,
+        requestId: 'req-classification',
+        error: code != null ? ErrorResponse(code: code) : null,
+      );
+
+      test('isClientError is true only for 4xx', () {
+        expect(failure(statusCode: 400).isClientError, isTrue);
+        expect(failure(statusCode: 499).isClientError, isTrue);
+        expect(failure(statusCode: 399).isClientError, isFalse);
+        expect(failure(statusCode: 500).isClientError, isFalse);
+        expect(failure(statusCode: null).isClientError, isFalse);
+      });
+
+      test('isServerError is true only for 5xx', () {
+        expect(failure(statusCode: 500).isServerError, isTrue);
+        expect(failure(statusCode: 599).isServerError, isTrue);
+        expect(failure(statusCode: 499).isServerError, isFalse);
+        expect(failure(statusCode: null).isServerError, isFalse);
+      });
+
+      test('isTransient is true only for 408, 425 and 429', () {
+        expect(failure(statusCode: 408).isTransient, isTrue);
+        expect(failure(statusCode: 425).isTransient, isTrue);
+        expect(failure(statusCode: 429).isTransient, isTrue);
+        expect(failure(statusCode: 422).isTransient, isFalse);
+        expect(failure(statusCode: 503).isTransient, isFalse);
+        expect(failure(statusCode: null).isTransient, isFalse);
+      });
+
+      test('errorCode exposes the backend error code when present', () {
+        expect(failure(statusCode: 422, code: 'some_code').errorCode, 'some_code');
+        expect(failure(statusCode: 422).errorCode, isNull);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Overview

`RequestFailure` consumers currently classify failures by hand-rolling status-code ranges (`statusCode >= 400 && statusCode < 500`) and digging into `error?.code` at every call site. That knowledge is HTTP/contract semantics and belongs to the API package, not to app-layer code.

This PR adds four classification getters to `RequestFailure` (inherited by all its typed subclasses):

- `isClientError` - the response is a 4xx
- `isServerError` - the response is a 5xx
- `isTransient` - the status is transient by HTTP semantics (408 Request Timeout, 425 Too Early, 429 Too Many Requests): the server explicitly asks to retry, so the response carries no lasting verdict
- `errorCode` - the backend-produced error code from the response body; a response without one was likely produced by an intermediary (load balancer, proxy, WAF) rather than the backend itself

No behavior changes - purely additive API surface with unit tests. First consumer lands separately.

## Changes

- `packages/webtrit_api/lib/src/exceptions.dart`: the four getters + the transient status set
- `packages/webtrit_api/test/request_failure_test.dart`: 4 tests covering range boundaries (incl. null status), the exact transient set and errorCode extraction

## Testing

- `webtrit_api` package tests green (8)
- `flutter analyze` clean, full app suite green on pre-push