### PR TITLE
refactor: import trusted certificates explicitly in the isolate manager

### DIFF
--- a/lib/features/call/services/isolate_manager.dart
+++ b/lib/features/call/services/isolate_manager.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:logging/logging.dart';
 
-import 'package:ssl_certificates/ssl_certificates.dart';
+import 'package:ssl_certificates/ssl_certificates.dart' show TrustedCertificates;
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';


### PR DESCRIPTION
## Overview

The isolate manager uses exactly one symbol from `ssl_certificates` (`TrustedCertificates`). The import now says so with a `show` combinator: the dependency is explicit, and an incidental re-export appearing elsewhere can never make the plain import look redundant (which is exactly what happened on a feature branch, where the analyzer suggested dropping it while develop still needs it).

No behavior changes; `flutter analyze` clean.