### PR TITLE
fix: resolve colliding voicemail contacts deterministically (WT-719)

### DIFF
--- a/packages/data/app_database/lib/src/daos/voicemail_dao.dart
+++ b/packages/data/app_database/lib/src/daos/voicemail_dao.dart
@@ -42,41 +42,43 @@ class VoicemailDao extends DatabaseAccessor<AppDatabase> with _$VoicemailDaoMixi
   }
 
   Future<List<VoicemailWithContact>> getVoicemailsWithContacts() async {
-    final voicemail = voicemailTable;
-    final contactPhones = db.contactPhonesTable;
-    final contacts = db.contactsTable;
-
-    final query = select(voicemail).join([
-      leftOuterJoin(contactPhones, contactPhones.number.equalsExp(voicemail.sender)),
-      leftOuterJoin(contacts, contacts.id.equalsExp(contactPhones.contactId)),
-    ]);
-
-    final rows = await query.get();
-
-    return rows.map((row) {
-      final voicemail = row.readTable(voicemailTable);
-      final contact = row.readTableOrNull(contacts);
-      return VoicemailWithContact(voicemail: voicemail, contact: contact);
-    }).toList();
+    final rows = await _voicemailsWithContactsQuery().get();
+    return _collapseVoicemailRows(rows);
   }
 
   Stream<List<VoicemailWithContact>> watchVoicemailsWithContacts() {
+    return _voicemailsWithContactsQuery().watch().map(_collapseVoicemailRows);
+  }
+
+  JoinedSelectStatement _voicemailsWithContactsQuery() {
     final voicemail = voicemailTable;
     final contactPhones = db.contactPhonesTable;
     final contacts = db.contactsTable;
 
-    final query = select(voicemail).join([
-      leftOuterJoin(contactPhones, contactPhones.number.equalsExp(voicemail.sender)),
-      leftOuterJoin(contacts, contacts.id.equalsExp(contactPhones.contactId)),
-    ]);
+    return select(voicemail).join([
+        leftOuterJoin(contactPhones, contactPhones.number.equalsExp(voicemail.sender)),
+        leftOuterJoin(contacts, contacts.id.equalsExp(contactPhones.contactId)),
+      ])
+      // The trailing source-priority term is a per-voicemail tie-break so a
+      // sender number shared by a local and an external (PBX) contact
+      // resolves to the external one (the first row kept by the collapse).
+      ..orderBy([OrderingTerm.asc(voicemail.rowId), ...contacts.sourcePriorityOrder()]);
+  }
 
-    return query.watch().map((rows) {
-      return rows.map((row) {
-        final voicemail = row.readTable(voicemailTable);
-        final contact = row.readTableOrNull(contacts);
-        return VoicemailWithContact(voicemail: voicemail, contact: contact);
-      }).toList();
-    });
+  /// The contact join yields one row per matching contact; keep exactly one
+  /// entry per voicemail, letting the ordering above pick the winner.
+  List<VoicemailWithContact> _collapseVoicemailRows(List<TypedResult> rows) {
+    final byId = <String, VoicemailWithContact>{};
+
+    for (final row in rows) {
+      final voicemail = row.readTable(voicemailTable);
+      byId.putIfAbsent(
+        voicemail.id,
+        () => VoicemailWithContact(voicemail: voicemail, contact: row.readTableOrNull(db.contactsTable)),
+      );
+    }
+
+    return byId.values.toList();
   }
 }
 

--- a/packages/data/app_database/test/voicemail_dao_test.dart
+++ b/packages/data/app_database/test/voicemail_dao_test.dart
@@ -1,0 +1,63 @@
+import 'package:test/test.dart';
+
+import 'package:drift/native.dart';
+
+import 'package:app_database/app_database.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  VoicemailData createVoicemail({String id = 'vm-1'}) {
+    return VoicemailData(
+      id: id,
+      date: '2026-01-01T00:00:00Z',
+      duration: 3.5,
+      sender: '555001',
+      receiver: '555002',
+      seen: false,
+      size: 5,
+      type: 'voice',
+    );
+  }
+
+  group('contact resolution', () {
+    test('collapses colliding contacts to one deterministic row per voicemail', () async {
+      await db.contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.local),
+          sourceId: Value('local-1'),
+          firstName: Value('Local'),
+          lastName: Value('Contact'),
+        ),
+      );
+      await db.contactsDao.insertOnUniqueConflictUpdateContact(
+        ContactDataCompanion(
+          sourceType: Value(ContactSourceTypeEnum.external),
+          sourceId: Value('pbx-1'),
+          firstName: Value('External'),
+          lastName: Value('Contact'),
+        ),
+      );
+      await db.contactPhonesDao.insertOnUniqueConflictUpdateContactPhone(
+        ContactPhoneDataCompanion(contactId: Value(1), number: Value('555001'), label: Value('Home')),
+      );
+      await db.contactPhonesDao.insertOnUniqueConflictUpdateContactPhone(
+        ContactPhoneDataCompanion(contactId: Value(2), number: Value('555001'), label: Value('Work')),
+      );
+      await db.voicemailDao.insertOrUpdateVoicemail(createVoicemail());
+
+      final rows = await db.voicemailDao.getVoicemailsWithContacts();
+
+      expect(rows, hasLength(1));
+      expect(rows.single.contact?.sourceType, ContactSourceTypeEnum.external);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

When a voicemail sender number is present in both the local (device phonebook) and the external (PBX) contact source, the voicemail-contact join returns one row per matching contact: the voicemail list shows the message twice, and which contact name wins is left to SQLite's unspecified row order.

The list query now applies the shared `sourcePriorityOrder()` tie-break (the same policy the recents list already uses: the external contact wins) and collapses the join to exactly one entry per voicemail. Covered by a dao test reproducing the collision.

Found while work on voicemail transcription branch, but the bug exists on develop independently of it.