### PR TITLE
build: bump app_version build iteration to 1.15.4+8

### DIFF
--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -14,6 +14,7 @@
   ],
   "loginConfig": {
     "signinOrder": ["passwordSignin", "otpSignin", "signup"],
+    "qr": { "enabled": false, "formats": [{ "type": "uri", "schemes": ["csc"] }, { "type": "json" }], "expectedHost": null },
     "common": {
       "fullScreenLaunchEmbeddedResourceId": null
     },

--- a/assets/themes/app.config.json
+++ b/assets/themes/app.config.json
@@ -13,6 +13,7 @@
     }
   ],
   "loginConfig": {
+    "signinOrder": ["passwordSignin", "otpSignin", "signup"],
     "common": {
       "fullScreenLaunchEmbeddedResourceId": null
     },

--- a/docs/application_config.md
+++ b/docs/application_config.md
@@ -6,6 +6,8 @@ navigation structure, and screen-specific behaviors.
 ## Table of Contents
 
 - [Login Configuration](#login-configuration)
+  - [Sign-In Tab Order](#sign-in-tab-order)
+  - [Login QR Sign-In](#login-qr-sign-in)
   - [Login Common](#login-common)
   - [Login Mode Select](#login-mode-select)
 - [Main Configuration](#main-configuration)
@@ -27,6 +29,15 @@ The `loginConfig` section defines the app’s login screen behavior and embedded
 ```json
 {
   "loginConfig": {
+    "signinOrder": ["passwordSignin", "otpSignin", "signup"],
+    "qr": {
+      "enabled": false,
+      "formats": [
+        { "type": "uri", "schemes": ["csc"] },
+        { "type": "json" }
+      ],
+      "expectedHost": null
+    },
     "common": {
       "fullScreenLaunchEmbeddedResourceId": "1"
     },
@@ -49,6 +60,24 @@ The `loginConfig` section defines the app’s login screen behavior and embedded
   }
 }
 ```
+
+### Sign-In Tab Order
+
+| Field         | Type           | Default                                    | Description                                                                                                                    |
+|---------------|----------------|--------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `signinOrder` | `List<String>` | `["passwordSignin", "otpSignin", "signup"]` | Order of the sign-in tabs on the login switch screen, by login type name (incl. `qrSignin`). Only the types actually available are shown; the first one is selected by default. Unknown or omitted names are placed last. |
+
+### Login QR Sign-In
+
+The `qr` block enables signing in by scanning a provisioning QR code
+(`scheme:user:password@host`). See [qr_signin.md](qr_signin.md) for the payload
+format, scheme descriptions and screen behavior.
+
+| Field          | Type           | Default   | Description                                                                                   |
+|----------------|----------------|-----------|-----------------------------------------------------------------------------------------------|
+| `enabled`      | `bool`         | `false`   | Whether the QR sign-in tab is available. The tab also requires the backend to support password sign-in. |
+| `formats`      | `List<Format>` | uri (csc) + json | Accepted payload formats (`{ "type": "uri" | "json", "schemes": [...] }`), probed in this order; `schemes` applies to `uri` only. |
+| `expectedHost` | `string?`      | `null`    | Expected host (cloud id) of the code, shared by all formats; mismatching codes are rejected. `null` accepts any host. |
 
 ### Login Common
 

--- a/docs/qr_signin.md
+++ b/docs/qr_signin.md
@@ -1,0 +1,202 @@
+# QR Code Sign-In
+
+## Overview
+
+The login switch screen can offer a "QR code" tab next to the Password/OTP/Sign-up
+tabs. Scanning a provisioning QR code signs the user in through the regular password
+login: the code carries a plain user reference and password, the app parses them and
+performs the same `POST /session` request as manual entry.
+
+The primary use case is migrating users from provisioning portals that already issue
+such codes (for example the Cloud Softphone portal QR generator), so a user's first
+login is a single scan instead of typing credentials.
+
+## Table of Contents
+
+- [Payload Formats](#payload-formats)
+- [URI Format](#uri-format)
+- [JSON Format](#json-format)
+- [Supported Schemes](#supported-schemes)
+- [Configuration](#configuration)
+- [When the Tab Appears](#when-the-tab-appears)
+- [Screen States](#screen-states)
+- [Security Notes](#security-notes)
+- [Platform Notes](#platform-notes)
+
+---
+
+## Payload Formats
+
+Payloads are interpreted by a chain of format decoders (adapters), probed in the
+order of the `loginConfig.qr.formats` entries: the first decoder that RECOGNIZES the payload
+fully decides the outcome (including failures such as a host mismatch); when none
+does, the code is reported as "not a sign-in code". Supporting a new payload
+structure is one new decoder class
+(`lib/features/login/features/login_qr_signin/models/qr_signin_payload_decoder.dart`)
+plus its name in the `formats` list - the scanner, cubit and login flow are
+format-agnostic and stay untouched.
+
+Built-in formats:
+
+| Format | Shape                                          | Typical producer                          |
+|--------|--------------------------------------------------|---------------------------------------------|
+| `uri`  | `scheme:USER_REF:PASSWORD@HOST[?query]`          | Provisioning portals (Cloud Softphone QR generator) |
+| `json` | Marker-discriminated JSON object (`"t"` field)   | Reserved for WebTrit-issued codes            |
+
+## URI Format
+
+```
+scheme:USER_REF:PASSWORD@HOST[?query]
+```
+
+Example:
+
+```
+csc:user123:p%40ssword@EXAMPLE
+```
+
+| Part       | Description                                                                                                                              |
+|------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `scheme`   | URI scheme name, matched case-insensitively against the configured `schemes` list (default `csc`).                                        |
+| `USER_REF` | Percent-encoded user reference (account id, phone number or email). Decoded as `user123`.                                              |
+| `PASSWORD` | Percent-encoded password. `p%40ssword` decodes to `p@ssword`. May be empty or omitted - see below.                                        |
+| `HOST`     | Cloud/tenant identifier of the issuing portal. Validated against `expectedHost` when configured, otherwise ignored. A trailing `*` (test-version marker) is stripped before comparison. |
+| `?query`   | Optional. Unknown parameters are ignored so generator-side extras do not break scanning.                                                   |
+
+Parsing rules:
+
+- The `?query` tail is cut off first; the remainder is split at the LAST `@` (host)
+  and the FIRST `:` (credentials). Since the credential segments are percent-encoded,
+  a literal `:` or `@` can only appear between them, which makes the split unambiguous.
+- The reserved query parameter `m` selects the sign-in method. Absent means
+  `password`; any other value is rejected as unsupported (reserved for future methods
+  such as token-based auto-provisioning).
+- Query parameters that would redirect the sign-in to another core (`core`, `tenant`,
+  `core_url`, `tenant_id`) are rejected: a scanned code must not choose where
+  credentials are sent.
+- A code with an empty or omitted password (`csc:user:@HOST`, `csc:user@HOST`) does
+  not fail: the user reference is prefilled on the password tab and the user finishes
+  signing in manually.
+
+The decoder lives in
+`lib/features/login/features/login_qr_signin/models/uri_qr_signin_payload_decoder.dart`
+and is covered by a unit-test matrix in
+`test/features/login/qr_signin_payload_parser_test.dart`.
+
+## JSON Format
+
+```json
+{"t": "webtrit-signin", "v": 1, "user": "user123", "password": "p@ssword", "host": "EXAMPLE"}
+```
+
+| Field      | Required | Description                                                                                                   |
+|------------|----------|-----------------------------------------------------------------------------------------------------------------|
+| `t`        | yes      | Marker discriminator; must be `webtrit-signin`. Bare JSON has no scheme, so any other JSON falls through as unrecognized. |
+| `v`        | no       | Payload version; absent means `1`. Other versions are rejected as unsupported.                                    |
+| `user`     | yes      | Plain (not encoded) user reference.                                                                               |
+| `password` | no       | Plain password; missing or empty prefills the password tab instead of signing in.                                 |
+| `host`     | see note | Cloud/tenant identifier. When `expectedHost` is configured the field must be present and match; otherwise ignored. |
+
+Rules shared with the URI format: fields that would redirect the sign-in to another
+core (`core`, `tenant`, `core_url`, `tenant_id`) are rejected; unknown fields are
+ignored so the format can grow without breaking older builds. The JSON form is
+reserved for WebTrit-issued codes (nothing produces it yet); prefer the URI form for
+plain user+password codes - it makes a sparser, easier-to-scan QR.
+
+The field layout (marker, version and field names) is described by a
+`JsonQrSigninStructure` value: a dialect that only renames fields or uses another
+marker is a different structure passed to the same decoder, not a new decoder class.
+Payloads whose shape differs beyond field names still get their own decoder.
+
+The decoder lives in
+`lib/features/login/features/login_qr_signin/models/json_qr_signin_payload_decoder.dart`.
+
+## Supported Schemes
+
+The scheme name identifies which provisioning system issued the code; all configured
+schemes share the same grammar above. A code whose scheme is not in the configured
+`schemes` list is rejected as "not a sign-in code" (the scanner shows the invalid-code
+hint and keeps scanning).
+
+| Scheme | Issued by                                                                 | Notes                                                                                                                             |
+|--------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `csc`  | Cloud Softphone provider portal (Tools -> QR code generator)                | The default and currently the only known producer. `HOST` is the portal's cloud id (an opaque identifier assigned by the portal); a trailing `*` marks a test (non-approved) app version and is tolerated. The portal URL-encodes the username/password segments. |
+
+Adding a scheme is a config-only change: list its name in the `schemes` of the `uri` entry under `loginConfig.qr.formats`.
+Use this when a brand's provisioning system issues codes in the same
+`scheme:user:password@host` shape under a different name. Codes with a different
+STRUCTURE (not just a different scheme name) are not supported by configuration and
+require a parser extension.
+
+## Configuration
+
+The feature is driven by the `qr` block of `loginConfig` in the application config
+(see [application_config.md](application_config.md)):
+
+```json
+{
+  "loginConfig": {
+    "signinOrder": ["passwordSignin", "otpSignin", "signup", "qrSignin"],
+    "qr": {
+      "enabled": true,
+      "formats": [
+        { "type": "uri", "schemes": ["csc"] },
+        { "type": "json" }
+      ],
+      "expectedHost": "EXAMPLE"
+    }
+  }
+}
+```
+
+| Field          | Type           | Default   | Description                                                                                   |
+|----------------|----------------|-----------|-----------------------------------------------------------------------------------------------|
+| `enabled`      | `bool`         | `false`   | Whether the QR sign-in tab is available at all.                                                |
+| `formats`      | `List<Format>` | uri (csc) + json | Accepted payload formats with their per-format options, probed in this order.           |
+| `expectedHost` | `string?`      | `null`    | Expected host (cloud id) of the code, shared by all formats. When set, codes issued for a different host are rejected; `null` accepts any host. |
+
+Each `formats` entry:
+
+| Field     | Type            | Applies to | Description                                                                 |
+|-----------|-----------------|------------|-------------------------------------------------------------------------------|
+| `type`    | `string`        | all        | Decoder name: `uri` or `json`. Unknown types are ignored.                       |
+| `schemes` | `List<String>?` | `uri`      | Accepted scheme names, matched case-insensitively. Defaults to `["csc"]`.       |
+
+The tab's position and default selection follow the regular `signinOrder` mechanism;
+add `qrSignin` to the list to control its placement (unlisted types go last).
+
+## When the Tab Appears
+
+The QR tab is NOT a backend capability. It is offered when BOTH hold:
+
+1. `loginConfig.qr.enabled` is `true` in the app config, and
+2. the backend adapter advertises `passwordSignin` in `system-info`
+   (`adapter.supported`) - the scanned code carries plain credentials, so QR sign-in
+   is a client-side companion of password login.
+
+## Screen States
+
+| State                | Behavior                                                                                                             |
+|----------------------|----------------------------------------------------------------------------------------------------------------------|
+| Scanner              | Camera viewfinder (a neutral backdrop keeps the shape while the camera initializes). Detected codes are deduplicated. |
+| Signing in           | Spinner + "Signing you in..." while the session is created (the shared login `processing` state).                     |
+| Invalid code         | Inline error line under the viewfinder; scanning resumes automatically after a short cooldown.                        |
+| No camera permission | Single action: "Allow camera access" triggers the system request; once the denial is permanent it is replaced by "Open settings". Re-checked when the app returns from the settings screen. |
+| Failed sign-in       | Regular login error notification; the same code is retried only after a cooldown so a code left in the viewfinder does not loop attempts. |
+
+## Security Notes
+
+- The raw QR payload is never logged: it may carry plain credentials. Only the
+  rejection reason (scheme/host/method/malformed) is logged.
+- Codes that try to override the target core are rejected (see parsing rules).
+- A password inside a QR image is plaintext at rest (paper, screenshots). The format
+  exists for portal-driven migration; prefer token-based provisioning for new
+  deployments.
+
+## Platform Notes
+
+- Scanning uses the `mobile_scanner` plugin: AVFoundation/Apple Vision on iOS/macOS,
+  CameraX + the bundled ML Kit model on Android (works without Google Play Services),
+  ZXing on web.
+- iOS `NSCameraUsageDescription` mentions QR scanning; Android camera permission is
+  merged from the plugin manifest.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -61,7 +61,7 @@
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>This app requires permission to access the camera to make video calls</string>
+	<string>This app requires permission to access the camera to make video calls and scan QR codes</string>
 	<key>NSContactsUsageDescription</key>
 	<string>This app requires permission to access contacts to make calls within your address book</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -111,6 +111,7 @@ class AppRouter extends RootStackRouter {
                   ],
                 ),
                 AutoRoute(page: LoginPasswordSigninScreenPageRoute.page, maintainState: false),
+                AutoRoute(page: LoginQrSigninScreenPageRoute.page, maintainState: false),
                 AutoRoute(
                   page: LoginSignupRouterPageRoute.page,
                   maintainState: false,

--- a/lib/app/router/app_router.gr.dart
+++ b/lib/app/router/app_router.gr.dart
@@ -859,6 +859,22 @@ class LoginPasswordSigninScreenPageRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [LoginQrSigninScreenPage]
+class LoginQrSigninScreenPageRoute extends PageRouteInfo<void> {
+  const LoginQrSigninScreenPageRoute({List<PageRouteInfo>? children})
+    : super(LoginQrSigninScreenPageRoute.name, initialChildren: children);
+
+  static const String name = 'LoginQrSigninScreenPageRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return LoginQrSigninScreenPage();
+    },
+  );
+}
+
+/// generated route for
 /// [LoginRouterPage]
 class LoginRouterPageRoute extends PageRouteInfo<LoginRouterPageRouteArgs> {
   LoginRouterPageRoute({

--- a/lib/data/app_permissions.dart
+++ b/lib/data/app_permissions.dart
@@ -203,4 +203,17 @@ class AppPermissions {
     final status = await Permission.contacts.request();
     return status.isGranted;
   }
+
+  /// Full camera permission status (unlike the boolean helpers, callers need
+  /// to distinguish a permanent denial to offer the settings screen instead
+  /// of a pointless request).
+  Future<PermissionStatus> getCameraPermissionStatus() async {
+    return Permission.camera.status;
+  }
+
+  Future<PermissionStatus> requestCameraPermission() async {
+    final status = await Permission.camera.request();
+    _logger.info('Camera permission request result: $status');
+    return status;
+  }
 }

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -113,35 +113,14 @@ class FeatureAccess extends Equatable {
       // Note: TermsConfig must be initialized before SettingsConfig because Settings might fallback to Terms config.
       final termsConfig = TermsMapper.map(embeddedResources);
 
-      final loginConfig = LoginMapper.map(
-        appConfig,
-        embeddedConfig.embeddedResources,
-      );
-      final bottomMenuConfig = BottomMenuMapper.map(
-        appConfig,
-        embeddedConfig,
-        coreSupport,
-        featureOverrides,
-      );
-      final settingsConfig = SettingsMapper.map(
-        appConfig,
-        embeddedResources,
-        coreSupport,
-        termsConfig,
-      );
+      final loginConfig = LoginMapper.map(appConfig, embeddedConfig.embeddedResources);
+      final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig, coreSupport, featureOverrides);
+      final settingsConfig = SettingsMapper.map(appConfig, embeddedResources, coreSupport, termsConfig);
       final callConfig = CallMapper.map(appConfig, featureOverrides);
       final messagingConfig = MessagingMapper.map(appConfig, coreSupport);
       final contactsConfig = ContactsMapper.map(appConfig);
-      final systemNotificationsConfig = SystemNotificationsMapper.map(
-        coreSupport,
-        appConfig,
-        featureOverrides,
-      );
-      final sipPresenceConfig = SipPresenceMapper.map(
-        systemInfo,
-        appConfig,
-        featureOverrides,
-      );
+      final systemNotificationsConfig = SystemNotificationsMapper.map(coreSupport, appConfig, featureOverrides);
+      final sipPresenceConfig = SipPresenceMapper.map(systemInfo, appConfig, featureOverrides);
       final loggingConfig = LoggingMapper.map(appConfig, featureOverrides);
 
       final supportedConfig = SupportedMapper.map(appConfig.supported);
@@ -197,16 +176,12 @@ abstract final class LoginMapper {
   // Currently, modeSelectActions control both the launch screen and the buttons on the login_mode_select_screen,
   // which leads to unclear and tightly coupled logic.
   static LoginConfig map(AppConfig appConfig, List<EmbeddedData> embeddedData) {
-    final rawButtons = appConfig.loginConfig.modeSelect.actions.where(
-      (button) => button.enabled,
-    );
+    final rawButtons = appConfig.loginConfig.modeSelect.actions.where((button) => button.enabled);
     final buttons = <LoginModeAction>[];
 
     for (final action in rawButtons) {
       final loginFlavor = LoginFlavor.values.byName(action.type);
-      final loginEmbeddedData = embeddedData.firstWhereOrNull(
-        (dto) => dto.id == action.embeddedId,
-      );
+      final loginEmbeddedData = embeddedData.firstWhereOrNull((dto) => dto.id == action.embeddedId);
 
       if (loginEmbeddedData != null && loginFlavor == LoginFlavor.embedded) {
         buttons.add(
@@ -217,23 +192,23 @@ abstract final class LoginMapper {
           ),
         );
       } else if (loginFlavor == LoginFlavor.login) {
-        buttons.add(
-          LoginDefaultModeAction(
-            titleL10n: action.titleL10n,
-            flavor: loginFlavor,
-          ),
-        );
+        buttons.add(LoginDefaultModeAction(titleL10n: action.titleL10n, flavor: loginFlavor));
       }
     }
+
+    final qr = appConfig.loginConfig.qr;
 
     return LoginConfig(
       titleL10n: appConfig.loginConfig.modeSelect.greetingL10n,
       actions: List.unmodifiable(buttons),
       signinOrder: appConfig.loginConfig.signinOrder,
+      qrSignin: QrSigninConfig(
+        enabled: qr.enabled,
+        formats: [for (final format in qr.formats) QrSigninFormatConfig(type: format.type, schemes: format.schemes)],
+        expectedHost: qr.expectedHost,
+      ),
       launchLoginPage: embeddedData.firstWhereOrNull(
-        (it) =>
-            it.id ==
-            appConfig.loginConfig.common.fullScreenLaunchEmbeddedResourceId,
+        (it) => it.id == appConfig.loginConfig.common.fullScreenLaunchEmbeddedResourceId,
       ),
     );
   }
@@ -263,14 +238,8 @@ abstract final class BottomMenuMapper {
 
     final bottomMenuTabs = bottomMenu.tabs
         .where((tab) => tab.enabled)
-        .map(
-          (tab) =>
-              _createBottomMenuTab(tab, embeddedConfig, coreSupport, overrides),
-        )
-        .where(
-          (tab) =>
-              !(tab is ContactsBottomMenuTab && tab.contactSourceTypes.isEmpty),
-        )
+        .map((tab) => _createBottomMenuTab(tab, embeddedConfig, coreSupport, overrides))
+        .where((tab) => !(tab is ContactsBottomMenuTab && tab.contactSourceTypes.isEmpty))
         .toList();
 
     if (bottomMenuTabs.isEmpty) {
@@ -296,31 +265,23 @@ abstract final class BottomMenuMapper {
       // Local flag (config) can be overridden by Firebase Remote Config, then gated by the core
       // capability: call history is shown only when the resolved local flag AND the server
       // callHistory capability are both true.
-      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) =>
-          RecentsBottomMenuTab(
-            supportsCallHistory:
-                (overrides.isCallHistoryEnabled ?? supportsCallHistory) &&
-                coreSupport.supportsCallHistory,
-            enabled: tab.enabled,
-            initial: tab.initial,
-            titleL10n: tab.titleL10n,
-            icon: tab.icon.toIconData(),
-          ),
-      contacts: (enabled, initial, titleL10n, icon, contactSourceTypes) =>
-          ContactsBottomMenuTab(
-            enabled: tab.enabled,
-            initial: tab.initial,
-            titleL10n: tab.titleL10n,
-            icon: tab.icon.toIconData(),
-            contactSourceTypes: contactSourceTypes
-                .map((type) => ContactSourceType.values.byName(type))
-                .where(
-                  (type) =>
-                      type != ContactSourceType.external ||
-                      coreSupport.supportsExtensions,
-                )
-                .toList(),
-          ),
+      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) => RecentsBottomMenuTab(
+        supportsCallHistory: (overrides.isCallHistoryEnabled ?? supportsCallHistory) && coreSupport.supportsCallHistory,
+        enabled: tab.enabled,
+        initial: tab.initial,
+        titleL10n: tab.titleL10n,
+        icon: tab.icon.toIconData(),
+      ),
+      contacts: (enabled, initial, titleL10n, icon, contactSourceTypes) => ContactsBottomMenuTab(
+        enabled: tab.enabled,
+        initial: tab.initial,
+        titleL10n: tab.titleL10n,
+        icon: tab.icon.toIconData(),
+        contactSourceTypes: contactSourceTypes
+            .map((type) => ContactSourceType.values.byName(type))
+            .where((type) => type != ContactSourceType.external || coreSupport.supportsExtensions)
+            .toList(),
+      ),
       keypad: (enabled, initial, titleL10n, icon) => KeypadBottomMenuTab(
         enabled: tab.enabled,
         initial: tab.initial,
@@ -334,8 +295,9 @@ abstract final class BottomMenuMapper {
         icon: tab.icon.toIconData(),
       ),
       embedded: (enabled, initial, titleL10n, icon, embeddedId) {
-        final embeddedResource = embeddedConfig.embeddedResources
-            .firstWhereOrNull((resource) => resource.id == embeddedId);
+        final embeddedResource = embeddedConfig.embeddedResources.firstWhereOrNull(
+          (resource) => resource.id == embeddedId,
+        );
         return EmbeddedBottomMenuTab(
           id: embeddedId,
           enabled: tab.enabled,
@@ -362,9 +324,7 @@ abstract final class SettingsMapper {
     final settingSections = <SettingsSection>[];
     bool hasVoicemail = false;
 
-    for (final section in appConfig.settingsConfig.sections.where(
-      (s) => s.enabled,
-    )) {
+    for (final section in appConfig.settingsConfig.sections.where((s) => s.enabled)) {
       final items = <SettingItem>[];
 
       for (final item in section.items.where((i) => i.enabled)) {
@@ -381,12 +341,7 @@ abstract final class SettingsMapper {
           titleL10n: item.titleL10n,
           icon: item.icon.toIconData(),
           iconColor: item.iconColor?.toColor(),
-          data: _getEmbeddedDataResource(
-            embeddedResources,
-            item,
-            flavor,
-            termsConfig,
-          ),
+          data: _getEmbeddedDataResource(embeddedResources, item, flavor, termsConfig),
           flavor: flavor,
         );
 
@@ -394,29 +349,19 @@ abstract final class SettingsMapper {
       }
 
       if (items.isNotEmpty) {
-        settingSections.add(
-          SettingsSection(titleL10n: section.titleL10n, items: items),
-        );
+        settingSections.add(SettingsSection(titleL10n: section.titleL10n, items: items));
       }
     }
 
-    return SettingsConfig(
-      voicemailsEnabled: hasVoicemail,
-      sections: List.unmodifiable(settingSections),
-    );
+    return SettingsConfig(voicemailsEnabled: hasVoicemail, sections: List.unmodifiable(settingSections));
   }
 
   // TODO (Serdun): Move platform-specific configuration to a separate config file.
   static bool _isFeatureSupportedByPlatform(SettingsFlavor flavor) {
-    return !(flavor == SettingsFlavor.network &&
-        !kIsWeb &&
-        !Platform.isAndroid);
+    return !(flavor == SettingsFlavor.network && !kIsWeb && !Platform.isAndroid);
   }
 
-  static bool _isFeatureSupportedByCore(
-    SettingsFlavor flavor,
-    CoreSupport coreSupport,
-  ) {
+  static bool _isFeatureSupportedByCore(SettingsFlavor flavor, CoreSupport coreSupport) {
     return flavor != SettingsFlavor.voicemail || coreSupport.supportsVoicemail;
   }
 
@@ -426,9 +371,7 @@ abstract final class SettingsMapper {
     SettingsFlavor flavor,
     TermsConfig termsConfig,
   ) {
-    final resource = embeddedResources.firstWhereOrNull(
-      (r) => r.id == item.embeddedResourceId,
-    );
+    final resource = embeddedResources.firstWhereOrNull((r) => r.id == item.embeddedResourceId);
 
     if (resource?.uriOrNull == null && flavor == SettingsFlavor.terms) {
       return termsConfig.configData;
@@ -454,10 +397,7 @@ abstract final class SettingsMapper {
 /// and environment settings.
 abstract final class CallMapper {
   /// Maps [AppConfig] to [CallCapabilitiesConfig].
-  static CallConfig map(
-    AppConfig appConfig,
-    FeatureOverrides featureOverrides,
-  ) {
+  static CallConfig map(AppConfig appConfig, FeatureOverrides featureOverrides) {
     final rawCallConfig = appConfig.callConfig;
     final transferConfig = rawCallConfig.transfer;
     final encodingConfig = rawCallConfig.encoding;
@@ -466,15 +406,11 @@ abstract final class CallMapper {
 
     // Determine if the media settings UI should be accessible
     final encodingViewEnabled = appConfig.settingsConfig.sections.any(
-      (section) => section.items.any(
-        (item) =>
-            item.type == SettingsFlavor.mediaSettings.name && item.enabled,
-      ),
+      (section) => section.items.any((item) => item.type == SettingsFlavor.mediaSettings.name && item.enabled),
     );
 
     // Apply remote overrides
-    final isVideoEnabled =
-        featureOverrides.isVideoCallEnabled ?? rawCallConfig.videoEnabled;
+    final isVideoEnabled = featureOverrides.isVideoCallEnabled ?? rawCallConfig.videoEnabled;
 
     return CallConfig(
       capabilities: CallCapabilitiesConfig(
@@ -500,8 +436,7 @@ abstract final class CallMapper {
           opusBitrate: defaultPresetOverride.opusBitrate,
           opusStereo: defaultPresetOverride.opusStereo,
           opusDtx: defaultPresetOverride.opusDtx,
-          removeStaticAudioRtpMaps:
-              defaultPresetOverride.removeStaticAudioRtpMaps,
+          removeStaticAudioRtpMaps: defaultPresetOverride.removeStaticAudioRtpMaps,
           remapTE8payloadTo101: defaultPresetOverride.remapTE8payloadTo101,
           removeREMBFeedback: defaultPresetOverride.removeREMBFeedback,
           removeTWCCFeedback: defaultPresetOverride.removeTWCCFeedback,
@@ -510,9 +445,7 @@ abstract final class CallMapper {
       ),
       peerConnection: PeerConnectionSettings(
         negotiationSettings: NegotiationSettings(
-          includeInactiveVideoInOfferAnswer: peerConnectionConfig
-              .negotiation
-              .includeInactiveVideoInOfferAnswer,
+          includeInactiveVideoInOfferAnswer: peerConnectionConfig.negotiation.includeInactiveVideoInOfferAnswer,
         ),
       ),
     );
@@ -520,13 +453,7 @@ abstract final class CallMapper {
 
   static List<SdpExtmapType>? _parseExtmapList(List<String>? names) {
     if (names == null) return null;
-    return names
-        .map(
-          (name) =>
-              SdpExtmapType.values.where((t) => t.name == name).firstOrNull,
-        )
-        .nonNulls
-        .toList();
+    return names.map((name) => SdpExtmapType.values.where((t) => t.name == name).firstOrNull).nonNulls.toList();
   }
 }
 
@@ -534,10 +461,7 @@ abstract final class MessagingMapper {
   /// Maps configuration and core support to [MessagingConfig].
   static MessagingConfig map(AppConfig appConfig, CoreSupport coreSupport) {
     final tabEnabled = appConfig.mainConfig.bottomMenu.tabs.any(
-      (tab) => tab.maybeWhen(
-        messaging: (enabled, _, _, _) => enabled,
-        orElse: () => false,
-      ),
+      (tab) => tab.maybeWhen(messaging: (enabled, _, _, _) => enabled, orElse: () => false),
     );
 
     return MessagingConfig(
@@ -545,8 +469,7 @@ abstract final class MessagingMapper {
       coreChatsSupport: coreSupport.supportsChats,
       tabEnabled: tabEnabled,
       groupChatSupport: appConfig.messaging.chats.groupChatButtonEnabled,
-      contactInfoVideoCallSupport:
-          appConfig.messaging.chats.contactInfo.showVideoButtonAction,
+      contactInfoVideoCallSupport: appConfig.messaging.chats.contactInfo.showVideoButtonAction,
     );
   }
 }
@@ -559,9 +482,7 @@ abstract final class TermsMapper {
   /// either from a provided embedded resource ID or by searching for a resource of type `terms`.
   static TermsConfig map(List<EmbeddedResource> embeddedResources) {
     // Attempt to find the terms resource from the embedded resources list.
-    final termsResource = embeddedResources.firstWhereOrNull(
-      (resource) => resource.type == EmbeddedResourceType.terms,
-    );
+    final termsResource = embeddedResources.firstWhereOrNull((resource) => resource.type == EmbeddedResourceType.terms);
 
     // TODO(Serdun): It would be better to add a separate privacy policy feature in AppConfig,
     // with a direct link to the embedded resource. Implement logic to check if the feature access
@@ -597,9 +518,7 @@ abstract final class EmbeddedMapper {
         id: resource.id,
         uri: Uri.parse(resource.uri),
         reconnectStrategy: reconnectStrategy,
-        payload: resource.payload
-            .map((it) => EmbeddedPayloadData.values.byName(it))
-            .toList(),
+        payload: resource.payload.map((it) => EmbeddedPayloadData.values.byName(it)).toList(),
       );
     }).toList();
 
@@ -615,9 +534,7 @@ abstract final class SystemNotificationsMapper {
     AppConfig appConfig,
     FeatureOverrides featureOverrides,
   ) {
-    final supportedFeature = appConfig.supported
-        .whereType<SupportedSystemNotifications>()
-        .firstOrNull;
+    final supportedFeature = appConfig.supported.whereType<SupportedSystemNotifications>().firstOrNull;
 
     // TODO: Migrate client configurations first before fully removing this property.
     final baseAppSupport =
@@ -625,42 +542,29 @@ abstract final class SystemNotificationsMapper {
         // ignore: deprecated_member_use_from_same_package, deprecated_member_use
         appConfig.mainConfig.systemNotificationsEnabled;
     // Apply remote config overrides
-    final appSupport =
-        featureOverrides.isSystemNotificationsEnabled ?? baseAppSupport;
+    final appSupport = featureOverrides.isSystemNotificationsEnabled ?? baseAppSupport;
     // Check if the backend supports system notifications
     final backendSupport = coreSupport.supportsSystemNotifications;
 
     final isEnabled = appSupport && backendSupport;
     final withPush = isEnabled && coreSupport.supportsSystemPushNotifications;
 
-    return SystemNotificationsConfig(
-      systemNotificationsSupport: isEnabled,
-      systemNotificationsPushSupport: withPush,
-    );
+    return SystemNotificationsConfig(systemNotificationsSupport: isEnabled, systemNotificationsPushSupport: withPush);
   }
 }
 
 /// Mapper responsible for evaluating SIP presence support based on config and core capabilities.
 abstract final class SipPresenceMapper {
   /// Maps [CoreSupport] and [AppConfig] to [SipPresenceConfig].
-  static SipPresenceConfig map(
-    WebtritSystemInfo? systemInfo,
-    AppConfig appConfig,
-    FeatureOverrides featureOverrides,
-  ) {
-    final appSupportsBase = appConfig.supported
-        .whereType<SupportedHybridPresence>()
-        .isNotEmpty;
-    final appSupports =
-        featureOverrides.hybridPresenceSupport ?? appSupportsBase;
+  static SipPresenceConfig map(WebtritSystemInfo? systemInfo, AppConfig appConfig, FeatureOverrides featureOverrides) {
+    final appSupportsBase = appConfig.supported.whereType<SupportedHybridPresence>().isNotEmpty;
+    final appSupports = featureOverrides.hybridPresenceSupport ?? appSupportsBase;
 
     final backendSupports = systemInfo?.core.hybridPresenceAware ?? false;
 
     final isSupported = appSupports && backendSupports;
-    final withBlfViaSip =
-        isSupported && (systemInfo?.adapter?.supportsSipDialogs ?? false);
-    final withpresenceViaSip =
-        isSupported && (systemInfo?.adapter?.supportsSipPresence ?? false);
+    final withBlfViaSip = isSupported && (systemInfo?.adapter?.supportsSipDialogs ?? false);
+    final withpresenceViaSip = isSupported && (systemInfo?.adapter?.supportsSipPresence ?? false);
 
     return SipPresenceConfig(
       hybridPresenceSupport: isSupported,
@@ -673,12 +577,9 @@ abstract final class SipPresenceMapper {
 /// Mapper responsible for parsing and preparing [ContactsConfig] from application configuration.
 abstract final class ContactsMapper {
   static const Set<ContactAction> _defaultAppBarActions = {ContactAction.chat};
-  static const Set<ContactAction> _defaultEmailActions = {
-    ContactAction.sendEmail,
-  };
+  static const Set<ContactAction> _defaultEmailActions = {ContactAction.sendEmail};
 
-  static final Map<String, ContactAction> _actionByName = ContactAction.values
-      .asNameMap();
+  static final Map<String, ContactAction> _actionByName = ContactAction.values.asNameMap();
 
   /// Maps [AppConfig] to [ContactsConfig].
   ///
@@ -688,39 +589,22 @@ abstract final class ContactsMapper {
     final detailsDto = appConfig.contacts.details;
 
     // Pre-calculate the default "All except chat" for phone tiles.
-    final defaultPhoneActions = ContactAction.values
-        .where((action) => action != ContactAction.chat)
-        .toSet();
+    final defaultPhoneActions = ContactAction.values.where((action) => action != ContactAction.chat).toSet();
 
     return ContactsConfig(
       detailsConfig: ContactDetailsConfig(
-        appBarActions: _parseActions(
-          detailsDto.actions.appBar,
-          fallback: _defaultAppBarActions,
-        ),
-        phoneTileActions: _parseActions(
-          detailsDto.actions.phoneTile,
-          fallback: defaultPhoneActions,
-        ),
-        emailTileActions: _parseActions(
-          detailsDto.actions.emailTile,
-          fallback: _defaultEmailActions,
-        ),
+        appBarActions: _parseActions(detailsDto.actions.appBar, fallback: _defaultAppBarActions),
+        phoneTileActions: _parseActions(detailsDto.actions.phoneTile, fallback: defaultPhoneActions),
+        emailTileActions: _parseActions(detailsDto.actions.emailTile, fallback: _defaultEmailActions),
       ),
     );
   }
 
   /// Parses a list of raw action strings into a set of [ContactAction] enums.
-  static Set<ContactAction> _parseActions(
-    List<String>? rawActions, {
-    required Set<ContactAction> fallback,
-  }) {
+  static Set<ContactAction> _parseActions(List<String>? rawActions, {required Set<ContactAction> fallback}) {
     if (rawActions == null) return fallback;
 
-    final parsed = rawActions
-        .map((e) => _actionByName[e])
-        .whereType<ContactAction>()
-        .toSet();
+    final parsed = rawActions.map((e) => _actionByName[e]).whereType<ContactAction>().toSet();
 
     return parsed.isEmpty ? fallback : parsed;
   }
@@ -741,10 +625,7 @@ abstract final class SupportedMapper {
   /// Maps a list of [SupportedFeature]s to a [SupportedConfig].
   static SupportedConfig map(List<SupportedFeature> supportedFeatures) {
     final themeFeature =
-        supportedFeatures.firstWhere(
-              (e) => e is SupportedThemeMode,
-              orElse: () => const SupportedFeature.themeMode(),
-            )
+        supportedFeatures.firstWhere((e) => e is SupportedThemeMode, orElse: () => const SupportedFeature.themeMode())
             as SupportedThemeMode;
 
     final videoCallFeature =
@@ -760,10 +641,7 @@ abstract final class SupportedMapper {
       ThemeModeConfig.dark => ThemeMode.dark,
     };
 
-    return SupportedConfig(
-      themeMode: configThemeMode,
-      isVideoCallEnabled: videoCallFeature.enabled,
-    );
+    return SupportedConfig(themeMode: configThemeMode, isVideoCallEnabled: videoCallFeature.enabled);
   }
 }
 
@@ -780,9 +658,7 @@ abstract final class LocalizationMapper {
     // so unknown codes are logged and ignored, and resolve() keeps at least the
     // full bundled set.
     if (enabledLanguages.isNotEmpty) {
-      final bundledCodes = bundled
-          .map((l) => l.languageCode.toLowerCase())
-          .toSet();
+      final bundledCodes = bundled.map((l) => l.languageCode.toLowerCase()).toSet();
       final unknown = enabledLanguages
           .map((code) => code.trim().toLowerCase())
           .where((code) => code.isNotEmpty && !bundledCodes.contains(code))
@@ -795,19 +671,10 @@ abstract final class LocalizationMapper {
       }
     }
 
-    final supportedLocales = LocalizationConfig.resolve(
-      bundled,
-      enabledLanguages,
-    );
-    if (enabledLanguages.isNotEmpty &&
-        supportedLocales.length == bundled.length) {
-      final requested = enabledLanguages
-          .map((c) => c.trim().toLowerCase())
-          .where((c) => c.isNotEmpty)
-          .toSet();
-      final anyValid = bundled.any(
-        (l) => requested.contains(l.languageCode.toLowerCase()),
-      );
+    final supportedLocales = LocalizationConfig.resolve(bundled, enabledLanguages);
+    if (enabledLanguages.isNotEmpty && supportedLocales.length == bundled.length) {
+      final requested = enabledLanguages.map((c) => c.trim().toLowerCase()).where((c) => c.isNotEmpty).toSet();
+      final anyValid = bundled.any((l) => requested.contains(l.languageCode.toLowerCase()));
       if (!anyValid) {
         _logger.warning(
           'localization.enabledLanguages ($enabledLanguages) matched no bundled '
@@ -827,33 +694,23 @@ abstract final class LoggingMapper {
 
   static LoggingConfig map(AppConfig appConfig, FeatureOverrides overrides) {
     final loggingFeature =
-        appConfig.supported.firstWhereOrNull((e) => e is SupportedLoggingConfig)
-            as SupportedLoggingConfig?;
+        appConfig.supported.firstWhereOrNull((e) => e is SupportedLoggingConfig) as SupportedLoggingConfig?;
 
     final logLevel =
         overrides.logLevel ??
         (loggingFeature != null
-            ? Level.LEVELS
-                      .where((l) => l.name == loggingFeature.logLevel)
-                      .firstOrNull ??
-                  _defaultLogLevel
+            ? Level.LEVELS.where((l) => l.name == loggingFeature.logLevel).firstOrNull ?? _defaultLogLevel
             : _defaultLogLevel);
 
     final monitorCheckInterval =
         overrides.monitorCheckInterval ??
-        (loggingFeature != null
-            ? Duration(seconds: loggingFeature.checkIntervalSec)
-            : _defaultInterval);
+        (loggingFeature != null ? Duration(seconds: loggingFeature.checkIntervalSec) : _defaultInterval);
 
     return LoggingConfig(
       logLevel: logLevel,
       monitorCheckInterval: monitorCheckInterval,
-      remoteLoggingEnabled:
-          overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
-      anonymizationEnabled:
-          overrides.isLogAnonymizationEnabled ??
-          loggingFeature?.anonymizationEnabled ??
-          true,
+      remoteLoggingEnabled: overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
+      anonymizationEnabled: overrides.isLogAnonymizationEnabled ?? loggingFeature?.anonymizationEnabled ?? true,
     );
   }
 
@@ -861,8 +718,7 @@ abstract final class LoggingMapper {
     return LoggingConfig(
       logLevel: overrides.logLevel ?? _defaultLogLevel,
       monitorCheckInterval: overrides.monitorCheckInterval ?? _defaultInterval,
-      remoteLoggingEnabled:
-          overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
+      remoteLoggingEnabled: overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
       anonymizationEnabled: overrides.isLogAnonymizationEnabled ?? true,
     );
   }

--- a/lib/data/feature_access.dart
+++ b/lib/data/feature_access.dart
@@ -113,14 +113,35 @@ class FeatureAccess extends Equatable {
       // Note: TermsConfig must be initialized before SettingsConfig because Settings might fallback to Terms config.
       final termsConfig = TermsMapper.map(embeddedResources);
 
-      final loginConfig = LoginMapper.map(appConfig, embeddedConfig.embeddedResources);
-      final bottomMenuConfig = BottomMenuMapper.map(appConfig, embeddedConfig, coreSupport, featureOverrides);
-      final settingsConfig = SettingsMapper.map(appConfig, embeddedResources, coreSupport, termsConfig);
+      final loginConfig = LoginMapper.map(
+        appConfig,
+        embeddedConfig.embeddedResources,
+      );
+      final bottomMenuConfig = BottomMenuMapper.map(
+        appConfig,
+        embeddedConfig,
+        coreSupport,
+        featureOverrides,
+      );
+      final settingsConfig = SettingsMapper.map(
+        appConfig,
+        embeddedResources,
+        coreSupport,
+        termsConfig,
+      );
       final callConfig = CallMapper.map(appConfig, featureOverrides);
       final messagingConfig = MessagingMapper.map(appConfig, coreSupport);
       final contactsConfig = ContactsMapper.map(appConfig);
-      final systemNotificationsConfig = SystemNotificationsMapper.map(coreSupport, appConfig, featureOverrides);
-      final sipPresenceConfig = SipPresenceMapper.map(systemInfo, appConfig, featureOverrides);
+      final systemNotificationsConfig = SystemNotificationsMapper.map(
+        coreSupport,
+        appConfig,
+        featureOverrides,
+      );
+      final sipPresenceConfig = SipPresenceMapper.map(
+        systemInfo,
+        appConfig,
+        featureOverrides,
+      );
       final loggingConfig = LoggingMapper.map(appConfig, featureOverrides);
 
       final supportedConfig = SupportedMapper.map(appConfig.supported);
@@ -176,12 +197,16 @@ abstract final class LoginMapper {
   // Currently, modeSelectActions control both the launch screen and the buttons on the login_mode_select_screen,
   // which leads to unclear and tightly coupled logic.
   static LoginConfig map(AppConfig appConfig, List<EmbeddedData> embeddedData) {
-    final rawButtons = appConfig.loginConfig.modeSelect.actions.where((button) => button.enabled);
+    final rawButtons = appConfig.loginConfig.modeSelect.actions.where(
+      (button) => button.enabled,
+    );
     final buttons = <LoginModeAction>[];
 
     for (final action in rawButtons) {
       final loginFlavor = LoginFlavor.values.byName(action.type);
-      final loginEmbeddedData = embeddedData.firstWhereOrNull((dto) => dto.id == action.embeddedId);
+      final loginEmbeddedData = embeddedData.firstWhereOrNull(
+        (dto) => dto.id == action.embeddedId,
+      );
 
       if (loginEmbeddedData != null && loginFlavor == LoginFlavor.embedded) {
         buttons.add(
@@ -192,15 +217,23 @@ abstract final class LoginMapper {
           ),
         );
       } else if (loginFlavor == LoginFlavor.login) {
-        buttons.add(LoginDefaultModeAction(titleL10n: action.titleL10n, flavor: loginFlavor));
+        buttons.add(
+          LoginDefaultModeAction(
+            titleL10n: action.titleL10n,
+            flavor: loginFlavor,
+          ),
+        );
       }
     }
 
     return LoginConfig(
       titleL10n: appConfig.loginConfig.modeSelect.greetingL10n,
       actions: List.unmodifiable(buttons),
+      signinOrder: appConfig.loginConfig.signinOrder,
       launchLoginPage: embeddedData.firstWhereOrNull(
-        (it) => it.id == appConfig.loginConfig.common.fullScreenLaunchEmbeddedResourceId,
+        (it) =>
+            it.id ==
+            appConfig.loginConfig.common.fullScreenLaunchEmbeddedResourceId,
       ),
     );
   }
@@ -230,8 +263,14 @@ abstract final class BottomMenuMapper {
 
     final bottomMenuTabs = bottomMenu.tabs
         .where((tab) => tab.enabled)
-        .map((tab) => _createBottomMenuTab(tab, embeddedConfig, coreSupport, overrides))
-        .where((tab) => !(tab is ContactsBottomMenuTab && tab.contactSourceTypes.isEmpty))
+        .map(
+          (tab) =>
+              _createBottomMenuTab(tab, embeddedConfig, coreSupport, overrides),
+        )
+        .where(
+          (tab) =>
+              !(tab is ContactsBottomMenuTab && tab.contactSourceTypes.isEmpty),
+        )
         .toList();
 
     if (bottomMenuTabs.isEmpty) {
@@ -257,23 +296,31 @@ abstract final class BottomMenuMapper {
       // Local flag (config) can be overridden by Firebase Remote Config, then gated by the core
       // capability: call history is shown only when the resolved local flag AND the server
       // callHistory capability are both true.
-      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) => RecentsBottomMenuTab(
-        supportsCallHistory: (overrides.isCallHistoryEnabled ?? supportsCallHistory) && coreSupport.supportsCallHistory,
-        enabled: tab.enabled,
-        initial: tab.initial,
-        titleL10n: tab.titleL10n,
-        icon: tab.icon.toIconData(),
-      ),
-      contacts: (enabled, initial, titleL10n, icon, contactSourceTypes) => ContactsBottomMenuTab(
-        enabled: tab.enabled,
-        initial: tab.initial,
-        titleL10n: tab.titleL10n,
-        icon: tab.icon.toIconData(),
-        contactSourceTypes: contactSourceTypes
-            .map((type) => ContactSourceType.values.byName(type))
-            .where((type) => type != ContactSourceType.external || coreSupport.supportsExtensions)
-            .toList(),
-      ),
+      recents: (enabled, initial, titleL10n, icon, supportsCallHistory) =>
+          RecentsBottomMenuTab(
+            supportsCallHistory:
+                (overrides.isCallHistoryEnabled ?? supportsCallHistory) &&
+                coreSupport.supportsCallHistory,
+            enabled: tab.enabled,
+            initial: tab.initial,
+            titleL10n: tab.titleL10n,
+            icon: tab.icon.toIconData(),
+          ),
+      contacts: (enabled, initial, titleL10n, icon, contactSourceTypes) =>
+          ContactsBottomMenuTab(
+            enabled: tab.enabled,
+            initial: tab.initial,
+            titleL10n: tab.titleL10n,
+            icon: tab.icon.toIconData(),
+            contactSourceTypes: contactSourceTypes
+                .map((type) => ContactSourceType.values.byName(type))
+                .where(
+                  (type) =>
+                      type != ContactSourceType.external ||
+                      coreSupport.supportsExtensions,
+                )
+                .toList(),
+          ),
       keypad: (enabled, initial, titleL10n, icon) => KeypadBottomMenuTab(
         enabled: tab.enabled,
         initial: tab.initial,
@@ -287,9 +334,8 @@ abstract final class BottomMenuMapper {
         icon: tab.icon.toIconData(),
       ),
       embedded: (enabled, initial, titleL10n, icon, embeddedId) {
-        final embeddedResource = embeddedConfig.embeddedResources.firstWhereOrNull(
-          (resource) => resource.id == embeddedId,
-        );
+        final embeddedResource = embeddedConfig.embeddedResources
+            .firstWhereOrNull((resource) => resource.id == embeddedId);
         return EmbeddedBottomMenuTab(
           id: embeddedId,
           enabled: tab.enabled,
@@ -316,7 +362,9 @@ abstract final class SettingsMapper {
     final settingSections = <SettingsSection>[];
     bool hasVoicemail = false;
 
-    for (final section in appConfig.settingsConfig.sections.where((s) => s.enabled)) {
+    for (final section in appConfig.settingsConfig.sections.where(
+      (s) => s.enabled,
+    )) {
       final items = <SettingItem>[];
 
       for (final item in section.items.where((i) => i.enabled)) {
@@ -333,7 +381,12 @@ abstract final class SettingsMapper {
           titleL10n: item.titleL10n,
           icon: item.icon.toIconData(),
           iconColor: item.iconColor?.toColor(),
-          data: _getEmbeddedDataResource(embeddedResources, item, flavor, termsConfig),
+          data: _getEmbeddedDataResource(
+            embeddedResources,
+            item,
+            flavor,
+            termsConfig,
+          ),
           flavor: flavor,
         );
 
@@ -341,19 +394,29 @@ abstract final class SettingsMapper {
       }
 
       if (items.isNotEmpty) {
-        settingSections.add(SettingsSection(titleL10n: section.titleL10n, items: items));
+        settingSections.add(
+          SettingsSection(titleL10n: section.titleL10n, items: items),
+        );
       }
     }
 
-    return SettingsConfig(voicemailsEnabled: hasVoicemail, sections: List.unmodifiable(settingSections));
+    return SettingsConfig(
+      voicemailsEnabled: hasVoicemail,
+      sections: List.unmodifiable(settingSections),
+    );
   }
 
   // TODO (Serdun): Move platform-specific configuration to a separate config file.
   static bool _isFeatureSupportedByPlatform(SettingsFlavor flavor) {
-    return !(flavor == SettingsFlavor.network && !kIsWeb && !Platform.isAndroid);
+    return !(flavor == SettingsFlavor.network &&
+        !kIsWeb &&
+        !Platform.isAndroid);
   }
 
-  static bool _isFeatureSupportedByCore(SettingsFlavor flavor, CoreSupport coreSupport) {
+  static bool _isFeatureSupportedByCore(
+    SettingsFlavor flavor,
+    CoreSupport coreSupport,
+  ) {
     return flavor != SettingsFlavor.voicemail || coreSupport.supportsVoicemail;
   }
 
@@ -363,7 +426,9 @@ abstract final class SettingsMapper {
     SettingsFlavor flavor,
     TermsConfig termsConfig,
   ) {
-    final resource = embeddedResources.firstWhereOrNull((r) => r.id == item.embeddedResourceId);
+    final resource = embeddedResources.firstWhereOrNull(
+      (r) => r.id == item.embeddedResourceId,
+    );
 
     if (resource?.uriOrNull == null && flavor == SettingsFlavor.terms) {
       return termsConfig.configData;
@@ -389,7 +454,10 @@ abstract final class SettingsMapper {
 /// and environment settings.
 abstract final class CallMapper {
   /// Maps [AppConfig] to [CallCapabilitiesConfig].
-  static CallConfig map(AppConfig appConfig, FeatureOverrides featureOverrides) {
+  static CallConfig map(
+    AppConfig appConfig,
+    FeatureOverrides featureOverrides,
+  ) {
     final rawCallConfig = appConfig.callConfig;
     final transferConfig = rawCallConfig.transfer;
     final encodingConfig = rawCallConfig.encoding;
@@ -398,11 +466,15 @@ abstract final class CallMapper {
 
     // Determine if the media settings UI should be accessible
     final encodingViewEnabled = appConfig.settingsConfig.sections.any(
-      (section) => section.items.any((item) => item.type == SettingsFlavor.mediaSettings.name && item.enabled),
+      (section) => section.items.any(
+        (item) =>
+            item.type == SettingsFlavor.mediaSettings.name && item.enabled,
+      ),
     );
 
     // Apply remote overrides
-    final isVideoEnabled = featureOverrides.isVideoCallEnabled ?? rawCallConfig.videoEnabled;
+    final isVideoEnabled =
+        featureOverrides.isVideoCallEnabled ?? rawCallConfig.videoEnabled;
 
     return CallConfig(
       capabilities: CallCapabilitiesConfig(
@@ -428,7 +500,8 @@ abstract final class CallMapper {
           opusBitrate: defaultPresetOverride.opusBitrate,
           opusStereo: defaultPresetOverride.opusStereo,
           opusDtx: defaultPresetOverride.opusDtx,
-          removeStaticAudioRtpMaps: defaultPresetOverride.removeStaticAudioRtpMaps,
+          removeStaticAudioRtpMaps:
+              defaultPresetOverride.removeStaticAudioRtpMaps,
           remapTE8payloadTo101: defaultPresetOverride.remapTE8payloadTo101,
           removeREMBFeedback: defaultPresetOverride.removeREMBFeedback,
           removeTWCCFeedback: defaultPresetOverride.removeTWCCFeedback,
@@ -437,7 +510,9 @@ abstract final class CallMapper {
       ),
       peerConnection: PeerConnectionSettings(
         negotiationSettings: NegotiationSettings(
-          includeInactiveVideoInOfferAnswer: peerConnectionConfig.negotiation.includeInactiveVideoInOfferAnswer,
+          includeInactiveVideoInOfferAnswer: peerConnectionConfig
+              .negotiation
+              .includeInactiveVideoInOfferAnswer,
         ),
       ),
     );
@@ -445,7 +520,13 @@ abstract final class CallMapper {
 
   static List<SdpExtmapType>? _parseExtmapList(List<String>? names) {
     if (names == null) return null;
-    return names.map((name) => SdpExtmapType.values.where((t) => t.name == name).firstOrNull).nonNulls.toList();
+    return names
+        .map(
+          (name) =>
+              SdpExtmapType.values.where((t) => t.name == name).firstOrNull,
+        )
+        .nonNulls
+        .toList();
   }
 }
 
@@ -453,7 +534,10 @@ abstract final class MessagingMapper {
   /// Maps configuration and core support to [MessagingConfig].
   static MessagingConfig map(AppConfig appConfig, CoreSupport coreSupport) {
     final tabEnabled = appConfig.mainConfig.bottomMenu.tabs.any(
-      (tab) => tab.maybeWhen(messaging: (enabled, _, _, _) => enabled, orElse: () => false),
+      (tab) => tab.maybeWhen(
+        messaging: (enabled, _, _, _) => enabled,
+        orElse: () => false,
+      ),
     );
 
     return MessagingConfig(
@@ -461,7 +545,8 @@ abstract final class MessagingMapper {
       coreChatsSupport: coreSupport.supportsChats,
       tabEnabled: tabEnabled,
       groupChatSupport: appConfig.messaging.chats.groupChatButtonEnabled,
-      contactInfoVideoCallSupport: appConfig.messaging.chats.contactInfo.showVideoButtonAction,
+      contactInfoVideoCallSupport:
+          appConfig.messaging.chats.contactInfo.showVideoButtonAction,
     );
   }
 }
@@ -474,7 +559,9 @@ abstract final class TermsMapper {
   /// either from a provided embedded resource ID or by searching for a resource of type `terms`.
   static TermsConfig map(List<EmbeddedResource> embeddedResources) {
     // Attempt to find the terms resource from the embedded resources list.
-    final termsResource = embeddedResources.firstWhereOrNull((resource) => resource.type == EmbeddedResourceType.terms);
+    final termsResource = embeddedResources.firstWhereOrNull(
+      (resource) => resource.type == EmbeddedResourceType.terms,
+    );
 
     // TODO(Serdun): It would be better to add a separate privacy policy feature in AppConfig,
     // with a direct link to the embedded resource. Implement logic to check if the feature access
@@ -510,7 +597,9 @@ abstract final class EmbeddedMapper {
         id: resource.id,
         uri: Uri.parse(resource.uri),
         reconnectStrategy: reconnectStrategy,
-        payload: resource.payload.map((it) => EmbeddedPayloadData.values.byName(it)).toList(),
+        payload: resource.payload
+            .map((it) => EmbeddedPayloadData.values.byName(it))
+            .toList(),
       );
     }).toList();
 
@@ -526,7 +615,9 @@ abstract final class SystemNotificationsMapper {
     AppConfig appConfig,
     FeatureOverrides featureOverrides,
   ) {
-    final supportedFeature = appConfig.supported.whereType<SupportedSystemNotifications>().firstOrNull;
+    final supportedFeature = appConfig.supported
+        .whereType<SupportedSystemNotifications>()
+        .firstOrNull;
 
     // TODO: Migrate client configurations first before fully removing this property.
     final baseAppSupport =
@@ -534,29 +625,42 @@ abstract final class SystemNotificationsMapper {
         // ignore: deprecated_member_use_from_same_package, deprecated_member_use
         appConfig.mainConfig.systemNotificationsEnabled;
     // Apply remote config overrides
-    final appSupport = featureOverrides.isSystemNotificationsEnabled ?? baseAppSupport;
+    final appSupport =
+        featureOverrides.isSystemNotificationsEnabled ?? baseAppSupport;
     // Check if the backend supports system notifications
     final backendSupport = coreSupport.supportsSystemNotifications;
 
     final isEnabled = appSupport && backendSupport;
     final withPush = isEnabled && coreSupport.supportsSystemPushNotifications;
 
-    return SystemNotificationsConfig(systemNotificationsSupport: isEnabled, systemNotificationsPushSupport: withPush);
+    return SystemNotificationsConfig(
+      systemNotificationsSupport: isEnabled,
+      systemNotificationsPushSupport: withPush,
+    );
   }
 }
 
 /// Mapper responsible for evaluating SIP presence support based on config and core capabilities.
 abstract final class SipPresenceMapper {
   /// Maps [CoreSupport] and [AppConfig] to [SipPresenceConfig].
-  static SipPresenceConfig map(WebtritSystemInfo? systemInfo, AppConfig appConfig, FeatureOverrides featureOverrides) {
-    final appSupportsBase = appConfig.supported.whereType<SupportedHybridPresence>().isNotEmpty;
-    final appSupports = featureOverrides.hybridPresenceSupport ?? appSupportsBase;
+  static SipPresenceConfig map(
+    WebtritSystemInfo? systemInfo,
+    AppConfig appConfig,
+    FeatureOverrides featureOverrides,
+  ) {
+    final appSupportsBase = appConfig.supported
+        .whereType<SupportedHybridPresence>()
+        .isNotEmpty;
+    final appSupports =
+        featureOverrides.hybridPresenceSupport ?? appSupportsBase;
 
     final backendSupports = systemInfo?.core.hybridPresenceAware ?? false;
 
     final isSupported = appSupports && backendSupports;
-    final withBlfViaSip = isSupported && (systemInfo?.adapter?.supportsSipDialogs ?? false);
-    final withpresenceViaSip = isSupported && (systemInfo?.adapter?.supportsSipPresence ?? false);
+    final withBlfViaSip =
+        isSupported && (systemInfo?.adapter?.supportsSipDialogs ?? false);
+    final withpresenceViaSip =
+        isSupported && (systemInfo?.adapter?.supportsSipPresence ?? false);
 
     return SipPresenceConfig(
       hybridPresenceSupport: isSupported,
@@ -569,9 +673,12 @@ abstract final class SipPresenceMapper {
 /// Mapper responsible for parsing and preparing [ContactsConfig] from application configuration.
 abstract final class ContactsMapper {
   static const Set<ContactAction> _defaultAppBarActions = {ContactAction.chat};
-  static const Set<ContactAction> _defaultEmailActions = {ContactAction.sendEmail};
+  static const Set<ContactAction> _defaultEmailActions = {
+    ContactAction.sendEmail,
+  };
 
-  static final Map<String, ContactAction> _actionByName = ContactAction.values.asNameMap();
+  static final Map<String, ContactAction> _actionByName = ContactAction.values
+      .asNameMap();
 
   /// Maps [AppConfig] to [ContactsConfig].
   ///
@@ -581,22 +688,39 @@ abstract final class ContactsMapper {
     final detailsDto = appConfig.contacts.details;
 
     // Pre-calculate the default "All except chat" for phone tiles.
-    final defaultPhoneActions = ContactAction.values.where((action) => action != ContactAction.chat).toSet();
+    final defaultPhoneActions = ContactAction.values
+        .where((action) => action != ContactAction.chat)
+        .toSet();
 
     return ContactsConfig(
       detailsConfig: ContactDetailsConfig(
-        appBarActions: _parseActions(detailsDto.actions.appBar, fallback: _defaultAppBarActions),
-        phoneTileActions: _parseActions(detailsDto.actions.phoneTile, fallback: defaultPhoneActions),
-        emailTileActions: _parseActions(detailsDto.actions.emailTile, fallback: _defaultEmailActions),
+        appBarActions: _parseActions(
+          detailsDto.actions.appBar,
+          fallback: _defaultAppBarActions,
+        ),
+        phoneTileActions: _parseActions(
+          detailsDto.actions.phoneTile,
+          fallback: defaultPhoneActions,
+        ),
+        emailTileActions: _parseActions(
+          detailsDto.actions.emailTile,
+          fallback: _defaultEmailActions,
+        ),
       ),
     );
   }
 
   /// Parses a list of raw action strings into a set of [ContactAction] enums.
-  static Set<ContactAction> _parseActions(List<String>? rawActions, {required Set<ContactAction> fallback}) {
+  static Set<ContactAction> _parseActions(
+    List<String>? rawActions, {
+    required Set<ContactAction> fallback,
+  }) {
     if (rawActions == null) return fallback;
 
-    final parsed = rawActions.map((e) => _actionByName[e]).whereType<ContactAction>().toSet();
+    final parsed = rawActions
+        .map((e) => _actionByName[e])
+        .whereType<ContactAction>()
+        .toSet();
 
     return parsed.isEmpty ? fallback : parsed;
   }
@@ -617,7 +741,10 @@ abstract final class SupportedMapper {
   /// Maps a list of [SupportedFeature]s to a [SupportedConfig].
   static SupportedConfig map(List<SupportedFeature> supportedFeatures) {
     final themeFeature =
-        supportedFeatures.firstWhere((e) => e is SupportedThemeMode, orElse: () => const SupportedFeature.themeMode())
+        supportedFeatures.firstWhere(
+              (e) => e is SupportedThemeMode,
+              orElse: () => const SupportedFeature.themeMode(),
+            )
             as SupportedThemeMode;
 
     final videoCallFeature =
@@ -633,7 +760,10 @@ abstract final class SupportedMapper {
       ThemeModeConfig.dark => ThemeMode.dark,
     };
 
-    return SupportedConfig(themeMode: configThemeMode, isVideoCallEnabled: videoCallFeature.enabled);
+    return SupportedConfig(
+      themeMode: configThemeMode,
+      isVideoCallEnabled: videoCallFeature.enabled,
+    );
   }
 }
 
@@ -650,7 +780,9 @@ abstract final class LocalizationMapper {
     // so unknown codes are logged and ignored, and resolve() keeps at least the
     // full bundled set.
     if (enabledLanguages.isNotEmpty) {
-      final bundledCodes = bundled.map((l) => l.languageCode.toLowerCase()).toSet();
+      final bundledCodes = bundled
+          .map((l) => l.languageCode.toLowerCase())
+          .toSet();
       final unknown = enabledLanguages
           .map((code) => code.trim().toLowerCase())
           .where((code) => code.isNotEmpty && !bundledCodes.contains(code))
@@ -663,10 +795,19 @@ abstract final class LocalizationMapper {
       }
     }
 
-    final supportedLocales = LocalizationConfig.resolve(bundled, enabledLanguages);
-    if (enabledLanguages.isNotEmpty && supportedLocales.length == bundled.length) {
-      final requested = enabledLanguages.map((c) => c.trim().toLowerCase()).where((c) => c.isNotEmpty).toSet();
-      final anyValid = bundled.any((l) => requested.contains(l.languageCode.toLowerCase()));
+    final supportedLocales = LocalizationConfig.resolve(
+      bundled,
+      enabledLanguages,
+    );
+    if (enabledLanguages.isNotEmpty &&
+        supportedLocales.length == bundled.length) {
+      final requested = enabledLanguages
+          .map((c) => c.trim().toLowerCase())
+          .where((c) => c.isNotEmpty)
+          .toSet();
+      final anyValid = bundled.any(
+        (l) => requested.contains(l.languageCode.toLowerCase()),
+      );
       if (!anyValid) {
         _logger.warning(
           'localization.enabledLanguages ($enabledLanguages) matched no bundled '
@@ -686,23 +827,33 @@ abstract final class LoggingMapper {
 
   static LoggingConfig map(AppConfig appConfig, FeatureOverrides overrides) {
     final loggingFeature =
-        appConfig.supported.firstWhereOrNull((e) => e is SupportedLoggingConfig) as SupportedLoggingConfig?;
+        appConfig.supported.firstWhereOrNull((e) => e is SupportedLoggingConfig)
+            as SupportedLoggingConfig?;
 
     final logLevel =
         overrides.logLevel ??
         (loggingFeature != null
-            ? Level.LEVELS.where((l) => l.name == loggingFeature.logLevel).firstOrNull ?? _defaultLogLevel
+            ? Level.LEVELS
+                      .where((l) => l.name == loggingFeature.logLevel)
+                      .firstOrNull ??
+                  _defaultLogLevel
             : _defaultLogLevel);
 
     final monitorCheckInterval =
         overrides.monitorCheckInterval ??
-        (loggingFeature != null ? Duration(seconds: loggingFeature.checkIntervalSec) : _defaultInterval);
+        (loggingFeature != null
+            ? Duration(seconds: loggingFeature.checkIntervalSec)
+            : _defaultInterval);
 
     return LoggingConfig(
       logLevel: logLevel,
       monitorCheckInterval: monitorCheckInterval,
-      remoteLoggingEnabled: overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
-      anonymizationEnabled: overrides.isLogAnonymizationEnabled ?? loggingFeature?.anonymizationEnabled ?? true,
+      remoteLoggingEnabled:
+          overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
+      anonymizationEnabled:
+          overrides.isLogAnonymizationEnabled ??
+          loggingFeature?.anonymizationEnabled ??
+          true,
     );
   }
 
@@ -710,7 +861,8 @@ abstract final class LoggingMapper {
     return LoggingConfig(
       logLevel: overrides.logLevel ?? _defaultLogLevel,
       monitorCheckInterval: overrides.monitorCheckInterval ?? _defaultInterval,
-      remoteLoggingEnabled: overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
+      remoteLoggingEnabled:
+          overrides.remoteLoggingEnabled ?? _defaultRemoteLoggingEnabled,
       anonymizationEnabled: overrides.isLogAnonymizationEnabled ?? true,
     );
   }

--- a/lib/features/cdrs/view/recent_cdrs_screen.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone/app/constants.dart';
 
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/features/recents/view/recents_screen_styles.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -48,14 +49,17 @@ class _RecentCdrsScreenState extends State<RecentCdrsScreen> with TickerProvider
     final l10n = context.l10n;
 
     final themeData = Theme.of(context);
+    final effectiveStyle = themeData.extension<RecentsScreenStyles>()?.primary;
 
-    return Scaffold(
+    return ThemedScaffold(
+      background: effectiveStyle?.background,
+      contentThemeOverride: effectiveStyle?.contentThemeOverride ?? ThemeMode.system,
+      applyToAppBar: effectiveStyle?.applyToAppBar ?? false,
       extendBodyBehindAppBar: true,
       appBar: MainAppBar(
         title: widget.title,
         context: context,
-        backgroundColor: themeData.canvasColor.withAlpha(150),
-        flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
+        flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kMainAppBarBottomTabHeight),
           child: Padding(

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -20,8 +20,7 @@ part 'login_cubit.freezed.dart';
 
 part 'login_state.dart';
 
-typedef LoginSuccessCallback =
-    void Function(Session session, WebtritSystemInfo systemInfo);
+typedef LoginSuccessCallback = void Function(Session session, WebtritSystemInfo systemInfo);
 
 final _logger = Logger('LoginCubit');
 
@@ -31,7 +30,9 @@ class LoginCubit extends Cubit<LoginState> {
     required this.notificationsBloc,
     required this.onLoginSuccess,
     this.signinOrder = const [],
-  }) : super(const LoginState());
+    QrSigninConfig? qrSigninConfig,
+  }) : qrSigninConfig = qrSigninConfig ?? QrSigninConfig.disabled,
+       super(const LoginState());
 
   final AuthRepository authRepository;
 
@@ -42,11 +43,13 @@ class LoginCubit extends Cubit<LoginState> {
   /// Configured order of the sign-in tabs, by login type name (from app config).
   final List<String> signinOrder;
 
+  /// Configuration of the QR-code sign-in tab (from app config).
+  final QrSigninConfig qrSigninConfig;
+
   // Environment getters
   String? get coreUrlFromEnvironment => EnvironmentConfig.CORE_URL;
 
-  String? get credentialsRequestUrl =>
-      EnvironmentConfig.APP_CREDENTIALS_REQUEST_URL;
+  String? get credentialsRequestUrl => EnvironmentConfig.APP_CREDENTIALS_REQUEST_URL;
 
   String? get demoCoreUrlFromEnvironment => EnvironmentConfig.DEMO_CORE_URL;
 
@@ -81,15 +84,7 @@ class LoginCubit extends Cubit<LoginState> {
     final token = state.token!;
     final userId = state.userId!;
 
-    onLoginSuccess(
-      Session(
-        coreUrl: coreUrl,
-        tenantId: tenantId,
-        token: token,
-        userId: userId,
-      ),
-      systemInfo,
-    );
+    onLoginSuccess(Session(coreUrl: coreUrl, tenantId: tenantId, token: token, userId: userId), systemInfo);
   }
 
   void launchLinkableElement(LinkableElement link) async {
@@ -99,11 +94,7 @@ class LoginCubit extends Cubit<LoginState> {
     }
   }
 
-  Future<void> _processSystemInfo(
-    String coreUrl,
-    String tenantId, [
-    bool demo = false,
-  ]) async {
+  Future<void> _processSystemInfo(String coreUrl, String tenantId, [bool demo = false]) async {
     emit(state.copyWith(processing: true));
 
     try {
@@ -114,28 +105,25 @@ class LoginCubit extends Cubit<LoginState> {
       }
 
       final supportedFeatures = systemInfo.adapter?.supported ?? [];
-      final parsedLoginTypes = supportedFeatures
-          .where((f) => LoginType.values.map((e) => e.name).contains(f))
-          .map((f) => LoginType.values.byName(f))
-          .toList();
+      // Only these types are accepted from the backend; qrSignin is client-side
+      // (added below), so an adapter advertising it must not bypass the config
+      // gate or duplicate the tab.
+      const backendLoginTypes = [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup];
+      final parsedLoginTypes = backendLoginTypes.where((type) => supportedFeatures.contains(type.name)).toList();
+      // The QR tab is not a backend capability: the scanned code carries plain
+      // credentials, so it is offered whenever password sign-in is available
+      // and the app config enables it.
+      if (qrSigninConfig.enabled && parsedLoginTypes.contains(LoginType.passwordSignin)) {
+        parsedLoginTypes.add(LoginType.qrSignin);
+      }
       // Backend may list the options in an unstable order; impose a deterministic
       // client-side order (driven by app config) so the login tabs do not jump
       // around between requests.
-      final supportedLoginTypes = sortLoginTypes(
-        parsedLoginTypes,
-        orderConfig: signinOrder,
-      );
-      if (demo)
-        supportedLoginTypes.removeWhere(
-          (loginType) => loginType != LoginType.signup,
-        );
+      final supportedLoginTypes = sortLoginTypes(parsedLoginTypes, orderConfig: signinOrder);
+      if (demo) supportedLoginTypes.removeWhere((loginType) => loginType != LoginType.signup);
 
       if (supportedLoginTypes.isEmpty) {
-        notificationsBloc.add(
-          const NotificationsSubmitted(
-            SupportedLoginTypeMissedErrorNotification(),
-          ),
-        );
+        notificationsBloc.add(const NotificationsSubmitted(SupportedLoginTypeMissedErrorNotification()));
         emit(state.copyWith(processing: false));
         return;
       }
@@ -155,20 +143,14 @@ class LoginCubit extends Cubit<LoginState> {
     }
   }
 
-  Future<WebtritSystemInfo?> _loadAndValidateSystemInfo(
-    String coreUrl,
-    String tenantId,
-  ) async {
+  Future<WebtritSystemInfo?> _loadAndValidateSystemInfo(String coreUrl, String tenantId) async {
     final systemInfo = await authRepository.getSystemInfo(coreUrl, tenantId);
 
     final coreInfo = systemInfo.core;
     final isCoreSupported = coreInfo.verifyVersionStr(coreVersionConstraint);
 
     if (!isCoreSupported) {
-      final notification = CoreVersionUnsupportedErrorNotification(
-        coreInfo.version.toString(),
-        coreVersionConstraint,
-      );
+      final notification = CoreVersionUnsupportedErrorNotification(coreInfo.version.toString(), coreVersionConstraint);
       notificationsBloc.add(NotificationsSubmitted(notification));
       return null;
     }
@@ -184,17 +166,14 @@ class LoginCubit extends Cubit<LoginState> {
     final demo = mode == LoginMode.demoCore;
     final coreUrl = demo ? demoCoreUrlFromEnvironment : coreUrlFromEnvironment;
 
-    if (coreUrl != null)
-      await _processSystemInfo(coreUrl, defaultTenantId, demo);
+    if (coreUrl != null) await _processSystemInfo(coreUrl, defaultTenantId, demo);
   }
 
   void setEmbedded(EmbeddedData embedded) {
     emit(
       state.copyWith(
         embedded: embedded,
-        coreUrl: isDemoModeEnabled
-            ? demoCoreUrlFromEnvironment
-            : coreUrlFromEnvironment,
+        coreUrl: isDemoModeEnabled ? demoCoreUrlFromEnvironment : coreUrlFromEnvironment,
       ),
     );
   }
@@ -276,10 +255,7 @@ class LoginCubit extends Cubit<LoginState> {
       emit(
         state.copyWith(
           processing: false,
-          otpSigninSessionOtpProvisionalWithDateTime: (
-            sessionOtpProvisional,
-            DateTime.now(),
-          ),
+          otpSigninSessionOtpProvisionalWithDateTime: (sessionOtpProvisional, DateTime.now()),
         ),
       );
     } catch (e, s) {
@@ -305,8 +281,7 @@ class LoginCubit extends Cubit<LoginState> {
       final sessionToken = await authRepository.verifyOtp(
         coreUrl: state.coreUrl!,
         tenantId: state.tenantId!,
-        sessionOtpProvisional:
-            state.otpSigninSessionOtpProvisionalWithDateTime!.$1,
+        sessionOtpProvisional: state.otpSigninSessionOtpProvisionalWithDateTime!.$1,
         code: state.otpSigninCodeInput.value,
       );
 
@@ -327,12 +302,7 @@ class LoginCubit extends Cubit<LoginState> {
   }
 
   void loginOptSigninVerifyBack() async {
-    emit(
-      state.copyWith(
-        otpSigninSessionOtpProvisionalWithDateTime: null,
-        otpSigninCodeInput: const CodeInput.pure(),
-      ),
-    );
+    emit(state.copyWith(otpSigninSessionOtpProvisionalWithDateTime: null, otpSigninCodeInput: const CodeInput.pure()));
   }
 
   void loginOptSigninVerifyRepeat() {
@@ -346,26 +316,44 @@ class LoginCubit extends Cubit<LoginState> {
   }
 
   void passwordSigninPasswordInputChanged(String value) {
-    emit(
-      state.copyWith(passwordSigninPasswordInput: PasswordInput.dirty(value)),
-    );
+    emit(state.copyWith(passwordSigninPasswordInput: PasswordInput.dirty(value)));
   }
 
   void passwordSigninPasswordInputObscureTextToggled() {
-    emit(
-      state.copyWith(
-        passwordSigninPasswordInputObscureText:
-            !state.passwordSigninPasswordInputObscureText,
-      ),
-    );
+    emit(state.copyWith(passwordSigninPasswordInputObscureText: !state.passwordSigninPasswordInputObscureText));
   }
 
   void loginPasswordSigninSubmitted() async {
-    if (state.processing ||
-        !state.passwordSigninUserRefInput.isValid ||
-        !state.passwordSigninPasswordInput.isValid) {
+    if (!state.passwordSigninUserRefInput.isValid || !state.passwordSigninPasswordInput.isValid) {
       return;
     }
+
+    await _submitPasswordLogin(
+      userRef: state.passwordSigninUserRefInput.value,
+      password: state.passwordSigninPasswordInput.value,
+      errorContext: 'LoginPasswordSigninSubmitted',
+    );
+  }
+
+  // LoginQrSignin
+
+  /// Signs in with credentials decoded from a scanned QR code.
+  ///
+  /// Follows the same session path as [loginPasswordSigninSubmitted]; the
+  /// credentials come from the scanner instead of the input fields. Completes
+  /// when the attempt is over so the caller can resume scanning on failure.
+  Future<void> loginQrSigninSubmitted({required String userRef, required String password}) {
+    return _submitPasswordLogin(userRef: userRef, password: password, errorContext: 'LoginQrSigninSubmitted');
+  }
+
+  /// Shared session-creation path of the password-based sign-ins (manual entry
+  /// and scanned QR credentials).
+  Future<void> _submitPasswordLogin({
+    required String userRef,
+    required String password,
+    required String errorContext,
+  }) async {
+    if (state.processing) return;
 
     emit(state.copyWith(processing: true));
 
@@ -373,8 +361,8 @@ class LoginCubit extends Cubit<LoginState> {
       final sessionToken = await authRepository.login(
         coreUrl: state.coreUrl!,
         tenantId: state.tenantId!,
-        userRef: state.passwordSigninUserRefInput.value,
-        password: state.passwordSigninPasswordInput.value,
+        userRef: userRef,
+        password: password,
       );
 
       // does not set processing to false to hold processing widgets state during navigation
@@ -382,7 +370,7 @@ class LoginCubit extends Cubit<LoginState> {
     } catch (e, s) {
       emit(state.copyWith(processing: false));
 
-      handleError(e, s, 'LoginSignupVerifySubmitted');
+      handleError(e, s, errorContext);
     }
   }
 
@@ -435,32 +423,22 @@ class LoginCubit extends Cubit<LoginState> {
     );
 
     try {
-      final tenantId =
-          extras?['tenant_id'] ?? state.tenantId ?? defaultTenantId;
+      final tenantId = extras?['tenant_id'] ?? state.tenantId ?? defaultTenantId;
 
       // In cases where the embedded page acts as the launch welcome screen,
       // the systemInfo might not be loaded yet. Perform an additional check
       // and attempt to load it if necessary.
-      final result = await authRepository.signup(
-        coreUrl: state.coreUrl!,
-        tenantId: tenantId,
-        extraPayload: extras,
-      );
+      final result = await authRepository.signup(coreUrl: state.coreUrl!, tenantId: tenantId, extraPayload: extras);
 
       if (state.systemInfo == null) {
         emit(state.copyWith(processing: true));
-        final systemInfo = await _loadAndValidateSystemInfo(
-          state.coreUrl!,
-          tenantId,
-        );
+        final systemInfo = await _loadAndValidateSystemInfo(state.coreUrl!, tenantId);
         emit(state.copyWith(systemInfo: systemInfo, processing: false));
       }
 
       // Executes optional post-login callback request if provided by embedded flow.
       if (result is SessionToken) {
-        final postRequest = embeddedCallbackData != null
-            ? RawHttpRequest.fromJson(embeddedCallbackData)
-            : null;
+        final postRequest = embeddedCallbackData != null ? RawHttpRequest.fromJson(embeddedCallbackData) : null;
         await authRepository.executePostLoginHttpRequest(postRequest);
       }
 
@@ -560,8 +538,7 @@ class LoginCubit extends Cubit<LoginState> {
       final sessionToken = await authRepository.verifyOtp(
         coreUrl: state.coreUrl!,
         tenantId: state.tenantId!,
-        sessionOtpProvisional:
-            state.signupSessionOtpProvisionalWithDateTime!.$1,
+        sessionOtpProvisional: state.signupSessionOtpProvisionalWithDateTime!.$1,
         code: state.signupCodeInput.value,
       );
 
@@ -581,12 +558,7 @@ class LoginCubit extends Cubit<LoginState> {
   }
 
   void loginSignupVerifyBack() async {
-    emit(
-      state.copyWith(
-        signupSessionOtpProvisionalWithDateTime: null,
-        signupCodeInput: const CodeInput.pure(),
-      ),
-    );
+    emit(state.copyWith(signupSessionOtpProvisionalWithDateTime: null, signupCodeInput: const CodeInput.pure()));
   }
 
   void loginSignupVerifyRepeat() {
@@ -597,9 +569,7 @@ class LoginCubit extends Cubit<LoginState> {
     if (error is RequestFailure) {
       if (error is UserNotFoundException) {
         _logger.warning('Known login error occurred: $error', error);
-        notificationsBloc.add(
-          NotificationsSubmitted(const LoginUserNotFoundNotification()),
-        );
+        notificationsBloc.add(NotificationsSubmitted(const LoginUserNotFoundNotification()));
         return;
       }
 
@@ -608,18 +578,14 @@ class LoginCubit extends Cubit<LoginState> {
         'otp_not_found' => const LoginOtpNotFoundNotification(),
         'incorrect_otp_code' => const LoginIncorrectOtpCodeNotification(),
         'otp_expired' => const LoginOtpExpiredNotification(),
-        'otp_verification_attempts_exceeded' =>
-          const LoginOtpVerificationAttemptsExceededNotification(),
+        'otp_verification_attempts_exceeded' => const LoginOtpVerificationAttemptsExceededNotification(),
         'otp_already_verified' => const LoginOtpAlreadyVerifiedNotification(),
         'phone_not_found' => const LoginPhoneNotFoundNotification(),
-        'incorrect_credentials' =>
-          const LoginIncorrectCredentialsNotification(),
+        'incorrect_credentials' => const LoginIncorrectCredentialsNotification(),
         'user_not_found' => const LoginUserNotFoundNotification(),
-        'unconfigured_bundle_id' =>
-          const LoginUnconfiguredBundleIdNotification(),
+        'unconfigured_bundle_id' => const LoginUnconfiguredBundleIdNotification(),
         'validation_error' => const LoginValidationErrorNotification(),
-        'parameters_apply_issue' =>
-          const LoginParametersApplyIssueNotification(),
+        'parameters_apply_issue' => const LoginParametersApplyIssueNotification(),
         'empty_email' => const LoginEmptyEmailNotification(),
         _ => null,
       };

--- a/lib/features/login/cubit/login_cubit.dart
+++ b/lib/features/login/cubit/login_cubit.dart
@@ -20,13 +20,18 @@ part 'login_cubit.freezed.dart';
 
 part 'login_state.dart';
 
-typedef LoginSuccessCallback = void Function(Session session, WebtritSystemInfo systemInfo);
+typedef LoginSuccessCallback =
+    void Function(Session session, WebtritSystemInfo systemInfo);
 
 final _logger = Logger('LoginCubit');
 
 class LoginCubit extends Cubit<LoginState> {
-  LoginCubit({required this.authRepository, required this.notificationsBloc, required this.onLoginSuccess})
-    : super(const LoginState());
+  LoginCubit({
+    required this.authRepository,
+    required this.notificationsBloc,
+    required this.onLoginSuccess,
+    this.signinOrder = const [],
+  }) : super(const LoginState());
 
   final AuthRepository authRepository;
 
@@ -34,10 +39,14 @@ class LoginCubit extends Cubit<LoginState> {
 
   final NotificationsBloc notificationsBloc;
 
+  /// Configured order of the sign-in tabs, by login type name (from app config).
+  final List<String> signinOrder;
+
   // Environment getters
   String? get coreUrlFromEnvironment => EnvironmentConfig.CORE_URL;
 
-  String? get credentialsRequestUrl => EnvironmentConfig.APP_CREDENTIALS_REQUEST_URL;
+  String? get credentialsRequestUrl =>
+      EnvironmentConfig.APP_CREDENTIALS_REQUEST_URL;
 
   String? get demoCoreUrlFromEnvironment => EnvironmentConfig.DEMO_CORE_URL;
 
@@ -72,7 +81,15 @@ class LoginCubit extends Cubit<LoginState> {
     final token = state.token!;
     final userId = state.userId!;
 
-    onLoginSuccess(Session(coreUrl: coreUrl, tenantId: tenantId, token: token, userId: userId), systemInfo);
+    onLoginSuccess(
+      Session(
+        coreUrl: coreUrl,
+        tenantId: tenantId,
+        token: token,
+        userId: userId,
+      ),
+      systemInfo,
+    );
   }
 
   void launchLinkableElement(LinkableElement link) async {
@@ -82,7 +99,11 @@ class LoginCubit extends Cubit<LoginState> {
     }
   }
 
-  Future<void> _processSystemInfo(String coreUrl, String tenantId, [bool demo = false]) async {
+  Future<void> _processSystemInfo(
+    String coreUrl,
+    String tenantId, [
+    bool demo = false,
+  ]) async {
     emit(state.copyWith(processing: true));
 
     try {
@@ -93,14 +114,28 @@ class LoginCubit extends Cubit<LoginState> {
       }
 
       final supportedFeatures = systemInfo.adapter?.supported ?? [];
-      final supportedLoginTypes = supportedFeatures
+      final parsedLoginTypes = supportedFeatures
           .where((f) => LoginType.values.map((e) => e.name).contains(f))
           .map((f) => LoginType.values.byName(f))
           .toList();
-      if (demo) supportedLoginTypes.removeWhere((loginType) => loginType != LoginType.signup);
+      // Backend may list the options in an unstable order; impose a deterministic
+      // client-side order (driven by app config) so the login tabs do not jump
+      // around between requests.
+      final supportedLoginTypes = sortLoginTypes(
+        parsedLoginTypes,
+        orderConfig: signinOrder,
+      );
+      if (demo)
+        supportedLoginTypes.removeWhere(
+          (loginType) => loginType != LoginType.signup,
+        );
 
       if (supportedLoginTypes.isEmpty) {
-        notificationsBloc.add(const NotificationsSubmitted(SupportedLoginTypeMissedErrorNotification()));
+        notificationsBloc.add(
+          const NotificationsSubmitted(
+            SupportedLoginTypeMissedErrorNotification(),
+          ),
+        );
         emit(state.copyWith(processing: false));
         return;
       }
@@ -120,14 +155,20 @@ class LoginCubit extends Cubit<LoginState> {
     }
   }
 
-  Future<WebtritSystemInfo?> _loadAndValidateSystemInfo(String coreUrl, String tenantId) async {
+  Future<WebtritSystemInfo?> _loadAndValidateSystemInfo(
+    String coreUrl,
+    String tenantId,
+  ) async {
     final systemInfo = await authRepository.getSystemInfo(coreUrl, tenantId);
 
     final coreInfo = systemInfo.core;
     final isCoreSupported = coreInfo.verifyVersionStr(coreVersionConstraint);
 
     if (!isCoreSupported) {
-      final notification = CoreVersionUnsupportedErrorNotification(coreInfo.version.toString(), coreVersionConstraint);
+      final notification = CoreVersionUnsupportedErrorNotification(
+        coreInfo.version.toString(),
+        coreVersionConstraint,
+      );
       notificationsBloc.add(NotificationsSubmitted(notification));
       return null;
     }
@@ -143,14 +184,17 @@ class LoginCubit extends Cubit<LoginState> {
     final demo = mode == LoginMode.demoCore;
     final coreUrl = demo ? demoCoreUrlFromEnvironment : coreUrlFromEnvironment;
 
-    if (coreUrl != null) await _processSystemInfo(coreUrl, defaultTenantId, demo);
+    if (coreUrl != null)
+      await _processSystemInfo(coreUrl, defaultTenantId, demo);
   }
 
   void setEmbedded(EmbeddedData embedded) {
     emit(
       state.copyWith(
         embedded: embedded,
-        coreUrl: isDemoModeEnabled ? demoCoreUrlFromEnvironment : coreUrlFromEnvironment,
+        coreUrl: isDemoModeEnabled
+            ? demoCoreUrlFromEnvironment
+            : coreUrlFromEnvironment,
       ),
     );
   }
@@ -232,7 +276,10 @@ class LoginCubit extends Cubit<LoginState> {
       emit(
         state.copyWith(
           processing: false,
-          otpSigninSessionOtpProvisionalWithDateTime: (sessionOtpProvisional, DateTime.now()),
+          otpSigninSessionOtpProvisionalWithDateTime: (
+            sessionOtpProvisional,
+            DateTime.now(),
+          ),
         ),
       );
     } catch (e, s) {
@@ -258,7 +305,8 @@ class LoginCubit extends Cubit<LoginState> {
       final sessionToken = await authRepository.verifyOtp(
         coreUrl: state.coreUrl!,
         tenantId: state.tenantId!,
-        sessionOtpProvisional: state.otpSigninSessionOtpProvisionalWithDateTime!.$1,
+        sessionOtpProvisional:
+            state.otpSigninSessionOtpProvisionalWithDateTime!.$1,
         code: state.otpSigninCodeInput.value,
       );
 
@@ -279,7 +327,12 @@ class LoginCubit extends Cubit<LoginState> {
   }
 
   void loginOptSigninVerifyBack() async {
-    emit(state.copyWith(otpSigninSessionOtpProvisionalWithDateTime: null, otpSigninCodeInput: const CodeInput.pure()));
+    emit(
+      state.copyWith(
+        otpSigninSessionOtpProvisionalWithDateTime: null,
+        otpSigninCodeInput: const CodeInput.pure(),
+      ),
+    );
   }
 
   void loginOptSigninVerifyRepeat() {
@@ -293,15 +346,24 @@ class LoginCubit extends Cubit<LoginState> {
   }
 
   void passwordSigninPasswordInputChanged(String value) {
-    emit(state.copyWith(passwordSigninPasswordInput: PasswordInput.dirty(value)));
+    emit(
+      state.copyWith(passwordSigninPasswordInput: PasswordInput.dirty(value)),
+    );
   }
 
   void passwordSigninPasswordInputObscureTextToggled() {
-    emit(state.copyWith(passwordSigninPasswordInputObscureText: !state.passwordSigninPasswordInputObscureText));
+    emit(
+      state.copyWith(
+        passwordSigninPasswordInputObscureText:
+            !state.passwordSigninPasswordInputObscureText,
+      ),
+    );
   }
 
   void loginPasswordSigninSubmitted() async {
-    if (state.processing || !state.passwordSigninUserRefInput.isValid || !state.passwordSigninPasswordInput.isValid) {
+    if (state.processing ||
+        !state.passwordSigninUserRefInput.isValid ||
+        !state.passwordSigninPasswordInput.isValid) {
       return;
     }
 
@@ -373,22 +435,32 @@ class LoginCubit extends Cubit<LoginState> {
     );
 
     try {
-      final tenantId = extras?['tenant_id'] ?? state.tenantId ?? defaultTenantId;
+      final tenantId =
+          extras?['tenant_id'] ?? state.tenantId ?? defaultTenantId;
 
       // In cases where the embedded page acts as the launch welcome screen,
       // the systemInfo might not be loaded yet. Perform an additional check
       // and attempt to load it if necessary.
-      final result = await authRepository.signup(coreUrl: state.coreUrl!, tenantId: tenantId, extraPayload: extras);
+      final result = await authRepository.signup(
+        coreUrl: state.coreUrl!,
+        tenantId: tenantId,
+        extraPayload: extras,
+      );
 
       if (state.systemInfo == null) {
         emit(state.copyWith(processing: true));
-        final systemInfo = await _loadAndValidateSystemInfo(state.coreUrl!, tenantId);
+        final systemInfo = await _loadAndValidateSystemInfo(
+          state.coreUrl!,
+          tenantId,
+        );
         emit(state.copyWith(systemInfo: systemInfo, processing: false));
       }
 
       // Executes optional post-login callback request if provided by embedded flow.
       if (result is SessionToken) {
-        final postRequest = embeddedCallbackData != null ? RawHttpRequest.fromJson(embeddedCallbackData) : null;
+        final postRequest = embeddedCallbackData != null
+            ? RawHttpRequest.fromJson(embeddedCallbackData)
+            : null;
         await authRepository.executePostLoginHttpRequest(postRequest);
       }
 
@@ -488,7 +560,8 @@ class LoginCubit extends Cubit<LoginState> {
       final sessionToken = await authRepository.verifyOtp(
         coreUrl: state.coreUrl!,
         tenantId: state.tenantId!,
-        sessionOtpProvisional: state.signupSessionOtpProvisionalWithDateTime!.$1,
+        sessionOtpProvisional:
+            state.signupSessionOtpProvisionalWithDateTime!.$1,
         code: state.signupCodeInput.value,
       );
 
@@ -508,7 +581,12 @@ class LoginCubit extends Cubit<LoginState> {
   }
 
   void loginSignupVerifyBack() async {
-    emit(state.copyWith(signupSessionOtpProvisionalWithDateTime: null, signupCodeInput: const CodeInput.pure()));
+    emit(
+      state.copyWith(
+        signupSessionOtpProvisionalWithDateTime: null,
+        signupCodeInput: const CodeInput.pure(),
+      ),
+    );
   }
 
   void loginSignupVerifyRepeat() {
@@ -519,7 +597,9 @@ class LoginCubit extends Cubit<LoginState> {
     if (error is RequestFailure) {
       if (error is UserNotFoundException) {
         _logger.warning('Known login error occurred: $error', error);
-        notificationsBloc.add(NotificationsSubmitted(const LoginUserNotFoundNotification()));
+        notificationsBloc.add(
+          NotificationsSubmitted(const LoginUserNotFoundNotification()),
+        );
         return;
       }
 
@@ -528,14 +608,18 @@ class LoginCubit extends Cubit<LoginState> {
         'otp_not_found' => const LoginOtpNotFoundNotification(),
         'incorrect_otp_code' => const LoginIncorrectOtpCodeNotification(),
         'otp_expired' => const LoginOtpExpiredNotification(),
-        'otp_verification_attempts_exceeded' => const LoginOtpVerificationAttemptsExceededNotification(),
+        'otp_verification_attempts_exceeded' =>
+          const LoginOtpVerificationAttemptsExceededNotification(),
         'otp_already_verified' => const LoginOtpAlreadyVerifiedNotification(),
         'phone_not_found' => const LoginPhoneNotFoundNotification(),
-        'incorrect_credentials' => const LoginIncorrectCredentialsNotification(),
+        'incorrect_credentials' =>
+          const LoginIncorrectCredentialsNotification(),
         'user_not_found' => const LoginUserNotFoundNotification(),
-        'unconfigured_bundle_id' => const LoginUnconfiguredBundleIdNotification(),
+        'unconfigured_bundle_id' =>
+          const LoginUnconfiguredBundleIdNotification(),
         'validation_error' => const LoginValidationErrorNotification(),
-        'parameters_apply_issue' => const LoginParametersApplyIssueNotification(),
+        'parameters_apply_issue' =>
+          const LoginParametersApplyIssueNotification(),
         'empty_email' => const LoginEmptyEmailNotification(),
         _ => null,
       };

--- a/lib/features/login/extensions/login_type.dart
+++ b/lib/features/login/extensions/login_type.dart
@@ -13,6 +13,7 @@ extension LoginTypeL10n on LoginType {
       LoginType.otpSignin => context.l10n.loginType_otpSignin,
       LoginType.passwordSignin => context.l10n.loginType_passwordSignin,
       LoginType.signup => context.l10n.loginType_signup,
+      LoginType.qrSignin => context.l10n.loginType_qrSignin,
     };
   }
 }
@@ -23,6 +24,7 @@ extension LoginTypePageRouteInfo on LoginType {
       LoginType.otpSignin => const LoginOtpSigninRouterPageRoute(),
       LoginType.passwordSignin => const LoginPasswordSigninScreenPageRoute(),
       LoginType.signup => const LoginSignupRouterPageRoute(),
+      LoginType.qrSignin => const LoginQrSigninScreenPageRoute(),
     };
   }
 }
@@ -33,6 +35,7 @@ extension LoginTypeLoginSegmentKey on LoginType {
       LoginType.otpSignin => const Key('loginTypeSegment_otpSignin'),
       LoginType.passwordSignin => const Key('loginTypeSegment_passwordSignin'),
       LoginType.signup => const Key('loginTypeSegment_signup'),
+      LoginType.qrSignin => const Key('loginTypeSegment_qrSignin'),
     };
   }
 }

--- a/lib/features/login/features/features.dart
+++ b/lib/features/login/features/features.dart
@@ -1,3 +1,4 @@
 export 'login_otp_signin/login_otp_signin.dart';
 export 'login_password_signin/login_password_signin.dart';
+export 'login_qr_signin/login_qr_signin.dart';
 export 'login_signup/login_signup.dart';

--- a/lib/features/login/features/login_qr_signin/cubit/cubit.dart
+++ b/lib/features/login/features/login_qr_signin/cubit/cubit.dart
@@ -1,0 +1,1 @@
+export 'qr_signin_cubit.dart';

--- a/lib/features/login/features/login_qr_signin/cubit/qr_signin_cubit.dart
+++ b/lib/features/login/features/login_qr_signin/cubit/qr_signin_cubit.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:logging/logging.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import 'package:webtrit_phone/data/data.dart';
+
+import '../models/qr_signin_parse_result.dart';
+import '../models/qr_signin_payload_parser.dart';
+
+part 'qr_signin_cubit.freezed.dart';
+
+part 'qr_signin_state.dart';
+
+final _logger = Logger('QrSigninCubit');
+
+/// Drives the QR sign-in tab: camera permission and interpretation of the
+/// scanned payloads.
+///
+/// The cubit deliberately does not create the session itself - a successfully
+/// parsed code is exposed as [QrSigninState.detection] for the view to hand
+/// over to the login flow, which keeps a single owner of the sign-in pipeline.
+class QrSigninCubit extends Cubit<QrSigninState> {
+  QrSigninCubit({required this.appPermissions, required this.parser}) : super(const QrSigninState()) {
+    _checkPermission();
+  }
+
+  final AppPermissions appPermissions;
+  final QrSigninPayloadParser parser;
+
+  /// How long an unrecognized code stays reported before scanning resumes,
+  /// and repeated detections of the same payload are ignored.
+  static const errorDisplayDuration = Duration(seconds: 3);
+
+  Timer? _errorResetTimer;
+  Timer? _retryCooldownTimer;
+  String? _lastRaw;
+
+  Future<void> _checkPermission() async {
+    final status = await appPermissions.getCameraPermissionStatus();
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        status: status.isGranted ? QrSigninStatus.scanning : QrSigninStatus.permissionRequired,
+        cameraPermanentlyDenied: status.isPermanentlyDenied,
+      ),
+    );
+  }
+
+  /// Re-runs the permission check, e.g. when the app returns from the
+  /// settings screen.
+  Future<void> recheckPermission() async {
+    if (state.status != QrSigninStatus.permissionRequired) return;
+    await _checkPermission();
+  }
+
+  Future<void> requestPermission() async {
+    final status = await appPermissions.requestCameraPermission();
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        status: status.isGranted ? QrSigninStatus.scanning : QrSigninStatus.permissionRequired,
+        cameraPermanentlyDenied: status.isPermanentlyDenied,
+      ),
+    );
+  }
+
+  Future<void> openAppSettings() => appPermissions.toAppSettings();
+
+  /// Handles a payload detected by the scanner.
+  void barcodeDetected(String? rawValue) {
+    if (rawValue == null || rawValue.isEmpty) return;
+    if (state.status != QrSigninStatus.scanning || state.detection != null) return;
+    // The scanner keeps re-detecting the code while it stays in the viewfinder.
+    if (rawValue == _lastRaw) return;
+    _lastRaw = rawValue;
+
+    // The raw payload is never logged: it may carry plain credentials.
+    switch (parser.parse(rawValue)) {
+      case QrSigninParseFailure(:final error):
+        _logger.info('Scanned code rejected: ${error.name}');
+        emit(state.copyWith(parseError: error));
+        _errorResetTimer?.cancel();
+        _errorResetTimer = Timer(errorDisplayDuration, () {
+          if (isClosed) return;
+          _lastRaw = null;
+          emit(state.copyWith(parseError: null));
+        });
+      case final QrSigninCredentials credentials:
+        _errorResetTimer?.cancel();
+        emit(state.copyWith(parseError: null, detection: credentials));
+      case final QrSigninUserRefOnly userRefOnly:
+        _errorResetTimer?.cancel();
+        emit(state.copyWith(parseError: null, detection: userRefOnly));
+    }
+  }
+
+  /// Clears the reported detection so scanning can continue, e.g. after a
+  /// failed sign-in attempt.
+  ///
+  /// The last payload stays ignored for a short cooldown: a rejected code is
+  /// usually still in the viewfinder, and clearing it right away would retry
+  /// the same failing sign-in in a tight loop. May be reached after the tab
+  /// (and this cubit) is gone when the sign-in attempt outlives it.
+  void detectionHandled() {
+    if (isClosed) return;
+    _retryCooldownTimer?.cancel();
+    _retryCooldownTimer = Timer(errorDisplayDuration, () => _lastRaw = null);
+    emit(state.copyWith(detection: null));
+  }
+
+  @override
+  Future<void> close() {
+    _errorResetTimer?.cancel();
+    _retryCooldownTimer?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/login/features/login_qr_signin/cubit/qr_signin_cubit.freezed.dart
+++ b/lib/features/login/features/login_qr_signin/cubit/qr_signin_cubit.freezed.dart
@@ -1,0 +1,202 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'qr_signin_cubit.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$QrSigninState {
+
+ QrSigninStatus get status; bool get cameraPermanentlyDenied; QrSigninParseError? get parseError; QrSigninParseResult? get detection;
+/// Create a copy of QrSigninState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$QrSigninStateCopyWith<QrSigninState> get copyWith => _$QrSigninStateCopyWithImpl<QrSigninState>(this as QrSigninState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is QrSigninState&&(identical(other.status, status) || other.status == status)&&(identical(other.cameraPermanentlyDenied, cameraPermanentlyDenied) || other.cameraPermanentlyDenied == cameraPermanentlyDenied)&&(identical(other.parseError, parseError) || other.parseError == parseError)&&(identical(other.detection, detection) || other.detection == detection));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,status,cameraPermanentlyDenied,parseError,detection);
+
+@override
+String toString() {
+  return 'QrSigninState(status: $status, cameraPermanentlyDenied: $cameraPermanentlyDenied, parseError: $parseError, detection: $detection)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $QrSigninStateCopyWith<$Res>  {
+  factory $QrSigninStateCopyWith(QrSigninState value, $Res Function(QrSigninState) _then) = _$QrSigninStateCopyWithImpl;
+@useResult
+$Res call({
+ QrSigninStatus status, bool cameraPermanentlyDenied, QrSigninParseError? parseError, QrSigninParseResult? detection
+});
+
+
+
+
+}
+/// @nodoc
+class _$QrSigninStateCopyWithImpl<$Res>
+    implements $QrSigninStateCopyWith<$Res> {
+  _$QrSigninStateCopyWithImpl(this._self, this._then);
+
+  final QrSigninState _self;
+  final $Res Function(QrSigninState) _then;
+
+/// Create a copy of QrSigninState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? cameraPermanentlyDenied = null,Object? parseError = freezed,Object? detection = freezed,}) {
+  return _then(QrSigninState(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as QrSigninStatus,cameraPermanentlyDenied: null == cameraPermanentlyDenied ? _self.cameraPermanentlyDenied : cameraPermanentlyDenied // ignore: cast_nullable_to_non_nullable
+as bool,parseError: freezed == parseError ? _self.parseError : parseError // ignore: cast_nullable_to_non_nullable
+as QrSigninParseError?,detection: freezed == detection ? _self.detection : detection // ignore: cast_nullable_to_non_nullable
+as QrSigninParseResult?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [QrSigninState].
+extension QrSigninStatePatterns on QrSigninState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+// dart format on

--- a/lib/features/login/features/login_qr_signin/cubit/qr_signin_state.dart
+++ b/lib/features/login/features/login_qr_signin/cubit/qr_signin_state.dart
@@ -1,0 +1,39 @@
+part of 'qr_signin_cubit.dart';
+
+enum QrSigninStatus {
+  /// The camera permission is being determined; nothing is shown yet.
+  checkingPermission,
+
+  /// The camera is available and the scanner is (or may be) running.
+  scanning,
+
+  /// The camera permission is missing; the user has to grant it to proceed.
+  permissionRequired,
+}
+
+@freezed
+class QrSigninState with _$QrSigninState {
+  const QrSigninState({
+    this.status = QrSigninStatus.checkingPermission,
+    this.cameraPermanentlyDenied = false,
+    this.parseError,
+    this.detection,
+  });
+
+  @override
+  final QrSigninStatus status;
+
+  /// Whether asking again is pointless (the OS will not show the dialog);
+  /// the user has to enable the permission on the settings screen instead.
+  @override
+  final bool cameraPermanentlyDenied;
+
+  /// Why the last scanned code was rejected; cleared automatically after
+  /// [QrSigninCubit.errorDisplayDuration].
+  @override
+  final QrSigninParseError? parseError;
+
+  /// A successfully parsed code waiting to be handed over to the login flow.
+  @override
+  final QrSigninParseResult? detection;
+}

--- a/lib/features/login/features/login_qr_signin/login_qr_signin.dart
+++ b/lib/features/login/features/login_qr_signin/login_qr_signin.dart
@@ -1,0 +1,4 @@
+export 'cubit/cubit.dart';
+export 'models/models.dart';
+export 'view/view.dart';
+export 'widgets/widgets.dart';

--- a/lib/features/login/features/login_qr_signin/models/json_qr_signin_payload_decoder.dart
+++ b/lib/features/login/features/login_qr_signin/models/json_qr_signin_payload_decoder.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+
+import 'qr_signin_parse_result.dart';
+import 'qr_signin_payload_decoder.dart';
+
+/// Where the sign-in fields live in a JSON payload.
+///
+/// The default layout is the WebTrit-issued code shape; a dialect that only
+/// renames fields or uses another marker is a different [JsonQrSigninStructure]
+/// passed to the same decoder - no new decoder class needed. Payloads whose
+/// shape differs beyond field names (nesting, different semantics) still get
+/// their own [QrSigninPayloadDecoder].
+class JsonQrSigninStructure {
+  const JsonQrSigninStructure({
+    this.markerKey = 't',
+    this.markerValue = 'webtrit-signin',
+    this.versionKey = 'v',
+    this.supportedVersion = 1,
+    this.userKey = 'user',
+    this.passwordKey = 'password',
+    this.hostKey = 'host',
+  });
+
+  /// Discriminator field and its expected value: bare JSON has no scheme, so
+  /// only objects declaring the marker are treated as sign-in codes.
+  final String markerKey;
+  final String markerValue;
+
+  /// Payload version field; an absent field means [supportedVersion].
+  final String versionKey;
+  final int supportedVersion;
+
+  final String userKey;
+  final String passwordKey;
+  final String hostKey;
+}
+
+/// Decodes credential payloads carried as a JSON object:
+///
+/// ```json
+/// {"t": "webtrit-signin", "v": 1, "user": "user123", "password": "p@ssword", "host": "EXAMPLE"}
+/// ```
+///
+/// The field layout comes from [structure] (see [JsonQrSigninStructure]); any
+/// JSON not declaring the structure's marker falls through to the next
+/// decoder. `password` may be omitted or empty - the user reference is then
+/// prefilled on the password tab. Unknown fields are ignored so the format can
+/// grow without breaking older builds.
+class JsonQrSigninPayloadDecoder implements QrSigninPayloadDecoder {
+  JsonQrSigninPayloadDecoder({this.expectedHost, this.structure = const JsonQrSigninStructure()});
+
+  final String? expectedHost;
+  final JsonQrSigninStructure structure;
+
+  /// Fields that would redirect the sign-in to another core; rejected
+  /// regardless of the structure because a scanned code must not choose where
+  /// credentials go.
+  static const _coreOverrideKeys = {'core', 'tenant', 'core_url', 'tenant_id'};
+
+  @override
+  QrSigninParseResult? decode(String raw) {
+    // Cheap pre-check: JSON objects of interest always start with a brace.
+    if (!raw.startsWith('{')) return null;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return null; // Not JSON at all - not this decoder's payload.
+    }
+    if (decoded is! Map<String, Object?>) return null;
+    if (decoded[structure.markerKey] != structure.markerValue) return null;
+
+    final version = decoded[structure.versionKey] ?? structure.supportedVersion;
+    if (version != structure.supportedVersion) {
+      return const QrSigninParseFailure(QrSigninParseError.unsupportedVersion);
+    }
+
+    if (decoded.keys.any(_coreOverrideKeys.contains)) {
+      return const QrSigninParseFailure(QrSigninParseError.coreOverrideNotAllowed);
+    }
+
+    final expectedHost = this.expectedHost;
+    if (expectedHost != null) {
+      final host = decoded[structure.hostKey];
+      if (host is! String || host.toLowerCase() != expectedHost.toLowerCase()) {
+        return const QrSigninParseFailure(QrSigninParseError.hostMismatch);
+      }
+    }
+
+    final userRef = decoded[structure.userKey];
+    if (userRef is! String || userRef.isEmpty) return const QrSigninParseFailure(QrSigninParseError.malformed);
+
+    final password = decoded[structure.passwordKey];
+    if (password != null && password is! String) return const QrSigninParseFailure(QrSigninParseError.malformed);
+    if (password == null || (password as String).isEmpty) return QrSigninUserRefOnly(userRef: userRef);
+
+    return QrSigninCredentials(userRef: userRef, password: password);
+  }
+}

--- a/lib/features/login/features/login_qr_signin/models/models.dart
+++ b/lib/features/login/features/login_qr_signin/models/models.dart
@@ -1,0 +1,5 @@
+export 'json_qr_signin_payload_decoder.dart';
+export 'qr_signin_parse_result.dart';
+export 'qr_signin_payload_decoder.dart';
+export 'qr_signin_payload_parser.dart';
+export 'uri_qr_signin_payload_decoder.dart';

--- a/lib/features/login/features/login_qr_signin/models/qr_signin_parse_result.dart
+++ b/lib/features/login/features/login_qr_signin/models/qr_signin_parse_result.dart
@@ -1,0 +1,47 @@
+/// Outcome of parsing a scanned QR payload.
+sealed class QrSigninParseResult {
+  const QrSigninParseResult();
+}
+
+/// Full credentials: the code carries both the user reference and the password.
+class QrSigninCredentials extends QrSigninParseResult {
+  const QrSigninCredentials({required this.userRef, required this.password});
+
+  final String userRef;
+  final String password;
+}
+
+/// The code carries only the user reference (password omitted or empty);
+/// the user finishes signing in on the password tab.
+class QrSigninUserRefOnly extends QrSigninParseResult {
+  const QrSigninUserRefOnly({required this.userRef});
+
+  final String userRef;
+}
+
+/// The payload is not a sign-in code this build accepts.
+class QrSigninParseFailure extends QrSigninParseResult {
+  const QrSigninParseFailure(this.error);
+
+  final QrSigninParseError error;
+}
+
+enum QrSigninParseError {
+  /// No configured decoder recognized the payload as a sign-in code.
+  unrecognized,
+
+  /// The code was issued for a different host (cloud id).
+  hostMismatch,
+
+  /// The code selects a sign-in method this build does not support.
+  unsupportedMethod,
+
+  /// The code tries to redirect the sign-in to another core.
+  coreOverrideNotAllowed,
+
+  /// The code declares a payload version this build does not understand.
+  unsupportedVersion,
+
+  /// The payload was recognized but its content is broken.
+  malformed,
+}

--- a/lib/features/login/features/login_qr_signin/models/qr_signin_payload_decoder.dart
+++ b/lib/features/login/features/login_qr_signin/models/qr_signin_payload_decoder.dart
@@ -1,0 +1,12 @@
+import 'qr_signin_parse_result.dart';
+
+/// One payload format the QR sign-in understands.
+///
+/// Decoders are probed in order by `QrSigninPayloadParser`: the first one that
+/// RECOGNIZES the payload wins and fully decides the outcome (including
+/// failures such as a host mismatch). Returning null means "this is not my
+/// format, let the next decoder try" - it must be reserved for payloads the
+/// decoder cannot claim at all, never for recognized-but-invalid ones.
+abstract interface class QrSigninPayloadDecoder {
+  QrSigninParseResult? decode(String raw);
+}

--- a/lib/features/login/features/login_qr_signin/models/qr_signin_payload_parser.dart
+++ b/lib/features/login/features/login_qr_signin/models/qr_signin_payload_parser.dart
@@ -1,0 +1,55 @@
+import 'package:webtrit_phone/models/models.dart';
+
+import 'json_qr_signin_payload_decoder.dart';
+import 'qr_signin_parse_result.dart';
+import 'qr_signin_payload_decoder.dart';
+import 'uri_qr_signin_payload_decoder.dart';
+
+/// Interprets scanned QR payloads by probing the configured
+/// [QrSigninPayloadDecoder]s in order: the first decoder that recognizes the
+/// payload fully decides the outcome; when none does, the payload is not a
+/// sign-in code.
+///
+/// Supporting a new payload STRUCTURE is one new decoder plus its name in
+/// [QrSigninConfig.formats]; existing decoders and callers stay untouched.
+class QrSigninPayloadParser {
+  QrSigninPayloadParser(List<QrSigninPayloadDecoder> decoders) : _decoders = List.unmodifiable(decoders);
+
+  /// Builds the decoder chain from the app config, preserving the
+  /// [QrSigninConfig.formats] order. Unknown format types are ignored.
+  factory QrSigninPayloadParser.fromConfig(QrSigninConfig config) {
+    return QrSigninPayloadParser([
+      for (final format in config.formats)
+        ?switch (format.type) {
+          uriFormat => UriQrSigninPayloadDecoder(
+            schemes: format.schemes ?? const [defaultUriScheme],
+            expectedHost: config.expectedHost,
+          ),
+          jsonFormat => JsonQrSigninPayloadDecoder(expectedHost: config.expectedHost),
+          _ => null,
+        },
+    ]);
+  }
+
+  /// The `scheme:user:password@host` provisioning URI format.
+  static const uriFormat = 'uri';
+
+  /// The marker-discriminated JSON object format.
+  static const jsonFormat = 'json';
+
+  /// Scheme assumed for a `uri` format entry that does not list its own.
+  static const defaultUriScheme = 'csc';
+
+  final List<QrSigninPayloadDecoder> _decoders;
+
+  QrSigninParseResult parse(String rawValue) {
+    final raw = rawValue.trim();
+    if (raw.isNotEmpty) {
+      for (final decoder in _decoders) {
+        final result = decoder.decode(raw);
+        if (result != null) return result;
+      }
+    }
+    return const QrSigninParseFailure(QrSigninParseError.unrecognized);
+  }
+}

--- a/lib/features/login/features/login_qr_signin/models/uri_qr_signin_payload_decoder.dart
+++ b/lib/features/login/features/login_qr_signin/models/uri_qr_signin_payload_decoder.dart
@@ -1,0 +1,94 @@
+import 'qr_signin_parse_result.dart';
+import 'qr_signin_payload_decoder.dart';
+
+/// Decodes provisioning sign-in URIs of the form
+/// `scheme:userRef:password@host[?query]` (for example
+/// `csc:user123:p%40ssword@EXAMPLE`).
+///
+/// The `userRef` and `password` segments are percent-encoded, so a literal
+/// `:` or `@` can only appear between them; this makes splitting at the last
+/// `@` (host) and the first `:` (credentials) unambiguous. A `?query` tail is
+/// cut off before the split; unknown query parameters are ignored so that
+/// generator-side extras do not break scanning. The reserved parameter `m`
+/// selects the sign-in method; only the default `password` method is supported.
+///
+/// [Uri.parse] is not applicable here: without a `//` the URI has no authority
+/// component, so the userinfo/host parts would not be recognized.
+class UriQrSigninPayloadDecoder implements QrSigninPayloadDecoder {
+  UriQrSigninPayloadDecoder({required List<String> schemes, this.expectedHost})
+    : _schemes = schemes.map((s) => s.toLowerCase()).toList();
+
+  final List<String> _schemes;
+  final String? expectedHost;
+
+  /// Query parameter selecting the sign-in method. Absent means password.
+  static const _methodKey = 'm';
+  static const _passwordMethod = 'password';
+
+  /// Query parameters that would redirect the sign-in to another core;
+  /// rejected because a scanned code must not choose where credentials go.
+  static const _coreOverrideKeys = {'core', 'tenant', 'core_url', 'tenant_id'};
+
+  /// Marker suffix of a test (non-approved) host in the generator portal.
+  static const _testHostSuffix = '*';
+
+  @override
+  QrSigninParseResult? decode(String raw) {
+    final schemeEnd = raw.indexOf(':');
+    if (schemeEnd <= 0) return null;
+    final scheme = raw.substring(0, schemeEnd).toLowerCase();
+    // An unknown scheme is not this decoder's payload at all.
+    if (!_schemes.contains(scheme)) return null;
+
+    var body = raw.substring(schemeEnd + 1);
+    Map<String, String> query = const {};
+    final queryStart = body.indexOf('?');
+    if (queryStart != -1) {
+      try {
+        query = Uri.splitQueryString(body.substring(queryStart + 1));
+        // Broken percent-encoding surfaces as ArgumentError, not FormatException.
+      } on ArgumentError {
+        return const QrSigninParseFailure(QrSigninParseError.malformed);
+      } on FormatException {
+        return const QrSigninParseFailure(QrSigninParseError.malformed);
+      }
+      body = body.substring(0, queryStart);
+    }
+
+    final method = query[_methodKey] ?? _passwordMethod;
+    if (method != _passwordMethod) return const QrSigninParseFailure(QrSigninParseError.unsupportedMethod);
+    if (query.keys.any(_coreOverrideKeys.contains)) {
+      return const QrSigninParseFailure(QrSigninParseError.coreOverrideNotAllowed);
+    }
+
+    final hostStart = body.lastIndexOf('@');
+    if (hostStart == -1) return const QrSigninParseFailure(QrSigninParseError.malformed);
+    final userinfo = body.substring(0, hostStart);
+    var host = body.substring(hostStart + 1);
+    if (host.endsWith(_testHostSuffix)) host = host.substring(0, host.length - 1);
+    if (host.isEmpty) return const QrSigninParseFailure(QrSigninParseError.malformed);
+
+    final expectedHost = this.expectedHost;
+    if (expectedHost != null && host.toLowerCase() != expectedHost.toLowerCase()) {
+      return const QrSigninParseFailure(QrSigninParseError.hostMismatch);
+    }
+
+    if (userinfo.isEmpty) return const QrSigninParseFailure(QrSigninParseError.malformed);
+    final passwordStart = userinfo.indexOf(':');
+    final encodedUserRef = passwordStart == -1 ? userinfo : userinfo.substring(0, passwordStart);
+    final encodedPassword = passwordStart == -1 ? '' : userinfo.substring(passwordStart + 1);
+
+    final String userRef;
+    final String password;
+    try {
+      userRef = Uri.decodeComponent(encodedUserRef);
+      password = Uri.decodeComponent(encodedPassword);
+    } on ArgumentError {
+      return const QrSigninParseFailure(QrSigninParseError.malformed);
+    }
+    if (userRef.isEmpty) return const QrSigninParseFailure(QrSigninParseError.malformed);
+
+    if (password.isEmpty) return QrSigninUserRefOnly(userRef: userRef);
+    return QrSigninCredentials(userRef: userRef, password: password);
+  }
+}

--- a/lib/features/login/features/login_qr_signin/view/login_qr_signin_screen.dart
+++ b/lib/features/login/features/login_qr_signin/view/login_qr_signin_screen.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/features/features.dart';
+
+class LoginQrSigninScreen extends StatefulWidget {
+  const LoginQrSigninScreen({super.key});
+
+  @override
+  State<LoginQrSigninScreen> createState() => _LoginQrSigninScreenState();
+}
+
+class _LoginQrSigninScreenState extends State<LoginQrSigninScreen> with WidgetsBindingObserver {
+  final _scannerController = MobileScannerController(formats: [BarcodeFormat.qrCode]);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // The MobileScanner widget manages the app lifecycle only for its own
+    // internal controller; with an external one the camera session must be
+    // stopped and resumed here, or the preview stays frozen after the app
+    // returns from the background.
+    switch (state) {
+      case AppLifecycleState.resumed:
+        // The permission may have been granted on the system settings screen.
+        context.read<QrSigninCubit>().recheckPermission();
+        if (_isScannerVisible) _startScannerSafely();
+      case AppLifecycleState.inactive:
+        unawaited(_scannerController.stop());
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        break;
+    }
+  }
+
+  /// Whether the scanner preview is currently part of the tree: the camera is
+  /// pointless while the sign-in request is in flight or the permission view
+  /// is shown.
+  bool get _isScannerVisible =>
+      context.read<QrSigninCubit>().state.status == QrSigninStatus.scanning &&
+      !context.read<LoginCubit>().state.processing;
+
+  /// Starting is a no-op when the camera is already running, but throws while
+  /// a concurrent start (e.g. the remounted widget's auto-start) is still in
+  /// flight - tolerate that instead of crashing.
+  void _startScannerSafely() {
+    unawaited(_scannerController.start().onError<MobileScannerException>((_, _) {}));
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    final rawValue = capture.barcodes.firstOrNull?.rawValue;
+    context.read<QrSigninCubit>().barcodeDetected(rawValue);
+  }
+
+  Future<void> _onDetectionReported(BuildContext context, QrSigninParseResult detection) async {
+    final loginCubit = context.read<LoginCubit>();
+    final qrSigninCubit = context.read<QrSigninCubit>();
+
+    // No explicit camera stop/start here: swapping the scanner widget out for
+    // the verifying view (and back) already stops and restarts the camera, and
+    // an extra start() would race the remounted widget's auto-start.
+    switch (detection) {
+      case QrSigninCredentials(:final userRef, :final password):
+        await loginCubit.loginQrSigninSubmitted(userRef: userRef, password: password);
+      case QrSigninUserRefOnly(:final userRef):
+        // The code carries no password: let the user finish on the password tab.
+        loginCubit.passwordSigninUserRefInputChanged(userRef);
+        final supportedLoginTypes = loginCubit.state.supportedLoginTypes ?? const [];
+        final passwordTabIndex = supportedLoginTypes.indexOf(LoginType.passwordSignin);
+        if (context.mounted && passwordTabIndex != -1) {
+          AutoTabsRouter.of(context).setActiveIndex(passwordTabIndex);
+        }
+      case QrSigninParseFailure():
+        break; // Failures are reported via [QrSigninState.parseError], not here.
+    }
+
+    // Reached when the sign-in attempt failed (on success this widget is gone)
+    // or after the prefill handoff: let the scanner accept codes again.
+    qrSigninCubit.detectionHandled();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<QrSigninCubit, QrSigninState>(
+      listenWhen: (previous, current) => previous.detection != current.detection && current.detection != null,
+      listener: (context, state) => _onDetectionReported(context, state.detection!),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(kInset, kInset / 2, kInset, kInset),
+        color: Theme.of(context).scaffoldBackgroundColor,
+        child: BlocBuilder<LoginCubit, LoginState>(
+          buildWhen: (previous, current) => previous.processing != current.processing,
+          builder: (context, loginState) {
+            return BlocBuilder<QrSigninCubit, QrSigninState>(
+              builder: (context, state) {
+                if (loginState.processing) return const QrSigninVerifyingView();
+
+                return switch (state.status) {
+                  QrSigninStatus.checkingPermission => const SizedBox.shrink(),
+                  QrSigninStatus.permissionRequired => QrSigninPermissionView(
+                    permanentlyDenied: state.cameraPermanentlyDenied,
+                    onRequestPermission: context.read<QrSigninCubit>().requestPermission,
+                    onOpenSettings: context.read<QrSigninCubit>().openAppSettings,
+                  ),
+                  QrSigninStatus.scanning => QrScannerView(
+                    controller: _scannerController,
+                    onDetect: _onDetect,
+                    parseError: state.parseError,
+                  ),
+                };
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/login/features/login_qr_signin/view/login_qr_signin_screen_page.dart
+++ b/lib/features/login/features/login_qr_signin/view/login_qr_signin_screen_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/features/features.dart';
+
+@RoutePage()
+class LoginQrSigninScreenPage extends StatelessWidget {
+  // ignore: use_key_in_widget_constructors
+  const LoginQrSigninScreenPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => QrSigninCubit(
+        appPermissions: context.read<AppPermissions>(),
+        parser: QrSigninPayloadParser.fromConfig(context.read<FeatureAccess>().loginConfig.qrSignin),
+      ),
+      child: const LoginQrSigninScreen(),
+    );
+  }
+}

--- a/lib/features/login/features/login_qr_signin/view/view.dart
+++ b/lib/features/login/features/login_qr_signin/view/view.dart
@@ -1,0 +1,2 @@
+export 'login_qr_signin_screen.dart';
+export 'login_qr_signin_screen_page.dart';

--- a/lib/features/login/features/login_qr_signin/widgets/qr_scanner_view.dart
+++ b/lib/features/login/features/login_qr_signin/widgets/qr_scanner_view.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+import '../models/qr_signin_parse_result.dart';
+
+/// The scanning state of the QR sign-in tab: hint text, camera viewfinder and
+/// an inline line for the last rejection reason.
+class QrScannerView extends StatelessWidget {
+  const QrScannerView({super.key, required this.controller, required this.onDetect, this.parseError});
+
+  final MobileScannerController controller;
+  final ValueChanged<BarcodeCapture> onDetect;
+  final QrSigninParseError? parseError;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          context.l10n.login_Text_qrSigninScanHint,
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.bodyLarge,
+        ),
+        const SizedBox(height: kInset),
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 320, maxHeight: 320),
+            child: AspectRatio(
+              aspectRatio: 1,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(kInset),
+                // The neutral backdrop keeps the viewfinder shape visible while
+                // the camera initializes (the preview flickers in otherwise).
+                child: ColoredBox(
+                  color: themeData.colorScheme.surfaceContainerHighest,
+                  child: MobileScanner(
+                    controller: controller,
+                    onDetect: onDetect,
+                    placeholderBuilder: (context) => const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: kInset / 2),
+        // Reserve the line so the layout does not jump when an error appears.
+        Text(
+          parseError != null ? context.l10n.login_Text_qrSigninInvalidCodeError : '',
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.bodyMedium?.copyWith(color: themeData.colorScheme.error),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/login/features/login_qr_signin/widgets/qr_signin_permission_view.dart
+++ b/lib/features/login/features/login_qr_signin/widgets/qr_signin_permission_view.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+/// The no-camera-permission state of the QR sign-in tab.
+///
+/// Offers a single action: request the permission while the OS can still show
+/// the dialog; once the denial is permanent, the settings screen is the only
+/// way left, so the button is replaced rather than stacked.
+class QrSigninPermissionView extends StatelessWidget {
+  const QrSigninPermissionView({
+    super.key,
+    required this.permanentlyDenied,
+    required this.onRequestPermission,
+    required this.onOpenSettings,
+  });
+
+  final bool permanentlyDenied;
+  final VoidCallback onRequestPermission;
+  final VoidCallback onOpenSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Center(
+          child: CircleAvatar(
+            radius: 40,
+            backgroundColor: themeData.colorScheme.surfaceContainerHighest,
+            child: Icon(Icons.no_photography_outlined, size: 36, color: themeData.colorScheme.onSurfaceVariant),
+          ),
+        ),
+        const SizedBox(height: kInset),
+        Text(
+          context.l10n.login_Text_qrSigninCameraPermissionTitle,
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.titleLarge,
+        ),
+        const SizedBox(height: kInset / 2),
+        Text(
+          context.l10n.login_Text_qrSigninCameraPermissionDescription,
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: kInset),
+        if (permanentlyDenied)
+          ElevatedButton(onPressed: onOpenSettings, child: Text(context.l10n.login_Button_qrSigninOpenSettings))
+        else
+          ElevatedButton(
+            onPressed: onRequestPermission,
+            child: Text(context.l10n.login_Button_qrSigninAllowCameraAccess),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/login/features/login_qr_signin/widgets/qr_signin_verifying_view.dart
+++ b/lib/features/login/features/login_qr_signin/widgets/qr_signin_verifying_view.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+
+/// The in-progress state of the QR sign-in tab: a scanned code is being
+/// verified with the server.
+class QrSigninVerifyingView extends StatelessWidget {
+  const QrSigninVerifyingView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Center(child: CircularProgressIndicator()),
+        const SizedBox(height: kInset),
+        Text(
+          context.l10n.login_Text_qrSigninVerifyingTitle,
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.titleLarge,
+        ),
+        const SizedBox(height: kInset / 2),
+        Text(
+          context.l10n.login_Text_qrSigninVerifyingDescription,
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/login/features/login_qr_signin/widgets/widgets.dart
+++ b/lib/features/login/features/login_qr_signin/widgets/widgets.dart
@@ -1,0 +1,3 @@
+export 'qr_scanner_view.dart';
+export 'qr_signin_permission_view.dart';
+export 'qr_signin_verifying_view.dart';

--- a/lib/features/login/models/login_type.dart
+++ b/lib/features/login/models/login_type.dart
@@ -1,1 +1,7 @@
-enum LoginType { otpSignin, passwordSignin, signup }
+/// Sign-in tabs of the login switch screen.
+///
+/// [otpSignin], [passwordSignin] and [signup] are advertised by the backend
+/// adapter; [qrSignin] is a client-side companion of [passwordSignin] (the
+/// scanned code carries plain credentials) offered when enabled in the app
+/// config and the backend supports password sign-in.
+enum LoginType { otpSignin, passwordSignin, signup, qrSignin }

--- a/lib/features/login/models/login_type_order.dart
+++ b/lib/features/login/models/login_type_order.dart
@@ -3,11 +3,13 @@ import 'package:webtrit_phone/features/login/models/login_type.dart';
 /// Built-in order applied when no explicit order is configured.
 ///
 /// When both are available the regular password login comes first: it is faster
-/// for frequent users, while OTP delivery takes a moment anyway.
+/// for frequent users, while OTP delivery takes a moment anyway. The QR tab is
+/// an optional companion of the password login, so by default it goes last.
 const kDefaultLoginTypeOrder = <LoginType>[
   LoginType.passwordSignin,
   LoginType.otpSignin,
   LoginType.signup,
+  LoginType.qrSignin,
 ];
 
 /// Returns [types] reordered deterministically on the client.
@@ -19,10 +21,7 @@ const kDefaultLoginTypeOrder = <LoginType>[
 /// falls back to [kDefaultLoginTypeOrder]. Login types not covered by the
 /// resolved order are kept and pushed to the end, preserving their relative
 /// order.
-List<LoginType> sortLoginTypes(
-  List<LoginType> types, {
-  List<String> orderConfig = const [],
-}) {
+List<LoginType> sortLoginTypes(List<LoginType> types, {List<String> orderConfig = const []}) {
   final nameMap = LoginType.values.asNameMap();
   final priority = [
     for (final name in orderConfig)

--- a/lib/features/login/models/login_type_order.dart
+++ b/lib/features/login/models/login_type_order.dart
@@ -1,0 +1,44 @@
+import 'package:webtrit_phone/features/login/models/login_type.dart';
+
+/// Built-in order applied when no explicit order is configured.
+///
+/// When both are available the regular password login comes first: it is faster
+/// for frequent users, while OTP delivery takes a moment anyway.
+const kDefaultLoginTypeOrder = <LoginType>[
+  LoginType.passwordSignin,
+  LoginType.otpSignin,
+  LoginType.signup,
+];
+
+/// Returns [types] reordered deterministically on the client.
+///
+/// The order the backend lists the login options in is intentionally ignored:
+/// it is not stable across requests, so relying on it makes the login tabs jump
+/// around. [orderConfig] is a list of [LoginType] names (e.g. from a build-time
+/// environment value); unknown names are ignored and an empty/invalid config
+/// falls back to [kDefaultLoginTypeOrder]. Login types not covered by the
+/// resolved order are kept and pushed to the end, preserving their relative
+/// order.
+List<LoginType> sortLoginTypes(
+  List<LoginType> types, {
+  List<String> orderConfig = const [],
+}) {
+  final nameMap = LoginType.values.asNameMap();
+  final priority = [
+    for (final name in orderConfig)
+      if (nameMap.containsKey(name)) nameMap[name]!,
+  ];
+  final order = priority.isNotEmpty ? priority : kDefaultLoginTypeOrder;
+
+  int rank(LoginType type) {
+    final index = order.indexOf(type);
+    return index == -1 ? order.length : index;
+  }
+
+  final indexed = [for (var i = 0; i < types.length; i++) (i, types[i])];
+  indexed.sort((a, b) {
+    final byRank = rank(a.$2).compareTo(rank(b.$2));
+    return byRank != 0 ? byRank : a.$1.compareTo(b.$1);
+  });
+  return [for (final entry in indexed) entry.$2];
+}

--- a/lib/features/login/models/models.dart
+++ b/lib/features/login/models/models.dart
@@ -3,6 +3,7 @@ export 'email_input.dart';
 export 'notifications.dart';
 export 'login_mode.dart';
 export 'login_type.dart';
+export 'login_type_order.dart';
 export 'otp_signin_identifier.dart';
 export 'password_input.dart';
 export 'phone_input.dart';

--- a/lib/features/login/view/login_router_page.dart
+++ b/lib/features/login/view/login_router_page.dart
@@ -14,8 +14,7 @@ import 'package:webtrit_phone/repositories/repositories.dart';
 
 bool whenLoginRouterPageChange(LoginState previous, LoginState current) {
   return (previous.mode != current.mode) ||
-      (previous.coreUrl != current.coreUrl ||
-          previous.supportedLoginTypes != current.supportedLoginTypes) ||
+      (previous.coreUrl != current.coreUrl || previous.supportedLoginTypes != current.supportedLoginTypes) ||
       previous.embedded != current.embedded;
 }
 
@@ -34,8 +33,7 @@ bool whenLoginSwitchScreenPageActive(LoginState state) {
 @RoutePage()
 class LoginRouterPage extends StatelessWidget {
   // ignore: use_key_in_widget_constructors
-  const LoginRouterPage({EmbeddedData? launchEmbeddedData})
-    : _launchEmbeddedData = launchEmbeddedData;
+  const LoginRouterPage({EmbeddedData? launchEmbeddedData}) : _launchEmbeddedData = launchEmbeddedData;
 
   final EmbeddedData? _launchEmbeddedData;
 
@@ -45,27 +43,20 @@ class LoginRouterPage extends StatelessWidget {
       buildWhen: whenLoginRouterPageChange,
       builder: (context, state) {
         return AutoRouter.declarative(
-          navigatorObservers: () => [
-            _HideCurrentSnackBarNavigatorObserver(context),
-          ],
+          navigatorObservers: () => [_HideCurrentSnackBarNavigatorObserver(context)],
           routes: (handler) {
             return [
               // Embedded page was not provided as launch, so use the native UI.
-              if (_launchEmbeddedData == null)
-                const LoginModeSelectScreenPageRoute(),
+              if (_launchEmbeddedData == null) const LoginModeSelectScreenPageRoute(),
 
               // Open the core URL assignment screen (used in demo mode).
               // Note: this should be refactored to rely on a dedicated flag instead of demo mode.
-              if (whenLoginCoreUrlAssignScreenPageActive(state))
-                const LoginCoreUrlAssignScreenPageRoute(),
+              if (whenLoginCoreUrlAssignScreenPageActive(state)) const LoginCoreUrlAssignScreenPageRoute(),
 
               // After receiving server-provided login types (triggered from LoginModeSelectScreenPageRoute),
               // open the login switch screen.
-              if (_launchEmbeddedData == null &&
-                  whenLoginSwitchScreenPageActive(state))
-                LoginSwitchScreenPageRoute(
-                  bodySafeAreaSides: const {SafeAreaSide.bottom},
-                ),
+              if (_launchEmbeddedData == null && whenLoginSwitchScreenPageActive(state))
+                LoginSwitchScreenPageRoute(bodySafeAreaSides: const {SafeAreaSide.bottom}),
 
               // Embedded page was provided, so use the embedded UI via LoginSwitchScreenPageRoute.
               // Force a single login type to disable rendering of other tabs.
@@ -102,17 +93,14 @@ class LoginRouterPage extends StatelessWidget {
       notificationsBloc: context.read<NotificationsBloc>(),
       authRepository: context.read<AuthRepository>(),
       signinOrder: context.read<FeatureAccess>().loginConfig.signinOrder,
-      onLoginSuccess: (session, systemInfo) => context.read<AppBloc>().add(
-        AppLoggedIn(session: session, systemInfo: systemInfo),
-      ),
+      qrSigninConfig: context.read<FeatureAccess>().loginConfig.qrSignin,
+      onLoginSuccess: (session, systemInfo) =>
+          context.read<AppBloc>().add(AppLoggedIn(session: session, systemInfo: systemInfo)),
     );
     if (_launchEmbeddedData != null) {
       login.setEmbedded(_launchEmbeddedData);
     }
-    final provider = BlocProvider(
-      create: (context) => login,
-      child: declarativeAutoRouter,
-    );
+    final provider = BlocProvider(create: (context) => login, child: declarativeAutoRouter);
     return provider;
   }
 

--- a/lib/features/login/view/login_router_page.dart
+++ b/lib/features/login/view/login_router_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone/app/notifications/notifications.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/blocs/blocs.dart';
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
@@ -13,7 +14,8 @@ import 'package:webtrit_phone/repositories/repositories.dart';
 
 bool whenLoginRouterPageChange(LoginState previous, LoginState current) {
   return (previous.mode != current.mode) ||
-      (previous.coreUrl != current.coreUrl || previous.supportedLoginTypes != current.supportedLoginTypes) ||
+      (previous.coreUrl != current.coreUrl ||
+          previous.supportedLoginTypes != current.supportedLoginTypes) ||
       previous.embedded != current.embedded;
 }
 
@@ -32,7 +34,8 @@ bool whenLoginSwitchScreenPageActive(LoginState state) {
 @RoutePage()
 class LoginRouterPage extends StatelessWidget {
   // ignore: use_key_in_widget_constructors
-  const LoginRouterPage({EmbeddedData? launchEmbeddedData}) : _launchEmbeddedData = launchEmbeddedData;
+  const LoginRouterPage({EmbeddedData? launchEmbeddedData})
+    : _launchEmbeddedData = launchEmbeddedData;
 
   final EmbeddedData? _launchEmbeddedData;
 
@@ -42,20 +45,27 @@ class LoginRouterPage extends StatelessWidget {
       buildWhen: whenLoginRouterPageChange,
       builder: (context, state) {
         return AutoRouter.declarative(
-          navigatorObservers: () => [_HideCurrentSnackBarNavigatorObserver(context)],
+          navigatorObservers: () => [
+            _HideCurrentSnackBarNavigatorObserver(context),
+          ],
           routes: (handler) {
             return [
               // Embedded page was not provided as launch, so use the native UI.
-              if (_launchEmbeddedData == null) const LoginModeSelectScreenPageRoute(),
+              if (_launchEmbeddedData == null)
+                const LoginModeSelectScreenPageRoute(),
 
               // Open the core URL assignment screen (used in demo mode).
               // Note: this should be refactored to rely on a dedicated flag instead of demo mode.
-              if (whenLoginCoreUrlAssignScreenPageActive(state)) const LoginCoreUrlAssignScreenPageRoute(),
+              if (whenLoginCoreUrlAssignScreenPageActive(state))
+                const LoginCoreUrlAssignScreenPageRoute(),
 
               // After receiving server-provided login types (triggered from LoginModeSelectScreenPageRoute),
               // open the login switch screen.
-              if (_launchEmbeddedData == null && whenLoginSwitchScreenPageActive(state))
-                LoginSwitchScreenPageRoute(bodySafeAreaSides: const {SafeAreaSide.bottom}),
+              if (_launchEmbeddedData == null &&
+                  whenLoginSwitchScreenPageActive(state))
+                LoginSwitchScreenPageRoute(
+                  bodySafeAreaSides: const {SafeAreaSide.bottom},
+                ),
 
               // Embedded page was provided, so use the embedded UI via LoginSwitchScreenPageRoute.
               // Force a single login type to disable rendering of other tabs.
@@ -91,13 +101,18 @@ class LoginRouterPage extends StatelessWidget {
     final login = LoginCubit(
       notificationsBloc: context.read<NotificationsBloc>(),
       authRepository: context.read<AuthRepository>(),
-      onLoginSuccess: (session, systemInfo) =>
-          context.read<AppBloc>().add(AppLoggedIn(session: session, systemInfo: systemInfo)),
+      signinOrder: context.read<FeatureAccess>().loginConfig.signinOrder,
+      onLoginSuccess: (session, systemInfo) => context.read<AppBloc>().add(
+        AppLoggedIn(session: session, systemInfo: systemInfo),
+      ),
     );
     if (_launchEmbeddedData != null) {
       login.setEmbedded(_launchEmbeddedData);
     }
-    final provider = BlocProvider(create: (context) => login, child: declarativeAutoRouter);
+    final provider = BlocProvider(
+      create: (context) => login,
+      child: declarativeAutoRouter,
+    );
     return provider;
   }
 

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1725,6 +1725,54 @@ abstract class AppLocalizations {
   /// **'A one-time verification code was sent to {email}.'**
   String login_Text_signupVerifyPreDescriptionEmail(String email);
 
+  /// No description provided for @login_Text_qrSigninScanHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan the QR code to log in.'**
+  String get login_Text_qrSigninScanHint;
+
+  /// No description provided for @login_Text_qrSigninVerifyingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Signing you in...'**
+  String get login_Text_qrSigninVerifyingTitle;
+
+  /// No description provided for @login_Text_qrSigninVerifyingDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'QR code scanned. Verifying with the server.'**
+  String get login_Text_qrSigninVerifyingDescription;
+
+  /// No description provided for @login_Text_qrSigninCameraPermissionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera access is off'**
+  String get login_Text_qrSigninCameraPermissionTitle;
+
+  /// No description provided for @login_Text_qrSigninCameraPermissionDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera access is needed to scan a QR code. Enable it to continue.'**
+  String get login_Text_qrSigninCameraPermissionDescription;
+
+  /// No description provided for @login_Button_qrSigninAllowCameraAccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow camera access'**
+  String get login_Button_qrSigninAllowCameraAccess;
+
+  /// No description provided for @login_Button_qrSigninOpenSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Open settings'**
+  String get login_Button_qrSigninOpenSettings;
+
+  /// No description provided for @login_Text_qrSigninInvalidCodeError.
+  ///
+  /// In en, this message translates to:
+  /// **'This QR code cannot be used to sign in.'**
+  String get login_Text_qrSigninInvalidCodeError;
+
   /// No description provided for @loginType_otpSignin.
   ///
   /// In en, this message translates to:
@@ -1736,6 +1784,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Password sign in'**
   String get loginType_passwordSignin;
+
+  /// No description provided for @loginType_qrSignin.
+  ///
+  /// In en, this message translates to:
+  /// **'QR code'**
+  String get loginType_qrSignin;
 
   /// No description provided for @loginType_signup.
   ///

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -450,8 +450,22 @@ extension AppLocalizationsExtension on AppLocalizations {
         login_Text_signupRequestPreDescriptionDemo,
       'login_Text_signupVerifyPostDescriptionGeneral' =>
         login_Text_signupVerifyPostDescriptionGeneral,
+      'login_Text_qrSigninScanHint' => login_Text_qrSigninScanHint,
+      'login_Text_qrSigninVerifyingTitle' => login_Text_qrSigninVerifyingTitle,
+      'login_Text_qrSigninVerifyingDescription' =>
+        login_Text_qrSigninVerifyingDescription,
+      'login_Text_qrSigninCameraPermissionTitle' =>
+        login_Text_qrSigninCameraPermissionTitle,
+      'login_Text_qrSigninCameraPermissionDescription' =>
+        login_Text_qrSigninCameraPermissionDescription,
+      'login_Button_qrSigninAllowCameraAccess' =>
+        login_Button_qrSigninAllowCameraAccess,
+      'login_Button_qrSigninOpenSettings' => login_Button_qrSigninOpenSettings,
+      'login_Text_qrSigninInvalidCodeError' =>
+        login_Text_qrSigninInvalidCodeError,
       'loginType_otpSignin' => loginType_otpSignin,
       'loginType_passwordSignin' => loginType_passwordSignin,
+      'loginType_qrSignin' => loginType_qrSignin,
       'loginType_signup' => loginType_signup,
       'login_validationCoreUrlError' => login_validationCoreUrlError,
       'login_validationEmailError' => login_validationEmailError,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -930,10 +930,38 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get login_Text_qrSigninScanHint => 'Scan the QR code to log in.';
+
+  @override
+  String get login_Text_qrSigninVerifyingTitle => 'Signing you in...';
+
+  @override
+  String get login_Text_qrSigninVerifyingDescription => 'QR code scanned. Verifying with the server.';
+
+  @override
+  String get login_Text_qrSigninCameraPermissionTitle => 'Camera access is off';
+
+  @override
+  String get login_Text_qrSigninCameraPermissionDescription =>
+      'Camera access is needed to scan a QR code. Enable it to continue.';
+
+  @override
+  String get login_Button_qrSigninAllowCameraAccess => 'Allow camera access';
+
+  @override
+  String get login_Button_qrSigninOpenSettings => 'Open settings';
+
+  @override
+  String get login_Text_qrSigninInvalidCodeError => 'This QR code cannot be used to sign in.';
+
+  @override
   String get loginType_otpSignin => 'OTP sign in';
 
   @override
   String get loginType_passwordSignin => 'Password sign in';
+
+  @override
+  String get loginType_qrSignin => 'QR code';
 
   @override
   String get loginType_signup => 'Sign up';

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -936,10 +936,38 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get login_Text_qrSigninScanHint => 'Scansiona il codice QR per accedere.';
+
+  @override
+  String get login_Text_qrSigninVerifyingTitle => 'Accesso in corso...';
+
+  @override
+  String get login_Text_qrSigninVerifyingDescription => 'Codice QR scansionato. Verifica con il server in corso.';
+
+  @override
+  String get login_Text_qrSigninCameraPermissionTitle => 'L\'accesso alla fotocamera è disattivato';
+
+  @override
+  String get login_Text_qrSigninCameraPermissionDescription =>
+      'L\'accesso alla fotocamera è necessario per scansionare un codice QR. Attivalo per continuare.';
+
+  @override
+  String get login_Button_qrSigninAllowCameraAccess => 'Consenti l\'accesso alla fotocamera';
+
+  @override
+  String get login_Button_qrSigninOpenSettings => 'Apri le impostazioni';
+
+  @override
+  String get login_Text_qrSigninInvalidCodeError => 'Questo codice QR non può essere utilizzato per accedere.';
+
+  @override
   String get loginType_otpSignin => 'Accesso con OTP';
 
   @override
   String get loginType_passwordSignin => 'Accesso con password';
+
+  @override
+  String get loginType_qrSignin => 'Codice QR';
 
   @override
   String get loginType_signup => 'Iscrizione';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -939,10 +939,38 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get login_Text_qrSigninScanHint => 'Відскануйте QR-код, щоб увійти.';
+
+  @override
+  String get login_Text_qrSigninVerifyingTitle => 'Виконуємо вхід...';
+
+  @override
+  String get login_Text_qrSigninVerifyingDescription => 'QR-код відскановано. Перевірка на сервері.';
+
+  @override
+  String get login_Text_qrSigninCameraPermissionTitle => 'Доступ до камери вимкнено';
+
+  @override
+  String get login_Text_qrSigninCameraPermissionDescription =>
+      'Для сканування QR-коду потрібен доступ до камери. Увімкніть його, щоб продовжити.';
+
+  @override
+  String get login_Button_qrSigninAllowCameraAccess => 'Надати доступ до камери';
+
+  @override
+  String get login_Button_qrSigninOpenSettings => 'Відкрити налаштування';
+
+  @override
+  String get login_Text_qrSigninInvalidCodeError => 'Цей QR-код не можна використати для входу.';
+
+  @override
   String get loginType_otpSignin => 'Увійти за OTP';
 
   @override
   String get loginType_passwordSignin => 'Вхід за паролем';
+
+  @override
+  String get loginType_qrSignin => 'QR-код';
 
   @override
   String get loginType_signup => 'Зареєструватися';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -531,7 +531,9 @@
   "diagnosticNetworkTestItem_subtitle_publicIps": "Public: {ips}",
   "@diagnosticNetworkTestItem_subtitle_publicIps": {
     "placeholders": {
-      "ips": {"type": "String"}
+      "ips": {
+        "type": "String"
+      }
     }
   },
   "diagnosticNetworkTestItem_subtitle_stunBlocked": "STUN blocked · relay available",
@@ -780,10 +782,28 @@
       }
     }
   },
+  "login_Text_qrSigninScanHint": "Scan the QR code to log in.",
+  "@login_Text_qrSigninScanHint": {},
+  "login_Text_qrSigninVerifyingTitle": "Signing you in...",
+  "@login_Text_qrSigninVerifyingTitle": {},
+  "login_Text_qrSigninVerifyingDescription": "QR code scanned. Verifying with the server.",
+  "@login_Text_qrSigninVerifyingDescription": {},
+  "login_Text_qrSigninCameraPermissionTitle": "Camera access is off",
+  "@login_Text_qrSigninCameraPermissionTitle": {},
+  "login_Text_qrSigninCameraPermissionDescription": "Camera access is needed to scan a QR code. Enable it to continue.",
+  "@login_Text_qrSigninCameraPermissionDescription": {},
+  "login_Button_qrSigninAllowCameraAccess": "Allow camera access",
+  "@login_Button_qrSigninAllowCameraAccess": {},
+  "login_Button_qrSigninOpenSettings": "Open settings",
+  "@login_Button_qrSigninOpenSettings": {},
+  "login_Text_qrSigninInvalidCodeError": "This QR code cannot be used to sign in.",
+  "@login_Text_qrSigninInvalidCodeError": {},
   "loginType_otpSignin": "OTP sign in",
   "@loginType_otpSignin": {},
   "loginType_passwordSignin": "Password sign in",
   "@loginType_passwordSignin": {},
+  "loginType_qrSignin": "QR code",
+  "@loginType_qrSignin": {},
   "loginType_signup": "Sign up",
   "@loginType_signup": {},
   "login_validationCoreUrlError": "Please enter a valid URL",
@@ -2280,7 +2300,6 @@
   "cdr_disconnectReason_nextNodeIsUnreachable": "Next node is unreachable",
   "cdr_disconnectReason_holstTelephonyServiceProviderModuleHtspmIsOutOfService": "Holst Telephony Service Provider Module (HTSPM) is out of service",
   "cdr_disconnectReason_dtlTransitIsNotMyNodeId": "DTL transit is not my node ID",
-
   "devTools_AppBarTitle": "Dev Tools",
   "@devTools_AppBarTitle": {},
   "devTools_signalingService_groupTitle": "Signaling Service",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -531,7 +531,9 @@
   "diagnosticNetworkTestItem_subtitle_publicIps": "Pubblica: {ips}",
   "@diagnosticNetworkTestItem_subtitle_publicIps": {
     "placeholders": {
-      "ips": {"type": "String"}
+      "ips": {
+        "type": "String"
+      }
     }
   },
   "diagnosticNetworkTestItem_subtitle_stunBlocked": "STUN bloccato · relay disponibile",
@@ -780,10 +782,28 @@
       }
     }
   },
+  "login_Text_qrSigninScanHint": "Scansiona il codice QR per accedere.",
+  "@login_Text_qrSigninScanHint": {},
+  "login_Text_qrSigninVerifyingTitle": "Accesso in corso...",
+  "@login_Text_qrSigninVerifyingTitle": {},
+  "login_Text_qrSigninVerifyingDescription": "Codice QR scansionato. Verifica con il server in corso.",
+  "@login_Text_qrSigninVerifyingDescription": {},
+  "login_Text_qrSigninCameraPermissionTitle": "L'accesso alla fotocamera è disattivato",
+  "@login_Text_qrSigninCameraPermissionTitle": {},
+  "login_Text_qrSigninCameraPermissionDescription": "L'accesso alla fotocamera è necessario per scansionare un codice QR. Attivalo per continuare.",
+  "@login_Text_qrSigninCameraPermissionDescription": {},
+  "login_Button_qrSigninAllowCameraAccess": "Consenti l'accesso alla fotocamera",
+  "@login_Button_qrSigninAllowCameraAccess": {},
+  "login_Button_qrSigninOpenSettings": "Apri le impostazioni",
+  "@login_Button_qrSigninOpenSettings": {},
+  "login_Text_qrSigninInvalidCodeError": "Questo codice QR non può essere utilizzato per accedere.",
+  "@login_Text_qrSigninInvalidCodeError": {},
   "loginType_otpSignin": "Accesso con OTP",
   "@loginType_otpSignin": {},
   "loginType_passwordSignin": "Accesso con password",
   "@loginType_passwordSignin": {},
+  "loginType_qrSignin": "Codice QR",
+  "@loginType_qrSignin": {},
   "loginType_signup": "Iscrizione",
   "@loginType_signup": {},
   "login_validationCoreUrlError": "Prego inserisci un URL valido",
@@ -810,7 +830,7 @@
   "@logRecordsConsole_Text_failure": {
     "description": "Shown in the Log Console screen when an unexpected error occurs while loading or displaying log records."
   },
-  "logRecordsConsole_Text_recordsCountHint": "{count, plural, one{Visualizzazione dell\u2019ultimo {count} record. Usa Condividi per esportare il log completo.} other{Visualizzazione degli ultimi {count} record. Usa Condividi per esportare il log completo.}}",
+  "logRecordsConsole_Text_recordsCountHint": "{count, plural, one{Visualizzazione dell’ultimo {count} record. Usa Condividi per esportare il log completo.} other{Visualizzazione degli ultimi {count} record. Usa Condividi per esportare il log completo.}}",
   "@logRecordsConsole_Text_recordsCountHint": {
     "description": "Shown in the info dialog to inform the user that only the most recent records are displayed and the share button exports the complete log.",
     "placeholders": {

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -531,7 +531,9 @@
   "diagnosticNetworkTestItem_subtitle_publicIps": "Публічна: {ips}",
   "@diagnosticNetworkTestItem_subtitle_publicIps": {
     "placeholders": {
-      "ips": {"type": "String"}
+      "ips": {
+        "type": "String"
+      }
     }
   },
   "diagnosticNetworkTestItem_subtitle_stunBlocked": "STUN заблоковано · ретранслятор доступний",
@@ -780,10 +782,28 @@
       }
     }
   },
+  "login_Text_qrSigninScanHint": "Відскануйте QR-код, щоб увійти.",
+  "@login_Text_qrSigninScanHint": {},
+  "login_Text_qrSigninVerifyingTitle": "Виконуємо вхід...",
+  "@login_Text_qrSigninVerifyingTitle": {},
+  "login_Text_qrSigninVerifyingDescription": "QR-код відскановано. Перевірка на сервері.",
+  "@login_Text_qrSigninVerifyingDescription": {},
+  "login_Text_qrSigninCameraPermissionTitle": "Доступ до камери вимкнено",
+  "@login_Text_qrSigninCameraPermissionTitle": {},
+  "login_Text_qrSigninCameraPermissionDescription": "Для сканування QR-коду потрібен доступ до камери. Увімкніть його, щоб продовжити.",
+  "@login_Text_qrSigninCameraPermissionDescription": {},
+  "login_Button_qrSigninAllowCameraAccess": "Надати доступ до камери",
+  "@login_Button_qrSigninAllowCameraAccess": {},
+  "login_Button_qrSigninOpenSettings": "Відкрити налаштування",
+  "@login_Button_qrSigninOpenSettings": {},
+  "login_Text_qrSigninInvalidCodeError": "Цей QR-код не можна використати для входу.",
+  "@login_Text_qrSigninInvalidCodeError": {},
   "loginType_otpSignin": "Увійти за OTP",
   "@loginType_otpSignin": {},
   "loginType_passwordSignin": "Вхід за паролем",
   "@loginType_passwordSignin": {},
+  "loginType_qrSignin": "QR-код",
+  "@loginType_qrSignin": {},
   "loginType_signup": "Зареєструватися",
   "@loginType_signup": {},
   "login_validationCoreUrlError": "Будь ласка, введіть правильний URL",

--- a/lib/models/feature_access/feature_access.dart
+++ b/lib/models/feature_access/feature_access.dart
@@ -12,6 +12,7 @@ export 'login_config.dart';
 export 'login_mode_action.dart';
 export 'messaging_config.dart';
 export 'logging_config.dart';
+export 'qr_signin_config.dart';
 export 'settings_config.dart';
 export 'settings_feature.dart';
 export 'sip_presence_config.dart';

--- a/lib/models/feature_access/login_config.dart
+++ b/lib/models/feature_access/login_config.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 
 import '../embedded/embedded_data.dart';
 import 'login_mode_action.dart';
+import 'qr_signin_config.dart';
 
 /// Configuration for the login feature, defining UI titles and available login actions.
 class LoginConfig extends Equatable {
@@ -10,8 +11,10 @@ class LoginConfig extends Equatable {
     required this.titleL10n,
     required this.launchLoginPage,
     List<String> signinOrder = const [],
+    QrSigninConfig? qrSignin,
   }) : _actions = List.unmodifiable(actions),
-       signinOrder = List.unmodifiable(signinOrder);
+       signinOrder = List.unmodifiable(signinOrder),
+       qrSignin = qrSignin ?? QrSigninConfig.disabled;
 
   /// The key to use to look up the localized title.
   final String? titleL10n;
@@ -19,6 +22,9 @@ class LoginConfig extends Equatable {
   /// Order of the sign-in tabs (login switch screen) by login type name.
   /// Empty falls back to the built-in default at the consumption site.
   final List<String> signinOrder;
+
+  /// Configuration of the QR-code sign-in tab.
+  final QrSigninConfig qrSignin;
 
   final List<LoginModeAction> _actions;
 
@@ -29,8 +35,7 @@ class LoginConfig extends Equatable {
   final EmbeddedData? launchLoginPage;
 
   /// Returns only the actions that represent embedded login configurations.
-  List<LoginEmbeddedModeButton> get embeddedConfigurations =>
-      _actions.whereType<LoginEmbeddedModeButton>().toList();
+  List<LoginEmbeddedModeButton> get embeddedConfigurations => _actions.whereType<LoginEmbeddedModeButton>().toList();
 
   /// Whether there are any embedded login pages available.
   bool get hasEmbeddedPage => embeddedConfigurations.isNotEmpty;
@@ -39,10 +44,5 @@ class LoginConfig extends Equatable {
   List<LoginModeAction> get launchButtons => _actions.toList();
 
   @override
-  List<Object?> get props => [
-    titleL10n,
-    _actions,
-    launchLoginPage,
-    signinOrder,
-  ];
+  List<Object?> get props => [titleL10n, _actions, launchLoginPage, signinOrder, qrSignin];
 }

--- a/lib/models/feature_access/login_config.dart
+++ b/lib/models/feature_access/login_config.dart
@@ -5,11 +5,20 @@ import 'login_mode_action.dart';
 
 /// Configuration for the login feature, defining UI titles and available login actions.
 class LoginConfig extends Equatable {
-  LoginConfig({required List<LoginModeAction> actions, required this.titleL10n, required this.launchLoginPage})
-    : _actions = List.unmodifiable(actions);
+  LoginConfig({
+    required List<LoginModeAction> actions,
+    required this.titleL10n,
+    required this.launchLoginPage,
+    List<String> signinOrder = const [],
+  }) : _actions = List.unmodifiable(actions),
+       signinOrder = List.unmodifiable(signinOrder);
 
   /// The key to use to look up the localized title.
   final String? titleL10n;
+
+  /// Order of the sign-in tabs (login switch screen) by login type name.
+  /// Empty falls back to the built-in default at the consumption site.
+  final List<String> signinOrder;
 
   final List<LoginModeAction> _actions;
 
@@ -20,7 +29,8 @@ class LoginConfig extends Equatable {
   final EmbeddedData? launchLoginPage;
 
   /// Returns only the actions that represent embedded login configurations.
-  List<LoginEmbeddedModeButton> get embeddedConfigurations => _actions.whereType<LoginEmbeddedModeButton>().toList();
+  List<LoginEmbeddedModeButton> get embeddedConfigurations =>
+      _actions.whereType<LoginEmbeddedModeButton>().toList();
 
   /// Whether there are any embedded login pages available.
   bool get hasEmbeddedPage => embeddedConfigurations.isNotEmpty;
@@ -29,5 +39,10 @@ class LoginConfig extends Equatable {
   List<LoginModeAction> get launchButtons => _actions.toList();
 
   @override
-  List<Object?> get props => [titleL10n, _actions, launchLoginPage];
+  List<Object?> get props => [
+    titleL10n,
+    _actions,
+    launchLoginPage,
+    signinOrder,
+  ];
 }

--- a/lib/models/feature_access/qr_signin_config.dart
+++ b/lib/models/feature_access/qr_signin_config.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+
+/// Configuration of the QR-code sign-in tab.
+///
+/// The scanned code carries plain credentials in a provisioning payload;
+/// signing in goes through the regular password login, so the tab is offered
+/// only when the backend supports password sign-in.
+class QrSigninConfig extends Equatable {
+  QrSigninConfig({
+    this.enabled = false,
+    List<QrSigninFormatConfig> formats = const [
+      QrSigninFormatConfig(type: 'uri', schemes: ['csc']),
+      QrSigninFormatConfig(type: 'json'),
+    ],
+    this.expectedHost,
+  }) : formats = List.unmodifiable(formats);
+
+  /// Whether the QR-code sign-in tab is available at all.
+  final bool enabled;
+
+  /// Accepted payload formats with their per-format options, probed in this
+  /// order.
+  final List<QrSigninFormatConfig> formats;
+
+  /// Expected host (cloud id) of the code, shared by all formats; null
+  /// accepts any host.
+  final String? expectedHost;
+
+  static final disabled = QrSigninConfig();
+
+  @override
+  List<Object?> get props => [enabled, formats, expectedHost];
+}
+
+/// One accepted QR payload format and its format-specific options.
+class QrSigninFormatConfig extends Equatable {
+  const QrSigninFormatConfig({required this.type, this.schemes});
+
+  /// Decoder name (`uri`, `json`).
+  final String type;
+
+  /// `uri` only: accepted scheme names, matched case-insensitively.
+  final List<String>? schemes;
+
+  @override
+  List<Object?> get props => [type, schemes];
+}

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -48,8 +48,7 @@ class AppConfig with _$AppConfig {
   @override
   final List<SupportedFeature> supported;
 
-  factory AppConfig.fromJson(Map<String, Object?> json) =>
-      _$AppConfigFromJson(json);
+  factory AppConfig.fromJson(Map<String, Object?> json) => _$AppConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigToJson(this);
 }
@@ -61,6 +60,7 @@ class AppConfigLogin with _$AppConfigLogin {
     this.common = const AppConfigLoginCommon(),
     this.modeSelect = const AppConfigLoginModeSelect(),
     this.signinOrder = const ['passwordSignin', 'otpSignin', 'signup'],
+    this.qr = const AppConfigLoginQr(),
   });
 
   @override
@@ -70,16 +70,75 @@ class AppConfigLogin with _$AppConfigLogin {
   final AppConfigLoginModeSelect modeSelect;
 
   /// Order of the sign-in tabs on the login switch screen, by login type name
-  /// (passwordSignin, otpSignin, signup). Only the types advertised by the
-  /// backend are shown; this controls their order and which one is selected by
-  /// default. Unknown or omitted names are placed last.
+  /// (passwordSignin, otpSignin, signup, qrSignin). Only the types advertised by
+  /// the backend are shown; this controls their order and which one is selected
+  /// by default. Unknown or omitted names are placed last.
   @override
   final List<String> signinOrder;
 
-  factory AppConfigLogin.fromJson(Map<String, Object?> json) =>
-      _$AppConfigLoginFromJson(json);
+  @override
+  final AppConfigLoginQr qr;
+
+  factory AppConfigLogin.fromJson(Map<String, Object?> json) => _$AppConfigLoginFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigLoginToJson(this);
+}
+
+/// Configuration of the QR-code sign-in tab.
+///
+/// The QR code carries plain credentials in a provisioning URI (for example
+/// `csc:username:password@EXAMPLE` with percent-encoded segments); scanning it
+/// signs the user in through the regular password login. The tab appears only
+/// when [enabled] is true and the backend supports password sign-in; its
+/// position among the other tabs follows [AppConfigLogin.signinOrder].
+@freezed
+@JsonSerializable(explicitToJson: true)
+class AppConfigLoginQr with _$AppConfigLoginQr {
+  const AppConfigLoginQr({
+    this.enabled = false,
+    this.formats = const [
+      AppConfigLoginQrFormat(type: 'uri', schemes: ['csc']),
+      AppConfigLoginQrFormat(type: 'json'),
+    ],
+    this.expectedHost,
+  });
+
+  /// Whether the QR-code sign-in tab is available at all.
+  @override
+  final bool enabled;
+
+  /// Accepted payload formats with their per-format options, probed in this
+  /// order.
+  @override
+  final List<AppConfigLoginQrFormat> formats;
+
+  /// Expected host (cloud id) of the code, shared by all formats. When set,
+  /// codes issued for a different host are rejected; null accepts any host.
+  @override
+  final String? expectedHost;
+
+  factory AppConfigLoginQr.fromJson(Map<String, Object?> json) => _$AppConfigLoginQrFromJson(json);
+
+  Map<String, Object?> toJson() => _$AppConfigLoginQrToJson(this);
+}
+
+/// One accepted QR payload format and its format-specific options.
+@freezed
+@JsonSerializable(explicitToJson: true)
+class AppConfigLoginQrFormat with _$AppConfigLoginQrFormat {
+  const AppConfigLoginQrFormat({required this.type, this.schemes});
+
+  /// Decoder name (`uri`, `json`).
+  @override
+  final String type;
+
+  /// `uri` only: accepted scheme names, matched case-insensitively.
+  @override
+  final List<String>? schemes;
+
+  factory AppConfigLoginQrFormat.fromJson(Map<String, Object?> json) => _$AppConfigLoginQrFormatFromJson(json);
+
+  Map<String, Object?> toJson() => _$AppConfigLoginQrFormatToJson(this);
 }
 
 @freezed
@@ -90,8 +149,7 @@ class AppConfigLoginCommon with _$AppConfigLoginCommon {
   @override
   final String? fullScreenLaunchEmbeddedResourceId;
 
-  factory AppConfigLoginCommon.fromJson(Map<String, Object?> json) =>
-      _$AppConfigLoginCommonFromJson(json);
+  factory AppConfigLoginCommon.fromJson(Map<String, Object?> json) => _$AppConfigLoginCommonFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigLoginCommonToJson(this);
 }
@@ -102,11 +160,7 @@ class AppConfigLoginModeSelect with _$AppConfigLoginModeSelect {
   const AppConfigLoginModeSelect({
     this.greetingL10n,
     this.actions = const [
-      AppConfigModeSelectAction(
-        enabled: true,
-        type: 'login',
-        titleL10n: 'login_Button_signUpToDemoInstance',
-      ),
+      AppConfigModeSelectAction(enabled: true, type: 'login', titleL10n: 'login_Button_signUpToDemoInstance'),
     ],
   });
 
@@ -116,8 +170,7 @@ class AppConfigLoginModeSelect with _$AppConfigLoginModeSelect {
   @override
   final List<AppConfigModeSelectAction> actions;
 
-  factory AppConfigLoginModeSelect.fromJson(Map<String, Object?> json) =>
-      _$AppConfigLoginModeSelectFromJson(json);
+  factory AppConfigLoginModeSelect.fromJson(Map<String, Object?> json) => _$AppConfigLoginModeSelectFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigLoginModeSelectToJson(this);
 }
@@ -144,8 +197,7 @@ class AppConfigModeSelectAction with _$AppConfigModeSelectAction {
   @override
   final String? embeddedId;
 
-  factory AppConfigModeSelectAction.fromJson(Map<String, Object?> json) =>
-      _$AppConfigModeSelectActionFromJson(json);
+  factory AppConfigModeSelectAction.fromJson(Map<String, Object?> json) => _$AppConfigModeSelectActionFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigModeSelectActionToJson(this);
 }
@@ -201,8 +253,7 @@ class AppConfigMain with _$AppConfigMain {
   @Deprecated('Use SupportedFeature.systemNotifications instead')
   final bool systemNotificationsEnabled;
 
-  factory AppConfigMain.fromJson(Map<String, Object?> json) =>
-      _$AppConfigMainFromJson(json);
+  factory AppConfigMain.fromJson(Map<String, Object?> json) => _$AppConfigMainFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigMainToJson(this);
 }
@@ -210,10 +261,7 @@ class AppConfigMain with _$AppConfigMain {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigBottomMenu with _$AppConfigBottomMenu {
-  const AppConfigBottomMenu({
-    this.cacheSelectedTab = true,
-    this.tabs = const [],
-  });
+  const AppConfigBottomMenu({this.cacheSelectedTab = true, this.tabs = const []});
 
   @override
   final bool cacheSelectedTab;
@@ -221,8 +269,7 @@ class AppConfigBottomMenu with _$AppConfigBottomMenu {
   @override
   final List<BottomMenuTabScheme> tabs;
 
-  factory AppConfigBottomMenu.fromJson(Map<String, Object?> json) =>
-      _$AppConfigBottomMenuFromJson(json);
+  factory AppConfigBottomMenu.fromJson(Map<String, Object?> json) => _$AppConfigBottomMenuFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigBottomMenuToJson(this);
 }
@@ -232,10 +279,7 @@ class AppConfigBottomMenu with _$AppConfigBottomMenu {
 class AppConfigCall with _$AppConfigCall {
   const AppConfigCall({
     this.videoEnabled = true,
-    this.transfer = const AppConfigTransfer(
-      enableBlindTransfer: true,
-      enableAttendedTransfer: true,
-    ),
+    this.transfer = const AppConfigTransfer(enableBlindTransfer: true, enableAttendedTransfer: true),
     this.encoding = const AppConfigEncoding(),
     this.peerConnection = const AppConfigPeerConnection(),
   });
@@ -252,8 +296,7 @@ class AppConfigCall with _$AppConfigCall {
   @override
   final AppConfigPeerConnection peerConnection;
 
-  factory AppConfigCall.fromJson(Map<String, Object?> json) =>
-      _$AppConfigCallFromJson(json);
+  factory AppConfigCall.fromJson(Map<String, Object?> json) => _$AppConfigCallFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigCallToJson(this);
 }
@@ -261,10 +304,7 @@ class AppConfigCall with _$AppConfigCall {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigTransfer with _$AppConfigTransfer {
-  const AppConfigTransfer({
-    this.enableBlindTransfer = true,
-    this.enableAttendedTransfer = true,
-  });
+  const AppConfigTransfer({this.enableBlindTransfer = true, this.enableAttendedTransfer = true});
 
   @override
   final bool enableBlindTransfer;
@@ -272,8 +312,7 @@ class AppConfigTransfer with _$AppConfigTransfer {
   @override
   final bool enableAttendedTransfer;
 
-  factory AppConfigTransfer.fromJson(Map<String, Object?> json) =>
-      _$AppConfigTransferFromJson(json);
+  factory AppConfigTransfer.fromJson(Map<String, Object?> json) => _$AppConfigTransferFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigTransferToJson(this);
 }
@@ -292,8 +331,7 @@ class AppConfigEncoding with _$AppConfigEncoding {
   @override
   final EncodingDefaultPresetOverride defaultPresetOverride;
 
-  factory AppConfigEncoding.fromJson(Map<String, Object?> json) =>
-      _$AppConfigEncodingFromJson(json);
+  factory AppConfigEncoding.fromJson(Map<String, Object?> json) => _$AppConfigEncodingFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigEncodingToJson(this);
 }
@@ -301,36 +339,28 @@ class AppConfigEncoding with _$AppConfigEncoding {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigPeerConnection with _$AppConfigPeerConnection {
-  const AppConfigPeerConnection({
-    this.negotiation = const AppConfigNegotiationSettingsOverride(),
-  });
+  const AppConfigPeerConnection({this.negotiation = const AppConfigNegotiationSettingsOverride()});
 
   @override
   final AppConfigNegotiationSettingsOverride negotiation;
 
-  factory AppConfigPeerConnection.fromJson(Map<String, Object?> json) =>
-      _$AppConfigPeerConnectionFromJson(json);
+  factory AppConfigPeerConnection.fromJson(Map<String, Object?> json) => _$AppConfigPeerConnectionFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigPeerConnectionToJson(this);
 }
 
 @freezed
 @JsonSerializable(explicitToJson: true)
-class AppConfigNegotiationSettingsOverride
-    with _$AppConfigNegotiationSettingsOverride {
-  const AppConfigNegotiationSettingsOverride({
-    this.includeInactiveVideoInOfferAnswer = false,
-  });
+class AppConfigNegotiationSettingsOverride with _$AppConfigNegotiationSettingsOverride {
+  const AppConfigNegotiationSettingsOverride({this.includeInactiveVideoInOfferAnswer = false});
 
   @override
   final bool includeInactiveVideoInOfferAnswer;
 
-  factory AppConfigNegotiationSettingsOverride.fromJson(
-    Map<String, Object?> json,
-  ) => _$AppConfigNegotiationSettingsOverrideFromJson(json);
+  factory AppConfigNegotiationSettingsOverride.fromJson(Map<String, Object?> json) =>
+      _$AppConfigNegotiationSettingsOverrideFromJson(json);
 
-  Map<String, Object?> toJson() =>
-      _$AppConfigNegotiationSettingsOverrideToJson(this);
+  Map<String, Object?> toJson() => _$AppConfigNegotiationSettingsOverrideToJson(this);
 }
 
 @freezed
@@ -400,8 +430,7 @@ class EncodingDefaultPresetOverride with _$EncodingDefaultPresetOverride {
 // Migration shim for the recents tab call-history flag: prefer the current
 // `supportsCallHistory` key (when present, even if null), fall back to the
 // legacy `useCdrs` key, then let the field default apply when neither is present.
-Object? _readRecentsSupportsCallHistory(Map json, String key) =>
-    json.containsKey(key) ? json[key] : json['useCdrs'];
+Object? _readRecentsSupportsCallHistory(Map json, String key) => json.containsKey(key) ? json[key] : json['useCdrs'];
 
 @Freezed(unionKey: 'type')
 sealed class BottomMenuTabScheme with _$BottomMenuTabScheme {
@@ -425,9 +454,7 @@ sealed class BottomMenuTabScheme with _$BottomMenuTabScheme {
     // `callHistory` adapter capability in feature_access (both must be true).
     // Reads the `supportsCallHistory` key and falls back to the legacy `useCdrs`
     // key so existing configs keep their value.
-    @JsonKey(readValue: _readRecentsSupportsCallHistory)
-    @Default(true)
-    bool supportsCallHistory,
+    @JsonKey(readValue: _readRecentsSupportsCallHistory) @Default(true) bool supportsCallHistory,
   }) = RecentsTabScheme;
 
   @JsonSerializable(explicitToJson: true)
@@ -464,8 +491,7 @@ sealed class BottomMenuTabScheme with _$BottomMenuTabScheme {
     @IntToStringConverter() required String embeddedResourceId,
   }) = EmbeddedTabScheme;
 
-  factory BottomMenuTabScheme.fromJson(Map<String, dynamic> json) =>
-      _$BottomMenuTabSchemeFromJson(json);
+  factory BottomMenuTabScheme.fromJson(Map<String, dynamic> json) => _$BottomMenuTabSchemeFromJson(json);
 }
 
 @freezed
@@ -528,8 +554,7 @@ class AppConfigSettings with _$AppConfigSettings {
   @override
   final List<AppConfigSettingsSection> sections;
 
-  factory AppConfigSettings.fromJson(Map<String, Object?> json) =>
-      _$AppConfigSettingsFromJson(json);
+  factory AppConfigSettings.fromJson(Map<String, Object?> json) => _$AppConfigSettingsFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigSettingsToJson(this);
 }
@@ -537,11 +562,7 @@ class AppConfigSettings with _$AppConfigSettings {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigSettingsSection with _$AppConfigSettingsSection {
-  const AppConfigSettingsSection({
-    required this.titleL10n,
-    this.enabled = true,
-    this.items = const [],
-  });
+  const AppConfigSettingsSection({required this.titleL10n, this.enabled = true, this.items = const []});
 
   @override
   final String titleL10n;
@@ -552,8 +573,7 @@ class AppConfigSettingsSection with _$AppConfigSettingsSection {
   @override
   final List<AppConfigSettingsItem> items;
 
-  factory AppConfigSettingsSection.fromJson(Map<String, Object?> json) =>
-      _$AppConfigSettingsSectionFromJson(json);
+  factory AppConfigSettingsSection.fromJson(Map<String, Object?> json) => _$AppConfigSettingsSectionFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigSettingsSectionToJson(this);
 }
@@ -595,8 +615,7 @@ class AppConfigSettingsItem with _$AppConfigSettingsItem {
   @IntToStringOptionalConverter()
   final String? embeddedResourceId;
 
-  factory AppConfigSettingsItem.fromJson(Map<String, Object?> json) =>
-      _$AppConfigSettingsItemFromJson(json);
+  factory AppConfigSettingsItem.fromJson(Map<String, Object?> json) => _$AppConfigSettingsItemFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigSettingsItemToJson(this);
 }
@@ -604,10 +623,7 @@ class AppConfigSettingsItem with _$AppConfigSettingsItem {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigContacts with _$AppConfigContacts {
-  const AppConfigContacts({
-    this.list = const AppConfigContactList(),
-    this.details = const AppConfigContactDetails(),
-  });
+  const AppConfigContacts({this.list = const AppConfigContactList(), this.details = const AppConfigContactDetails()});
 
   @override
   final AppConfigContactList list;
@@ -615,8 +631,7 @@ class AppConfigContacts with _$AppConfigContacts {
   @override
   final AppConfigContactDetails details;
 
-  factory AppConfigContacts.fromJson(Map<String, Object?> json) =>
-      _$AppConfigContactsFromJson(json);
+  factory AppConfigContacts.fromJson(Map<String, Object?> json) => _$AppConfigContactsFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigContactsToJson(this);
 }
@@ -626,8 +641,7 @@ class AppConfigContacts with _$AppConfigContacts {
 class AppConfigContactList with _$AppConfigContactList {
   const AppConfigContactList();
 
-  factory AppConfigContactList.fromJson(Map<String, Object?> json) =>
-      _$AppConfigContactListFromJson(json);
+  factory AppConfigContactList.fromJson(Map<String, Object?> json) => _$AppConfigContactListFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigContactListToJson(this);
 }
@@ -635,15 +649,12 @@ class AppConfigContactList with _$AppConfigContactList {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigContactDetails with _$AppConfigContactDetails {
-  const AppConfigContactDetails({
-    this.actions = const AppConfigContactDetailsActions(),
-  });
+  const AppConfigContactDetails({this.actions = const AppConfigContactDetailsActions()});
 
   @override
   final AppConfigContactDetailsActions actions;
 
-  factory AppConfigContactDetails.fromJson(Map<String, Object?> json) =>
-      _$AppConfigContactDetailsFromJson(json);
+  factory AppConfigContactDetails.fromJson(Map<String, Object?> json) => _$AppConfigContactDetailsFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigContactDetailsToJson(this);
 }
@@ -651,11 +662,7 @@ class AppConfigContactDetails with _$AppConfigContactDetails {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigContactDetailsActions with _$AppConfigContactDetailsActions {
-  const AppConfigContactDetailsActions({
-    this.appBar,
-    this.phoneTile,
-    this.emailTile,
-  });
+  const AppConfigContactDetailsActions({this.appBar, this.phoneTile, this.emailTile});
 
   @override
   final List<String>? appBar;
@@ -675,10 +682,7 @@ class AppConfigContactDetailsActions with _$AppConfigContactDetailsActions {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigMessaging with _$AppConfigMessaging {
-  const AppConfigMessaging({
-    this.sms = const AppConfigSms(),
-    this.chats = const AppConfigChats(),
-  });
+  const AppConfigMessaging({this.sms = const AppConfigSms(), this.chats = const AppConfigChats()});
 
   @override
   final AppConfigSms sms;
@@ -686,8 +690,7 @@ class AppConfigMessaging with _$AppConfigMessaging {
   @override
   final AppConfigChats chats;
 
-  factory AppConfigMessaging.fromJson(Map<String, Object?> json) =>
-      _$AppConfigMessagingFromJson(json);
+  factory AppConfigMessaging.fromJson(Map<String, Object?> json) => _$AppConfigMessagingFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigMessagingToJson(this);
 }
@@ -697,8 +700,7 @@ class AppConfigMessaging with _$AppConfigMessaging {
 class AppConfigSms with _$AppConfigSms {
   const AppConfigSms();
 
-  factory AppConfigSms.fromJson(Map<String, Object?> json) =>
-      _$AppConfigSmsFromJson(json);
+  factory AppConfigSms.fromJson(Map<String, Object?> json) => _$AppConfigSmsFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigSmsToJson(this);
 }
@@ -706,10 +708,7 @@ class AppConfigSms with _$AppConfigSms {
 @freezed
 @JsonSerializable(explicitToJson: true)
 class AppConfigChats with _$AppConfigChats {
-  const AppConfigChats({
-    this.groupChatButtonEnabled = true,
-    this.contactInfo = const ChatContactInfo(),
-  });
+  const AppConfigChats({this.groupChatButtonEnabled = true, this.contactInfo = const ChatContactInfo()});
 
   @override
   final bool groupChatButtonEnabled;
@@ -717,8 +716,7 @@ class AppConfigChats with _$AppConfigChats {
   @override
   final ChatContactInfo contactInfo;
 
-  factory AppConfigChats.fromJson(Map<String, Object?> json) =>
-      _$AppConfigChatsFromJson(json);
+  factory AppConfigChats.fromJson(Map<String, Object?> json) => _$AppConfigChatsFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigChatsToJson(this);
 }
@@ -731,8 +729,7 @@ class ChatContactInfo with _$ChatContactInfo {
   @override
   final bool showVideoButtonAction;
 
-  factory ChatContactInfo.fromJson(Map<String, Object?> json) =>
-      _$ChatContactInfoFromJson(json);
+  factory ChatContactInfo.fromJson(Map<String, Object?> json) => _$ChatContactInfoFromJson(json);
 
   Map<String, Object?> toJson() => _$ChatContactInfoToJson(this);
 }
@@ -750,8 +747,7 @@ class AppConfigLocalization with _$AppConfigLocalization {
   @override
   final List<String> enabledLanguages;
 
-  factory AppConfigLocalization.fromJson(Map<String, Object?> json) =>
-      _$AppConfigLocalizationFromJson(json);
+  factory AppConfigLocalization.fromJson(Map<String, Object?> json) => _$AppConfigLocalizationFromJson(json);
 
   Map<String, Object?> toJson() => _$AppConfigLocalizationToJson(this);
 }

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -60,6 +60,7 @@ class AppConfigLogin with _$AppConfigLogin {
   const AppConfigLogin({
     this.common = const AppConfigLoginCommon(),
     this.modeSelect = const AppConfigLoginModeSelect(),
+    this.signinOrder = const ['passwordSignin', 'otpSignin', 'signup'],
   });
 
   @override
@@ -67,6 +68,13 @@ class AppConfigLogin with _$AppConfigLogin {
 
   @override
   final AppConfigLoginModeSelect modeSelect;
+
+  /// Order of the sign-in tabs on the login switch screen, by login type name
+  /// (passwordSignin, otpSignin, signup). Only the types advertised by the
+  /// backend are shown; this controls their order and which one is selected by
+  /// default. Unknown or omitted names are placed last.
+  @override
+  final List<String> signinOrder;
 
   factory AppConfigLogin.fromJson(Map<String, Object?> json) =>
       _$AppConfigLoginFromJson(json);

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
@@ -208,7 +208,7 @@ case _:
 /// @nodoc
 mixin _$AppConfigLogin {
 
- AppConfigLoginCommon get common; AppConfigLoginModeSelect get modeSelect; List<String> get signinOrder;
+ AppConfigLoginCommon get common; AppConfigLoginModeSelect get modeSelect; List<String> get signinOrder; AppConfigLoginQr get qr;
 /// Create a copy of AppConfigLogin
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -219,16 +219,16 @@ $AppConfigLoginCopyWith<AppConfigLogin> get copyWith => _$AppConfigLoginCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigLogin&&(identical(other.common, common) || other.common == common)&&(identical(other.modeSelect, modeSelect) || other.modeSelect == modeSelect)&&const DeepCollectionEquality().equals(other.signinOrder, signinOrder));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigLogin&&(identical(other.common, common) || other.common == common)&&(identical(other.modeSelect, modeSelect) || other.modeSelect == modeSelect)&&const DeepCollectionEquality().equals(other.signinOrder, signinOrder)&&(identical(other.qr, qr) || other.qr == qr));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,common,modeSelect,const DeepCollectionEquality().hash(signinOrder));
+int get hashCode => Object.hash(runtimeType,common,modeSelect,const DeepCollectionEquality().hash(signinOrder),qr);
 
 @override
 String toString() {
-  return 'AppConfigLogin(common: $common, modeSelect: $modeSelect, signinOrder: $signinOrder)';
+  return 'AppConfigLogin(common: $common, modeSelect: $modeSelect, signinOrder: $signinOrder, qr: $qr)';
 }
 
 
@@ -239,7 +239,7 @@ abstract mixin class $AppConfigLoginCopyWith<$Res>  {
   factory $AppConfigLoginCopyWith(AppConfigLogin value, $Res Function(AppConfigLogin) _then) = _$AppConfigLoginCopyWithImpl;
 @useResult
 $Res call({
- AppConfigLoginCommon common, AppConfigLoginModeSelect modeSelect, List<String> signinOrder
+ AppConfigLoginCommon common, AppConfigLoginModeSelect modeSelect, List<String> signinOrder, AppConfigLoginQr qr
 });
 
 
@@ -256,12 +256,13 @@ class _$AppConfigLoginCopyWithImpl<$Res>
 
 /// Create a copy of AppConfigLogin
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? common = null,Object? modeSelect = null,Object? signinOrder = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? common = null,Object? modeSelect = null,Object? signinOrder = null,Object? qr = null,}) {
   return _then(AppConfigLogin(
 common: null == common ? _self.common : common // ignore: cast_nullable_to_non_nullable
 as AppConfigLoginCommon,modeSelect: null == modeSelect ? _self.modeSelect : modeSelect // ignore: cast_nullable_to_non_nullable
 as AppConfigLoginModeSelect,signinOrder: null == signinOrder ? _self.signinOrder : signinOrder // ignore: cast_nullable_to_non_nullable
-as List<String>,
+as List<String>,qr: null == qr ? _self.qr : qr // ignore: cast_nullable_to_non_nullable
+as AppConfigLoginQr,
   ));
 }
 
@@ -270,6 +271,381 @@ as List<String>,
 
 /// Adds pattern-matching-related methods to [AppConfigLogin].
 extension AppConfigLoginPatterns on AppConfigLogin {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$AppConfigLoginQr {
+
+ bool get enabled; List<AppConfigLoginQrFormat> get formats; String? get expectedHost;
+/// Create a copy of AppConfigLoginQr
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AppConfigLoginQrCopyWith<AppConfigLoginQr> get copyWith => _$AppConfigLoginQrCopyWithImpl<AppConfigLoginQr>(this as AppConfigLoginQr, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigLoginQr&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other.formats, formats)&&(identical(other.expectedHost, expectedHost) || other.expectedHost == expectedHost));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(formats),expectedHost);
+
+@override
+String toString() {
+  return 'AppConfigLoginQr(enabled: $enabled, formats: $formats, expectedHost: $expectedHost)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AppConfigLoginQrCopyWith<$Res>  {
+  factory $AppConfigLoginQrCopyWith(AppConfigLoginQr value, $Res Function(AppConfigLoginQr) _then) = _$AppConfigLoginQrCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled, List<AppConfigLoginQrFormat> formats, String? expectedHost
+});
+
+
+
+
+}
+/// @nodoc
+class _$AppConfigLoginQrCopyWithImpl<$Res>
+    implements $AppConfigLoginQrCopyWith<$Res> {
+  _$AppConfigLoginQrCopyWithImpl(this._self, this._then);
+
+  final AppConfigLoginQr _self;
+  final $Res Function(AppConfigLoginQr) _then;
+
+/// Create a copy of AppConfigLoginQr
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? formats = null,Object? expectedHost = freezed,}) {
+  return _then(AppConfigLoginQr(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,formats: null == formats ? _self.formats : formats // ignore: cast_nullable_to_non_nullable
+as List<AppConfigLoginQrFormat>,expectedHost: freezed == expectedHost ? _self.expectedHost : expectedHost // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AppConfigLoginQr].
+extension AppConfigLoginQrPatterns on AppConfigLoginQr {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$AppConfigLoginQrFormat {
+
+ String get type; List<String>? get schemes;
+/// Create a copy of AppConfigLoginQrFormat
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AppConfigLoginQrFormatCopyWith<AppConfigLoginQrFormat> get copyWith => _$AppConfigLoginQrFormatCopyWithImpl<AppConfigLoginQrFormat>(this as AppConfigLoginQrFormat, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigLoginQrFormat&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other.schemes, schemes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,const DeepCollectionEquality().hash(schemes));
+
+@override
+String toString() {
+  return 'AppConfigLoginQrFormat(type: $type, schemes: $schemes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AppConfigLoginQrFormatCopyWith<$Res>  {
+  factory $AppConfigLoginQrFormatCopyWith(AppConfigLoginQrFormat value, $Res Function(AppConfigLoginQrFormat) _then) = _$AppConfigLoginQrFormatCopyWithImpl;
+@useResult
+$Res call({
+ String type, List<String>? schemes
+});
+
+
+
+
+}
+/// @nodoc
+class _$AppConfigLoginQrFormatCopyWithImpl<$Res>
+    implements $AppConfigLoginQrFormatCopyWith<$Res> {
+  _$AppConfigLoginQrFormatCopyWithImpl(this._self, this._then);
+
+  final AppConfigLoginQrFormat _self;
+  final $Res Function(AppConfigLoginQrFormat) _then;
+
+/// Create a copy of AppConfigLoginQrFormat
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? schemes = freezed,}) {
+  return _then(AppConfigLoginQrFormat(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,schemes: freezed == schemes ? _self.schemes : schemes // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AppConfigLoginQrFormat].
+extension AppConfigLoginQrFormatPatterns on AppConfigLoginQrFormat {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.freezed.dart
@@ -208,7 +208,7 @@ case _:
 /// @nodoc
 mixin _$AppConfigLogin {
 
- AppConfigLoginCommon get common; AppConfigLoginModeSelect get modeSelect;
+ AppConfigLoginCommon get common; AppConfigLoginModeSelect get modeSelect; List<String> get signinOrder;
 /// Create a copy of AppConfigLogin
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -219,16 +219,16 @@ $AppConfigLoginCopyWith<AppConfigLogin> get copyWith => _$AppConfigLoginCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigLogin&&(identical(other.common, common) || other.common == common)&&(identical(other.modeSelect, modeSelect) || other.modeSelect == modeSelect));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppConfigLogin&&(identical(other.common, common) || other.common == common)&&(identical(other.modeSelect, modeSelect) || other.modeSelect == modeSelect)&&const DeepCollectionEquality().equals(other.signinOrder, signinOrder));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,common,modeSelect);
+int get hashCode => Object.hash(runtimeType,common,modeSelect,const DeepCollectionEquality().hash(signinOrder));
 
 @override
 String toString() {
-  return 'AppConfigLogin(common: $common, modeSelect: $modeSelect)';
+  return 'AppConfigLogin(common: $common, modeSelect: $modeSelect, signinOrder: $signinOrder)';
 }
 
 
@@ -239,7 +239,7 @@ abstract mixin class $AppConfigLoginCopyWith<$Res>  {
   factory $AppConfigLoginCopyWith(AppConfigLogin value, $Res Function(AppConfigLogin) _then) = _$AppConfigLoginCopyWithImpl;
 @useResult
 $Res call({
- AppConfigLoginCommon common, AppConfigLoginModeSelect modeSelect
+ AppConfigLoginCommon common, AppConfigLoginModeSelect modeSelect, List<String> signinOrder
 });
 
 
@@ -256,11 +256,12 @@ class _$AppConfigLoginCopyWithImpl<$Res>
 
 /// Create a copy of AppConfigLogin
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? common = null,Object? modeSelect = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? common = null,Object? modeSelect = null,Object? signinOrder = null,}) {
   return _then(AppConfigLogin(
 common: null == common ? _self.common : common // ignore: cast_nullable_to_non_nullable
 as AppConfigLoginCommon,modeSelect: null == modeSelect ? _self.modeSelect : modeSelect // ignore: cast_nullable_to_non_nullable
-as AppConfigLoginModeSelect,
+as AppConfigLoginModeSelect,signinOrder: null == signinOrder ? _self.signinOrder : signinOrder // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
@@ -67,6 +67,9 @@ AppConfigLogin _$AppConfigLoginFromJson(Map<String, dynamic> json) =>
               ?.map((e) => e as String)
               .toList() ??
           const ['passwordSignin', 'otpSignin', 'signup'],
+      qr: json['qr'] == null
+          ? const AppConfigLoginQr()
+          : AppConfigLoginQr.fromJson(json['qr'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$AppConfigLoginToJson(AppConfigLogin instance) =>
@@ -74,7 +77,45 @@ Map<String, dynamic> _$AppConfigLoginToJson(AppConfigLogin instance) =>
       'common': instance.common.toJson(),
       'modeSelect': instance.modeSelect.toJson(),
       'signinOrder': instance.signinOrder,
+      'qr': instance.qr.toJson(),
     };
+
+AppConfigLoginQr _$AppConfigLoginQrFromJson(Map<String, dynamic> json) =>
+    AppConfigLoginQr(
+      enabled: json['enabled'] as bool? ?? false,
+      formats:
+          (json['formats'] as List<dynamic>?)
+              ?.map(
+                (e) =>
+                    AppConfigLoginQrFormat.fromJson(e as Map<String, dynamic>),
+              )
+              .toList() ??
+          const [
+            AppConfigLoginQrFormat(type: 'uri', schemes: ['csc']),
+            AppConfigLoginQrFormat(type: 'json'),
+          ],
+      expectedHost: json['expectedHost'] as String?,
+    );
+
+Map<String, dynamic> _$AppConfigLoginQrToJson(AppConfigLoginQr instance) =>
+    <String, dynamic>{
+      'enabled': instance.enabled,
+      'formats': instance.formats.map((e) => e.toJson()).toList(),
+      'expectedHost': instance.expectedHost,
+    };
+
+AppConfigLoginQrFormat _$AppConfigLoginQrFormatFromJson(
+  Map<String, dynamic> json,
+) => AppConfigLoginQrFormat(
+  type: json['type'] as String,
+  schemes: (json['schemes'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+);
+
+Map<String, dynamic> _$AppConfigLoginQrFormatToJson(
+  AppConfigLoginQrFormat instance,
+) => <String, dynamic>{'type': instance.type, 'schemes': instance.schemes};
 
 AppConfigLoginCommon _$AppConfigLoginCommonFromJson(
   Map<String, dynamic> json,

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
@@ -62,12 +62,18 @@ AppConfigLogin _$AppConfigLoginFromJson(Map<String, dynamic> json) =>
           : AppConfigLoginModeSelect.fromJson(
               json['modeSelect'] as Map<String, dynamic>,
             ),
+      signinOrder:
+          (json['signinOrder'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const ['passwordSignin', 'otpSignin', 'signup'],
     );
 
 Map<String, dynamic> _$AppConfigLoginToJson(AppConfigLogin instance) =>
     <String, dynamic>{
       'common': instance.common.toJson(),
       'modeSelect': instance.modeSelect.toJson(),
+      'signinOrder': instance.signinOrder,
     };
 
 AppConfigLoginCommon _$AppConfigLoginCommonFromJson(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1183,6 +1183,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mobile_scanner:
+    dependency: "direct main"
+    description:
+      name: mobile_scanner
+      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -1984,58 +1992,74 @@ packages:
   webtrit_callkeep:
     dependency: "direct main"
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep"
-      relative: true
-    source: path
-    version: "1.1.0+0"
+      path: webtrit_callkeep
+      ref: "1.2.0"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
+    version: "1.2.0+0"
   webtrit_callkeep_android:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_android"
-      relative: true
-    source: path
+      path: webtrit_callkeep_android
+      ref: "895c160d28015d769dafa310066d99fa6810a460"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_ios:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_ios"
-      relative: true
-    source: path
+      path: webtrit_callkeep_ios
+      ref: "895c160d28015d769dafa310066d99fa6810a460"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_linux:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_linux"
-      relative: true
-    source: path
+      path: webtrit_callkeep_linux
+      ref: "895c160d28015d769dafa310066d99fa6810a460"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_macos:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_macos"
-      relative: true
-    source: path
+      path: webtrit_callkeep_macos
+      ref: "895c160d28015d769dafa310066d99fa6810a460"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_callkeep_platform_interface:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_platform_interface"
-      relative: true
-    source: path
+      path: webtrit_callkeep_platform_interface
+      ref: "895c160d28015d769dafa310066d99fa6810a460"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_web:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_web"
-      relative: true
-    source: path
+      path: webtrit_callkeep_web
+      ref: "895c160d28015d769dafa310066d99fa6810a460"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.0.0+0"
   webtrit_callkeep_windows:
     dependency: transitive
     description:
-      path: "../webtrit_callkeep/webtrit_callkeep_windows"
-      relative: true
-    source: path
+      path: webtrit_callkeep_windows
+      ref: "895c160d28015d769dafa310066d99fa6810a460"
+      resolved-ref: "895c160d28015d769dafa310066d99fa6810a460"
+      url: "https://github.com/WebTrit/webtrit_callkeep.git"
+    source: git
     version: "0.1.0+1"
   webtrit_signaling_service:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.15.4+7
+app_version: 1.15.4+8
 
 environment:
   sdk: ^3.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,6 +89,7 @@ dependencies:
   mask_text_input_formatter: ^2.9.0
   material_color_utilities: any
   meta: any
+  mobile_scanner: ^7.2.0
   package_info_plus: ^10.1.0
   path: ^1.9.1
   path_provider: ^2.1.5

--- a/screenshots/lib/screenshots/login_screenshot.dart
+++ b/screenshots/lib/screenshots/login_screenshot.dart
@@ -14,17 +14,25 @@ import 'package:screenshots/mocks/mocks.dart';
 /// Single, parameterized and interactive login screenshot.
 ///
 /// Replaces the former one-screenshot-per-tab duplication: [initialLoginType]
-/// selects which tab is shown first, and tapping a tab actually switches the
-/// body when pointer interaction is enabled (snapshot mode just renders the
-/// initial tab).
+/// pins which tab is shown first (used by the per-tab snapshots); when it is
+/// null the first tab of the configured order is selected, so the interactive
+/// preview follows `signinOrder`. Tapping a tab actually switches the body when
+/// pointer interaction is enabled (snapshot mode just renders the initial tab).
+///
+/// The tab order itself always follows the app config `signinOrder` (read from
+/// [FeatureAccess]), mirroring the real app via [sortLoginTypes].
 class LoginScreenshot extends StatefulWidget {
   const LoginScreenshot({
     super.key,
-    this.initialLoginType = LoginType.otpSignin,
-    this.supportedLoginTypes = const [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup],
+    this.initialLoginType,
+    this.supportedLoginTypes = const [
+      LoginType.otpSignin,
+      LoginType.passwordSignin,
+      LoginType.signup,
+    ],
   });
 
-  final LoginType initialLoginType;
+  final LoginType? initialLoginType;
   final List<LoginType> supportedLoginTypes;
 
   @override
@@ -32,38 +40,66 @@ class LoginScreenshot extends StatefulWidget {
 }
 
 class _LoginScreenshotState extends State<LoginScreenshot> {
-  late LoginType _type = widget.initialLoginType;
+  /// Set only once the user taps a tab in the interactive preview; keeps the
+  /// manual selection while the configured order drives the default otherwise.
+  LoginType? _userType;
 
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final localStyle = themeData.extension<LoginSwitchScreenStyles>()?.primary;
 
+    final featureAccess = context.watch<FeatureAccess?>();
     final embedded =
-        context.watch<FeatureAccess?>()?.loginConfig.actions.firstWhereOrNull(
+        featureAccess?.loginConfig.actions.firstWhereOrNull(
               (element) => element.flavor == LoginFlavor.embedded,
             )
             as LoginEmbeddedModeButton?;
 
+    final signinOrder =
+        featureAccess?.loginConfig.signinOrder ?? const <String>[];
+    final orderedLoginTypes = sortLoginTypes(
+      widget.supportedLoginTypes,
+      orderConfig: signinOrder,
+    );
+    final currentType = _resolveCurrentType(orderedLoginTypes);
+
     return BlocProvider<LoginCubit>(
-      create: (context) => MockLoginCubit.loginSwitchScreen(embedded: embedded?.customLoginFeature),
+      create: (context) => MockLoginCubit.loginSwitchScreen(
+        embedded: embedded?.customLoginFeature,
+      ),
       child: LoginSwitchScreen(
-        appBar: AppBar(leading: const ExtBackButton(disabled: false), backgroundColor: Colors.transparent),
+        appBar: AppBar(
+          leading: const ExtBackButton(disabled: false),
+          backgroundColor: Colors.transparent,
+        ),
         header: Column(
           children: [
             ConfigurableThemeImage(style: localStyle?.pictureLogoStyle),
             const SizedBox(height: kInset),
           ],
         ),
-        body: _bodyFor(context, _type, embedded),
-        currentLoginType: _type,
-        supportedLoginTypes: widget.supportedLoginTypes,
-        onLoginTypeChanged: (type) => setState(() => _type = type),
+        body: _bodyFor(context, currentType, embedded),
+        currentLoginType: currentType,
+        supportedLoginTypes: orderedLoginTypes,
+        onLoginTypeChanged: (type) => setState(() => _userType = type),
       ),
     );
   }
 
-  Widget _bodyFor(BuildContext context, LoginType type, LoginEmbeddedModeButton? embedded) {
+  /// A manual tap wins (while still available); otherwise a pinned
+  /// [LoginScreenshot.initialLoginType] wins; otherwise the configured first tab.
+  LoginType _resolveCurrentType(List<LoginType> ordered) {
+    if (_userType != null && ordered.contains(_userType)) return _userType!;
+    if (widget.initialLoginType != null) return widget.initialLoginType!;
+    return ordered.isNotEmpty ? ordered.first : LoginType.otpSignin;
+  }
+
+  Widget _bodyFor(
+    BuildContext context,
+    LoginType type,
+    LoginEmbeddedModeButton? embedded,
+  ) {
     switch (type) {
       case LoginType.otpSignin:
         return const LoginOtpSigninRequestScreen();
@@ -87,7 +123,8 @@ class _LoginScreenshotState extends State<LoginScreenshot> {
       mediaQueryMetricsData: null,
       deviceInfoData: null,
       pageInjectionStrategyBuilder: () => DefaultPayloadInjectionStrategy(),
-      connectivityRecoveryStrategyBuilder: () => NoneConnectivityRecoveryStrategy(),
+      connectivityRecoveryStrategyBuilder: () =>
+          NoneConnectivityRecoveryStrategy(),
     );
   }
 }

--- a/screenshots/lib/screenshots/login_screenshot.dart
+++ b/screenshots/lib/screenshots/login_screenshot.dart
@@ -25,11 +25,7 @@ class LoginScreenshot extends StatefulWidget {
   const LoginScreenshot({
     super.key,
     this.initialLoginType,
-    this.supportedLoginTypes = const [
-      LoginType.otpSignin,
-      LoginType.passwordSignin,
-      LoginType.signup,
-    ],
+    this.supportedLoginTypes = const [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup],
   });
 
   final LoginType? initialLoginType;
@@ -51,28 +47,17 @@ class _LoginScreenshotState extends State<LoginScreenshot> {
 
     final featureAccess = context.watch<FeatureAccess?>();
     final embedded =
-        featureAccess?.loginConfig.actions.firstWhereOrNull(
-              (element) => element.flavor == LoginFlavor.embedded,
-            )
+        featureAccess?.loginConfig.actions.firstWhereOrNull((element) => element.flavor == LoginFlavor.embedded)
             as LoginEmbeddedModeButton?;
 
-    final signinOrder =
-        featureAccess?.loginConfig.signinOrder ?? const <String>[];
-    final orderedLoginTypes = sortLoginTypes(
-      widget.supportedLoginTypes,
-      orderConfig: signinOrder,
-    );
+    final signinOrder = featureAccess?.loginConfig.signinOrder ?? const <String>[];
+    final orderedLoginTypes = sortLoginTypes(widget.supportedLoginTypes, orderConfig: signinOrder);
     final currentType = _resolveCurrentType(orderedLoginTypes);
 
     return BlocProvider<LoginCubit>(
-      create: (context) => MockLoginCubit.loginSwitchScreen(
-        embedded: embedded?.customLoginFeature,
-      ),
+      create: (context) => MockLoginCubit.loginSwitchScreen(embedded: embedded?.customLoginFeature),
       child: LoginSwitchScreen(
-        appBar: AppBar(
-          leading: const ExtBackButton(disabled: false),
-          backgroundColor: Colors.transparent,
-        ),
+        appBar: AppBar(leading: const ExtBackButton(disabled: false), backgroundColor: Colors.transparent),
         header: Column(
           children: [
             ConfigurableThemeImage(style: localStyle?.pictureLogoStyle),
@@ -95,16 +80,14 @@ class _LoginScreenshotState extends State<LoginScreenshot> {
     return ordered.isNotEmpty ? ordered.first : LoginType.otpSignin;
   }
 
-  Widget _bodyFor(
-    BuildContext context,
-    LoginType type,
-    LoginEmbeddedModeButton? embedded,
-  ) {
+  Widget _bodyFor(BuildContext context, LoginType type, LoginEmbeddedModeButton? embedded) {
     switch (type) {
       case LoginType.otpSignin:
         return const LoginOtpSigninRequestScreen();
       case LoginType.passwordSignin:
         return const LoginPasswordSigninScreen();
+      case LoginType.qrSignin:
+        return const LoginQrSigninScreen();
       case LoginType.signup:
         return _signupBody(context, embedded);
     }
@@ -123,8 +106,7 @@ class _LoginScreenshotState extends State<LoginScreenshot> {
       mediaQueryMetricsData: null,
       deviceInfoData: null,
       pageInjectionStrategyBuilder: () => DefaultPayloadInjectionStrategy(),
-      connectivityRecoveryStrategyBuilder: () =>
-          NoneConnectivityRecoveryStrategy(),
+      connectivityRecoveryStrategyBuilder: () => NoneConnectivityRecoveryStrategy(),
     );
   }
 }

--- a/screenshots/lib/screenshots/login_switch_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_switch_screen_screenshot.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/features.dart';
 
 class LoginSwitchScreenScreenshot extends StatelessWidget {
@@ -7,12 +10,21 @@ class LoginSwitchScreenScreenshot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final signinOrder =
+        context.watch<FeatureAccess?>()?.loginConfig.signinOrder ??
+        const <String>[];
+    final orderedLoginTypes = sortLoginTypes(const [
+      LoginType.otpSignin,
+      LoginType.passwordSignin,
+      LoginType.signup,
+    ], orderConfig: signinOrder);
+
     return LoginSwitchScreen(
       appBar: AppBar(title: const Text('Sign In')),
       header: null,
       body: const Center(child: Text('Login form content')),
-      currentLoginType: LoginType.otpSignin,
-      supportedLoginTypes: const [LoginType.otpSignin, LoginType.passwordSignin, LoginType.signup],
+      currentLoginType: orderedLoginTypes.first,
+      supportedLoginTypes: orderedLoginTypes,
       onLoginTypeChanged: null,
     );
   }

--- a/screenshots/lib/screenshots/login_switch_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/login_switch_screen_screenshot.dart
@@ -10,9 +10,7 @@ class LoginSwitchScreenScreenshot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final signinOrder =
-        context.watch<FeatureAccess?>()?.loginConfig.signinOrder ??
-        const <String>[];
+    final signinOrder = context.watch<FeatureAccess?>()?.loginConfig.signinOrder ?? const <String>[];
     final orderedLoginTypes = sortLoginTypes(const [
       LoginType.otpSignin,
       LoginType.passwordSignin,

--- a/screenshots/lib/screenshots/main_screen_screenshot.dart
+++ b/screenshots/lib/screenshots/main_screen_screenshot.dart
@@ -160,6 +160,24 @@ class _MainScreenScreenshotState extends State<MainScreenScreenshot> {
           ),
         );
       case MainFlavor.recents:
+        // Mirror the app's tab routing: with the callHistory adapter capability
+        // the recents tab shows remote CDRs instead of local recents.
+        final recentsTab = featureAccess?.bottomMenuConfig.getTabEnabled<RecentsBottomMenuTab>();
+        if (recentsTab?.supportsCallHistory ?? false) {
+          return MultiBlocProvider(
+            providers: [
+              BlocProvider<FullRecentCdrsCubit>(create: (_) => MockFullRecentCdrsCubit.withCdrs()),
+              BlocProvider<MissedRecentCdrsCubit>(create: (_) => MockMissedRecentCdrsCubit.withRecords()),
+            ],
+            child: RecentCdrsScreen(
+              title: widget.title,
+              transferEnabled: false,
+              videoEnabled: true,
+              chatsEnabled: false,
+              smssEnabled: false,
+            ),
+          );
+        }
         return BlocProvider<RecentsBloc>(
           create: (_) => MockRecentsBloc.mainScreen(),
           child: RecentsScreen(

--- a/test/features/login/login_cubit_qr_signin_gate_test.dart
+++ b/test/features/login/login_cubit_qr_signin_gate_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import 'package:webtrit_phone/app/notifications/notifications.dart';
+import 'package:webtrit_phone/features/login/login.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+WebtritSystemInfo _systemInfo({List<String> supported = const ['passwordSignin']}) {
+  return WebtritSystemInfo(
+    core: CoreInfo(version: Version(1, 0, 0)),
+    postgres: PostgresInfo(),
+    adapter: AdapterInfo(supported: supported),
+  );
+}
+
+void main() {
+  late _MockAuthRepository authRepository;
+  late NotificationsBloc notificationsBloc;
+
+  setUp(() {
+    authRepository = _MockAuthRepository();
+    notificationsBloc = NotificationsBloc();
+  });
+
+  tearDown(() {
+    notificationsBloc.close();
+  });
+
+  LoginCubit buildCubit({QrSigninConfig? qrSigninConfig, List<String> signinOrder = const []}) {
+    return LoginCubit(
+      authRepository: authRepository,
+      notificationsBloc: notificationsBloc,
+      signinOrder: signinOrder,
+      qrSigninConfig: qrSigninConfig,
+      onLoginSuccess: (_, _) {},
+    );
+  }
+
+  Future<void> submitCoreUrl(LoginCubit cubit) async {
+    cubit.coreUrlInputChanged('https://demo.example.com');
+    cubit.loginCoreUrlAssignSubmitted();
+    await pumpEventQueue();
+  }
+
+  group('QR sign-in tab gating', () {
+    test('offered after the backend types when enabled and password sign-in is supported', () async {
+      when(
+        () => authRepository.getSystemInfo(any(), any()),
+      ).thenAnswer((_) async => _systemInfo(supported: ['otpSignin', 'passwordSignin']));
+
+      final cubit = buildCubit(qrSigninConfig: QrSigninConfig(enabled: true));
+      await submitCoreUrl(cubit);
+
+      expect(cubit.state.supportedLoginTypes, [LoginType.passwordSignin, LoginType.otpSignin, LoginType.qrSignin]);
+    });
+
+    test('not offered when disabled', () async {
+      when(() => authRepository.getSystemInfo(any(), any())).thenAnswer((_) async => _systemInfo());
+
+      final cubit = buildCubit();
+      await submitCoreUrl(cubit);
+
+      expect(cubit.state.supportedLoginTypes, [LoginType.passwordSignin]);
+    });
+
+    test('not offered when the backend has no password sign-in', () async {
+      when(
+        () => authRepository.getSystemInfo(any(), any()),
+      ).thenAnswer((_) async => _systemInfo(supported: ['otpSignin']));
+
+      final cubit = buildCubit(qrSigninConfig: QrSigninConfig(enabled: true));
+      await submitCoreUrl(cubit);
+
+      expect(cubit.state.supportedLoginTypes, [LoginType.otpSignin]);
+    });
+
+    test('a backend-advertised qrSignin is ignored: it must not bypass the config gate', () async {
+      when(
+        () => authRepository.getSystemInfo(any(), any()),
+      ).thenAnswer((_) async => _systemInfo(supported: ['passwordSignin', 'qrSignin']));
+
+      final cubit = buildCubit();
+      await submitCoreUrl(cubit);
+
+      expect(cubit.state.supportedLoginTypes, [LoginType.passwordSignin]);
+    });
+
+    test('a backend-advertised qrSignin does not duplicate the enabled tab', () async {
+      when(
+        () => authRepository.getSystemInfo(any(), any()),
+      ).thenAnswer((_) async => _systemInfo(supported: ['passwordSignin', 'qrSignin']));
+
+      final cubit = buildCubit(qrSigninConfig: QrSigninConfig(enabled: true));
+      await submitCoreUrl(cubit);
+
+      expect(cubit.state.supportedLoginTypes, [LoginType.passwordSignin, LoginType.qrSignin]);
+    });
+
+    test('position follows the configured sign-in order', () async {
+      when(() => authRepository.getSystemInfo(any(), any())).thenAnswer((_) async => _systemInfo());
+
+      final cubit = buildCubit(
+        qrSigninConfig: QrSigninConfig(enabled: true),
+        signinOrder: ['qrSignin', 'passwordSignin'],
+      );
+      await submitCoreUrl(cubit);
+
+      expect(cubit.state.supportedLoginTypes, [LoginType.qrSignin, LoginType.passwordSignin]);
+    });
+  });
+}

--- a/test/features/login/login_type_order_test.dart
+++ b/test/features/login/login_type_order_test.dart
@@ -6,30 +6,16 @@ void main() {
   group('sortLoginTypes', () {
     test('applies the built-in default (password first) when no config', () {
       // Input in backend-ish, "unstable" order.
-      final result = sortLoginTypes([
-        LoginType.signup,
-        LoginType.otpSignin,
-        LoginType.passwordSignin,
-      ]);
+      final result = sortLoginTypes([LoginType.signup, LoginType.otpSignin, LoginType.passwordSignin]);
 
-      expect(result, [
-        LoginType.passwordSignin,
-        LoginType.otpSignin,
-        LoginType.signup,
-      ]);
+      expect(result, [LoginType.passwordSignin, LoginType.otpSignin, LoginType.signup]);
     });
 
     test('is stable regardless of input order', () {
       const expected = [LoginType.passwordSignin, LoginType.otpSignin];
 
-      expect(
-        sortLoginTypes([LoginType.otpSignin, LoginType.passwordSignin]),
-        expected,
-      );
-      expect(
-        sortLoginTypes([LoginType.passwordSignin, LoginType.otpSignin]),
-        expected,
-      );
+      expect(sortLoginTypes([LoginType.otpSignin, LoginType.passwordSignin]), expected);
+      expect(sortLoginTypes([LoginType.passwordSignin, LoginType.otpSignin]), expected);
     });
 
     test('honours an explicit configured order', () {
@@ -41,34 +27,24 @@ void main() {
       expect(result, [LoginType.otpSignin, LoginType.passwordSignin]);
     });
 
-    test(
-      'ignores unknown config names and falls back to default when none valid',
-      () {
-        final result = sortLoginTypes(
-          [LoginType.otpSignin, LoginType.passwordSignin],
-          orderConfig: const ['nope', 'bogus'],
-        );
+    test('ignores unknown config names and falls back to default when none valid', () {
+      final result = sortLoginTypes(
+        [LoginType.otpSignin, LoginType.passwordSignin],
+        orderConfig: const ['nope', 'bogus'],
+      );
 
-        expect(result, [LoginType.passwordSignin, LoginType.otpSignin]);
-      },
-    );
+      expect(result, [LoginType.passwordSignin, LoginType.otpSignin]);
+    });
 
-    test(
-      'keeps types missing from the config at the end, preserving relative order',
-      () {
-        final result = sortLoginTypes(
-          [LoginType.signup, LoginType.otpSignin, LoginType.passwordSignin],
-          orderConfig: const ['otpSignin'],
-        );
+    test('keeps types missing from the config at the end, preserving relative order', () {
+      final result = sortLoginTypes(
+        [LoginType.signup, LoginType.otpSignin, LoginType.passwordSignin],
+        orderConfig: const ['otpSignin'],
+      );
 
-        // otpSignin first (configured), then the rest in their original relative order.
-        expect(result, [
-          LoginType.otpSignin,
-          LoginType.signup,
-          LoginType.passwordSignin,
-        ]);
-      },
-    );
+      // otpSignin first (configured), then the rest in their original relative order.
+      expect(result, [LoginType.otpSignin, LoginType.signup, LoginType.passwordSignin]);
+    });
 
     test('returns empty for empty input', () {
       expect(sortLoginTypes(const []), isEmpty);

--- a/test/features/login/login_type_order_test.dart
+++ b/test/features/login/login_type_order_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/login/login.dart';
+
+void main() {
+  group('sortLoginTypes', () {
+    test('applies the built-in default (password first) when no config', () {
+      // Input in backend-ish, "unstable" order.
+      final result = sortLoginTypes([
+        LoginType.signup,
+        LoginType.otpSignin,
+        LoginType.passwordSignin,
+      ]);
+
+      expect(result, [
+        LoginType.passwordSignin,
+        LoginType.otpSignin,
+        LoginType.signup,
+      ]);
+    });
+
+    test('is stable regardless of input order', () {
+      const expected = [LoginType.passwordSignin, LoginType.otpSignin];
+
+      expect(
+        sortLoginTypes([LoginType.otpSignin, LoginType.passwordSignin]),
+        expected,
+      );
+      expect(
+        sortLoginTypes([LoginType.passwordSignin, LoginType.otpSignin]),
+        expected,
+      );
+    });
+
+    test('honours an explicit configured order', () {
+      final result = sortLoginTypes(
+        [LoginType.passwordSignin, LoginType.otpSignin],
+        orderConfig: const ['otpSignin', 'passwordSignin'],
+      );
+
+      expect(result, [LoginType.otpSignin, LoginType.passwordSignin]);
+    });
+
+    test(
+      'ignores unknown config names and falls back to default when none valid',
+      () {
+        final result = sortLoginTypes(
+          [LoginType.otpSignin, LoginType.passwordSignin],
+          orderConfig: const ['nope', 'bogus'],
+        );
+
+        expect(result, [LoginType.passwordSignin, LoginType.otpSignin]);
+      },
+    );
+
+    test(
+      'keeps types missing from the config at the end, preserving relative order',
+      () {
+        final result = sortLoginTypes(
+          [LoginType.signup, LoginType.otpSignin, LoginType.passwordSignin],
+          orderConfig: const ['otpSignin'],
+        );
+
+        // otpSignin first (configured), then the rest in their original relative order.
+        expect(result, [
+          LoginType.otpSignin,
+          LoginType.signup,
+          LoginType.passwordSignin,
+        ]);
+      },
+    );
+
+    test('returns empty for empty input', () {
+      expect(sortLoginTypes(const []), isEmpty);
+    });
+  });
+}

--- a/test/features/login/qr_signin_cubit_test.dart
+++ b/test/features/login/qr_signin_cubit_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+class _MockAppPermissions extends Mock implements AppPermissions {}
+
+void main() {
+  late _MockAppPermissions appPermissions;
+
+  setUp(() {
+    appPermissions = _MockAppPermissions();
+  });
+
+  QrSigninCubit buildCubit({PermissionStatus cameraStatus = PermissionStatus.granted}) {
+    when(() => appPermissions.getCameraPermissionStatus()).thenAnswer((_) async => cameraStatus);
+    return QrSigninCubit(
+      appPermissions: appPermissions,
+      parser: QrSigninPayloadParser.fromConfig(QrSigninConfig(enabled: true, expectedHost: 'EXAMPLE')),
+    );
+  }
+
+  group('QrSigninCubit', () {
+    group('camera permission', () {
+      test('granted permission moves to scanning', () async {
+        final cubit = buildCubit();
+        await pumpEventQueue();
+
+        expect(cubit.state.status, QrSigninStatus.scanning);
+        expect(cubit.state.cameraPermanentlyDenied, isFalse);
+      });
+
+      test('denied permission moves to permissionRequired', () async {
+        final cubit = buildCubit(cameraStatus: PermissionStatus.denied);
+        await pumpEventQueue();
+
+        expect(cubit.state.status, QrSigninStatus.permissionRequired);
+        expect(cubit.state.cameraPermanentlyDenied, isFalse);
+      });
+
+      test('permanent denial is reported so the view can offer the settings screen', () async {
+        final cubit = buildCubit(cameraStatus: PermissionStatus.permanentlyDenied);
+        await pumpEventQueue();
+
+        expect(cubit.state.status, QrSigninStatus.permissionRequired);
+        expect(cubit.state.cameraPermanentlyDenied, isTrue);
+      });
+
+      test('a granted request moves to scanning', () async {
+        final cubit = buildCubit(cameraStatus: PermissionStatus.denied);
+        await pumpEventQueue();
+        when(() => appPermissions.requestCameraPermission()).thenAnswer((_) async => PermissionStatus.granted);
+
+        await cubit.requestPermission();
+
+        expect(cubit.state.status, QrSigninStatus.scanning);
+      });
+
+      test('a permanently denied request flips the settings flag', () async {
+        final cubit = buildCubit(cameraStatus: PermissionStatus.denied);
+        await pumpEventQueue();
+        when(
+          () => appPermissions.requestCameraPermission(),
+        ).thenAnswer((_) async => PermissionStatus.permanentlyDenied);
+
+        await cubit.requestPermission();
+
+        expect(cubit.state.status, QrSigninStatus.permissionRequired);
+        expect(cubit.state.cameraPermanentlyDenied, isTrue);
+      });
+    });
+
+    group('barcode handling', () {
+      test('a valid code is reported as a detection', () async {
+        final cubit = buildCubit();
+        await pumpEventQueue();
+
+        cubit.barcodeDetected('csc:user123x777:p%40ss777@EXAMPLE');
+
+        final detection = cubit.state.detection;
+        expect(detection, isA<QrSigninCredentials>());
+        expect((detection as QrSigninCredentials).userRef, 'user123x777');
+        expect(cubit.state.parseError, isNull);
+      });
+
+      test('an invalid code sets the parse error and does not report a detection', () async {
+        final cubit = buildCubit();
+        await pumpEventQueue();
+
+        cubit.barcodeDetected('https://example.com');
+
+        expect(cubit.state.detection, isNull);
+        expect(cubit.state.parseError, QrSigninParseError.unrecognized);
+      });
+
+      test('nothing is handled before the permission check completes', () async {
+        final cubit = buildCubit();
+        // No pumpEventQueue: still checkingPermission.
+
+        cubit.barcodeDetected('csc:user:pass@EXAMPLE');
+
+        expect(cubit.state.detection, isNull);
+      });
+
+      test('a repeated payload is ignored while the detection is pending', () async {
+        final cubit = buildCubit();
+        await pumpEventQueue();
+
+        cubit.barcodeDetected('csc:user:pass@EXAMPLE');
+        final first = cubit.state.detection;
+        cubit.barcodeDetected('csc:user:pass@EXAMPLE');
+
+        expect(cubit.state.detection, same(first));
+      });
+
+      test('detectionHandled clears the detection', () async {
+        final cubit = buildCubit();
+        await pumpEventQueue();
+        cubit.barcodeDetected('csc:user:pass@EXAMPLE');
+
+        cubit.detectionHandled();
+
+        expect(cubit.state.detection, isNull);
+      });
+
+      test('detectionHandled after close is a no-op instead of a StateError', () async {
+        final cubit = buildCubit();
+        await pumpEventQueue();
+        cubit.barcodeDetected('csc:user:pass@EXAMPLE');
+
+        await cubit.close();
+
+        expect(cubit.detectionHandled, returnsNormally);
+      });
+    });
+  });
+}

--- a/test/features/login/qr_signin_payload_parser_test.dart
+++ b/test/features/login/qr_signin_payload_parser_test.dart
@@ -1,0 +1,273 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/models/models.dart';
+
+void main() {
+  QrSigninPayloadParser parser({List<QrSigninFormatConfig>? formats, String? expectedHost}) {
+    return QrSigninPayloadParser.fromConfig(
+      formats == null
+          ? QrSigninConfig(enabled: true, expectedHost: expectedHost)
+          : QrSigninConfig(enabled: true, formats: formats, expectedHost: expectedHost),
+    );
+  }
+
+  group('QrSigninPayloadParser', () {
+    group('decoder chain', () {
+      test('rejects payloads no decoder recognizes', () {
+        for (final raw in ['https://example.com', 'hello world', '', ':user:pass@EXAMPLE', '[1, 2]', '{"a": 1}']) {
+          final result = parser().parse(raw);
+
+          expect((result as QrSigninParseFailure).error, QrSigninParseError.unrecognized, reason: raw);
+        }
+      });
+
+      test('only the configured formats are probed', () {
+        final uriOnly = parser(formats: const [QrSigninFormatConfig(type: 'uri')]);
+        final jsonPayload = jsonEncode({'t': 'webtrit-signin', 'user': 'user123', 'password': 'p@ss'});
+
+        expect((uriOnly.parse(jsonPayload) as QrSigninParseFailure).error, QrSigninParseError.unrecognized);
+        expect(uriOnly.parse('csc:user:pass@EXAMPLE'), isA<QrSigninCredentials>());
+      });
+
+      test('unknown format types are ignored', () {
+        final result = parser(
+          formats: const [
+            QrSigninFormatConfig(type: 'xml'),
+            QrSigninFormatConfig(type: 'uri'),
+          ],
+        ).parse('csc:user:pass@EXAMPLE');
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+
+      test('a uri format entry without schemes falls back to csc', () {
+        final result = parser(formats: const [QrSigninFormatConfig(type: 'uri')]).parse('csc:user:pass@EXAMPLE');
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+    });
+
+    group('uri format', () {
+      test('parses the canonical provisioning URI', () {
+        final result = parser().parse('csc:user123x777:p%40ss777@EXAMPLE');
+
+        expect(result, isA<QrSigninCredentials>());
+        final credentials = result as QrSigninCredentials;
+        expect(credentials.userRef, 'user123x777');
+        expect(credentials.password, 'p@ss777');
+      });
+
+      test('decodes percent-encoded reserved characters in both segments', () {
+        final result = parser().parse('csc:user%3Aname%40host:p%40s%3As%3Fword@EXAMPLE');
+
+        final credentials = result as QrSigninCredentials;
+        expect(credentials.userRef, 'user:name@host');
+        expect(credentials.password, 'p@s:s?word');
+      });
+
+      test('trims surrounding whitespace', () {
+        final result = parser().parse('  csc:user:pass@EXAMPLE \n');
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+
+      test('matches the scheme case-insensitively', () {
+        expect(parser().parse('CSC:user:pass@EXAMPLE'), isA<QrSigninCredentials>());
+      });
+
+      test('accepts any configured scheme', () {
+        final result = parser(
+          formats: const [
+            QrSigninFormatConfig(type: 'uri', schemes: ['csc', 'acme']),
+          ],
+        ).parse('acme:user:pass@EXAMPLE');
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+
+      test('returns the user reference alone when the password is empty', () {
+        final result = parser().parse('csc:user:@EXAMPLE');
+
+        expect(result, isA<QrSigninUserRefOnly>());
+        expect((result as QrSigninUserRefOnly).userRef, 'user');
+      });
+
+      test('returns the user reference alone when the password is omitted', () {
+        final result = parser().parse('csc:user@EXAMPLE');
+
+        expect(result, isA<QrSigninUserRefOnly>());
+        expect((result as QrSigninUserRefOnly).userRef, 'user');
+      });
+
+      test('accepts a matching expected host regardless of case', () {
+        final result = parser(expectedHost: 'EXAMPLE').parse('csc:user:pass@example');
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+
+      test('accepts the test-version host marker', () {
+        final result = parser(expectedHost: 'EXAMPLE').parse('csc:user:pass@EXAMPLE*');
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+
+      test('rejects a foreign host when an expected host is configured', () {
+        final result = parser(expectedHost: 'EXAMPLE').parse('csc:user:pass@OTHER');
+
+        expect((result as QrSigninParseFailure).error, QrSigninParseError.hostMismatch);
+      });
+
+      test('accepts any host when no expected host is configured', () {
+        expect(parser().parse('csc:user:pass@ANY-HOST'), isA<QrSigninCredentials>());
+      });
+
+      test('ignores unknown query parameters', () {
+        final result = parser().parse('csc:user:pass@EXAMPLE?brand=acme&note=x%20y');
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+
+      test('accepts the explicit password method parameter', () {
+        expect(parser().parse('csc:user:pass@EXAMPLE?m=password'), isA<QrSigninCredentials>());
+      });
+
+      test('rejects an unsupported method parameter', () {
+        final result = parser().parse('csc:user:pass@EXAMPLE?m=autoprovision');
+
+        expect((result as QrSigninParseFailure).error, QrSigninParseError.unsupportedMethod);
+      });
+
+      test('rejects core override parameters', () {
+        for (final key in ['core', 'tenant', 'core_url', 'tenant_id']) {
+          final result = parser().parse('csc:user:pass@EXAMPLE?$key=value');
+
+          expect((result as QrSigninParseFailure).error, QrSigninParseError.coreOverrideNotAllowed, reason: key);
+        }
+      });
+
+      test('rejects malformed bodies', () {
+        for (final raw in ['csc:userpassEXAMPLE', 'csc:user:pass@', 'csc:@EXAMPLE', 'csc::pass@EXAMPLE']) {
+          final result = parser().parse(raw);
+
+          expect((result as QrSigninParseFailure).error, QrSigninParseError.malformed, reason: raw);
+        }
+      });
+
+      test('rejects broken percent-encoding', () {
+        final result = parser().parse('csc:user%G1:pass@EXAMPLE');
+
+        expect((result as QrSigninParseFailure).error, QrSigninParseError.malformed);
+      });
+
+      test('rejects broken percent-encoding in the query tail', () {
+        final result = parser().parse('csc:user:pass@EXAMPLE?x=%zz');
+
+        expect((result as QrSigninParseFailure).error, QrSigninParseError.malformed);
+      });
+    });
+
+    group('json format', () {
+      String payload(Map<String, Object?> fields) => jsonEncode({'t': 'webtrit-signin', ...fields});
+
+      test('parses a marker-discriminated credentials object', () {
+        final result = parser().parse(payload({'v': 1, 'user': 'user123', 'password': 'p@ssword'}));
+
+        expect(result, isA<QrSigninCredentials>());
+        final credentials = result as QrSigninCredentials;
+        expect(credentials.userRef, 'user123');
+        expect(credentials.password, 'p@ssword');
+      });
+
+      test('the version defaults to 1 when absent', () {
+        expect(parser().parse(payload({'user': 'user123', 'password': 'p'})), isA<QrSigninCredentials>());
+      });
+
+      test('rejects an unsupported version', () {
+        final result = parser().parse(payload({'v': 2, 'user': 'user123', 'password': 'p'}));
+
+        expect((result as QrSigninParseFailure).error, QrSigninParseError.unsupportedVersion);
+      });
+
+      test('returns the user reference alone when the password is missing or empty', () {
+        for (final fields in [
+          {'user': 'user123'},
+          {'user': 'user123', 'password': ''},
+        ]) {
+          final result = parser().parse(payload(fields));
+
+          expect(result, isA<QrSigninUserRefOnly>(), reason: '$fields');
+          expect((result as QrSigninUserRefOnly).userRef, 'user123');
+        }
+      });
+
+      test('validates the host against the expected one', () {
+        final pinned = parser(expectedHost: 'EXAMPLE');
+        final matching = payload({'user': 'u', 'password': 'p', 'host': 'example'});
+        final foreign = payload({'user': 'u', 'password': 'p', 'host': 'OTHER'});
+        final absent = payload({'user': 'u', 'password': 'p'});
+
+        expect(pinned.parse(matching), isA<QrSigninCredentials>());
+        expect((pinned.parse(foreign) as QrSigninParseFailure).error, QrSigninParseError.hostMismatch);
+        expect((pinned.parse(absent) as QrSigninParseFailure).error, QrSigninParseError.hostMismatch);
+      });
+
+      test('rejects core override fields', () {
+        for (final key in ['core', 'tenant', 'core_url', 'tenant_id']) {
+          final result = parser().parse(payload({'user': 'u', 'password': 'p', key: 'value'}));
+
+          expect((result as QrSigninParseFailure).error, QrSigninParseError.coreOverrideNotAllowed, reason: key);
+        }
+      });
+
+      test('ignores unknown fields', () {
+        final result = parser().parse(payload({'user': 'u', 'password': 'p', 'brand': 'acme'}));
+
+        expect(result, isA<QrSigninCredentials>());
+      });
+
+      test('rejects a missing or non-string user reference', () {
+        for (final fields in [
+          <String, Object?>{'password': 'p'},
+          {'user': '', 'password': 'p'},
+          {'user': 42, 'password': 'p'},
+        ]) {
+          final result = parser().parse(payload(fields));
+
+          expect((result as QrSigninParseFailure).error, QrSigninParseError.malformed, reason: '$fields');
+        }
+      });
+
+      test('JSON without the marker falls through as unrecognized', () {
+        final result = parser().parse(jsonEncode({'user': 'u', 'password': 'p'}));
+
+        expect((result as QrSigninParseFailure).error, QrSigninParseError.unrecognized);
+      });
+
+      test('a dialect with renamed fields is a structure parameter, not a new decoder', () {
+        final dialect = QrSigninPayloadParser([
+          JsonQrSigninPayloadDecoder(
+            structure: const JsonQrSigninStructure(
+              markerKey: 'kind',
+              markerValue: 'acme-login',
+              userKey: 'username',
+              passwordKey: 'pwd',
+            ),
+          ),
+        ]);
+
+        final result = dialect.parse(jsonEncode({'kind': 'acme-login', 'username': 'user123', 'pwd': 'p@ss'}));
+
+        expect(result, isA<QrSigninCredentials>());
+        final credentials = result as QrSigninCredentials;
+        expect(credentials.userRef, 'user123');
+        expect(credentials.password, 'p@ss');
+        // The default WebTrit shape is not this dialect's payload.
+        final webtrit = dialect.parse(jsonEncode({'t': 'webtrit-signin', 'user': 'u', 'password': 'p'}));
+        expect((webtrit as QrSigninParseFailure).error, QrSigninParseError.unrecognized);
+      });
+    });
+  });
+}

--- a/test/helpers/feature_access_factories.dart
+++ b/test/helpers/feature_access_factories.dart
@@ -61,6 +61,9 @@ AppConfig createMockAppConfig() {
 
   when(() => login.modeSelect).thenReturn(loginModeSelect);
   when(() => loginModeSelect.actions).thenReturn([]);
+  when(
+    () => login.signinOrder,
+  ).thenReturn(const ['passwordSignin', 'otpSignin', 'signup']);
   when(() => login.common).thenReturn(const AppConfigLoginCommon());
 
   when(() => main.bottomMenu).thenReturn(bottomMenu);

--- a/test/helpers/feature_access_factories.dart
+++ b/test/helpers/feature_access_factories.dart
@@ -26,9 +26,7 @@ EmbeddedResource createMockTermsResource() {
 
   when(() => resource.id).thenReturn('terms_id');
   when(() => resource.type).thenReturn(EmbeddedResourceType.terms);
-  when(
-    () => resource.uriOrNull,
-  ).thenReturn(Uri.parse('https://example.com/terms'));
+  when(() => resource.uriOrNull).thenReturn(Uri.parse('https://example.com/terms'));
   when(() => resource.uri).thenReturn('https://example.com/terms');
   when(() => resource.reconnectStrategy).thenReturn(null);
   when(() => resource.toolbar).thenReturn(toolbar);
@@ -61,15 +59,12 @@ AppConfig createMockAppConfig() {
 
   when(() => login.modeSelect).thenReturn(loginModeSelect);
   when(() => loginModeSelect.actions).thenReturn([]);
-  when(
-    () => login.signinOrder,
-  ).thenReturn(const ['passwordSignin', 'otpSignin', 'signup']);
+  when(() => login.signinOrder).thenReturn(const ['passwordSignin', 'otpSignin', 'signup']);
   when(() => login.common).thenReturn(const AppConfigLoginCommon());
+  when(() => login.qr).thenReturn(const AppConfigLoginQr());
 
   when(() => main.bottomMenu).thenReturn(bottomMenu);
-  when(() => bottomMenu.tabs).thenReturn([
-    BottomMenuTabScheme.keypad(titleL10n: 'Keypad', icon: '0xe1ce'),
-  ]);
+  when(() => bottomMenu.tabs).thenReturn([BottomMenuTabScheme.keypad(titleL10n: 'Keypad', icon: '0xe1ce')]);
   // TODO: Migrate client configurations first before fully removing this property.
   // ignore: deprecated_member_use_from_same_package, deprecated_member_use
   when(() => main.systemNotificationsEnabled).thenReturn(false);


### PR DESCRIPTION
## Overview

Patch for the 1.15.4-develop-untested client line: backports the QR sign-in feature and the recents toolbar theming fixes from develop, and bumps the build iteration.

- feat(login): enforce deterministic login options order - prerequisite of the QR feature (introduces the login type ordering the QR tab plugs into).
- feat: add QR code sign-in tab driven by app config - backport adapted to this branch: the Thai locale files are omitted (this line ships en/it/uk only; l10n regenerated accordingly), the camera-permission helpers drop the web-support guard that does not exist here, and the QR gating test matches this branch's `LoginCubit` constructor (no version-gate parameters).
- fix(screenshots): honor callHistory capability in the recents tab preview.
- fix(cdrs): apply themed styling to the recents CDR screen app bar - the CDR variant of the recents tab now renders the configured app bar background instead of the hardcoded translucent `canvasColor`.
- build: bump app_version build iteration to 1.15.4+8.

Some files carry formatting normalization: the cherry-picks touch files that predate the formatter migration on this branch, and the pre-commit format check requires them reformatted.

## Testing

- `flutter analyze` clean, full `flutter test` suite passes (pre-push), including the backported QR gating/parser/cubit tests
- Manual check pending: a build from this branch against a backend with password sign-in and the QR tab enabled in app config should show the QR sign-in tab; the recents CDR tab should render the themed app bar