### PR TITLE
fix(cdrs): apply themed styling to the recents CDR screen app bar

### DIFF
--- a/lib/features/cdrs/view/recent_cdrs_screen.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone/app/constants.dart';
 
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/features/recents/view/recents_screen_styles.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -48,14 +49,17 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
     final l10n = context.l10n;
 
     final themeData = Theme.of(context);
+    final effectiveStyle = themeData.extension<RecentsScreenStyles>()?.primary;
 
-    return Scaffold(
+    return ThemedScaffold(
+      background: effectiveStyle?.background,
+      contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
+      applyToAppBar: effectiveStyle?.applyToAppBar ?? false,
       extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
+        flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(


### PR DESCRIPTION
## Overview

When the backend advertises the `callHistory` capability, the recents tab renders `RecentCdrsScreen` instead of `RecentsScreen`. Unlike the local variant, the CDR screen hardcoded its app bar background to a translucent `canvasColor` with a fixed blur and used a plain `Scaffold`, so none of the configurator-driven theming reached it: `appBarTheme.backgroundColor` from the widget config, and the recents page config (`background`, `themeOverride`, `appBarBlurredSurface`) were all ignored. On white-label builds with a dark app bar configured, the recents tab showed a near-white toolbar while the rest of the theme applied (title and icons picked up the configured foreground), and the same tab previewed correctly in the configurator - which renders the local variant unless the capability is mocked.

The CDR screen now uses the same contract as `RecentsScreen`: a `ThemedScaffold` fed from `RecentsScreenStyles.primary` (background, content theme override, apply-to-app-bar), and the app bar takes its background from `appBarTheme` with the blur coming from the page config's `appBarBlurredSurface` instead of a hardcoded one. With the stock theme the look stays frosted - the default recents page config ships `appBarBlurredSurface` (`#96EEF5FA`, sigma 10) plus the gradient background, both of which the local recents tab already renders. Body layout, tabs, and the extended-body inset workaround are unchanged.

## Testing

- `flutter analyze` clean, full `flutter test` suite passes (pre-push)
- Manual check pending: a build against a `callHistory` backend with a themed app bar should show the configured app bar background on the recents tab, matching the configurator preview