### PR TITLE
fix(settings): correct language selection for narrowed language lists (WT-1683)

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -102,6 +102,7 @@ class _AppState extends State<App> {
       systemInfoRepository: context.read<SystemInfoRepository>(),
       appCompatibilityResolver: context.read<AppCompatibilityResolver>(),
       appInfo: context.read<AppInfo>(),
+      supportedLocales: featureAccess.localizationConfig.supportedLocales,
       userSessionCleanupResolver: RepositoryUserSessionCleanupResolver(
         systemInfoRepository: context.read<SystemInfoRepository>(),
         registerStatusRepository: context.read<RegisterStatusRepository>(),

--- a/lib/blocs/app/app_bloc.dart
+++ b/lib/blocs/app/app_bloc.dart
@@ -37,6 +37,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     required this.userSessionCleanupResolver,
     required this.systemInfoRepository,
     required this.appCompatibilityResolver,
+    List<Locale> supportedLocales = const <Locale>[],
     this.crashlyticsContext = const AppSessionCrashlyticsContext(),
   }) : super(
          AppState(
@@ -45,7 +46,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
                ? AppLifecycleStatus.authenticated
                : AppLifecycleStatus.unauthenticated,
            themeMode: themeModeRepository.getThemeMode(),
-           locale: localeRepository.getLocale(),
+           locale: _resolveInitialLocale(localeRepository.getLocale(), supportedLocales),
            userAgreementStatus: userAgreementStatusRepository.getUserAgreementStatus(),
            contactsAgreementStatus: contactsAgreementStatusRepository.getContactsAgreementStatus(),
          ),
@@ -90,6 +91,24 @@ class AppBloc extends Bloc<AppEvent, AppState> {
   final AppSessionCrashlyticsContext crashlyticsContext;
 
   StreamSubscription<WebtritSystemInfo>? _systemInfoSubscription;
+
+  /// Reconciles the persisted locale against the currently supported locales.
+  ///
+  /// A build can narrow the set of selectable languages (the per-brand
+  /// allowlist), so a previously persisted choice may no longer be offered
+  /// after an update, leaving a stale value that matches nothing in the picker.
+  ///   - Empty [supportedLocales] means unrestricted, so the choice is kept.
+  ///   - A single supported language pins to that language: it is the only
+  ///     selectable option (the picker drops the follow-system "default" entry),
+  ///     so the effective locale must be that language.
+  ///   - Otherwise keep the persisted choice when it is still supported, and
+  ///     fall back to the default (follow-system) locale when it is not.
+  static Locale _resolveInitialLocale(Locale persisted, List<Locale> supportedLocales) {
+    if (supportedLocales.isEmpty) return persisted;
+    if (supportedLocales.length == 1) return supportedLocales.single;
+    if (persisted == LocaleExtension.defaultNull) return persisted;
+    return supportedLocales.contains(persisted) ? persisted : LocaleExtension.defaultNull;
+  }
 
   @override
   Future<void> close() async {

--- a/lib/features/settings/features/language/view/language_screen.dart
+++ b/lib/features/settings/features/language/view/language_screen.dart
@@ -16,7 +16,11 @@ class LanguageScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final supportedLocales = context.read<FeatureAccess>().localizationConfig.supportedLocales;
-    final locales = [LocaleExtension.defaultNull, ...supportedLocales];
+    // With a single supported language there is nothing to follow the system to,
+    // so drop the "default" (follow-system) entry and offer that one language.
+    final locales = supportedLocales.length == 1
+        ? supportedLocales
+        : [LocaleExtension.defaultNull, ...supportedLocales];
 
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.settings_ListViewTileTitle_language), leading: const ExtBackButton()),

--- a/test/blocs/app/app_locale_reconciliation_test.dart
+++ b/test/blocs/app/app_locale_reconciliation_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import 'package:webtrit_phone/blocs/app/app_bloc.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/resolvers/resolvers.dart';
+
+class _MockUserAgreementStatusRepository extends Mock implements UserAgreementStatusRepository {}
+
+class _MockContactsAgreementStatusRepository extends Mock implements ContactsAgreementStatusRepository {}
+
+class _MockSessionRepository extends Mock implements SessionRepository {}
+
+class _MockLocaleRepository extends Mock implements LocaleRepository {}
+
+class _MockThemeModeRepository extends Mock implements ThemeModeRepository {}
+
+class _MockSystemInfoRepository extends Mock implements SystemInfoRepository {}
+
+class _MockUserSessionCleanupResolver extends Mock implements UserSessionCleanupResolver {}
+
+class _MockAppInfo extends Mock implements AppInfo {}
+
+void main() {
+  late _MockUserAgreementStatusRepository userAgreementStatusRepository;
+  late _MockContactsAgreementStatusRepository contactsAgreementStatusRepository;
+  late _MockSessionRepository sessionRepository;
+  late _MockLocaleRepository localeRepository;
+  late _MockThemeModeRepository themeModeRepository;
+  late _MockSystemInfoRepository systemInfoRepository;
+  late _MockUserSessionCleanupResolver userSessionCleanupResolver;
+  late _MockAppInfo appInfo;
+  late StreamController<WebtritSystemInfo> infoStreamController;
+
+  setUpAll(() {
+    registerFallbackValue(FetchPolicy.cacheFirst);
+  });
+
+  setUp(() {
+    userAgreementStatusRepository = _MockUserAgreementStatusRepository();
+    contactsAgreementStatusRepository = _MockContactsAgreementStatusRepository();
+    sessionRepository = _MockSessionRepository();
+    localeRepository = _MockLocaleRepository();
+    themeModeRepository = _MockThemeModeRepository();
+    systemInfoRepository = _MockSystemInfoRepository();
+    userSessionCleanupResolver = _MockUserSessionCleanupResolver();
+    appInfo = _MockAppInfo();
+    infoStreamController = StreamController<WebtritSystemInfo>.broadcast();
+
+    when(() => sessionRepository.getCurrent()).thenReturn(const Session());
+    when(() => themeModeRepository.getThemeMode()).thenReturn(ThemeMode.system);
+    when(() => userAgreementStatusRepository.getUserAgreementStatus()).thenReturn(AgreementStatus.accepted);
+    when(() => contactsAgreementStatusRepository.getContactsAgreementStatus()).thenReturn(AgreementStatus.accepted);
+    when(() => appInfo.version).thenReturn(Version(1, 0, 0));
+
+    when(() => systemInfoRepository.infoStream).thenAnswer((_) => infoStreamController.stream);
+    when(
+      () => systemInfoRepository.getSystemInfo(fetchPolicy: any(named: 'fetchPolicy')),
+    ).thenAnswer((_) async => null);
+  });
+
+  tearDown(() async {
+    await infoStreamController.close();
+  });
+
+  AppBloc buildBloc({required Locale persisted, required List<Locale> supportedLocales}) {
+    when(() => localeRepository.getLocale()).thenReturn(persisted);
+    return AppBloc(
+      userAgreementStatusRepository: userAgreementStatusRepository,
+      contactsAgreementStatusRepository: contactsAgreementStatusRepository,
+      sessionRepository: sessionRepository,
+      localeRepository: localeRepository,
+      themeModeRepository: themeModeRepository,
+      systemInfoRepository: systemInfoRepository,
+      userSessionCleanupResolver: userSessionCleanupResolver,
+      appInfo: appInfo,
+      appCompatibilityResolver: const DefaultAppCompatibilityResolver(),
+      supportedLocales: supportedLocales,
+    );
+  }
+
+  group('initial locale reconciliation against the supported locales', () {
+    test('keeps the persisted locale when it is still supported', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const [Locale('en'), Locale('uk')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('en'));
+    });
+
+    test('falls back to default when the persisted locale is no longer supported', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const [Locale('uk'), Locale('it')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, LocaleExtension.defaultNull);
+      expect(bloc.state.effectiveLocale, isNull);
+    });
+
+    test('keeps the default (follow-system) locale untouched with multiple languages', () {
+      final bloc = buildBloc(
+        persisted: LocaleExtension.defaultNull,
+        supportedLocales: const [Locale('uk'), Locale('it')],
+      );
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, LocaleExtension.defaultNull);
+    });
+
+    test('pins to the only supported language when the persisted locale differs', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const [Locale('uk')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('uk'));
+      expect(bloc.state.effectiveLocale, const Locale('uk'));
+    });
+
+    test('pins to the only supported language even when following the system', () {
+      final bloc = buildBloc(persisted: LocaleExtension.defaultNull, supportedLocales: const [Locale('uk')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('uk'));
+    });
+
+    test('treats an empty supported list as unrestricted and keeps the persisted locale', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const []);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('en'));
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Fixes the language settings picker when a build narrows the set of selectable UI languages (the per-brand language allowlist).

1. Persisted locale not reconciled. After an app update that narrows the languages, a previously persisted choice can fall outside the currently supported set. The picker matches the persisted locale against its options, so a stale value matched nothing and no radio appeared selected. `AppBloc` now reconciles the persisted locale against the supported locales at init:
   - a single supported language pins to that language;
   - with multiple languages, an unsupported persisted value falls back to the default (follow-system) locale, and a still-supported value is kept;
   - an empty list is treated as unrestricted (backward-compatible).

2. Redundant default with a single language. The picker always prepended a "default" (follow-system) entry, so a single-language build showed two options that resolve to the same locale. With one language the picker now shows just that language (no default entry).

Visibility of the language settings entry itself is left to the existing per-section config and is intentionally not changed here.

## Changes
- `AppBloc` reconciles the initial locale against a `supportedLocales` list passed from `app.dart`.
- Language picker drops the follow-system entry when only one language is available.
- Unit tests for the reconciliation cases.

## Repro
Languages en/it/th/uk with English selected -> update to a build allowing only Ukrainian -> before: two options (default + Ukrainian), none selected; after: a single Ukrainian option, selected, and the app runs in Ukrainian.