### PR TITLE
build: bump app version to 1.16.1+2

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -99,6 +99,7 @@ class _AppState extends State<App> {
       systemInfoRepository: context.read<SystemInfoRepository>(),
       appCompatibilityResolver: context.read<AppCompatibilityResolver>(),
       appInfo: context.read<AppInfo>(),
+      supportedLocales: featureAccess.localizationConfig.supportedLocales,
       userSessionCleanupResolver: RepositoryUserSessionCleanupResolver(
         systemInfoRepository: context.read<SystemInfoRepository>(),
         registerStatusRepository: context.read<RegisterStatusRepository>(),

--- a/lib/blocs/app/app_bloc.dart
+++ b/lib/blocs/app/app_bloc.dart
@@ -37,6 +37,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     required this.userSessionCleanupResolver,
     required this.systemInfoRepository,
     required this.appCompatibilityResolver,
+    List<Locale> supportedLocales = const <Locale>[],
   }) : super(
          AppState(
            session: sessionRepository.getCurrent(),
@@ -44,7 +45,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
                ? AppLifecycleStatus.authenticated
                : AppLifecycleStatus.unauthenticated,
            themeMode: themeModeRepository.getThemeMode(),
-           locale: localeRepository.getLocale(),
+           locale: _resolveInitialLocale(localeRepository.getLocale(), supportedLocales),
            userAgreementStatus: userAgreementStatusRepository.getUserAgreementStatus(),
            contactsAgreementStatus: contactsAgreementStatusRepository.getContactsAgreementStatus(),
          ),
@@ -76,6 +77,24 @@ class AppBloc extends Bloc<AppEvent, AppState> {
   final AppCompatibilityResolver appCompatibilityResolver;
 
   StreamSubscription<WebtritSystemInfo>? _systemInfoSubscription;
+
+  /// Reconciles the persisted locale against the currently supported locales.
+  ///
+  /// A build can narrow the set of selectable languages (the per-brand
+  /// allowlist), so a previously persisted choice may no longer be offered
+  /// after an update, leaving a stale value that matches nothing in the picker.
+  ///   - Empty [supportedLocales] means unrestricted, so the choice is kept.
+  ///   - A single supported language pins to that language: it is the only
+  ///     selectable option (the picker drops the follow-system "default" entry),
+  ///     so the effective locale must be that language.
+  ///   - Otherwise keep the persisted choice when it is still supported, and
+  ///     fall back to the default (follow-system) locale when it is not.
+  static Locale _resolveInitialLocale(Locale persisted, List<Locale> supportedLocales) {
+    if (supportedLocales.isEmpty) return persisted;
+    if (supportedLocales.length == 1) return supportedLocales.single;
+    if (persisted == LocaleExtension.defaultNull) return persisted;
+    return supportedLocales.contains(persisted) ? persisted : LocaleExtension.defaultNull;
+  }
 
   @override
   Future<void> close() async {

--- a/lib/features/call/view/call_screen_style.dart
+++ b/lib/features/call/view/call_screen_style.dart
@@ -166,6 +166,7 @@ class CallScreenActionsStyle with Diagnosticable {
     this.held,
     this.swap,
     this.key,
+    this.keypadInputTextStyle,
   });
 
   final ButtonStyle? callStart;
@@ -178,6 +179,9 @@ class CallScreenActionsStyle with Diagnosticable {
   final ButtonStyle? swap;
   final ButtonStyle? key;
 
+  /// Text style for the digits typed on the in-call DTMF keypad.
+  final TextStyle? keypadInputTextStyle;
+
   CallScreenActionsStyle copyWith({
     ButtonStyle? callStart,
     ButtonStyle? hangup,
@@ -188,6 +192,7 @@ class CallScreenActionsStyle with Diagnosticable {
     ButtonStyle? held,
     ButtonStyle? swap,
     ButtonStyle? key,
+    TextStyle? keypadInputTextStyle,
   }) {
     return CallScreenActionsStyle(
       callStart: callStart ?? this.callStart,
@@ -199,6 +204,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: held ?? this.held,
       swap: swap ?? this.swap,
       key: key ?? this.key,
+      keypadInputTextStyle: keypadInputTextStyle ?? this.keypadInputTextStyle,
     );
   }
 
@@ -207,6 +213,11 @@ class CallScreenActionsStyle with Diagnosticable {
     if (other == null) return this;
 
     ButtonStyle? mergeButtonStyle(ButtonStyle? a, ButtonStyle? b) {
+      if (a == null) return b;
+      return a.merge(b);
+    }
+
+    TextStyle? mergeTextStyle(TextStyle? a, TextStyle? b) {
       if (a == null) return b;
       return a.merge(b);
     }
@@ -221,6 +232,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: mergeButtonStyle(held, other.held),
       swap: mergeButtonStyle(swap, other.swap),
       key: mergeButtonStyle(key, other.key),
+      keypadInputTextStyle: mergeTextStyle(keypadInputTextStyle, other.keypadInputTextStyle),
     );
   }
 
@@ -236,6 +248,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: ButtonStyle.lerp(a?.held, b?.held, t),
       swap: ButtonStyle.lerp(a?.swap, b?.swap, t),
       key: ButtonStyle.lerp(a?.key, b?.key, t),
+      keypadInputTextStyle: TextStyle.lerp(a?.keypadInputTextStyle, b?.keypadInputTextStyle, t),
     );
   }
 
@@ -251,6 +264,7 @@ class CallScreenActionsStyle with Diagnosticable {
       ..add(DiagnosticsProperty<ButtonStyle?>('speaker', speaker))
       ..add(DiagnosticsProperty<ButtonStyle?>('held', held))
       ..add(DiagnosticsProperty<ButtonStyle?>('swap', swap))
-      ..add(DiagnosticsProperty<ButtonStyle?>('key', key));
+      ..add(DiagnosticsProperty<ButtonStyle?>('key', key))
+      ..add(DiagnosticsProperty<TextStyle?>('keypadInputTextStyle', keypadInputTextStyle));
   }
 }

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -130,7 +130,9 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
 
   void computeDimensions() {
     _inputDecorations = _themeData.extension<InputDecorations>();
-    _textStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
+    final baseKeypadInputStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
+    final configuredKeypadInputStyle = widget.style?.keypadInputTextStyle;
+    _textStyle = baseKeypadInputStyle?.merge(configuredKeypadInputStyle) ?? configuredKeypadInputStyle;
 
     _iconSize = _themeData.textTheme.headlineLarge?.fontSize;
 

--- a/lib/features/settings/features/language/view/language_screen.dart
+++ b/lib/features/settings/features/language/view/language_screen.dart
@@ -16,7 +16,11 @@ class LanguageScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final supportedLocales = context.read<FeatureAccess>().localizationConfig.supportedLocales;
-    final locales = [LocaleExtension.defaultNull, ...supportedLocales];
+    // With a single supported language there is nothing to follow the system to,
+    // so drop the "default" (follow-system) entry and offer that one language.
+    final locales = supportedLocales.length == 1
+        ? supportedLocales
+        : [LocaleExtension.defaultNull, ...supportedLocales];
 
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.settings_ListViewTileTitle_language), leading: const ExtBackButton()),

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -870,7 +870,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get locale_uk => 'Українська';
 
   @override
