### PR TITLE
build: bump app version to 1.16.1+3

### DIFF
--- a/makefile
+++ b/makefile
@@ -142,6 +142,9 @@ generate-launcher-icons-config:
 	@echo "  min_sdk_android: 23" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  adaptive_icon_background: \"$${ICON_BACKGROUND_COLOR:-$(ICON_BACKGROUND_COLOR)}\"" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  adaptive_icon_foreground: \"$${LAUNCHER_ICON_FOREGROUND:-$(LAUNCHER_ICON_FOREGROUND)}\"" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
+# The configurator export already bakes the adaptive safe-zone padding into the
+# foreground PNG; the package default inset of 16% would shrink the logo twice.
+	@echo "  adaptive_icon_foreground_inset: 0" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  ios: true" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  background_color_ios: \"$${ICON_BACKGROUND_COLOR:-$(ICON_BACKGROUND_COLOR)}\"" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)
 	@echo "  remove_alpha_ios: true" >> $(FLUTTER_LAUNCHER_ICONS_CONFIG)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ version: 0.0.0+0
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.1+2
+app_version: 1.16.1+3
 
 environment:
   sdk: ^3.12.0

--- a/tool/configs/flutter_launcher_icons.yaml
+++ b/tool/configs/flutter_launcher_icons.yaml
@@ -4,6 +4,10 @@ flutter_launcher_icons:
   min_sdk_android: 23
   adaptive_icon_background: "#123752"
   adaptive_icon_foreground: "tool/assets/launcher_icons/ic_foreground.png"
+  # The configurator export already bakes the adaptive safe-zone padding into
+  # the foreground PNG; the package default inset of 16% would shrink the logo
+  # twice.
+  adaptive_icon_foreground_inset: 0
   ios: true
   remove_alpha_ios: true
   image_path_ios: "tool/assets/launcher_icons/ios.png"


### PR DESCRIPTION
## Overview

Cherry-pick of #1502 into the 1.16.1 release line.

Disables the default 16% adaptive_icon_foreground_inset of flutter_launcher_icons 0.14+ in both config sources (the generate-launcher-icons-config makefile target and tool/configs/flutter_launcher_icons.yaml). The configurator export already bakes the adaptive safe-zone padding into the foreground PNG, so the default inset shrank the Android launcher icon a second time (~62% of the visible circle instead of ~92%).

Bumps app_version to 1.16.1+3 so rebuilt artifacts are distinguishable.