### PR TITLE
feat(call): configurable text style for in-call keypad input

### DIFF
--- a/lib/features/call/view/call_screen_style.dart
+++ b/lib/features/call/view/call_screen_style.dart
@@ -166,6 +166,7 @@ class CallScreenActionsStyle with Diagnosticable {
     this.held,
     this.swap,
     this.key,
+    this.keypadInputTextStyle,
   });
 
   final ButtonStyle? callStart;
@@ -178,6 +179,9 @@ class CallScreenActionsStyle with Diagnosticable {
   final ButtonStyle? swap;
   final ButtonStyle? key;
 
+  /// Text style for the digits typed on the in-call DTMF keypad.
+  final TextStyle? keypadInputTextStyle;
+
   CallScreenActionsStyle copyWith({
     ButtonStyle? callStart,
     ButtonStyle? hangup,
@@ -188,6 +192,7 @@ class CallScreenActionsStyle with Diagnosticable {
     ButtonStyle? held,
     ButtonStyle? swap,
     ButtonStyle? key,
+    TextStyle? keypadInputTextStyle,
   }) {
     return CallScreenActionsStyle(
       callStart: callStart ?? this.callStart,
@@ -199,6 +204,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: held ?? this.held,
       swap: swap ?? this.swap,
       key: key ?? this.key,
+      keypadInputTextStyle: keypadInputTextStyle ?? this.keypadInputTextStyle,
     );
   }
 
@@ -207,6 +213,11 @@ class CallScreenActionsStyle with Diagnosticable {
     if (other == null) return this;
 
     ButtonStyle? mergeButtonStyle(ButtonStyle? a, ButtonStyle? b) {
+      if (a == null) return b;
+      return a.merge(b);
+    }
+
+    TextStyle? mergeTextStyle(TextStyle? a, TextStyle? b) {
       if (a == null) return b;
       return a.merge(b);
     }
@@ -221,6 +232,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: mergeButtonStyle(held, other.held),
       swap: mergeButtonStyle(swap, other.swap),
       key: mergeButtonStyle(key, other.key),
+      keypadInputTextStyle: mergeTextStyle(keypadInputTextStyle, other.keypadInputTextStyle),
     );
   }
 
@@ -236,6 +248,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: ButtonStyle.lerp(a?.held, b?.held, t),
       swap: ButtonStyle.lerp(a?.swap, b?.swap, t),
       key: ButtonStyle.lerp(a?.key, b?.key, t),
+      keypadInputTextStyle: TextStyle.lerp(a?.keypadInputTextStyle, b?.keypadInputTextStyle, t),
     );
   }
 
@@ -251,6 +264,7 @@ class CallScreenActionsStyle with Diagnosticable {
       ..add(DiagnosticsProperty<ButtonStyle?>('speaker', speaker))
       ..add(DiagnosticsProperty<ButtonStyle?>('held', held))
       ..add(DiagnosticsProperty<ButtonStyle?>('swap', swap))
-      ..add(DiagnosticsProperty<ButtonStyle?>('key', key));
+      ..add(DiagnosticsProperty<ButtonStyle?>('key', key))
+      ..add(DiagnosticsProperty<TextStyle?>('keypadInputTextStyle', keypadInputTextStyle));
   }
 }

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -130,7 +130,8 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
 
   void computeDimensions() {
     _inputDecorations = _themeData.extension<InputDecorations>();
-    _textStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
+    final baseKeypadInputStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
+    _textStyle = baseKeypadInputStyle?.merge(widget.style?.keypadInputTextStyle);
 
     _iconSize = _themeData.textTheme.headlineLarge?.fontSize;
 

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -131,7 +131,8 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
   void computeDimensions() {
     _inputDecorations = _themeData.extension<InputDecorations>();
     final baseKeypadInputStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
-    _textStyle = baseKeypadInputStyle?.merge(widget.style?.keypadInputTextStyle);
+    final configuredKeypadInputStyle = widget.style?.keypadInputTextStyle;
+    _textStyle = baseKeypadInputStyle?.merge(configuredKeypadInputStyle) ?? configuredKeypadInputStyle;
 
     _iconSize = _themeData.textTheme.headlineLarge?.fontSize;
 

--- a/lib/theme/factory/styles/call_screen_style_factory.dart
+++ b/lib/theme/factory/styles/call_screen_style_factory.dart
@@ -204,6 +204,7 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
         baseBg: colors.surfaceContainerHigh,
         baseIcon: colors.onSurface,
       ),
+      keypadInputTextStyle: a.keypadInputStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
     );
   }
 

--- a/lib/theme/factory/styles/call_screen_style_factory.dart
+++ b/lib/theme/factory/styles/call_screen_style_factory.dart
@@ -128,6 +128,28 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
     );
   }
 