-  String get locale_th => 'тайська';
+  String get locale_th => 'Тайська';
 
   @override
   String get login_Button_coreUrlAssignProceed => 'Продовжити';

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -706,7 +706,7 @@
   "@locale_it": {},
   "locale_uk": "Українська",
   "@locale_uk": {},
-  "locale_th": "тайська",
+  "locale_th": "Тайська",
   "@locale_th": {},
   "login_Button_coreUrlAssignProceed": "Продовжити",
   "@login_Button_coreUrlAssignProceed": {},

--- a/lib/theme/factory/styles/call_screen_style_factory.dart
+++ b/lib/theme/factory/styles/call_screen_style_factory.dart
@@ -128,6 +128,28 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
     );
   }
 
+  /// Resolves the in-call keypad input text style so it can be merged over the
+  /// widget's base [TextTheme.displaySmall]. [TextStyleConfig.toTextStyle]
+  /// always emits a non-null fontWeight/fontStyle, which would override the base
+  /// during the merge; keep them only when the config sets them, so unset fields
+  /// inherit the base weight/style instead of being forced to normal.
+  TextStyle? _resolveKeypadInputTextStyle(TextStyleConfig? config) {
+    if (config == null) return null;
+    final resolved = config.toTextStyle(defaultFontFamily: defaultFontFamily);
+    return TextStyle(
+      fontFamily: resolved.fontFamily,
+      fontSize: resolved.fontSize,
+      fontWeight: config.fontWeight != null ? resolved.fontWeight : null,
+      fontStyle: config.fontStyle != null ? resolved.fontStyle : null,
+      color: resolved.color,
+      letterSpacing: resolved.letterSpacing,
+      wordSpacing: resolved.wordSpacing,
+      height: resolved.height,
+      decoration: resolved.decoration,
+      backgroundColor: resolved.backgroundColor,
+    );
+  }
+
   CallScreenActionsStyle? _resolveActionsStyle({
     CallPageActionsConfig? fromPage,
     // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
@@ -204,6 +226,7 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
         baseBg: colors.surfaceContainerHigh,
         baseIcon: colors.onSurface,
       ),
+      keypadInputTextStyle: _resolveKeypadInputTextStyle(a.keypadInputStyle),
     );
   }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -343,6 +343,7 @@ class CallPageActionsConfig with _$CallPageActionsConfig {
     this.held = const ElevatedButtonWidgetConfig(),
     this.swap = const ElevatedButtonWidgetConfig(),
     this.key = const ElevatedButtonWidgetConfig(),
+    this.keypadInputStyle,
   });
 
   @override
