### PR TITLE
build: bump app version to 1.16.1+1

### DIFF
--- a/lib/features/cdrs/view/recent_cdrs_screen.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone/app/constants.dart';
 
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/features/recents/view/recents_screen_styles.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -48,14 +49,17 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
     final l10n = context.l10n;
 
     final themeData = Theme.of(context);
+    final effectiveStyle = themeData.extension<RecentsScreenStyles>()?.primary;
 
-    return Scaffold(
+    return ThemedScaffold(
+      background: effectiveStyle?.background,
+      contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
+      applyToAppBar: effectiveStyle?.applyToAppBar ?? false,
       extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
+        flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ version: 0.0.0+0
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.1+0
+app_version: 1.16.1+1
 
 environment:
   sdk: ^3.12.0

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -159,6 +159,24 @@ class _MainScreenScreenshotState extends State<MainScreenScreenshot> {
           ),
         );
       case MainFlavor.recents:
+        // Mirror the app's tab routing: with the callHistory adapter capability
+        // the recents tab shows remote CDRs instead of local recents.
+        final recentsTab = featureAccess?.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>();
+        if (recentsTab?.supportsCallHistory ?? false) {
+          return MultiBlocProvider(
+            providers: [
+              BlocProvider<FullRecentCdrsCubit>(create: (_) => MockFullRecentCdrsCubit.withCdrs()),
+              BlocProvider<MissedRecentCdrsCubit>(create: (_) => MockMissedRecentCdrsCubit.withRecords()),
+            ],
+            child: RecentCdrsScreen(
+              title: widget.title,
+              transferEnabled: false,
+              videoEnabled: true,
+              chatsEnabled: false,
+              smssEnabled: false,
+            ),
+          );
+        }
         return BlocProvider<RecentsBloc>(
           create: (_) => MockRecentsBloc.mainScreen(),
           child: RecentsScreen(


### PR DESCRIPTION
## Overview

Hotfix patch for the 1.16.1 release line (in QA): cherry-picks two develop fixes so white-label builds render the configured recents toolbar, and bumps the app version iteration.

- fix(cdrs): apply themed styling to the recents CDR screen app bar - the CDR variant of the recents tab (shown when the backend advertises `callHistory`) hardcoded a translucent `canvasColor` app bar and ignored the configurator theme; it now uses the same `ThemedScaffold` + recents page style contract as the local recents screen, so `appBarTheme.backgroundColor` and the page config apply. The stock theme keeps its frosted look via the default `appBarBlurredSurface`.
- fix(screenshots): honor callHistory capability in the recents tab preview - the configurator's recents tab screenshot now switches to the CDR screen when the capability is enabled, matching the app's routing (dev-only `screenshots` package, not shipped in the app binary; keeps the versioned configurator build against this branch reproducible).
- build: bump app version to 1.16.1+1.

QA builds for 1.16.1 should be re-cut from the branch after this lands; the draft release PR to main picks these commits up automatically.

## Testing

- `flutter analyze` clean, full `flutter test` suite passes (pre-push)
- Cherry-picks applied clean from the develop squash commits