### PR TITLE
build: disable adaptive icon foreground inset in launcher icons config

### DIFF
--- a/makefile
+++ b/makefile
@@ -142,6 +142,9 @@ generate-launcher-icons-config:
 	@echo "  min_sdk_android: 23" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  adaptive_icon_background: \"$${ICON_BACKGROUND_COLOR:-$(ICON_BACKGROUND_COLOR)}\"" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  adaptive_icon_foreground: \"$${LAUNCHER_ICON_FOREGROUND:-$(LAUNCHER_ICON_FOREGROUND)}\"" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
+# The configurator export already bakes the adaptive safe-zone padding into the
+# foreground PNG; the package default inset of 16% would shrink the logo twice.
+	@echo "  adaptive_icon_foreground_inset: 0" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  ios: true" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  background_color_ios: \"$${ICON_BACKGROUND_COLOR:-$(ICON_BACKGROUND_COLOR)}\"" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  remove_alpha_ios: true" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)

--- a/tool/configs/flutter_launcher_icons.yaml
+++ b/tool/configs/flutter_launcher_icons.yaml
@@ -4,6 +4,10 @@ flutter_launcher_icons:
   min_sdk_android: 23
   adaptive_icon_background: "#123752"
   adaptive_icon_foreground: "tool/assets/launcher_icons/ic_foreground.png"
+  # The configurator export already bakes the adaptive safe-zone padding into
+  # the foreground PNG; the package default inset of 16% would shrink the logo
+  # twice.
+  adaptive_icon_foreground_inset: 0
   ios: true
   remove_alpha_ios: true
   image_path_ios: "tool/assets/launcher_icons/ios.png"


### PR DESCRIPTION
## Overview

On Android the launcher icon renders noticeably smaller than the configurator preview shows: the logo occupies about 62% of the visible icon circle instead of the expected 92%.

Root cause is a double inset. The configurator already bakes the adaptive safe-zone padding into the exported foreground PNG (108 dp canvas, logo fitted into the 66 dp safe zone). On top of that, flutter_launcher_icons 0.14.0+ introduced adaptive_icon_foreground_inset with a default of 16%, which wraps the foreground drawable in an inset element in ic_launcher.xml. That default assumes a full-bleed source image, so our pre-padded foreground gets shrunk a second time (66 dp x 0.68 = 44.9 dp inside the 72 dp mask). Confirmed by decoding ic_launcher.xml from production APKs: it carries inset 16%.

The fix sets adaptive_icon_foreground_inset: 0 in both places that produce the flutter_launcher_icons config:
- the generate-launcher-icons-config makefile target (used by the builder pipeline);
- the static tool/configs/flutter_launcher_icons.yaml (used by melos run icons:generate).

Verified by running dart run flutter_launcher_icons with the updated config: the generated mipmap-anydpi-v26/ic_launcher.xml now contains inset 0%, so the icon on device matches the configurator preview. iOS, web, and legacy Android icons are unaffected (the inset only exists in the Android adaptive XML).