### PR TITLE
build: bump app version to 1.16.0+8

### DIFF
--- a/lib/features/call/view/call_screen_style.dart
+++ b/lib/features/call/view/call_screen_style.dart
@@ -166,6 +166,7 @@ class CallScreenActionsStyle with Diagnosticable {
     this.held,
     this.swap,
     this.key,
+    this.keypadInputTextStyle,
   });
 
   final ButtonStyle? callStart;
@@ -178,6 +179,9 @@ class CallScreenActionsStyle with Diagnosticable {
   final ButtonStyle? swap;
   final ButtonStyle? key;
 
+  /// Text style for the digits typed on the in-call DTMF keypad.
+  final TextStyle? keypadInputTextStyle;
+
   CallScreenActionsStyle copyWith({
     ButtonStyle? callStart,
     ButtonStyle? hangup,
@@ -188,6 +192,7 @@ class CallScreenActionsStyle with Diagnosticable {
     ButtonStyle? held,
     ButtonStyle? swap,
     ButtonStyle? key,
+    TextStyle? keypadInputTextStyle,
   }) {
     return CallScreenActionsStyle(
       callStart: callStart ?? this.callStart,
@@ -199,6 +204,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: held ?? this.held,
       swap: swap ?? this.swap,
       key: key ?? this.key,
+      keypadInputTextStyle: keypadInputTextStyle ?? this.keypadInputTextStyle,
     );
   }
 
@@ -207,6 +213,11 @@ class CallScreenActionsStyle with Diagnosticable {
     if (other == null) return this;
 
     ButtonStyle? mergeButtonStyle(ButtonStyle? a, ButtonStyle? b) {
+      if (a == null) return b;
+      return a.merge(b);
+    }
+
+    TextStyle? mergeTextStyle(TextStyle? a, TextStyle? b) {
       if (a == null) return b;
       return a.merge(b);
     }
@@ -221,6 +232,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: mergeButtonStyle(held, other.held),
       swap: mergeButtonStyle(swap, other.swap),
       key: mergeButtonStyle(key, other.key),
+      keypadInputTextStyle: mergeTextStyle(keypadInputTextStyle, other.keypadInputTextStyle),
     );
   }
 
@@ -236,6 +248,7 @@ class CallScreenActionsStyle with Diagnosticable {
       held: ButtonStyle.lerp(a?.held, b?.held, t),
       swap: ButtonStyle.lerp(a?.swap, b?.swap, t),
       key: ButtonStyle.lerp(a?.key, b?.key, t),
+      keypadInputTextStyle: TextStyle.lerp(a?.keypadInputTextStyle, b?.keypadInputTextStyle, t),
     );
   }
 
@@ -251,6 +264,7 @@ class CallScreenActionsStyle with Diagnosticable {
       ..add(DiagnosticsProperty<ButtonStyle?>('speaker', speaker))
       ..add(DiagnosticsProperty<ButtonStyle?>('held', held))
       ..add(DiagnosticsProperty<ButtonStyle?>('swap', swap))
-      ..add(DiagnosticsProperty<ButtonStyle?>('key', key));
+      ..add(DiagnosticsProperty<ButtonStyle?>('key', key))
+      ..add(DiagnosticsProperty<TextStyle?>('keypadInputTextStyle', keypadInputTextStyle));
   }
 }

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -130,7 +130,9 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
 
   void computeDimensions() {
     _inputDecorations = _themeData.extension<InputDecorations>();
-    _textStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
+    final baseKeypadInputStyle = _themeData.textTheme.displaySmall?.copyWith(color: _themeData.colorScheme.surface);
+    final configuredKeypadInputStyle = widget.style?.keypadInputTextStyle;
+    _textStyle = baseKeypadInputStyle?.merge(configuredKeypadInputStyle) ?? configuredKeypadInputStyle;
 
     _iconSize = _themeData.textTheme.headlineLarge?.fontSize;
 

--- a/lib/theme/factory/styles/call_screen_style_factory.dart
+++ b/lib/theme/factory/styles/call_screen_style_factory.dart
@@ -128,6 +128,28 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
     );
   }
 
