### PR TITLE
refactor: declare endpoint optionality instead of treating any 404/501 as unsupported

### DIFF
--- a/lib/features/main/extensions/account_error_code.dart
+++ b/lib/features/main/extensions/account_error_code.dart
@@ -8,6 +8,7 @@ extension AccountErrorCodeL10n on AccountErrorCode {
   String l10n(BuildContext context) {
     return switch (this) {
       AccountErrorCode.passwordChangeRequired => context.l10n.account_selfCarePasswordExpired_message,
+      AccountErrorCode.userNotFound => context.l10n.login_RequestFailureUserNotFoundError,
     };
   }
 }

--- a/packages/webtrit_api/AGENTS.md
+++ b/packages/webtrit_api/AGENTS.md
@@ -27,9 +27,11 @@ WebtritApiClient(Uri baseUrl, String tenantId, {
 
 ## Request/Response Options
 
-- `WebtritApiRequestOptions` — retry count + delay. Factories: `withNoRetries()`,
+- `RequestOptions` — retry count + delay. Factories: `withNoRetries()`,
   `withDefaultRetries()` (3 retries, 1s delay), `withExtraRetries()`.
-- `WebtritApiResponseOptions` — decoding: `json` (default), `bytes`, or `raw`.
+- `ResponseOptions` — decoding: `json` (default), `bytes`, or `raw`; plus
+  `optionalEndpoint` (default `false`) marking the endpoint as optional in the
+  adapter contract. Constructed inside the client methods, not caller-supplied.
 
 ## Models
 
@@ -49,14 +51,22 @@ Never edit `.freezed.dart` / `.g.dart` — re-run `build_runner`.
 
 ## Exceptions
 
-All extend `RequestFailure`:
+All extend `RequestFailure`, which carries the status code, the parsed error
+body, and classification getters: `isClientError` (4xx), `isServerError` (5xx),
+`isTransient` (408/425/429), `errorCode` (backend error code from the body).
 
 | Exception | Trigger |
 |-----------|---------|
-| `EndpointNotSupportedException` | 404 or 501 |
-| `UserNotFoundException` | 404 on user endpoint |
-| `UnauthorizedException` | 422 with `refresh_token_invalid` |
 | `SessionMissingException` | 401 with `session_missing` |
+| `UnauthorizedException` | 401 with `token_invalid`; 422 with `refresh_token_invalid` |
+| `UserNotFoundException` | 404 with `user_not_found` (any endpoint); any 404 from `getUserInfo` / `createSessionOtp` |
+| `EndpointNotSupportedException` | methods declared `ResponseOptions(optionalEndpoint: true)` only: 501, or 404 without a backend error code |
+| `VoicemailNotConfiguredException` | `voicemail_not_configured` |
+| `PasswordChangeRequiredException` | `password_change_required` |
+
+Failure log level: client errors (4xx) log as `warning`; `severe` is reserved
+for server-side (5xx) and transport failures. `EndpointNotSupportedException`
+and `VoicemailNotConfiguredException` are not logged.
 
 ## Dependencies
 

--- a/packages/webtrit_api/lib/src/models/error_code.dart
+++ b/packages/webtrit_api/lib/src/models/error_code.dart
@@ -1,5 +1,6 @@
 enum AccountErrorCode {
-  passwordChangeRequired('password_change_required');
+  passwordChangeRequired('password_change_required'),
+  userNotFound('user_not_found');
 
   final String value;
 

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -63,6 +63,10 @@ class WebtritApiClient {
        _logger = Logger('WebtritApiClient'),
        tenantUrl = buildTenantUrl(baseUrl, tenantId);
 
+  // Declarations for endpoints that are optional in the adapter contract.
+  static const _optionalEndpoint = ResponseOptions(optionalEndpoint: true);
+  static const _optionalEndpointBytes = ResponseOptions(responseType: ResponseType.bytes, optionalEndpoint: true);
+
   final Uri tenantUrl;
   final http.Client _httpClient;
   final bool isDebug;
@@ -496,7 +500,7 @@ class WebtritApiClient {
       null,
       token,
       requestOptions: options,
-      responseOptions: const ResponseOptions(optionalEndpoint: true),
+      responseOptions: _optionalEndpoint,
     );
   }
 
@@ -614,7 +618,7 @@ class WebtritApiClient {
       token,
       {},
       requestOptions: options,
-      responseOptions: const ResponseOptions(optionalEndpoint: true),
+      responseOptions: _optionalEndpoint,
     );
 
     return ExternalPageAccessToken.fromJson(responseJson);
@@ -630,7 +634,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
-      responseOptions: const ResponseOptions(optionalEndpoint: true),
+      responseOptions: _optionalEndpoint,
     );
 
     return UserVoicemailListResponse.fromJson(responseJson);
@@ -647,7 +651,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
-      responseOptions: const ResponseOptions(optionalEndpoint: true),
+      responseOptions: _optionalEndpoint,
     );
 
     return UserVoicemail.fromJson(responseJson);
@@ -664,7 +668,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
-      responseOptions: const ResponseOptions(optionalEndpoint: true),
+      responseOptions: _optionalEndpoint,
     );
   }
 