@@ -371,6 +372,12 @@ class CallPageActionsConfig with _$CallPageActionsConfig {
 
   @override
   final ElevatedButtonWidgetConfig key;
+
+  /// Text style for the digits typed on the in-call DTMF keypad (the value shown
+  /// above the keys). When unset the app falls back to its default display text
+  /// style for the keypad input.
+  @override
+  final TextStyleConfig? keypadInputStyle;
 
   factory CallPageActionsConfig.fromJson(Map<String, Object?> json) => _$CallPageActionsConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -2098,7 +2098,7 @@ case _:
 /// @nodoc
 mixin _$CallPageActionsConfig {
 
- ElevatedButtonWidgetConfig get callStart; ElevatedButtonWidgetConfig get hangup; ElevatedButtonWidgetConfig get transfer; ElevatedButtonWidgetConfig get camera; ElevatedButtonWidgetConfig get muted; ElevatedButtonWidgetConfig get speaker; ElevatedButtonWidgetConfig get held; ElevatedButtonWidgetConfig get swap; ElevatedButtonWidgetConfig get key;
+ ElevatedButtonWidgetConfig get callStart; ElevatedButtonWidgetConfig get hangup; ElevatedButtonWidgetConfig get transfer; ElevatedButtonWidgetConfig get camera; ElevatedButtonWidgetConfig get muted; ElevatedButtonWidgetConfig get speaker; ElevatedButtonWidgetConfig get held; ElevatedButtonWidgetConfig get swap; ElevatedButtonWidgetConfig get key; TextStyleConfig? get keypadInputStyle;
 /// Create a copy of CallPageActionsConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2109,16 +2109,16 @@ $CallPageActionsConfigCopyWith<CallPageActionsConfig> get copyWith => _$CallPage
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageActionsConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.hangup, hangup) || other.hangup == hangup)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&(identical(other.camera, camera) || other.camera == camera)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.speaker, speaker) || other.speaker == speaker)&&(identical(other.held, held) || other.held == held)&&(identical(other.swap, swap) || other.swap == swap)&&(identical(other.key, key) || other.key == key));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageActionsConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.hangup, hangup) || other.hangup == hangup)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&(identical(other.camera, camera) || other.camera == camera)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.speaker, speaker) || other.speaker == speaker)&&(identical(other.held, held) || other.held == held)&&(identical(other.swap, swap) || other.swap == swap)&&(identical(other.key, key) || other.key == key)&&(identical(other.keypadInputStyle, keypadInputStyle) || other.keypadInputStyle == keypadInputStyle));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,callStart,hangup,transfer,camera,muted,speaker,held,swap,key);
+int get hashCode => Object.hash(runtimeType,callStart,hangup,transfer,camera,muted,speaker,held,swap,key,keypadInputStyle);
 
 @override
 String toString() {
-  return 'CallPageActionsConfig(callStart: $callStart, hangup: $hangup, transfer: $transfer, camera: $camera, muted: $muted, speaker: $speaker, held: $held, swap: $swap, key: $key)';
+  return 'CallPageActionsConfig(callStart: $callStart, hangup: $hangup, transfer: $transfer, camera: $camera, muted: $muted, speaker: $speaker, held: $held, swap: $swap, key: $key, keypadInputStyle: $keypadInputStyle)';
 }
 
 