+  /// Resolves the in-call keypad input text style so it can be merged over the
+  /// widget's base [TextTheme.displaySmall]. [TextStyleConfig.toTextStyle]
+  /// always emits a non-null fontWeight/fontStyle, which would override the base
+  /// during the merge; keep them only when the config sets them, so unset fields
+  /// inherit the base weight/style instead of being forced to normal.
+  TextStyle? _resolveKeypadInputTextStyle(TextStyleConfig? config) {
+    if (config == null) return null;
+    final resolved = config.toTextStyle(defaultFontFamily: defaultFontFamily);
+    return TextStyle(
+      fontFamily: resolved.fontFamily,
+      fontSize: resolved.fontSize,
+      fontWeight: config.fontWeight != null ? resolved.fontWeight : null,
+      fontStyle: config.fontStyle != null ? resolved.fontStyle : null,
+      color: resolved.color,
+      letterSpacing: resolved.letterSpacing,
+      wordSpacing: resolved.wordSpacing,
+      height: resolved.height,
+      decoration: resolved.decoration,
+      backgroundColor: resolved.backgroundColor,
+    );
+  }
+
   CallScreenActionsStyle? _resolveActionsStyle({
     CallPageActionsConfig? fromPage,
     // TODO(Serdun): Remove in future major release after migrating to CallPageActionsConfig
@@ -204,6 +226,7 @@ class CallScreenStyleFactory implements ThemeStyleFactory<CallScreenStyles> {
         baseBg: colors.surfaceContainerHigh,
         baseIcon: colors.onSurface,
       ),
+      keypadInputTextStyle: _resolveKeypadInputTextStyle(a.keypadInputStyle),
     );
   }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.dart
@@ -343,6 +343,7 @@ class CallPageActionsConfig with _$CallPageActionsConfig {
     this.held = const ElevatedButtonWidgetConfig(),
     this.swap = const ElevatedButtonWidgetConfig(),
     this.key = const ElevatedButtonWidgetConfig(),
+    this.keypadInputStyle,
   });
 
   @override
@@ -371,6 +372,12 @@ class CallPageActionsConfig with _$CallPageActionsConfig {
 
   @override
   final ElevatedButtonWidgetConfig key;
+
+  /// Text style for the digits typed on the in-call DTMF keypad (the value shown
+  /// above the keys). When unset the app falls back to its default display text
+  /// style for the keypad input.
+  @override
+  final TextStyleConfig? keypadInputStyle;
 
   factory CallPageActionsConfig.fromJson(Map<String, Object?> json) => _$CallPageActionsConfigFromJson(json);
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.freezed.dart
@@ -2098,7 +2098,7 @@ case _:
 /// @nodoc
 mixin _$CallPageActionsConfig {
 
- ElevatedButtonWidgetConfig get callStart; ElevatedButtonWidgetConfig get hangup; ElevatedButtonWidgetConfig get transfer; ElevatedButtonWidgetConfig get camera; ElevatedButtonWidgetConfig get muted; ElevatedButtonWidgetConfig get speaker; ElevatedButtonWidgetConfig get held; ElevatedButtonWidgetConfig get swap; ElevatedButtonWidgetConfig get key;
+ ElevatedButtonWidgetConfig get callStart; ElevatedButtonWidgetConfig get hangup; ElevatedButtonWidgetConfig get transfer; ElevatedButtonWidgetConfig get camera; ElevatedButtonWidgetConfig get muted; ElevatedButtonWidgetConfig get speaker; ElevatedButtonWidgetConfig get held; ElevatedButtonWidgetConfig get swap; ElevatedButtonWidgetConfig get key; TextStyleConfig? get keypadInputStyle;
 /// Create a copy of CallPageActionsConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2109,16 +2109,16 @@ $CallPageActionsConfigCopyWith<CallPageActionsConfig> get copyWith => _$CallPage
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageActionsConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.hangup, hangup) || other.hangup == hangup)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&(identical(other.camera, camera) || other.camera == camera)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.speaker, speaker) || other.speaker == speaker)&&(identical(other.held, held) || other.held == held)&&(identical(other.swap, swap) || other.swap == swap)&&(identical(other.key, key) || other.key == key));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallPageActionsConfig&&(identical(other.callStart, callStart) || other.callStart == callStart)&&(identical(other.hangup, hangup) || other.hangup == hangup)&&(identical(other.transfer, transfer) || other.transfer == transfer)&&(identical(other.camera, camera) || other.camera == camera)&&(identical(other.muted, muted) || other.muted == muted)&&(identical(other.speaker, speaker) || other.speaker == speaker)&&(identical(other.held, held) || other.held == held)&&(identical(other.swap, swap) || other.swap == swap)&&(identical(other.key, key) || other.key == key)&&(identical(other.keypadInputStyle, keypadInputStyle) || other.keypadInputStyle == keypadInputStyle));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,callStart,hangup,transfer,camera,muted,speaker,held,swap,key);
+int get hashCode => Object.hash(runtimeType,callStart,hangup,transfer,camera,muted,speaker,held,swap,key,keypadInputStyle);
 
 @override
 String toString() {
-  return 'CallPageActionsConfig(callStart: $callStart, hangup: $hangup, transfer: $transfer, camera: $camera, muted: $muted, speaker: $speaker, held: $held, swap: $swap, key: $key)';
+  return 'CallPageActionsConfig(callStart: $callStart, hangup: $hangup, transfer: $transfer, camera: $camera, muted: $muted, speaker: $speaker, held: $held, swap: $swap, key: $key, keypadInputStyle: $keypadInputStyle)';
 }
 
 