@@ -683,7 +687,7 @@ class WebtritApiClient {
       token,
       requestJson,
       requestOptions: options,
-      responseOptions: const ResponseOptions(optionalEndpoint: true),
+      responseOptions: _optionalEndpoint,
     );
   }
 
@@ -699,7 +703,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
-      responseOptions: const ResponseOptions(responseType: ResponseType.bytes, optionalEndpoint: true),
+      responseOptions: _optionalEndpointBytes,
     );
 
     return responseJson;

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -181,10 +181,9 @@ class WebtritApiClient {
             );
           }
 
-          // If the server responds with 404 or 501, it may indicate that a specific private endpoint
-          // is not implemented by the current adapter (e.g., tenant-specific or backend version mismatch).
-          // In such case, throw a dedicated exception to handle unsupported endpoint scenarios gracefully.
-          if (httpResponse.statusCode == 404 || httpResponse.statusCode == 501) {
+          // For endpoints declared optional in the adapter contract, 404/501 means
+          // the adapter does not implement the endpoint.
+          if (responseOptions.optionalEndpoint && (httpResponse.statusCode == 404 || httpResponse.statusCode == 501)) {
             throw EndpointNotSupportedException(
               url: tenantUrl,
               requestId: xRequestId,
@@ -476,7 +475,13 @@ class WebtritApiClient {
   }
 
   Future<void> deleteUserInfo(String token, {RequestOptions options = const RequestOptions()}) async {
-    await _httpClientExecuteDelete([..._apiBasePathSegmentsV1, 'user'], null, token, requestOptions: options);
+    await _httpClientExecuteDelete(
+      [..._apiBasePathSegmentsV1, 'user'],
+      null,
+      token,
+      requestOptions: options,
+      responseOptions: const ResponseOptions(optionalEndpoint: true),
+    );
   }
 
   Future<AppStatus> getAppStatus(String token, {RequestOptions options = const RequestOptions()}) async {
@@ -593,6 +598,7 @@ class WebtritApiClient {
       token,
       {},
       requestOptions: options,
+      responseOptions: const ResponseOptions(optionalEndpoint: true),
     );
 
     return ExternalPageAccessToken.fromJson(responseJson);
@@ -608,6 +614,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
+      responseOptions: const ResponseOptions(optionalEndpoint: true),
     );
 
     return UserVoicemailListResponse.fromJson(responseJson);
@@ -624,6 +631,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
+      responseOptions: const ResponseOptions(optionalEndpoint: true),
     );
 
     return UserVoicemail.fromJson(responseJson);
@@ -640,6 +648,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
+      responseOptions: const ResponseOptions(optionalEndpoint: true),
     );
   }
 
@@ -658,6 +667,7 @@ class WebtritApiClient {
       token,
       requestJson,
       requestOptions: options,
+      responseOptions: const ResponseOptions(optionalEndpoint: true),
     );
   }
 
@@ -673,7 +683,7 @@ class WebtritApiClient {
       locale != null ? {'Accept-Language': locale} : null,
       token,
       requestOptions: options,
-      responseOptions: ResponseOptions(responseType: ResponseType.bytes),
+      responseOptions: const ResponseOptions(responseType: ResponseType.bytes, optionalEndpoint: true),
     );
 
     return responseJson;

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -181,9 +181,18 @@ class WebtritApiClient {
             );
           }
 
