### PR TITLE
build: bump app version to 1.16.0+10

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2657,10 +2657,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     // A self-referential transfer (a REFER whose Replaces points at its own
     // dialog) is never valid and the backend rejects it; drop the request
-    // instead of sending it.
+    // instead of sending it, but surface it the same way a rejected request
+    // would be so a wiring regression never looks like a dead button.
     if (referorCall.callId == replaceCall.callId) {
-      _logger.warning(
-        '__onMutationControlAttendedTransfer: referorCall == replaceCall (${referorCall.callId}), skipping',
+      callErrorReporter.handle(
+        StateError('attended transfer: referorCall == replaceCall (${referorCall.callId})'),
+        StackTrace.current,
+        '__onMutationControlAttendedTransfer request error:',
       );
       return;
     }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2655,6 +2655,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final referorCall = e.referorCall;
     final replaceCall = e.replaceCall;
 
+    // A self-referential transfer (a REFER whose Replaces points at its own
+    // dialog) is never valid and the backend rejects it; drop the request
+    // instead of sending it.
+    if (referorCall.callId == replaceCall.callId) {
+      _logger.warning(
+        '__onMutationControlAttendedTransfer: referorCall == replaceCall (${referorCall.callId}), skipping',
+      );
+      return;
+    }
+
     try {
       final transferRequest = TransferRequest(
         transaction: WebtritSignalingClient.generateTransactionId(),

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -364,6 +364,16 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 // held original call being transferred (an incoming call
                                                 // grabs the selection at ring time), and using it as the
                                                 // replace target would produce a self-referential REFER.
+                                                //
+                                                // KNOWN LIMITATION: `current` is still a positional guess
+                                                // ("the live non-held call"), which breaks once a third,
+                                                // unrelated call is concurrently active - it can point at
+                                                // that call instead of the real consultation call. Left out
+                                                // of scope here: the server caps concurrent lines at 4, and
+                                                // this heuristic is unchanged from pre-1.16.0 behavior (not
+                                                // a new regression). A proper fix needs an explicit
+                                                // referor<->consultation link, not a positional guess -
+                                                // see git history for a prior (closed) attempt.
                                                 onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
                                                     ? (!activeCall.wasAccepted || focusedTransfer != null
                                                           ? null

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -359,14 +359,19 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                             })
                                                     : null,
                                                 // TODO (Serdun): Simplify complex condition in the widget tree.
+                                                // The submit acts on the consultation call (the derived
+                                                // `current`), not the focused one: focus may sit on the
+                                                // held original call being transferred (an incoming call
+                                                // grabs the selection at ring time), and using it as the
+                                                // replace target would produce a self-referential REFER.
                                                 onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
-                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
+                                                    ? (!activeCall.wasAccepted || focusedTransfer != null
                                                           ? null
                                                           : (ActiveCall referorCall) {
                                                               _callBloc.add(
                                                                 CallControlEvent.attendedTransferSubmitted(
                                                                   referorCall: referorCall,
-                                                                  replaceCall: focusedCall,
+                                                                  replaceCall: activeCall,
                                                                 ),
                                                               );
                                                             })

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.0+9
+app_version: 1.16.0+10
 
 environment:
   sdk: ^3.12.0

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call/view/call_active_scaffold.dart';
@@ -251,6 +252,72 @@ void main() {
       await tester.pump();
 
       verify(() => appPermissions.toAppSettings()).called(1);
+      await _teardown(tester);
+    });
+  });
+
+  group('CallActiveScaffold - attended transfer submit', () {
+    final original = _makeCall(callId: 'original', acceptedTime: DateTime(2024), held: true, displayName: 'Clara Diaz');
+    final consultation = _makeCall(
+      callId: 'consultation',
+      direction: CallDirection.outgoing,
+      acceptedTime: DateTime(2024),
+      displayName: 'Boris Klein',
+    );
+
+    Future<void> openTransferMenu(WidgetTester tester) async {
+      await tester.tap(find.byKey(callActionsTransferMenuKey));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('submit targets the consultation call when it is focused', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: consultation),
+      );
+
+      await openTransferMenu(tester);
+      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+      await tester.pumpAndSettle();
+
+      verify(
+        () =>
+            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
+      ).called(1);
+      await _teardown(tester);
+    });
+
+    testWidgets('submit still targets the consultation call when the held original call is focused', (tester) async {
+      // An incoming call grabs the selection at ring time and keeps it, so the
+      // held original call stays focused through the whole transfer flow. The
+      // replace target must be the consultation call regardless of focus - a
+      // self-referential transfer (referor == replace) is rejected by the
+      // backend.
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: original));
+
+      await openTransferMenu(tester);
+      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+      await tester.pumpAndSettle();
+
+      verify(
+        () =>
+            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
+      ).called(1);
+      await _teardown(tester);
+    });
+
+    testWidgets('attended item is absent while the consultation call is not yet accepted', (tester) async {
+      final ringingConsultation = _makeCall(
+        callId: 'consultation',
+        direction: CallDirection.outgoing,
+        displayName: 'Boris Klein',
+      );
+      await tester.pumpWidget(
+        _buildSubject(callBloc, activeCalls: [original, ringingConsultation], focusedCall: original),
+      );
+
+      await openTransferMenu(tester);
+
+      expect(find.byKey(callActionsTransferMenuNumberKey), findsNothing);
       await _teardown(tester);
     });
   });

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -270,40 +270,27 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    testWidgets('submit targets the consultation call when it is focused', (tester) async {
-      await tester.pumpWidget(
-        _buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: consultation),
-      );
+    // The replace target must always be the consultation call, regardless of
+    // which row is focused - an incoming call grabs the selection at ring
+    // time and keeps it, so the held original call may stay focused through
+    // the whole transfer flow. A self-referential transfer (referor ==
+    // replace) is rejected by the backend.
+    for (final focused in [consultation, original]) {
+      testWidgets('submit targets the consultation call when ${focused.callId} is focused', (tester) async {
+        await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: focused));
 
-      await openTransferMenu(tester);
-      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
-      await tester.pumpAndSettle();
+        await openTransferMenu(tester);
+        await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+        await tester.pumpAndSettle();
 
-      verify(
-        () =>
-            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
-      ).called(1);
-      await _teardown(tester);
-    });
-
-    testWidgets('submit still targets the consultation call when the held original call is focused', (tester) async {
-      // An incoming call grabs the selection at ring time and keeps it, so the
-      // held original call stays focused through the whole transfer flow. The
-      // replace target must be the consultation call regardless of focus - a
-      // self-referential transfer (referor == replace) is rejected by the
-      // backend.
-      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: original));
-
-      await openTransferMenu(tester);
-      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
-      await tester.pumpAndSettle();
-
-      verify(
-        () =>
-            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
-      ).called(1);
-      await _teardown(tester);
-    });
+        verify(
+          () => callBloc.add(
+            CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation),
+          ),
+        ).called(1);
+        await _teardown(tester);
+      });
+    }
 
     testWidgets('attended item is absent while the consultation call is not yet accepted', (tester) async {
       final ringingConsultation = _makeCall(


### PR DESCRIPTION
## Overview

Patch for the active release/1.16.0 line: cherry-picks the attended transfer fix from develop PR #1513 (WT-1728). Attended transfer sends a self-referential REFER when the original call is incoming - the submit action took its replace target from the focused call, and a ringing incoming call grabs and keeps the UI selection, so the focused call stays the original held call through the whole transfer flow. The submitted transfer then referenced the same call as both referor and replace target, which the backend rejects.

## Changes (cherry-picked from #1513)

- The attended transfer submit takes the replace target from the derived current call (the consultation one) instead of the focused call, and its enablement gate checks that same call is answered.
- CallBloc drops a self-referential transfer request (referor == replace) and surfaces it via `callErrorReporter.handle` instead of silently swallowing it.
- Widget tests cover the submit wiring for both focus positions plus the not-yet-answered consultation gate.
- Code comment documenting the known (pre-existing, unrelated to this fix) 3+ concurrent calls limitation.
- `app_version` bumped to `1.16.0+10`.

## Testing

- `flutter analyze` clean, full suite green (936 tests) on this branch.
- Verified on a 3-emulator setup against a test environment on develop: the transfer completes end to end after the fix.