### PR TITLE
fix(screenshots): honor callHistory capability in the recents tab preview

### DIFF
--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -159,6 +159,24 @@ class _MainScreenScreenshotState extends State<MainScreenScreenshot> {
           ),
         );
       case MainFlavor.recents:
+        // Mirror the app's tab routing: with the callHistory adapter capability
+        // the recents tab shows remote CDRs instead of local recents.
+        final recentsTab = featureAccess?.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>();
+        if (recentsTab?.supportsCallHistory ?? false) {
+          return MultiBlocProvider(
+            providers: [
+              BlocProvider<FullRecentCdrsCubit>(create: (_) => MockFullRecentCdrsCubit.withCdrs()),
+              BlocProvider<MissedRecentCdrsCubit>(create: (_) => MockMissedRecentCdrsCubit.withRecords()),
+            ],
+            child: RecentCdrsScreen(
+              title: widget.title,
+              transferEnabled: false,
+              videoEnabled: true,
+              chatsEnabled: false,
+              smssEnabled: false,
+            ),
+          );
+        }
         return BlocProvider<RecentsBloc>(
           create: (_) => MockRecentsBloc.mainScreen(),
           child: RecentsScreen(


### PR DESCRIPTION
## Overview

The theme-editor preview always rendered the recents tab as the local `RecentsScreen`, regardless of the `callHistory` adapter capability toggled in the configurator's Preview capabilities dialog. The real app picks the screen per capability (`main_screen_page.dart`): with `callHistory` the recents tab shows remote CDRs (`RecentCdrsScreen`). Because of that mismatch, toggling the capability did not change the main-screen preview, and the CDR variant of the tab (with its own app bar styling) was only reachable as a separate standalone screenshot further down the strip.

`MainScreenScreenshot` now mirrors the app's tab routing: when the recents tab resolved from `FeatureAccess` reports `supportsCallHistory`, the recents flavor renders `RecentCdrsScreen` backed by the existing CDR mocks (same wiring as `RecentCdrsScreenScreenshot`); otherwise it keeps rendering `RecentsScreen` as before. Previews without `FeatureAccess` fall back to the default tabs and are unaffected.

## Testing

- `flutter analyze` clean (root + screenshots package)
- `flutter test` - all tests pass
- Not covered by an automated test: visual check of the configurator preview after the toggle (screenshots harness has no widget tests)