+  /// Resolves the in-call keypad input text style so it can be merged over the
+  /// widget's base [TextTheme.displaySmall]. [TextStyleConfig.toTextStyle]
+  /// always emits a non-null fontWeight/fontStyle, which would override the base
+  /// during the merge; keep them only when the config sets them, so unset fields
+  /// inherit the base weight/style instead of being forced to normal.
+  TextStyle? _resolveKeypadInputTextStyle(TextStyleConfig? config) {
+    if (config == null) return null;
+    final resolved = config.toTextStyle(defaultFontFamily: defaultFontFamily);
+    return TextStyle(
+      fontFamily: resolved.fontFamily,
+      fontSize: resolved.fontSize,
+      fontWeight: config.fontWeight != null ? resolved.fontWeight : null,
+      fontStyle: config.fontStyle != null ? resolved.fontStyle : null,
+      color: resolved.color,
+      letterSpacing: resolved.letterSpacing,
+      wordSpacing: resolved.wordSpacing,
+      height: resolved.height,
+      decoration: resolved.decoration,
+      backgroundColor: resolved.backgroundColor,
+    );
+  }
+
   CallScreenActionsStyle? _resolveActionsStyle({
     CallPageActionsConfig? fromPage,
     // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
@@ -204,7 +226,7 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
         baseBg: colors.surfaceContainerHigh,
         baseIcon: colors.onSurface,
       ),
-      keypadInputTextStyle: a.keypadInputStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+      keypadInputTextStyle: _resolveKeypadInputTextStyle(a.keypadInputStyle),
     );
   }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -343,6 +343,7 @@ class CallPageActionsConfig with _$CallPageActionsConfig {
     this.held = const ElevatedButtonWidgetConfig(),
     this.swap = const ElevatedButtonWidgetConfig(),
     this.key = const ElevatedButtonWidgetConfig(),
+    this.keypadInputStyle,
   });
 
   @override
@@ -371,6 +372,12 @@ class CallPageActionsConfig with _$CallPageActionsConfig {
 
   @override
   final ElevatedButtonWidgetConfig key;
+
+  /// Text style for the digits typed on the in-call DTMF keypad (the value shown
+  /// above the keys). When unset the app falls back to the display text theme
+  /// colored with [ColorScheme.surface].
+  @override
+  final TextStyleConfig? keypadInputStyle;
 
   factory CallPageActionsConfig.fromJson(Map<String, Object?> json) => _$CallPageActionsConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -374,8 +374,8 @@ class CallPageActionsConfig with _$CallPageActionsConfig {
   final ElevatedButtonWidgetConfig key;
 
   /// Text style for the digits typed on the in-call DTMF keypad (the value shown
-  /// above the keys). When unset the app falls back to the display text theme
-  /// colored with [ColorScheme.surface].
+  /// above the keys). When unset the app falls back to its default display text
+  /// style for the keypad input.
   @override
   final TextStyleConfig? keypadInputStyle;
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -2098,7 +2098,7 @@ case _:
 /// @nodoc
 mixin _$CallPageActionsConfig {
 
- ElevatedButtonWidgetConfig get callStart; ElevatedButtonWidgetConfig get hangup; ElevatedButtonWidgetConfig get transfer; ElevatedButtonWidgetConfig get camera; ElevatedButtonWidgetConfig get muted; ElevatedButtonWidgetConfig get speaker; ElevatedButtonWidgetConfig get held; ElevatedButtonWidgetConfig get swap; ElevatedButtonWidgetConfig get key;
+ ElevatedButtonWidgetConfig get callStart; ElevatedButtonWidgetConfig get hangup; ElevatedButtonWidgetConfig get transfer; ElevatedButtonWidgetConfig get camera; ElevatedButtonWidgetConfig get muted; ElevatedButtonWidgetConfig get speaker; ElevatedButtonWidgetConfig get held; ElevatedButtonWidgetConfig get swap; ElevatedButtonWidgetConfig get key; TextStyleConfig? get keypadInputStyle;
 /// Create a copy of CallPageActionsConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2109,16 +2109,16 @@ $CallPageActionsConfigCopyWith<CallPageActionsConfig> get copyWith => _$CallPage
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageActionsConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.hangup, hangup) || other.hangup == hangup)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&(identical(other.camera, camera) || other.camera == camera)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.speaker, speaker) || other.speaker == speaker)&&(identical(other.held, held) || other.held == held)&&(identical(other.swap, swap) || other.swap == swap)&&(identical(other.key, key) || other.key == key));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageActionsConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.hangup, hangup) || other.hangup == hangup)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&(identical(other.camera, camera) || other.camera == camera)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.speaker, speaker) || other.speaker == speaker)&&(identical(other.held, held) || other.held == held)&&(identical(other.swap, swap) || other.swap == swap)&&(identical(other.key, key) || other.key == key)&&(identical(other.keypadInputStyle, keypadInputStyle) || other.keypadInputStyle == keypadInputStyle));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,callStart,hangup,transfer,camera,muted,speaker,held,swap,key);
+int get hashCode => Object.hash(runtimeType,callStart,hangup,transfer,camera,muted,speaker,held,swap,key,keypadInputStyle);
 
 @override
 String toString() {
-  return 'CallPageActionsConfig(callStart: $callStart, hangup: $hangup, transfer: $transfer, camera: $camera, muted: $muted, speaker: $speaker, held: $held, swap: $swap, key: $key)';
+  return 'CallPageActionsConfig(callStart: $callStart, hangup: $hangup, transfer: $transfer, camera: $camera, muted: $muted, speaker: $speaker, held: $held, swap: $swap, key: $key, keypadInputStyle: $keypadInputStyle)';
 }
 
 
