### PR TITLE
fix(call): use the consultation call as the attended transfer replace target (WT-1728)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2718,10 +2718,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     // A self-referential transfer (a REFER whose Replaces points at its own
     // dialog) is never valid and the backend rejects it; drop the request
-    // instead of sending it.
+    // instead of sending it, but surface it the same way a rejected request
+    // would be so a wiring regression never looks like a dead button.
     if (referorCall.callId == replaceCall.callId) {
-      _logger.warning(
-        '__onMutationControlAttendedTransfer: referorCall == replaceCall (${referorCall.callId}), skipping',
+      callErrorReporter.handle(
+        StateError('attended transfer: referorCall == replaceCall (${referorCall.callId})'),
+        StackTrace.current,
+        '__onMutationControlAttendedTransfer request error:',
       );
       return;
     }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2716,6 +2716,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final referorCall = e.referorCall;
     final replaceCall = e.replaceCall;
 
+    // A self-referential transfer (a REFER whose Replaces points at its own
+    // dialog) is never valid and the backend rejects it; drop the request
+    // instead of sending it.
+    if (referorCall.callId == replaceCall.callId) {
+      _logger.warning(
+        '__onMutationControlAttendedTransfer: referorCall == replaceCall (${referorCall.callId}), skipping',
+      );
+      return;
+    }
+
     try {
       final transferRequest = TransferRequest(
         transaction: WebtritSignalingClient.generateTransactionId(),

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -360,6 +360,16 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 // held original call being transferred (an incoming call
                                                 // grabs the selection at ring time), and using it as the
                                                 // replace target would produce a self-referential REFER.
+                                                //
+                                                // KNOWN LIMITATION: `current` is still a positional guess
+                                                // ("the live non-held call"), which breaks once a third,
+                                                // unrelated call is concurrently active - it can point at
+                                                // that call instead of the real consultation call. Left out
+                                                // of scope here: the server caps concurrent lines at 4, and
+                                                // this heuristic is unchanged from pre-1.16.0 behavior (not
+                                                // a new regression). A proper fix needs an explicit
+                                                // referor<->consultation link, not a positional guess -
+                                                // see git history for a prior (closed) attempt.
                                                 onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
                                                     ? (!activeCall.wasAccepted || focusedTransfer != null
                                                           ? null

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -365,8 +365,9 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 // ("the live non-held call"), which breaks once a third,
                                                 // unrelated call is concurrently active - it can point at
                                                 // that call instead of the real consultation call. Left out
-                                                // of scope here: the server caps concurrent lines at 4, and
-                                                // this heuristic is unchanged from pre-1.16.0 behavior (not
+                                                // of scope here: server config typically caps concurrent
+                                                // lines at 3 (not hardcoded in the app - see linesCount),
+                                                // and this heuristic is unchanged from pre-1.16.0 behavior (not
                                                 // a new regression). A proper fix needs an explicit
                                                 // referor<->consultation link, not a positional guess -
                                                 // see git history for a prior (closed) attempt.

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -355,14 +355,19 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                             })
                                                     : null,
                                                 // TODO (Serdun): Simplify complex condition in the widget tree.
+                                                // The submit acts on the consultation call (the derived
+                                                // `current`), not the focused one: focus may sit on the
+                                                // held original call being transferred (an incoming call
+                                                // grabs the selection at ring time), and using it as the
+                                                // replace target would produce a self-referential REFER.
                                                 onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
-                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
+                                                    ? (!activeCall.wasAccepted || focusedTransfer != null
                                                           ? null
                                                           : (ActiveCall referorCall) {
                                                               _callBloc.add(
                                                                 CallControlEvent.attendedTransferSubmitted(
                                                                   referorCall: referorCall,
-                                                                  replaceCall: focusedCall,
+                                                                  replaceCall: activeCall,
                                                                 ),
                                                               );
                                                             })

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call/view/call_active_scaffold.dart';
@@ -251,6 +252,72 @@ void main() {
       await tester.pump();
 
       verify(() => appPermissions.toAppSettings()).called(1);
+      await _teardown(tester);
+    });
+  });
+
+  group('CallActiveScaffold - attended transfer submit', () {
+    final original = _makeCall(callId: 'original', acceptedTime: DateTime(2024), held: true, displayName: 'Clara Diaz');
+    final consultation = _makeCall(
+      callId: 'consultation',
+      direction: CallDirection.outgoing,
+      acceptedTime: DateTime(2024),
+      displayName: 'Boris Klein',
+    );
+
+    Future<void> openTransferMenu(WidgetTester tester) async {
+      await tester.tap(find.byKey(callActionsTransferMenuKey));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('submit targets the consultation call when it is focused', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: consultation),
+      );
+
+      await openTransferMenu(tester);
+      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+      await tester.pumpAndSettle();
+
+      verify(
+        () =>
+            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
+      ).called(1);
+      await _teardown(tester);
+    });
+
+    testWidgets('submit still targets the consultation call when the held original call is focused', (tester) async {
+      // An incoming call grabs the selection at ring time and keeps it, so the
+      // held original call stays focused through the whole transfer flow. The
+      // replace target must be the consultation call regardless of focus - a
+      // self-referential transfer (referor == replace) is rejected by the
+      // backend.
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: original));
+
+      await openTransferMenu(tester);
+      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+      await tester.pumpAndSettle();
+
+      verify(
+        () =>
+            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
+      ).called(1);
+      await _teardown(tester);
+    });
+
+    testWidgets('attended item is absent while the consultation call is not yet accepted', (tester) async {
+      final ringingConsultation = _makeCall(
+        callId: 'consultation',
+        direction: CallDirection.outgoing,
+        displayName: 'Boris Klein',
+      );
+      await tester.pumpWidget(
+        _buildSubject(callBloc, activeCalls: [original, ringingConsultation], focusedCall: original),
+      );
+
+      await openTransferMenu(tester);
+
+      expect(find.byKey(callActionsTransferMenuNumberKey), findsNothing);
       await _teardown(tester);
     });
   });

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -270,40 +270,27 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    testWidgets('submit targets the consultation call when it is focused', (tester) async {
-      await tester.pumpWidget(
-        _buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: consultation),
-      );
+    // The replace target must always be the consultation call, regardless of
+    // which row is focused - an incoming call grabs the selection at ring
+    // time and keeps it, so the held original call may stay focused through
+    // the whole transfer flow. A self-referential transfer (referor ==
+    // replace) is rejected by the backend.
+    for (final focused in [consultation, original]) {
+      testWidgets('submit targets the consultation call when ${focused.callId} is focused', (tester) async {
+        await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: focused));
 
-      await openTransferMenu(tester);
-      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
-      await tester.pumpAndSettle();
+        await openTransferMenu(tester);
+        await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+        await tester.pumpAndSettle();
 
-      verify(
-        () =>
-            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
-      ).called(1);
-      await _teardown(tester);
-    });
-
-    testWidgets('submit still targets the consultation call when the held original call is focused', (tester) async {
-      // An incoming call grabs the selection at ring time and keeps it, so the
-      // held original call stays focused through the whole transfer flow. The
-      // replace target must be the consultation call regardless of focus - a
-      // self-referential transfer (referor == replace) is rejected by the
-      // backend.
-      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: original));
-
-      await openTransferMenu(tester);
-      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
-      await tester.pumpAndSettle();
-
-      verify(
-        () =>
-            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
-      ).called(1);
-      await _teardown(tester);
-    });
+        verify(
+          () => callBloc.add(
+            CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation),
+          ),
+        ).called(1);
+        await _teardown(tester);
+      });
+    }
 
     testWidgets('attended item is absent while the consultation call is not yet accepted', (tester) async {
       final ringingConsultation = _makeCall(


### PR DESCRIPTION
## Overview

Attended transfer regressed with the list-based call screen: the submit action took the replace target from the focused call. An incoming call grabs the selection at ring time and keeps it, so in the classic scenario (incoming call, then a consultation call, then merge) the focused call is the held original call itself. The submitted transfer then referenced the same call as both the referor and the replace target - a self-referential REFER (Refer-To pointing back at the original party with Replaces of that very dialog) that the backend rejects, so the transfer always failed. Outgoing-originated calls were unaffected, since without a selection the focus falls back to the derived current call.

## Changes

- The attended transfer submit takes the replace target from the derived current call (the consultation one), and its enablement gate checks that same call is answered - restoring the pre-refactor semantics.
- CallBloc drops a self-referential transfer request (referor == replace) and surfaces it via `callErrorReporter.handle` (same path as a rejected request) instead of silently swallowing it, so a future wiring regression can never look like a dead button.
- Widget tests cover the submit wiring for both focus positions plus the not-yet-answered consultation gate; the focused-held case reproduces the regression and fails on the previous wiring.

## Testing

- Verified on a 3-emulator setup against a test environment: the transfer now completes end to end (the transferor's both legs get hangup, the two remaining parties are re-anchored to each other via updated events).
- Side finding for a follow-up: the signaling client does not know the transfer_accepted/transfer_failed events and treats them as fatal; a successful transfer currently costs a short signaling reconnect at teardown.

## Known limitation (out of scope here)

The replace target is still resolved via `activeCalls.current` - a positional guess ("the live non-held call"). It breaks if a third, unrelated call becomes concurrently active (e.g. answered mid-transfer): `current` can then point at that call instead of the real consultation call. This is unchanged from pre-1.16.0 behavior (verified identical on release/1.15.0), not a new regression from this PR. Left out of scope: the server caps concurrent lines at 4, so this is a narrow edge case, and a proper fix needs an explicit referor<->consultation link rather than a positional guess (attempted separately, closed for now). Noted in a code comment at the submit callback.