### PR TITLE
fix(l10n): capitalize Thai language name in Ukrainian locale (WT-1683)

### DIFF
--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -870,7 +870,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get locale_uk => 'Українська';
 
   @override
-  String get locale_th => 'тайська';
+  String get locale_th => 'Тайська';
 
   @override
   String get login_Button_coreUrlAssignProceed => 'Продовжити';

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -708,7 +708,7 @@
   "@locale_it": {},
   "locale_uk": "Українська",
   "@locale_uk": {},
-  "locale_th": "тайська",
+  "locale_th": "Тайська",
   "@locale_th": {},
   "login_Button_coreUrlAssignProceed": "Продовжити",
   "@login_Button_coreUrlAssignProceed": {},


### PR DESCRIPTION
## Overview

The Ukrainian localization listed the Thai language name in lowercase ("тайська"), inconsistent with every other language label in the Ukrainian locale, which are capitalized (Англійська, Італійська, Українська). This was reported during QA of the configurable UI-language allowlist.

Fix: capitalize the value to "Тайська" in `app_uk.arb` and regenerate the localization sources.

## Scope
- Ukrainian locale only; `en`/`it`/`th` labels were already correct and consistent.
- No code/logic changes.