### PR TITLE
style: settle formatter debt in untouched files

### DIFF
--- a/lib/models/integration/raw_http_request.g.dart
+++ b/lib/models/integration/raw_http_request.g.dart
@@ -6,20 +6,16 @@ part of 'raw_http_request.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-RawHttpRequest _$RawHttpRequestFromJson(Map<String, dynamic> json) =>
-    RawHttpRequest(
-      method: json['method'] as String,
-      url: json['url'] as String,
-      headers: (json['headers'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-      data: json['data'] as Map<String, dynamic>?,
-    );
+RawHttpRequest _$RawHttpRequestFromJson(Map<String, dynamic> json) => RawHttpRequest(
+  method: json['method'] as String,
+  url: json['url'] as String,
+  headers: (json['headers'] as Map<String, dynamic>?)?.map((k, e) => MapEntry(k, e as String)),
+  data: json['data'] as Map<String, dynamic>?,
+);
 
-Map<String, dynamic> _$RawHttpRequestToJson(RawHttpRequest instance) =>
-    <String, dynamic>{
-      'method': instance.method,
-      'url': instance.url,
-      'headers': instance.headers,
-      'data': instance.data,
-    };
+Map<String, dynamic> _$RawHttpRequestToJson(RawHttpRequest instance) => <String, dynamic>{
+  'method': instance.method,
+  'url': instance.url,
+  'headers': instance.headers,
+  'data': instance.data,
+};

--- a/lib/models/metrics/media_query_metrics.g.dart
+++ b/lib/models/metrics/media_query_metrics.g.dart
@@ -6,18 +6,16 @@ part of 'media_query_metrics.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-MediaQueryMetrics _$MediaQueryMetricsFromJson(Map<String, dynamic> json) =>
-    MediaQueryMetrics(
-      brightness: json['brightness'] as String,
-      devicePixelRatio: (json['devicePixelRatio'] as num).toDouble(),
-      topSafeInset: (json['topSafeInset'] as num).toInt(),
-      bottomSafeInset: (json['bottomSafeInset'] as num).toInt(),
-    );
+MediaQueryMetrics _$MediaQueryMetricsFromJson(Map<String, dynamic> json) => MediaQueryMetrics(
+  brightness: json['brightness'] as String,
+  devicePixelRatio: (json['devicePixelRatio'] as num).toDouble(),
+  topSafeInset: (json['topSafeInset'] as num).toInt(),
+  bottomSafeInset: (json['bottomSafeInset'] as num).toInt(),
+);
 
-Map<String, dynamic> _$MediaQueryMetricsToJson(MediaQueryMetrics instance) =>
-    <String, dynamic>{
-      'brightness': instance.brightness,
-      'devicePixelRatio': instance.devicePixelRatio,
-      'topSafeInset': instance.topSafeInset,
-      'bottomSafeInset': instance.bottomSafeInset,
-    };
+Map<String, dynamic> _$MediaQueryMetricsToJson(MediaQueryMetrics instance) => <String, dynamic>{
+  'brightness': instance.brightness,
+  'devicePixelRatio': instance.devicePixelRatio,
+  'topSafeInset': instance.topSafeInset,
+  'bottomSafeInset': instance.bottomSafeInset,
+};

--- a/lib/widgets/no_data_placeholder.dart
+++ b/lib/widgets/no_data_placeholder.dart
@@ -104,14 +104,7 @@ class NoDataPlaceholder extends StatelessWidget {
     }
 
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ?iconWidget,
-          ?contentWidget,
-          ?actionsWidget,
-        ],
-      ),
+      child: Column(mainAxisSize: MainAxisSize.min, children: [?iconWidget, ?contentWidget, ?actionsWidget]),
     );
   }
 }

--- a/packages/data/app_database/lib/src/daos/dialog_info_dao.dart
+++ b/packages/data/app_database/lib/src/daos/dialog_info_dao.dart
@@ -29,8 +29,7 @@ class DialogInfoDao extends DatabaseAccessor<AppDatabase> with _$DialogInfoDaoMi
   }
 
   Future<int> deleteDialogInfoByIdsAndNumber(List<String> ids, String number) {
-    final query = delete(dialogInfoTable)
-      ..where((tbl) => tbl.entityNumber.equals(number) & tbl.idKey.isIn(ids));
+    final query = delete(dialogInfoTable)..where((tbl) => tbl.entityNumber.equals(number) & tbl.idKey.isIn(ids));
     return query.go();
   }
 }


### PR DESCRIPTION
## Overview

A few files did not match the current `dart format` output, so every formatter or build_runner run over them kept producing unrelated churn inside feature branches. This settles that debt once on develop:

- `dialog_info_dao.dart` - line wrap and a missing trailing newline;
- `no_data_placeholder.dart` - column literal collapsed to the current formatter shape;
- `raw_http_request.g.dart`, `media_query_metrics.g.dart` - regenerated json_serializable outputs reformatted to the current style.

No behavior changes; `flutter analyze` clean.