@@ -2129,7 +2129,7 @@ abstract mixin class $CallPageActionsConfigCopyWith<$Res>  {
   factory $CallPageActionsConfigCopyWith(CallPageActionsConfig value, $Res Function(CallPageActionsConfig) _then) = _$CallPageActionsConfigCopyWithImpl;
 @useResult
 $Res call({
- ElevatedButtonWidgetConfig callStart, ElevatedButtonWidgetConfig hangup, ElevatedButtonWidgetConfig transfer, ElevatedButtonWidgetConfig camera, ElevatedButtonWidgetConfig muted, ElevatedButtonWidgetConfig speaker, ElevatedButtonWidgetConfig held, ElevatedButtonWidgetConfig swap, ElevatedButtonWidgetConfig key
+ ElevatedButtonWidgetConfig callStart, ElevatedButtonWidgetConfig hangup, ElevatedButtonWidgetConfig transfer, ElevatedButtonWidgetConfig camera, ElevatedButtonWidgetConfig muted, ElevatedButtonWidgetConfig speaker, ElevatedButtonWidgetConfig held, ElevatedButtonWidgetConfig swap, ElevatedButtonWidgetConfig key, TextStyleConfig? keypadInputStyle
 });
 
 
@@ -2146,7 +2146,7 @@ class _$CallPageActionsConfigCopyWithImpl<$Res>
 
 /// Create a copy of CallPageActionsConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? hangup = null,Object? transfer = null,Object? camera = null,Object? muted = null,Object? speaker = null,Object? held = null,Object? swap = null,Object? key = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? callStart = null,Object? hangup = null,Object? transfer = null,Object? camera = null,Object? muted = null,Object? speaker = null,Object? held = null,Object? swap = null,Object? key = null,Object? keypadInputStyle = freezed,}) {
   return _then(CallPageActionsConfig(
 callStart: null == callStart ? _self.callStart : callStart // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,hangup: null == hangup ? _self.hangup : hangup // ignore: cast_nullable_to_non_nullable
@@ -2157,7 +2157,8 @@ as ElevatedButtonWidgetConfig,speaker: null == speaker ? _self.speaker : speaker
 as ElevatedButtonWidgetConfig,held: null == held ? _self.held : held // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,swap: null == swap ? _self.swap : swap // ignore: cast_nullable_to_non_nullable
 as ElevatedButtonWidgetConfig,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
-as ElevatedButtonWidgetConfig,
+as ElevatedButtonWidgetConfig,keypadInputStyle: freezed == keypadInputStyle ? _self.keypadInputStyle : keypadInputStyle // ignore: cast_nullable_to_non_nullable
+as TextStyleConfig?,
   ));
 }
 

