### PR TITLE
fix: keep initial loading indicator on Contacts and Recents until first fetch resolves (WT-1661)

### DIFF
--- a/lib/features/cdrs/cubit/full_recent_cdrs_cubit.dart
+++ b/lib/features/cdrs/cubit/full_recent_cdrs_cubit.dart
@@ -13,19 +13,41 @@ part 'full_recent_cdrs_state.dart';
 final _logger = Logger('FullRecentCdrsCubit');
 
 class FullRecentCdrsCubit extends Cubit<FullRecentCdrsState> {
-  FullRecentCdrsCubit(this._cdrsLocalRepository, this._cdrsRemoteRepository, {this.pageSize = 50})
-    : super(const FullRecentCdrsState());
+  FullRecentCdrsCubit(
+    this._cdrsLocalRepository,
+    this._cdrsRemoteRepository, {
+    this.pageSize = 50,
+    Future<void>? initialSyncDone,
+  }) : _initialSyncDone = initialSyncDone,
+       super(const FullRecentCdrsState());
 
   final CdrsLocalRepository _cdrsLocalRepository;
   final CdrsRemoteRepository _cdrsRemoteRepository;
   final int pageSize;
+
+  /// Resolves when the first remote sync cycle has completed. Used to keep the
+  /// initial loading indicator visible until the first `/user/history` fetch
+  /// resolves, instead of flashing an empty list while it is still in flight.
+  final Future<void>? _initialSyncDone;
+
   late final StreamSubscription _eventsSub;
 
   Future<void> init() async {
     _logger.info('Loading recent CDRs');
-    final recentCdrs = await _cdrsLocalRepository.getHistory(limit: pageSize);
-    emit(state.copyWith(records: recentCdrs, isLoading: false));
     _eventsSub = _cdrsLocalRepository.events.listen(_handleEvent);
+
+    final recentCdrs = await _cdrsLocalRepository.getHistory(limit: pageSize);
+    if (recentCdrs.isNotEmpty || _initialSyncDone == null) {
+      emit(state.copyWith(records: recentCdrs, isLoading: false));
+      return;
+    }
+
+    // Local cache is empty: keep loading until the first remote sync resolves,
+    // then re-read whatever it stored (records also arrive live via events).
+    await _initialSyncDone;
+    if (isClosed) return;
+    final syncedCdrs = await _cdrsLocalRepository.getHistory(limit: pageSize);
+    emit(state.copyWith(records: syncedCdrs, isLoading: false));
   }
 
   Future<void> fetchHistory() async {

--- a/lib/features/cdrs/cubit/missed_recent_cdrs_cubit.dart
+++ b/lib/features/cdrs/cubit/missed_recent_cdrs_cubit.dart
@@ -13,26 +13,50 @@ part 'missed_recent_cdrs_state.dart';
 final _logger = Logger('MissedRecentCdrsCubit');
 
 class MissedRecentCdrsCubit extends Cubit<MissedRecentCdrsState> {
-  MissedRecentCdrsCubit(this._cdrsLocalRepository, this._cdrsRemoteRepository, {this.pageSize = 50})
-    : super(const MissedRecentCdrsState());
+  MissedRecentCdrsCubit(
+    this._cdrsLocalRepository,
+    this._cdrsRemoteRepository, {
+    this.pageSize = 50,
+    Future<void>? initialSyncDone,
+  }) : _initialSyncDone = initialSyncDone,
+       super(const MissedRecentCdrsState());
 
   final CdrsLocalRepository _cdrsLocalRepository;
   final CdrsRemoteRepository _cdrsRemoteRepository;
   final int pageSize;
+
+  /// Resolves when the first remote sync cycle has completed. Used to keep the
+  /// initial loading indicator visible until the first `/user/history` fetch
+  /// and the missed-calls scan have resolved, instead of flashing an empty list.
+  final Future<void>? _initialSyncDone;
+
   late final StreamSubscription _eventsSub;
 
   Future<void> init() async {
     _logger.info('Loading missed CDRs');
+    _eventsSub = _cdrsLocalRepository.events.listen(_handleEvent);
+
     final missedCdrs = await _cdrsLocalRepository.getHistory(
       status: CdrStatus.missed,
       direction: CallDirection.incoming,
       limit: pageSize,
     );
-    emit(state.copyWith(records: missedCdrs, isLoading: false));
-    _eventsSub = _cdrsLocalRepository.events.listen(_handleEvent);
 
-    // If we didn't load enough missed CDRs, try to scan more from remote
-    if (missedCdrs.length < pageSize) fetchHistory();
+    if (missedCdrs.isNotEmpty || _initialSyncDone == null) {
+      emit(state.copyWith(records: missedCdrs, isLoading: false));
+      // If we didn't load enough missed CDRs, try to scan more from remote
+      if (missedCdrs.length < pageSize) fetchHistory();
+      return;
+    }
+
+    // Local cache is empty: wait for the first remote sync so the initial page
+    // is available locally, then scan for missed calls, keeping the loader
+    // visible until the scan completes.
+    await _initialSyncDone;
+    if (isClosed) return;
+    await fetchHistory();
+    if (isClosed) return;
+    emit(state.copyWith(isLoading: false));
   }
 
   Future<void> fetchHistory() async {

--- a/lib/features/cdrs/services/cdrs_sync_worker.dart
+++ b/lib/features/cdrs/services/cdrs_sync_worker.dart
@@ -23,6 +23,13 @@ class CdrsSyncWorker {
   final int pageSize;
   StreamSubscription? _syncSub;
 
+  final _initialSyncCompleter = Completer<void>();
+
+  /// Completes after the first sync cycle finishes (regardless of whether it
+  /// fetched any records or failed), so consumers can keep an initial loading
+  /// indicator until the first remote fetch has resolved.
+  Future<void> get initialSyncDone => _initialSyncCompleter.future;
+
   Future<void> init() async {
     // Uncomment to wipe local CDRs data on each start (for testing purposes)
     // await localRepo.wipeData();
@@ -66,6 +73,7 @@ class CdrsSyncWorker {
       } catch (e, s) {
         yield (e, s);
       } finally {
+        if (!_initialSyncCompleter.isCompleted) _initialSyncCompleter.complete();
         yield await Future.delayed(pollingInterval, () => _kRetryEventStub);
       }
     }

--- a/lib/features/cdrs/view/recent_cdrs_screen_page.dart
+++ b/lib/features/cdrs/view/recent_cdrs_screen_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/environment_config.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
 
 import '../cdrs.dart';
@@ -16,16 +17,23 @@ class RecentCdrsScreenPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final featureAccess = context.read<FeatureAccess>();
+    final initialSyncDone = context.readOrNull<CdrsSyncWorker>()?.initialSyncDone;
 
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          create: (context) =>
-              FullRecentCdrsCubit(context.read<CdrsLocalRepository>(), context.read<CdrsRemoteRepository>())..init(),
+          create: (context) => FullRecentCdrsCubit(
+            context.read<CdrsLocalRepository>(),
+            context.read<CdrsRemoteRepository>(),
+            initialSyncDone: initialSyncDone,
+          )..init(),
         ),
         BlocProvider(
-          create: (context) =>
-              MissedRecentCdrsCubit(context.read<CdrsLocalRepository>(), context.read<CdrsRemoteRepository>())..init(),
+          create: (context) => MissedRecentCdrsCubit(
+            context.read<CdrsLocalRepository>(),
+            context.read<CdrsRemoteRepository>(),
+            initialSyncDone: initialSyncDone,
+          )..init(),
         ),
       ],
       child: RecentCdrsScreen(

--- a/lib/features/contacts/features/contacts_external_tab/bloc/contacts_external_tab_bloc.dart
+++ b/lib/features/contacts/features/contacts_external_tab/bloc/contacts_external_tab_bloc.dart
@@ -64,12 +64,14 @@ class ContactsExternalTabBloc extends Bloc<ContactsExternalTabEvent, ContactsExt
   }
 
   ContactsExternalTabStatus _mapExternalContactsSyncStateToStatus(ExternalContactsSyncState externalContactsSyncState) {
-    if (externalContactsSyncState is ExternalContactsSyncRefreshInProgress) {
-      return ContactsExternalTabStatus.inProgress;
-    } else if (externalContactsSyncState is ExternalContactsSyncSuccess) {
+    if (externalContactsSyncState is ExternalContactsSyncSuccess) {
       return ContactsExternalTabStatus.success;
-    } else {
+    } else if (externalContactsSyncState is ExternalContactsSyncFailure) {
       return ContactsExternalTabStatus.failure;
+    } else {
+      // Initial (sync not finished yet) and RefreshInProgress both mean the first
+      // remote fetch is still running, so keep the loading state until it resolves.
+      return ContactsExternalTabStatus.inProgress;
     }
   }
 }

--- a/lib/features/contacts/features/contacts_external_tab/view/contacts_external_tab.dart
+++ b/lib/features/contacts/features/contacts_external_tab/view/contacts_external_tab.dart
@@ -32,9 +32,7 @@ class _ContactsExternalTabState extends State<ContactsExternalTab> {
 
     return BlocBuilder<ContactsExternalTabBloc, ContactsExternalTabState>(
       builder: (context, state) {
-        if (state.status == ContactsExternalTabStatus.initial) {
-          return const Center(child: CircularProgressIndicator());
-        } else if (state.contacts.isNotEmpty) {
+        if (state.contacts.isNotEmpty) {
           return RefreshIndicator(
             onRefresh: refreshContacts,
             child: ListView.builder(
@@ -51,21 +49,27 @@ class _ContactsExternalTabState extends State<ContactsExternalTab> {
               },
             ),
           );
-        } else {
-          if (state.status == ContactsExternalTabStatus.failure) {
+        }
+
+        // No contacts to show yet: keep a loading indicator visible while the
+        // initial remote fetch is still in flight, so an empty list is not
+        // mistaken for "no data".
+        switch (state.status) {
+          case ContactsExternalTabStatus.initial:
+          case ContactsExternalTabStatus.inProgress:
+            return const Center(child: CircularProgressIndicator());
+          case ContactsExternalTabStatus.failure:
             return NoDataPlaceholder(content: Text(context.l10n.contacts_ExternalTabText_failure));
-          } else {
+          case ContactsExternalTabStatus.success:
             if (state.searching) {
               return NoDataPlaceholder(content: Text(context.l10n.contacts_ExternalTabText_emptyOnSearching));
-            } else {
-              return NoDataPlaceholder(
-                content: Text(context.l10n.contacts_ExternalTabText_empty),
-                actions: [
-                  TextButton(onPressed: refreshContacts, child: Text(context.l10n.contacts_ExternalTabButton_refresh)),
-                ],
-              );
             }
-          }
+            return NoDataPlaceholder(
+              content: Text(context.l10n.contacts_ExternalTabText_empty),
+              actions: [
+                TextButton(onPressed: refreshContacts, child: Text(context.l10n.contacts_ExternalTabButton_refresh)),
+              ],
+            );
         }
       },
     );

--- a/test/features/cdrs/recent_cdrs_cubit_test.dart
+++ b/test/features/cdrs/recent_cdrs_cubit_test.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/features/cdrs/cdrs.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+
+class MockCdrsLocalRepository extends Mock implements CdrsLocalRepository {}
+
+class MockCdrsRemoteRepository extends Mock implements CdrsRemoteRepository {}
+
+CdrRecord _record(String id) => CdrRecord(
+  callId: id,
+  direction: CallDirection.incoming,
+  status: CdrStatus.accepted,
+  callee: '1000',
+  calleeNumber: '1000',
+  caller: '2000',
+  callerNumber: '2000',
+  connectTime: DateTime(2026, 1, 1),
+  disconnectTime: DateTime(2026, 1, 1),
+  disconnectReason: 'normal',
+  duration: const Duration(seconds: 10),
+);
+
+void main() {
+  late MockCdrsLocalRepository local;
+  late MockCdrsRemoteRepository remote;
+
+  setUp(() {
+    local = MockCdrsLocalRepository();
+    remote = MockCdrsRemoteRepository();
+    when(() => local.events).thenAnswer((_) => const Stream<CdrRecordsEvent>.empty());
+  });
+
+  group('FullRecentCdrsCubit.init', () {
+    test('empty local cache keeps isLoading until the initial sync resolves', () async {
+      final syncCompleter = Completer<void>();
+      var call = 0;
+      when(() => local.getHistory(limit: any(named: 'limit'))).thenAnswer((_) async {
+        call++;
+        return call == 1 ? <CdrRecord>[] : [_record('a')];
+      });
+
+      final cubit = FullRecentCdrsCubit(local, remote, initialSyncDone: syncCompleter.future);
+      final future = cubit.init();
+
+      // Local read resolved and returned empty, but the sync is still running:
+      // the loader must stay visible instead of showing an empty list.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(cubit.state.isLoading, isTrue);
+      expect(cubit.state.records, isEmpty);
+
+      syncCompleter.complete();
+      await future;
+
+      expect(cubit.state.isLoading, isFalse);
+      expect(cubit.state.records, [_record('a')]);
+      await cubit.close();
+    });
+
+    test('non-empty local cache clears isLoading immediately without waiting', () async {
+      when(() => local.getHistory(limit: any(named: 'limit'))).thenAnswer((_) async => [_record('a')]);
+
+      // A sync future that never completes: init must not await it.
+      final cubit = FullRecentCdrsCubit(local, remote, initialSyncDone: Completer<void>().future);
+      await cubit.init();
+
+      expect(cubit.state.isLoading, isFalse);
+      expect(cubit.state.records, [_record('a')]);
+      await cubit.close();
+    });
+
+    test('without a sync signal falls back to clearing isLoading after the local read', () async {
+      when(() => local.getHistory(limit: any(named: 'limit'))).thenAnswer((_) async => <CdrRecord>[]);
+
+      final cubit = FullRecentCdrsCubit(local, remote);
+      await cubit.init();
+
+      expect(cubit.state.isLoading, isFalse);
+      expect(cubit.state.records, isEmpty);
+      await cubit.close();
+    });
+  });
+
+  group('MissedRecentCdrsCubit.init', () {
+    setUp(() {
+      when(
+        () => local.getHistory(
+          number: any(named: 'number'),
+          destination: any(named: 'destination'),
+          status: any(named: 'status'),
+          direction: any(named: 'direction'),
+          from: any(named: 'from'),
+          to: any(named: 'to'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => <CdrRecord>[]);
+      when(() => local.getFirstRecordTime()).thenAnswer((_) async => null);
+      when(() => local.upsertCdrs(any(), silent: any(named: 'silent'))).thenAnswer((_) async {});
+      when(
+        () => remote.getHistory(
+          to: any(named: 'to'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => <CdrRecord>[]);
+    });
+
+    test('empty local cache keeps isLoading until the initial sync and scan resolve', () async {
+      final syncCompleter = Completer<void>();
+
+      final cubit = MissedRecentCdrsCubit(local, remote, initialSyncDone: syncCompleter.future);
+      final future = cubit.init();
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(cubit.state.isLoading, isTrue);
+
+      syncCompleter.complete();
+      await future;
+
+      expect(cubit.state.isLoading, isFalse);
+      await cubit.close();
+    });
+  });
+}

--- a/test/features/contacts/contacts_external_tab_bloc_test.dart
+++ b/test/features/contacts/contacts_external_tab_bloc_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:webtrit_phone/blocs/blocs.dart';
+import 'package:webtrit_phone/features/contacts/contacts.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+
+class MockContactsRepository extends Mock implements ContactsRepository {}
+
+class MockContactsBloc extends MockBloc<ContactsEvent, ContactsState> implements ContactsBloc {}
+
+class MockExternalContactsSyncBloc extends MockBloc<ExternalContactsSyncEvent, ExternalContactsSyncState>
+    implements ExternalContactsSyncBloc {}
+
+void main() {
+  late MockContactsRepository contactsRepository;
+  late MockContactsBloc searchBloc;
+  late MockExternalContactsSyncBloc syncBloc;
+
+  setUp(() {
+    contactsRepository = MockContactsRepository();
+    searchBloc = MockContactsBloc();
+    syncBloc = MockExternalContactsSyncBloc();
+
+    when(
+      () => contactsRepository.watchContacts('', ContactSourceType.external),
+    ).thenAnswer((_) => Stream.value(const <Contact>[]));
+    when(() => searchBloc.state).thenReturn(const ContactsState(sourceType: ContactSourceType.external));
+  });
+
+  ContactsExternalTabBloc build() => ContactsExternalTabBloc(
+    contactsRepository: contactsRepository,
+    contactsSearchBloc: searchBloc,
+    externalContactsSyncBloc: syncBloc,
+  );
+
+  void withSyncState(ExternalContactsSyncState syncState) {
+    when(() => syncBloc.state).thenReturn(syncState);
+  }
+
+  blocTest<ContactsExternalTabBloc, ContactsExternalTabState>(
+    'sync Initial with an empty cache maps to inProgress (loading), not failure',
+    setUp: () => withSyncState(const ExternalContactsSyncInitial()),
+    build: build,
+    act: (bloc) => bloc.add(const ContactsExternalTabStarted(search: '')),
+    expect: () => [
+      isA<ContactsExternalTabState>()
+          .having((s) => s.status, 'status', ContactsExternalTabStatus.inProgress)
+          .having((s) => s.contacts, 'contacts', isEmpty),
+    ],
+  );
+
+  blocTest<ContactsExternalTabBloc, ContactsExternalTabState>(
+    'sync RefreshInProgress with an empty cache maps to inProgress (loading)',
+    setUp: () => withSyncState(const ExternalContactsSyncRefreshInProgress()),
+    build: build,
+    act: (bloc) => bloc.add(const ContactsExternalTabStarted(search: '')),
+    expect: () => [
+      isA<ContactsExternalTabState>().having((s) => s.status, 'status', ContactsExternalTabStatus.inProgress),
+    ],
+  );
+
+  blocTest<ContactsExternalTabBloc, ContactsExternalTabState>(
+    'sync Success with an empty cache maps to success (empty state, not loading)',
+    setUp: () => withSyncState(const ExternalContactsSyncSuccess()),
+    build: build,
+    act: (bloc) => bloc.add(const ContactsExternalTabStarted(search: '')),
+    expect: () => [
+      isA<ContactsExternalTabState>().having((s) => s.status, 'status', ContactsExternalTabStatus.success),
+    ],
+  );
+
+  blocTest<ContactsExternalTabBloc, ContactsExternalTabState>(
+    'sync Failure maps to failure',
+    setUp: () => withSyncState(const ExternalContactsSyncRefreshFailure()),
+    build: build,
+    act: (bloc) => bloc.add(const ContactsExternalTabStarted(search: '')),
+    expect: () => [
+      isA<ContactsExternalTabState>().having((s) => s.status, 'status', ContactsExternalTabStatus.failure),
+    ],
+  );
+}


### PR DESCRIPTION
## Overview

The Contacts (external) and Recents / Call History (CDR) screens showed an empty-state placeholder instead of a loading indicator on first open when the local cache was empty. The loading flag was cleared as soon as the local cache resolved rather than when the first remote response arrived, so an in-flight initial load looked like "no data" - especially visible on slow API responses.

## Changes

- **Contacts external tab:** map the sync `Initial` state to `inProgress` (loading) instead of `failure`, and show the loader for `initial`/`inProgress` while the list is still empty. `Success` with no results still renders the distinct empty state.
- **CDR sync worker:** expose an `initialSyncDone` signal that completes after the first sync cycle (even on empty result or error).
- **CDR cubits (full + missed):** when the local cache is empty, keep `isLoading` true until `initialSyncDone` (and, for missed, the initial scan) resolves, then re-read locally. Non-empty cache or no signal keeps the previous immediate behavior. Avoids a duplicate remote fetch.

## Testing

- `flutter analyze` clean on the changed areas.
- 8 new unit tests: CDR cubits (empty cache holds loading until sync, non-empty clears immediately, no-signal fallback, missed scan) and the contacts external tab bloc mapping (`Initial`/`InProgress` -> loading, `Success` -> empty, `Failure` -> failure).

Pull-to-refresh behavior is unchanged; the empty state after a successful response remains visually distinct from loading.

Device verification on a throttled/slow API is still pending before ready-for-merge.