@@ -2129,7 +2129,7 @@ abstract mixin class $CallPageActionsConfigCopyWith<$Res>  {
   factory $CallPageActionsConfigCopyWith(CallPageActionsConfig value, $Res Function(CallPageActionsConfig) _then) = _$CallPageActionsConfigCopyWithImpl;
 @useResult
 $Res call({
- ElevatedButtonWidgetConfig callStart, ElevatedButtonWidgetConfig hangup, ElevatedButtonWidgetConfig transfer, ElevatedButtonWidgetConfig camera, ElevatedButtonWidgetConfig muted, ElevatedButtonWidgetConfig speaker, ElevatedButtonWidgetConfig held, ElevatedButtonWidgetConfig swap, ElevatedButtonWidgetConfig key
+ ElevatedButtonWidgetConfig callStart, ElevatedButtonWidgetConfig hangup, ElevatedButtonWidgetConfig transfer, ElevatedButtonWidgetConfig camera, ElevatedButtonWidgetConfig muted, ElevatedButtonWidgetConfig speaker, ElevatedButtonWidgetConfig held, ElevatedButtonWidgetConfig swap, ElevatedButtonWidgetConfig key, TextStyleConfig? keypadInputStyle
 });
 
 
@@ -2146,7 +2146,7 @@ class _$CallPageActionsConfigCopyWithImpl<$Res>
 
 /// Create a copy of CallPageActionsConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? hangup = null,Object? transfer = null,Object? camera = null,Object? muted = null,Object? speaker = null,Object? held = null,Object? swap = null,Object? key = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? hangup = null,Object? transfer = null,Object? camera = null,Object? muted = null,Object? speaker = null,Object? held = null,Object? swap = null,Object? key = null,Object? keypadInputStyle = freezed,}) {
   return _then(CallPageActionsConfig(
 callStart: null == callStart ? _self.callStart : callStart // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,hangup: null == hangup ? _self.hangup : hangup // ignore: cast_nullable_to_non_nullable
@@ -2157,7 +2157,8 @@ as ElevatedButtonWidgetConfig,speaker: null == speaker ? _self.speaker : speaker
 as ElevatedButtonWidgetConfig,held: null == held ? _self.held : held // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,swap: null == swap ? _self.swap : swap // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
-as ElevatedButtonWidgetConfig,
+as ElevatedButtonWidgetConfig,keypadInputStyle: freezed == keypadInputStyle ? _self.keypadInputStyle : keypadInputStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -402,6 +402,11 @@ CallPageActionsConfig _$CallPageActionsConfigFromJson(
       : ElevatedButtonWidgetConfig.fromJson(
           json['key'] as Map<String, dynamic>,
         ),
+  keypadInputStyle: json['keypadInputStyle'] == null
+      ? null
+      : TextStyleConfig.fromJson(
+          json['keypadInputStyle'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$CallPageActionsConfigToJson(
@@ -416,6 +421,7 @@ Map<String, dynamic> _$CallPageActionsConfigToJson(
   'held': instance.held.toJson(),
   'swap': instance.swap.toJson(),
   'key': instance.key.toJson(),
+  'keypadInputStyle': instance.keypadInputStyle?.toJson(),
 };
 
 CallPageInfoConfig _$CallPageInfoConfigFromJson(Map<String, dynamic> json) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ version: 0.0.0+0
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.1+1
+app_version: 1.16.1+2
 
 environment:
   sdk: ^3.12.0

--- a/screenshots/lib/mocks/interactive_call_bloc.dart
+++ b/screenshots/lib/mocks/interactive_call_bloc.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart' show Registration, RegistrationStatus;
 
 import 'package:screenshots/data/data.dart';
 
@@ -20,7 +21,13 @@ class InteractiveCallBloc extends Cubit<CallState> implements CallBloc {
     : _callId = (video ? dVideoActiveCall : dAudioActiveCall).callId,
       super(
         CallState(
-          callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+          // A registered signaling client yields CallStatus.ready, which the call
+          // screen requires to enable keypad/hold/transfer actions. Without it the
+          // status stays inProgress ("Connecting...") and those buttons are disabled.
+          callServiceState: const CallServiceState(
+            signalingClientStatus: SignalingClientStatus.connect,
+            registration: Registration(status: RegistrationStatus.registered),
+          ),
           activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
           // Built-in earpiece + speaker so the speaker toggle renders and can switch.
           audioDevice: _earpiece,

--- a/screenshots/lib/mocks/mock_call_bloc.dart
+++ b/screenshots/lib/mocks/mock_call_bloc.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart' show Registration, RegistrationStatus;
 
 import 'package:screenshots/data/data.dart';
 
@@ -38,7 +39,12 @@ class MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
       mock,
       const Stream<CallState>.empty(),
       initialState: CallState(
-        callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+        // Registered signaling -> CallStatus.ready, so the active call renders as
+        // connected instead of a perpetual "Connecting..." state.
+        callServiceState: const CallServiceState(
+          signalingClientStatus: SignalingClientStatus.connect,
+          registration: Registration(status: RegistrationStatus.registered),
+        ),
         activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
       ),
     );

--- a/screenshots/pubspec.yaml
+++ b/screenshots/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
     sdk: flutter
   webtrit_phone:
     path: ..
+  webtrit_signaling:
+    path: ../packages/webtrit_signaling
   mocktail: ^1.0.4
   provider: ^6.0.0
 

--- a/test/blocs/app/app_locale_reconciliation_test.dart
+++ b/test/blocs/app/app_locale_reconciliation_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import 'package:webtrit_phone/blocs/app/app_bloc.dart';
+import 'package:webtrit_phone/data/data.dart';
+import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/resolvers/resolvers.dart';
+
+class _MockUserAgreementStatusRepository extends Mock implements UserAgreementStatusRepository {}
+
+class _MockContactsAgreementStatusRepository extends Mock implements ContactsAgreementStatusRepository {}
+
+class _MockSessionRepository extends Mock implements SessionRepository {}
+
+class _MockLocaleRepository extends Mock implements LocaleRepository {}
+
+class _MockThemeModeRepository extends Mock implements ThemeModeRepository {}
+
+class _MockSystemInfoRepository extends Mock implements SystemInfoRepository {}
+
+class _MockUserSessionCleanupResolver extends Mock implements UserSessionCleanupResolver {}
+
+class _MockAppInfo extends Mock implements AppInfo {}
+
+void main() {
+  late _MockUserAgreementStatusRepository userAgreementStatusRepository;
+  late _MockContactsAgreementStatusRepository contactsAgreementStatusRepository;
+  late _MockSessionRepository sessionRepository;
+  late _MockLocaleRepository localeRepository;
+  late _MockThemeModeRepository themeModeRepository;
+  late _MockSystemInfoRepository systemInfoRepository;
+  late _MockUserSessionCleanupResolver userSessionCleanupResolver;
+  late _MockAppInfo appInfo;
+  late StreamController<WebtritSystemInfo> infoStreamController;
+
+  setUpAll(() {
+    registerFallbackValue(FetchPolicy.cacheFirst);
+  });
+
+  setUp(() {
+    userAgreementStatusRepository = _MockUserAgreementStatusRepository();
+    contactsAgreementStatusRepository = _MockContactsAgreementStatusRepository();
+    sessionRepository = _MockSessionRepository();
+    localeRepository = _MockLocaleRepository();
+    themeModeRepository = _MockThemeModeRepository();
+    systemInfoRepository = _MockSystemInfoRepository();
+    userSessionCleanupResolver = _MockUserSessionCleanupResolver();
+    appInfo = _MockAppInfo();
+    infoStreamController = StreamController<WebtritSystemInfo>.broadcast();
+
+    when(() => sessionRepository.getCurrent()).thenReturn(const Session());
+    when(() => themeModeRepository.getThemeMode()).thenReturn(ThemeMode.system);
+    when(() => userAgreementStatusRepository.getUserAgreementStatus()).thenReturn(AgreementStatus.accepted);
+    when(() => contactsAgreementStatusRepository.getContactsAgreementStatus()).thenReturn(AgreementStatus.accepted);
+    when(() => appInfo.version).thenReturn(Version(1, 0, 0));
+
+    when(() => systemInfoRepository.infoStream).thenAnswer((_) => infoStreamController.stream);
+    when(
+      () => systemInfoRepository.getSystemInfo(fetchPolicy: any(named: 'fetchPolicy')),
+    ).thenAnswer((_) async => null);
+  });
+
+  tearDown(() async {
+    await infoStreamController.close();
+  });
+
+  AppBloc buildBloc({required Locale persisted, required List<Locale> supportedLocales}) {
+    when(() => localeRepository.getLocale()).thenReturn(persisted);
+    return AppBloc(
+      userAgreementStatusRepository: userAgreementStatusRepository,
+      contactsAgreementStatusRepository: contactsAgreementStatusRepository,
+      sessionRepository: sessionRepository,
+      localeRepository: localeRepository,
+      themeModeRepository: themeModeRepository,
+      systemInfoRepository: systemInfoRepository,
+      userSessionCleanupResolver: userSessionCleanupResolver,
+      appInfo: appInfo,
+      appCompatibilityResolver: const DefaultAppCompatibilityResolver(),
+      supportedLocales: supportedLocales,
+    );
+  }
+
+  group('initial locale reconciliation against the supported locales', () {
+    test('keeps the persisted locale when it is still supported', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const [Locale('en'), Locale('uk')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('en'));
+    });
+
+    test('falls back to default when the persisted locale is no longer supported', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const [Locale('uk'), Locale('it')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, LocaleExtension.defaultNull);
+      expect(bloc.state.effectiveLocale, isNull);
+    });
+
+    test('keeps the default (follow-system) locale untouched with multiple languages', () {
+      final bloc = buildBloc(
+        persisted: LocaleExtension.defaultNull,
+        supportedLocales: const [Locale('uk'), Locale('it')],
+      );
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, LocaleExtension.defaultNull);
+    });
+
+    test('pins to the only supported language when the persisted locale differs', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const [Locale('uk')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('uk'));
+      expect(bloc.state.effectiveLocale, const Locale('uk'));
+    });
+
+    test('pins to the only supported language even when following the system', () {
+      final bloc = buildBloc(persisted: LocaleExtension.defaultNull, supportedLocales: const [Locale('uk')]);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('uk'));
+    });
+
+    test('treats an empty supported list as unrestricted and keeps the persisted locale', () {
+      final bloc = buildBloc(persisted: const Locale('en'), supportedLocales: const []);
+      addTearDown(bloc.close);
+      expect(bloc.state.locale, const Locale('en'));
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Patch for the 1.16.1 release line (in QA): cherry-picks four develop changes and bumps the app version iteration.

- fix(screenshots): register signaling so call preview reaches ready state - the configurator's call preview screenshot registers the mock signaling layer, so the preview renders the ready in-call state instead of hanging in connecting (dev-only screenshots package, not shipped in the app binary).
- feat(call): configurable text style for in-call keypad input - the in-call keypad input text style becomes configurable through the theme page config, so white-label themes can adjust it instead of inheriting the hardcoded style.
- fix(l10n): capitalize Thai language name in Ukrainian locale - the language picker showed the Thai entry lowercased in the Ukrainian locale.
- fix(settings): correct language selection for narrowed language lists - when a build narrows the selectable languages, a previously persisted choice that is no longer offered is reconciled on startup: a single-language allowlist pins to that language, an unsupported persisted choice falls back to follow-system. The cherry-pick to this branch drops an unrelated develop-only constructor parameter that does not exist on the release line; the change itself is intact.
- build: bump app version to 1.16.1+2.

## Testing

- flutter analyze clean, full flutter test suite passes (1005 tests, pre-push)
- Three of four cherry-picks applied clean from the develop squash commits; the settings one needed the trivial context resolution described above