--- a/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/theme_page_config.g.dart
@@ -402,6 +402,11 @@ CallPageActionsConfig _$CallPageActionsConfigFromJson(
       : ElevatedButtonWidgetConfig.fromJson(
           json['key'] as Map<String, dynamic>,
         ),
+  keypadInputStyle: json['keypadInputStyle'] == null
+      ? null
+      : TextStyleConfig.fromJson(
+          json['keypadInputStyle'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$CallPageActionsConfigToJson(
@@ -416,6 +421,7 @@ Map<String, dynamic> _$CallPageActionsConfigToJson(
   'held': instance.held.toJson(),
   'swap': instance.swap.toJson(),
   'key': instance.key.toJson(),
+  'keypadInputStyle': instance.keypadInputStyle?.toJson(),
 };
 
 CallPageInfoConfig _$CallPageInfoConfigFromJson(Map<String, dynamic> json) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.0+7
+app_version: 1.16.0+8
 
 environment:
   sdk: ^3.12.0

--- a/screenshots/lib/mocks/interactive_call_bloc.dart
+++ b/screenshots/lib/mocks/interactive_call_bloc.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart' show Registration, RegistrationStatus;
 
 import 'package:screenshots/data/data.dart';
 
@@ -20,7 +21,13 @@ class InteractiveCallBloc extends Cubit<CallState> implements CallBloc {
     : _callId = (video ? dVideoActiveCall : dAudioActiveCall).callId,
       super(
         CallState(
-          callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+          // A registered signaling client yields CallStatus.ready, which the call
+          // screen requires to enable keypad/hold/transfer actions. Without it the
+          // status stays inProgress ("Connecting...") and those buttons are disabled.
+          callServiceState: const CallServiceState(
+            signalingClientStatus: SignalingClientStatus.connect,
+            registration: Registration(status: RegistrationStatus.registered),
+          ),
           activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
           // Built-in earpiece + speaker so the speaker toggle renders and can switch.
           audioDevice: _earpiece,

--- a/screenshots/lib/mocks/mock_call_bloc.dart
+++ b/screenshots/lib/mocks/mock_call_bloc.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart' show Registration, RegistrationStatus;
 
 import 'package:screenshots/data/data.dart';
 
@@ -38,7 +39,12 @@ class MockCallBloc extends MockBloc<CallEvent, CallState> implements CallBloc {
       mock,
       const Stream<CallState>.empty(),
       initialState: CallState(
-        callServiceState: const CallServiceState(signalingClientStatus: SignalingClientStatus.connect),
+        // Registered signaling -> CallStatus.ready, so the active call renders as
+        // connected instead of a perpetual "Connecting..." state.
+        callServiceState: const CallServiceState(
+          signalingClientStatus: SignalingClientStatus.connect,
+          registration: Registration(status: RegistrationStatus.registered),
+        ),
         activeCalls: [if (video) dVideoActiveCall else dAudioActiveCall],
       ),
     );

--- a/screenshots/pubspec.yaml
+++ b/screenshots/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
     sdk: flutter
   webtrit_phone:
     path: ..
+  webtrit_signaling:
+    path: ../packages/webtrit_signaling
   mocktail: ^1.0.4
   provider: ^6.0.0
 


### PR DESCRIPTION
## Overview

Patch for the 1.16.0 release line: cherry-picks two develop changes and bumps the app version iteration.

- fix(screenshots): register signaling so call preview reaches ready state - the configurator's call preview screenshot registers the mock signaling layer, so the preview renders the ready in-call state instead of hanging in connecting (dev-only screenshots package, not shipped in the app binary).
- feat(call): configurable text style for in-call keypad input - the in-call keypad input text style becomes configurable through the theme page config, so white-label themes can adjust it instead of inheriting the hardcoded style.
- build: bump app version to 1.16.0+8.

The two language fixes that also land on the 1.16.1 line were intentionally NOT backported here: this release line predates both the per-brand language allowlist (nothing narrows the language list, so there is no stale selection to reconcile) and the Thai locale (the string being capitalized does not exist).

## Testing

- flutter analyze clean, full flutter test suite passes (933 tests, pre-push)
- Both cherry-picks applied clean from the develop squash commits