-          // For endpoints declared optional in the adapter contract, 404/501 means
-          // the adapter does not implement the endpoint.
-          if (responseOptions.optionalEndpoint && (httpResponse.statusCode == 404 || httpResponse.statusCode == 501)) {
+          // A 404 carrying the user_not_found code is a processed rejection:
+          // the user behind the session no longer exists on the backend.
+          if (httpResponse.statusCode == 404 && error?.code == 'user_not_found') {
+            throw UserNotFoundException(url: tenantUrl, requestId: xRequestId, statusCode: httpResponse.statusCode);
+          }
+
+          // For endpoints declared optional in the adapter contract, "not
+          // implemented" is a 501 or a 404 without a backend error code (absent
+          // route); a 404 carrying an error code is a domain rejection produced
+          // by a live endpoint.
+          if (responseOptions.optionalEndpoint &&
+              (httpResponse.statusCode == 501 || (httpResponse.statusCode == 404 && error?.code == null))) {
             throw EndpointNotSupportedException(
               url: tenantUrl,
               requestId: xRequestId,

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -225,7 +225,14 @@ class WebtritApiClient {
         }
       } catch (e) {
         if (e is! VoicemailNotConfiguredException && e is! EndpointNotSupportedException) {
-          _logger.severe('${method.toUpperCase()} failed for requestId: $xRequestId with error: $e');
+          final message = '${method.toUpperCase()} failed for requestId: $xRequestId with error: $e';
+          // A client error (4xx) is a rejection of this particular request;
+          // severe is reserved for server-side and transport failures.
+          if (e is RequestFailure && e.isClientError) {
+            _logger.warning(message);
+          } else {
+            _logger.severe(message);
+          }
         }
 
         // Do not retry for valid server responses with a defined HTTP status code.

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -187,7 +187,7 @@ class WebtritApiClient {
 
           // A 404 carrying the user_not_found code is a processed rejection:
           // the user behind the session no longer exists on the backend.
-          if (httpResponse.statusCode == 404 && error?.code == 'user_not_found') {
+          if (httpResponse.statusCode == 404 && error?.code == AccountErrorCode.userNotFound.value) {
             throw UserNotFoundException(url: tenantUrl, requestId: xRequestId, statusCode: httpResponse.statusCode);
           }
 

--- a/packages/webtrit_api/lib/src/webtrit_api_client.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_client.dart
@@ -63,8 +63,10 @@ class WebtritApiClient {
        _logger = Logger('WebtritApiClient'),
        tenantUrl = buildTenantUrl(baseUrl, tenantId);
 
-  // Declarations for endpoints that are optional in the adapter contract.
+  // Endpoint optional in the adapter contract, JSON response.
   static const _optionalEndpoint = ResponseOptions(optionalEndpoint: true);
+
+  // Endpoint optional in the adapter contract, binary response.
   static const _optionalEndpointBytes = ResponseOptions(responseType: ResponseType.bytes, optionalEndpoint: true);
 
   final Uri tenantUrl;

--- a/packages/webtrit_api/lib/src/webtrit_api_response_options.dart
+++ b/packages/webtrit_api/lib/src/webtrit_api_response_options.dart
@@ -3,5 +3,10 @@ enum ResponseType { json, bytes, raw }
 class ResponseOptions {
   final ResponseType responseType;
 
-  const ResponseOptions({this.responseType = ResponseType.json});
+  /// Marks the endpoint as optional in the adapter contract: a 404 or 501
+  /// response is reported as [EndpointNotSupportedException] instead of a
+  /// plain [RequestFailure].
+  final bool optionalEndpoint;
+
+  const ResponseOptions({this.responseType = ResponseType.json, this.optionalEndpoint = false});
 }

--- a/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
@@ -1,0 +1,48 @@
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import 'package:webtrit_api/webtrit_api.dart';
+
+void main() {
+  const authority = 'demo.webtrit.com';
+  const token = 'token_1';
+
+  WebtritApiClient clientAnswering(int statusCode) {
+    Future<Response> handler(Request request) async {
+      return Response('', statusCode, request: request);
+    }
+
+    final httpClient = MockClient(expectAsync1(handler));
+    return WebtritApiClient.inner(Uri.https(authority), '', httpClient: httpClient);
+  }
+
+  group('optional endpoint declaration', () {
+    test('optional endpoint throws EndpointNotSupportedException on 501', () {
+      final apiClient = clientAnswering(501);
+
+      expect(apiClient.getUserVoicemailList(token), throwsA(isA<EndpointNotSupportedException>()));
+    });
+
+    test('optional endpoint throws EndpointNotSupportedException on 404', () {
+      final apiClient = clientAnswering(404);
+
+      expect(apiClient.getUserVoicemailList(token), throwsA(isA<EndpointNotSupportedException>()));
+    });
+
+    test('mandatory endpoint throws plain RequestFailure on 501', () {
+      final apiClient = clientAnswering(501);
+
+      expect(
+        apiClient.getUserInfo(token, options: RequestOptions.withNoRetries()),
+        throwsA(isA<RequestFailure>().having((e) => e is EndpointNotSupportedException, 'is not typed', isFalse)),
+      );
+    });
+
+    test('mandatory user endpoint keeps UserNotFoundException on 404', () {
+      final apiClient = clientAnswering(404);
+
+      expect(apiClient.getUserInfo(token), throwsA(isA<UserNotFoundException>()));
+    });
+  });
+}

--- a/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
@@ -37,7 +37,7 @@ void main() {
       final apiClient = clientAnswering(501);
 
       expect(
-        apiClient.getUserInfo(token, options: RequestOptions.withNoRetries()),
+        apiClient.getUserInfo(token),
         throwsA(isA<RequestFailure>().having((e) => e is EndpointNotSupportedException, 'is not typed', isFalse)),
       );
     });

--- a/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
@@ -11,9 +11,9 @@ void main() {
   const authority = 'demo.webtrit.com';
   const token = 'token_1';
 
-  WebtritApiClient clientAnswering(int statusCode) {
+  WebtritApiClient clientAnswering(int statusCode, {String body = ''}) {
     Future<Response> handler(Request request) async {
-      return Response('', statusCode, request: request);
+      return Response(body, statusCode, request: request);
     }
 
     final httpClient = MockClient(expectAsync1(handler));
@@ -46,6 +46,37 @@ void main() {
       final apiClient = clientAnswering(404);
 
       expect(apiClient.getUserInfo(token), throwsA(isA<UserNotFoundException>()));
+    });
+
+    test('optional endpoint keeps EndpointNotSupportedException on 501 with a backend code', () {
+      final apiClient = clientAnswering(501, body: '{"code": "functionality_not_implemented"}');
+
+      expect(apiClient.getUserVoicemailList(token), throwsA(isA<EndpointNotSupportedException>()));
+    });
+
+    test('optional endpoint passes through a 404 carrying a backend code as plain RequestFailure', () {
+      final apiClient = clientAnswering(404, body: '{"code": "message_not_found"}');
+
+      expect(
+        apiClient.getUserVoicemail(token, 'message_1'),
+        throwsA(
+          isA<RequestFailure>()
+              .having((e) => e is EndpointNotSupportedException, 'is not typed', isFalse)
+              .having((e) => e.errorCode, 'errorCode', 'message_not_found'),
+        ),
+      );
+    });
+
+    test('optional endpoint throws UserNotFoundException on 404 with user_not_found', () {
+      final apiClient = clientAnswering(404, body: '{"code": "user_not_found"}');
+
+      expect(apiClient.deleteUserInfo(token), throwsA(isA<UserNotFoundException>()));
+    });
+
+    test('mandatory endpoint throws UserNotFoundException on 404 with user_not_found', () {
+      final apiClient = clientAnswering(404, body: '{"code": "user_not_found"}');
+
+      expect(apiClient.getUserContactList(token), throwsA(isA<UserNotFoundException>()));
     });
   });
 

--- a/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
+++ b/packages/webtrit_api/test/webtrit_api_client_optional_endpoint_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import 'package:webtrit_api/webtrit_api.dart';
@@ -43,6 +46,47 @@ void main() {
       final apiClient = clientAnswering(404);
 
       expect(apiClient.getUserInfo(token), throwsA(isA<UserNotFoundException>()));
+    });
+  });
+
+  group('failure log level', () {
+    late List<LogRecord> records;
+    late StreamSubscription<LogRecord> subscription;
+
+    setUp(() {
+      Logger.root.level = Level.ALL;
+      records = [];
+      subscription = Logger('WebtritApiClient').onRecord.listen((record) {
+        if (record.level > Level.INFO) records.add(record);
+      });
+    });
+
+    tearDown(() => subscription.cancel());
+
+    test('client error (mandatory 404) is logged as warning', () async {
+      final apiClient = clientAnswering(404);
+
+      await expectLater(apiClient.getUserContactList(token), throwsA(isA<RequestFailure>()));
+
+      expect(records, hasLength(1));
+      expect(records.single.level, Level.WARNING);
+    });
+
+    test('server error (500) is logged as severe', () async {
+      final apiClient = clientAnswering(500);
+
+      await expectLater(apiClient.getUserContactList(token), throwsA(isA<RequestFailure>()));
+
+      expect(records, hasLength(1));
+      expect(records.single.level, Level.SEVERE);
+    });
+
+    test('optional endpoint 404 is not logged', () async {
+      final apiClient = clientAnswering(404);
+
+      await expectLater(apiClient.getUserVoicemailList(token), throwsA(isA<EndpointNotSupportedException>()));
+
+      expect(records, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Overview

The client maps EVERY 404/501 from EVERY endpoint to `EndpointNotSupportedException`. That semantic is only correct for endpoints that are genuinely optional in the adapter contract; for a mandatory endpoint (e.g. `GET /user`, the source of SIP credentials) a 501 is a backend anomaly, yet today it wears the same "feature legitimately absent" label and hides deployment misconfigurations behind graceful feature-gating.

Optionality is a property of the endpoint contract, so it is now declared where the endpoint is defined - per client method, via the method-internal `ResponseOptions`:

- `ResponseOptions` gains `optionalEndpoint` (default `false`)
- the generic 404/501 -> `EndpointNotSupportedException` mapping fires only for methods declared optional
- declared optional (matches every consumer that catches `EndpointNotSupportedException` today): the voicemail family (`getUserVoicemailList`, `getUserVoicemail`, `deleteUserVoicemail`, `updateUserVoicemail`, `getUserVoicemailAttachment`), `getExternalPageAccessToken`, `deleteUserInfo`

For all other endpoints a 404/501 now surfaces as a plain `RequestFailure`. Dedicated per-endpoint mappings are unaffected (e.g. 404 on `GET /user` still becomes `UserNotFoundException`), and `ResponseOptions` is constructed inside the methods, so caller-supplied `RequestOptions` cannot accidentally reset the declaration.

The "not implemented" signal itself is refined against the reference adapter contract: it is a 501 (with or without a body - the adapter's own signal is 501 + `functionality_not_implemented`) or a 404 without a backend error code (absent route; the Phoenix router shape already parses to no code). A 404 carrying a backend error code is a domain rejection produced by a live endpoint and surfaces as a plain `RequestFailure` with the body intact even on declared-optional methods. On top of that, `404 + user_not_found` is mapped to `UserNotFoundException` in the generic layer (same pattern as the existing `401 + session_missing` / `422 + refresh_token_invalid` mappings): previously a server-side-deleted account answering Delete Account with `404 user_not_found` was reported as "delete account is not supported" and the session stayed alive; now the session guard logs it out.

Failure logging follows the same boundary: a client error (4xx) is a rejection of the particular request and is logged as `warning`; `severe` is reserved for server-side (5xx) and transport failures. Before this, a reclassified mandatory 404 (e.g. unknown user on sign-in) would have produced a `severe` record on every routine occurrence.

For the declared-optional endpoints the not-supported signals behave as before (501 with or without a body, and a bodyless 404, still map to `EndpointNotSupportedException`) - verified against every catch site in the app (voicemail feature-gating, delete-account guard, external page token). The one deliberate change on those endpoints follows the refined rule above: a 404 carrying a backend code (e.g. `message_not_found` on a single voicemail) no longer reads as "feature not supported", so a stale item cannot flip the voicemail feature flag off or masquerade as a missing endpoint.