@@ -2129,7 +2129,7 @@ abstract mixin class $CallPageActionsConfigCopyWith<$Res>  {
   factory $CallPageActionsConfigCopyWith(CallPageActionsConfig value, $Res Function(CallPageActionsConfig) _then) = _$CallPageActionsConfigCopyWithImpl;
 @useResult
 $Res call({
- ElevatedButtonWidgetConfig callStart, ElevatedButtonWidgetConfig hangup, ElevatedButtonWidgetConfig transfer, ElevatedButtonWidgetConfig camera, ElevatedButtonWidgetConfig muted, ElevatedButtonWidgetConfig speaker, ElevatedButtonWidgetConfig held, ElevatedButtonWidgetConfig swap, ElevatedButtonWidgetConfig key
+ ElevatedButtonWidgetConfig callStart, ElevatedButtonWidgetConfig hangup, ElevatedButtonWidgetConfig transfer, ElevatedButtonWidgetConfig camera, ElevatedButtonWidgetConfig muted, ElevatedButtonWidgetConfig speaker, ElevatedButtonWidgetConfig held, ElevatedButtonWidgetConfig swap, ElevatedButtonWidgetConfig key, TextStyleConfig? keypadInputStyle
 });
 
 
@@ -2146,7 +2146,7 @@ class _$CallPageActionsConfigCopyWithImpl<$Res>
 
 /// Create a copy of CallPageActionsConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? hangup = null,Object? transfer = null,Object? camera = null,Object? muted = null,Object? speaker = null,Object? held = null,Object? swap = null,Object? key = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? hangup = null,Object? transfer = null,Object? camera = null,Object? muted = null,Object? speaker = null,Object? held = null,Object? swap = null,Object? key = null,Object? keypadInputStyle = freezed,}) {
   return _then(CallPageActionsConfig(
 callStart: null == callStart ? _self.callStart : callStart // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,hangup: null == hangup ? _self.hangup : hangup // ignore: cast_nullable_to_non_nullable
@@ -2157,7 +2157,8 @@ as ElevatedButtonWidgetConfig,speaker: null == speaker ? _self.speaker : speaker
 as ElevatedButtonWidgetConfig,held: null == held ? _self.held : held // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,swap: null == swap ? _self.swap : swap // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
-as ElevatedButtonWidgetConfig,
+as ElevatedButtonWidgetConfig,keypadInputStyle: freezed == keypadInputStyle ? _self.keypadInputStyle : keypadInputStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -402,6 +402,11 @@ CallPageActionsConfig _$CallPageActionsConfigFromJson(
       : ElevatedButtonWidgetConfig.fromJson(
           json['key'] as Map<String, dynamic>,
         ),
+  keypadInputStyle: json['keypadInputStyle'] == null
+      ? null
+      : TextStyleConfig.fromJson(
+          json['keypadInputStyle'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$CallPageActionsConfigToJson(
@@ -416,6 +421,7 @@ Map<String, dynamic> _$CallPageActionsConfigToJson(
   'held': instance.held.toJson(),
   'swap': instance.swap.toJson(),
   'key': instance.key.toJson(),
+  'keypadInputStyle': instance.keypadInputStyle?.toJson(),
 };
 
 CallPageInfoConfig _$CallPageInfoConfigFromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
## Overview

The digits typed on the **in-call DTMF keypad** (the value shown above the keys during a call) were rendered with a hardcoded style — `textTheme.displaySmall` colored with `ColorScheme.surface` — so their appearance could not be themed. This adds a theme config for it.

## Changes

**Schema (`webtrit_appearance_theme`)**
- `CallPageActionsConfig`: new optional `keypadInputStyle` (`TextStyleConfig?`). Regenerated freezed/json.

**App wiring (`webtrit_phone`)**
- `CallScreenActionsStyle`: new `keypadInputTextStyle` (`TextStyle?`) — added to constructor, `copyWith`, `merge`, `lerp`, `debugFillProperties`.
- `CallScreenStyleFactory._mapActionsFromPage`: resolves `keypadInputStyle` → `keypadInputTextStyle` via `toTextStyle(defaultFontFamily:)`, matching how call-info text styles are resolved.
- `ActiveCallActions`: the keypad input `_textStyle` now merges the configured style over the existing default (`displaySmall` + `surface`).

## Backward compatibility

When `keypadInputStyle` is unset, `merge(null)` is a no-op, so the current appearance is preserved exactly. The legacy call-actions mapping path is untouched (leaves the field null → default).

## Notes

This is the schema + app half. The configurator UI to edit this field is a follow-up PR (the configurator consumes this via its local `webtrit_phone` path dependency, so this must land first).
