### PR TITLE
fix(screenshots): register signaling so call preview reaches ready state

### DIFF
--- a/screenshots/lib/mocks/interactive_call_bloc.dart
+++ b/screenshots/lib/mocks/interactive_call_bloc.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart' show Registration, RegistrationStatus;
 
 import 'package:screenshots/data/data.dart';
 
@@ -20,7 +21,13 @@ class InteractiveCallBloc extends Cubit<CallState> implements CallBloc {
     : _callId = (video ? dVideoActiveCall : dAudioActiveCall).callId,
       super(
         CallState(
-          callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+          // A registered signaling client yields CallStatus.ready, which the call
+          // screen requires to enable keypad/hold/transfer actions. Without it the
+          // status stays inProgress ("Connecting...") and those buttons are disabled.
+          callServiceState: const CallServiceState(
+            signalingClientStatus: SignalingClientStatus.connect,
+            registration: Registration(status: RegistrationStatus.registered),
+          ),
           activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
           // Built-in earpiece + speaker so the speaker toggle renders and can switch.
           audioDevice: _earpiece,

--- a/screenshots/lib/mocks/mock_call_bloc.dart
+++ b/screenshots/lib/mocks/mock_call_bloc.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart' show Registration, RegistrationStatus;
 
 import 'package:screenshots/data/data.dart';
 
@@ -38,7 +39,12 @@ class MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
       mock,
       const Stream<CallState>.empty(),
       initialState: CallState(
-        callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+        // Registered signaling -> CallStatus.ready, so the active call renders as
+        // connected instead of a perpetual "Connecting..." state.
+        callServiceState: const CallServiceState(
+          signalingClientStatus: SignalingClientStatus.connect,
+          registration: Registration(status: RegistrationStatus.registered),
+        ),
         activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
       ),
     );

--- a/screenshots/pubspec.yaml
+++ b/screenshots/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
     sdk: flutter
   webtrit_phone:
     path: ..
+  webtrit_signaling:
+    path: ../packages/webtrit_signaling
   mocktail: ^1.0.4
   provider: ^6.0.0
 


### PR DESCRIPTION
## Overview

In the configurator's **semi-dynamic** call-screen preview, tapping the keypad button did nothing — the DTMF keypad never appeared. Hold and transfer were silently inert too.

## Root cause

The keypad toggle is a local `setState` inside `ActiveCallActions`, but its button is disabled (`onPressed: null`) unless `enableInteractions == true`, which requires `callStatus == CallStatus.ready`. `CallServiceState.status` only returns `ready` when the signaling client is `connect` **and** `registration` is `registered`.

The preview mocks set `signalingClientStatus: connect` but left `registration` null, so status stayed `inProgress` — the screen rendered "Connecting…" and the keypad / hold / transfer buttons were disabled.

## Changes

- `InteractiveCallBloc` (semi-dynamic) and `MockCallBloc.callScreen` (static): register the mock signaling client via `Registration(status: RegistrationStatus.registered)`, so the preview reports `ready`.
- `screenshots/pubspec.yaml`: add a direct `webtrit_signaling` path dependency (imported with `show Registration, RegistrationStatus` to avoid the `CallEvent` name clash).

## Result

- Semi-dynamic preview: tapping the keypad now shows the DTMF pad; hold and transfer are enabled.
- Static preview: the call renders as connected instead of a perpetual "Connecting…".

`flutter analyze` on the changed files: no issues.
