### PR TITLE
fix(call): stop signaling disconnects from transfer_accepted/transfer_failed events(WT-1729)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -943,6 +943,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _CallSignalingEventPeerMediaState() => __onCallSignalingEventPeerMediaState(event, emit),
       _CallSignalingEventTransfer() => __onCallSignalingEventTransfer(event, emit),
       _CallSignalingEventTransferring() => __onCallSignalingEventTransfering(event, emit),
+      _CallSignalingEventTransferAccepted() => __onCallSignalingEventTransferAccepted(event, emit),
+      _CallSignalingEventTransferFailed() => __onCallSignalingEventTransferFailed(event, emit),
       _CallSignalingEventNotifyRefer() => __onCallSignalingEventNotifyRefer(event, emit),
       _CallSignalingEventNotifyUnknown() => __onCallSignalingEventNotifyUnknown(event, emit),
       _CallSignalingEventRegistration() => __onCallSignalingEventRegistration(event, emit),
@@ -1320,6 +1322,44 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     final callUpdate = call.copyWith(transfer: transfer);
     emit(state.copyWithMappedActiveCall(event.callId, (_) => callUpdate));
+  }
+
+  /// The transfer completed - the backend hangs up both of the transferor's
+  /// legs right after this, so there is nothing to roll back here. Clears
+  /// the transient [Transfer] state defensively in case that hangup is
+  /// delayed, so the UI never gets stuck showing "Transferring...".
+  Future<void> __onCallSignalingEventTransferAccepted(
+    _CallSignalingEventTransferAccepted event,
+    Emitter<CallState> emit,
+  ) async {
+    final call = state.retrieveActiveCall(event.callId);
+    if (call == null || call.transfer == null) return;
+
+    emit(state.copyWithMappedActiveCall(event.callId, (activeCall) => activeCall.copyWith(transfer: null)));
+  }
+
+  /// The backend rejected the transfer (e.g. a self-referential REFER, or the
+  /// consultation party is unreachable). Unlike [TransferringEvent] the call
+  /// is NOT hung up automatically, so roll back the transient [Transfer]
+  /// state, un-hold the call so the user can keep talking or retry, and
+  /// surface a notification - mirroring how [ReferFailed] already recovers a
+  /// blind transfer rejected mid-flight.
+  Future<void> __onCallSignalingEventTransferFailed(
+    _CallSignalingEventTransferFailed event,
+    Emitter<CallState> emit,
+  ) async {
+    final call = state.retrieveActiveCall(event.callId);
+    if (call == null) return;
+
+    _logger.warning('__onCallSignalingEventTransferFailed: transfer failed (code=${event.code}) for ${event.callId}');
+
+    emit(state.copyWithMappedActiveCall(event.callId, (activeCall) => activeCall.copyWith(transfer: null)));
+    await callkeep.setHeld(event.callId, onHold: false);
+    // The wording ("Transfer failed, returning to active call") is generic
+    // enough for both flavors - `transfer_failed` fires the same way for
+    // blind and attended transfer, and a dedicated notification/l10n key
+    // isn't worth it just to rename this for the attended case.
+    submitNotification(BlindTransferFailedNotification());
   }
 
   Future<void> __onGlobalEventNumberPresenceUpdate(
@@ -4156,6 +4196,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       add(const _CallSignalingEvent.registration(RegistrationStatus.unregistered));
     } else if (event is TransferringEvent) {
       add(_CallSignalingEvent.transferring(line: event.line, callId: event.callId));
+    } else if (event is TransferAcceptedEvent) {
+      add(_CallSignalingEvent.transferAccepted(line: event.line, callId: event.callId));
+    } else if (event is TransferFailedEvent) {
+      add(_CallSignalingEvent.transferFailed(line: event.line, callId: event.callId, code: event.code));
     } else if (event is GlobalEvent) {
       add(switch (event) {
         NumberPresenceUpdate event => _GlobalEvent.numberPresenceUpdate(

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2718,10 +2718,13 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     // A self-referential transfer (a REFER whose Replaces points at its own
     // dialog) is never valid and the backend rejects it; drop the request
-    // instead of sending it.
+    // instead of sending it, but surface it the same way a rejected request
+    // would be so a wiring regression never looks like a dead button.
     if (referorCall.callId == replaceCall.callId) {
-      _logger.warning(
-        '__onMutationControlAttendedTransfer: referorCall == replaceCall (${referorCall.callId}), skipping',
+      callErrorReporter.handle(
+        StateError('attended transfer: referorCall == replaceCall (${referorCall.callId})'),
+        StackTrace.current,
+        '__onMutationControlAttendedTransfer request error:',
       );
       return;
     }

--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2716,6 +2716,16 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     final referorCall = e.referorCall;
     final replaceCall = e.replaceCall;
 
+    // A self-referential transfer (a REFER whose Replaces points at its own
+    // dialog) is never valid and the backend rejects it; drop the request
+    // instead of sending it.
+    if (referorCall.callId == replaceCall.callId) {
+      _logger.warning(
+        '__onMutationControlAttendedTransfer: referorCall == replaceCall (${referorCall.callId}), skipping',
+      );
+      return;
+    }
+
     try {
       final transferRequest = TransferRequest(
         transaction: WebtritSignalingClient.generateTransactionId(),

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -210,6 +210,12 @@ sealed class _CallSignalingEvent extends CallEvent {
   const factory _CallSignalingEvent.transferring({required int? line, required String callId}) =
       _CallSignalingEventTransferring;
 
+  const factory _CallSignalingEvent.transferAccepted({required int? line, required String callId}) =
+      _CallSignalingEventTransferAccepted;
+
+  const factory _CallSignalingEvent.transferFailed({required int? line, required String callId, int? code}) =
+      _CallSignalingEventTransferFailed;
+
   const factory _CallSignalingEvent.notifyRefer({
     required int? line,
     required String callId,
@@ -464,6 +470,27 @@ class _CallSignalingEventTransferring extends _CallSignalingEvent {
 
   @override
   List<Object?> get props => [line, callId];
+}
+
+class _CallSignalingEventTransferAccepted extends _CallSignalingEvent {
+  const _CallSignalingEventTransferAccepted({required this.line, required this.callId});
+
+  final int? line;
+  final String callId;
+
+  @override
+  List<Object?> get props => [line, callId];
+}
+
+class _CallSignalingEventTransferFailed extends _CallSignalingEvent {
+  const _CallSignalingEventTransferFailed({required this.line, required this.callId, this.code});
+
+  final int? line;
+  final String callId;
+  final int? code;
+
+  @override
+  List<Object?> get props => [line, callId, code];
 }
 
 class _CallSignalingEventNotifyRefer extends _CallSignalingEvent {

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -360,6 +360,16 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 // held original call being transferred (an incoming call
                                                 // grabs the selection at ring time), and using it as the
                                                 // replace target would produce a self-referential REFER.
+                                                //
+                                                // KNOWN LIMITATION: `current` is still a positional guess
+                                                // ("the live non-held call"), which breaks once a third,
+                                                // unrelated call is concurrently active - it can point at
+                                                // that call instead of the real consultation call. Left out
+                                                // of scope here: the server caps concurrent lines at 4, and
+                                                // this heuristic is unchanged from pre-1.16.0 behavior (not
+                                                // a new regression). A proper fix needs an explicit
+                                                // referor<->consultation link, not a positional guess -
+                                                // see git history for a prior (closed) attempt.
                                                 onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
                                                     ? (!activeCall.wasAccepted || focusedTransfer != null
                                                           ? null

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -365,8 +365,9 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 // ("the live non-held call"), which breaks once a third,
                                                 // unrelated call is concurrently active - it can point at
                                                 // that call instead of the real consultation call. Left out
-                                                // of scope here: the server caps concurrent lines at 4, and
-                                                // this heuristic is unchanged from pre-1.16.0 behavior (not
+                                                // of scope here: server config typically caps concurrent
+                                                // lines at 3 (not hardcoded in the app - see linesCount),
+                                                // and this heuristic is unchanged from pre-1.16.0 behavior (not
                                                 // a new regression). A proper fix needs an explicit
                                                 // referor<->consultation link, not a positional guess -
                                                 // see git history for a prior (closed) attempt.

--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -355,14 +355,19 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                             })
                                                     : null,
                                                 // TODO (Serdun): Simplify complex condition in the widget tree.
+                                                // The submit acts on the consultation call (the derived
+                                                // `current`), not the focused one: focus may sit on the
+                                                // held original call being transferred (an incoming call
+                                                // grabs the selection at ring time), and using it as the
+                                                // replace target would produce a self-referential REFER.
                                                 onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
-                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
+                                                    ? (!activeCall.wasAccepted || focusedTransfer != null
                                                           ? null
                                                           : (ActiveCall referorCall) {
                                                               _callBloc.add(
                                                                 CallControlEvent.attendedTransferSubmitted(
                                                                   referorCall: referorCall,
-                                                                  replaceCall: focusedCall,
+                                                                  replaceCall: activeCall,
                                                                 ),
                                                               );
                                                             })

--- a/packages/webtrit_signaling/lib/src/events/call/call_events.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/call_events.dart
@@ -15,6 +15,8 @@ export 'progress_event.dart';
 export 'resuming_event.dart';
 export 'ringing_event.dart';
 export 'subscription_state.dart';
+export 'transfer_accepted_event.dart';
+export 'transfer_failed_event.dart';
 export 'transferring_event.dart';
 export 'updated_event.dart';
 export 'updating_call_event.dart';

--- a/packages/webtrit_signaling/lib/src/events/call/transfer_accepted_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/transfer_accepted_event.dart
@@ -1,12 +1,17 @@
 import '../abstract_events.dart';
 
 class TransferAcceptedEvent extends CallEvent {
-  const TransferAcceptedEvent({super.transaction, required super.line, required super.callId});
+  const TransferAcceptedEvent({super.transaction, required super.line, required super.callId, this.code});
 
   static const typeValue = 'transfer_accepted';
 
+  final int? code;
+
   @override
-  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+  List<Object?> get props => [...super.props, code];
+
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(typeValue), if (code != null) 'code': code};
 
   factory TransferAcceptedEvent.fromJson(Map<String, dynamic> json) {
     final eventTypeValue = json[Event.typeKey];
@@ -14,6 +19,11 @@ class TransferAcceptedEvent extends CallEvent {
       throw ArgumentError.value(eventTypeValue, Event.typeKey, 'Not equal $typeValue');
     }
 
-    return TransferAcceptedEvent(transaction: json['transaction'], line: json['line'], callId: json['call_id']);
+    return TransferAcceptedEvent(
+      transaction: json['transaction'],
+      line: json['line'],
+      callId: json['call_id'],
+      code: json['code'],
+    );
   }
 }

--- a/packages/webtrit_signaling/lib/src/events/call/transfer_accepted_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/transfer_accepted_event.dart
@@ -1,0 +1,19 @@
+import '../abstract_events.dart';
+
+class TransferAcceptedEvent extends CallEvent {
+  const TransferAcceptedEvent({super.transaction, required super.line, required super.callId});
+
+  static const typeValue = 'transfer_accepted';
+
+  @override
+  Map<String, dynamic> toJson() => callBaseJson(typeValue);
+
+  factory TransferAcceptedEvent.fromJson(Map<String, dynamic> json) {
+    final eventTypeValue = json[Event.typeKey];
+    if (eventTypeValue != typeValue) {
+      throw ArgumentError.value(eventTypeValue, Event.typeKey, 'Not equal $typeValue');
+    }
+
+    return TransferAcceptedEvent(transaction: json['transaction'], line: json['line'], callId: json['call_id']);
+  }
+}

--- a/packages/webtrit_signaling/lib/src/events/call/transfer_failed_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/transfer_failed_event.dart
@@ -1,0 +1,29 @@
+import '../abstract_events.dart';
+
+class TransferFailedEvent extends CallEvent {
+  const TransferFailedEvent({super.transaction, required super.line, required super.callId, this.code});
+
+  static const typeValue = 'transfer_failed';
+
+  final int? code;
+
+  @override
+  List<Object?> get props => [...super.props, code];
+
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(typeValue), if (code != null) 'code': code};
+
+  factory TransferFailedEvent.fromJson(Map<String, dynamic> json) {
+    final eventTypeValue = json[Event.typeKey];
+    if (eventTypeValue != typeValue) {
+      throw ArgumentError.value(eventTypeValue, Event.typeKey, 'Not equal $typeValue');
+    }
+
+    return TransferFailedEvent(
+      transaction: json['transaction'],
+      line: json['line'],
+      callId: json['call_id'],
+      code: json['code'],
+    );
+  }
+}

--- a/packages/webtrit_signaling/lib/src/events/call_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call_event.dart
@@ -46,6 +46,8 @@ abstract class CallEvent extends LineEvent {
     ProgressEvent.typeValue: ProgressEvent.fromJson,
     ResumingEvent.typeValue: ResumingEvent.fromJson,
     RingingEvent.typeValue: RingingEvent.fromJson,
+    TransferAcceptedEvent.typeValue: TransferAcceptedEvent.fromJson,
+    TransferFailedEvent.typeValue: TransferFailedEvent.fromJson,
     TransferringEvent.typeValue: TransferringEvent.fromJson,
     UpdatedEvent.typeValue: UpdatedEvent.fromJson,
     UpdatingCallEvent.typeValue: UpdatingCallEvent.fromJson,

--- a/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
+++ b/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
@@ -111,6 +111,23 @@ class StateHandshake extends Handshake {
       code: registrationMessage['code'],
       reason: registrationMessage['reason'],
     );
+    // TODO: an unrecognized/malformed entry in a line's or the guest line's
+    // call_logs below throws and fails this whole handshake. Since this
+    // handshake is replayed on every reconnect, one bad entry becomes a
+    // reconnect loop for as long as the call carrying it stays alive - not
+    // just a one-off failure. A prior attempt made per-entry parsing
+    // resilient (log + skip instead of throw), but that alone silently
+    // breaks a real invariant: consumers (e.g. the "latest call event"
+    // lookups in the call-restoration and push-isolate handshake handlers)
+    // assume call_logs is newest-first and complete, and use firstOrNull/
+    // lastOrNull to read the latest/earliest event - dropping an entry can
+    // make a server-terminated call look active or vice versa. A correct fix
+    // needs to either preserve position for unparseable entries (so
+    // consumers can detect "the newest entry was unparseable" and treat the
+    // read as inconclusive) or otherwise flag that entries were dropped, and
+    // should narrow the catch to the specific unrecognized-type case so a
+    // genuine parsing bug in an already-known type still fails loudly - not
+    // done here; see git history for a prior (closed) attempt.
     final linesJson = json['lines'] as List<dynamic>;
     final lines = linesJson
         .asMap()

--- a/packages/webtrit_signaling/test/src/events/call/transfer_accepted_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/transfer_accepted_event_test.dart
@@ -5,17 +5,35 @@ import 'package:test/test.dart';
 import 'package:webtrit_signaling/src/events/call/transfer_accepted_event.dart';
 
 void main() {
-  test('$TransferAcceptedEvent fromJson', () {
+  test('$TransferAcceptedEvent fromJson with code', () {
     const transferAcceptedEventJson = '''
     {
       "event": "transfer_accepted",
       "transaction": "transaction 1",
       "line": 0,
+      "call_id": "qwerty",
+      "code": 202
+    }
+    ''';
+
+    final event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 202);
+
+    expect(
+      TransferAcceptedEvent.fromJson(json.decode(transferAcceptedEventJson) as Map<String, dynamic>),
+      equals(event),
+    );
+  });
+
+  test('$TransferAcceptedEvent fromJson without code', () {
+    const transferAcceptedEventJson = '''
+    {
+      "event": "transfer_accepted",
+      "line": 0,
       "call_id": "qwerty"
     }
     ''';
 
-    final event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty');
+    final event = TransferAcceptedEvent(line: 0, callId: 'qwerty');
 
     expect(
       TransferAcceptedEvent.fromJson(json.decode(transferAcceptedEventJson) as Map<String, dynamic>),
@@ -24,7 +42,7 @@ void main() {
   });
 
   test('$TransferAcceptedEvent toJson round-trips', () {
-    const event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty');
+    const event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 202);
 
     expect(TransferAcceptedEvent.fromJson(event.toJson()), equals(event));
   });

--- a/packages/webtrit_signaling/test/src/events/call/transfer_accepted_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/transfer_accepted_event_test.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:webtrit_signaling/src/events/call/transfer_accepted_event.dart';
+
+void main() {
+  test('$TransferAcceptedEvent fromJson', () {
+    const transferAcceptedEventJson = '''
+    {
+      "event": "transfer_accepted",
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty"
+    }
+    ''';
+
+    final event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty');
+
+    expect(
+      TransferAcceptedEvent.fromJson(json.decode(transferAcceptedEventJson) as Map<String, dynamic>),
+      equals(event),
+    );
+  });
+
+  test('$TransferAcceptedEvent toJson round-trips', () {
+    const event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty');
+
+    expect(TransferAcceptedEvent.fromJson(event.toJson()), equals(event));
+  });
+}

--- a/packages/webtrit_signaling/test/src/events/call/transfer_failed_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/transfer_failed_event_test.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:webtrit_signaling/src/events/call/transfer_failed_event.dart';
+
+void main() {
+  test('$TransferFailedEvent fromJson with code', () {
+    const transferFailedEventJson = '''
+    {
+      "event": "transfer_failed",
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "code": 400
+    }
+    ''';
+
+    final event = TransferFailedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 400);
+
+    expect(TransferFailedEvent.fromJson(json.decode(transferFailedEventJson) as Map<String, dynamic>), equals(event));
+  });
+
+  test('$TransferFailedEvent fromJson without code', () {
+    const transferFailedEventJson = '''
+    {
+      "event": "transfer_failed",
+      "line": 0,
+      "call_id": "qwerty"
+    }
+    ''';
+
+    final event = TransferFailedEvent(line: 0, callId: 'qwerty');
+
+    expect(TransferFailedEvent.fromJson(json.decode(transferFailedEventJson) as Map<String, dynamic>), equals(event));
+  });
+
+  test('$TransferFailedEvent toJson round-trips', () {
+    const event = TransferFailedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 400);
+
+    expect(TransferFailedEvent.fromJson(event.toJson()), equals(event));
+  });
+}

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/data/data.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/call/view/call_active_scaffold.dart';
@@ -251,6 +252,72 @@ void main() {
       await tester.pump();
 
       verify(() => appPermissions.toAppSettings()).called(1);
+      await _teardown(tester);
+    });
+  });
+
+  group('CallActiveScaffold - attended transfer submit', () {
+    final original = _makeCall(callId: 'original', acceptedTime: DateTime(2024), held: true, displayName: 'Clara Diaz');
+    final consultation = _makeCall(
+      callId: 'consultation',
+      direction: CallDirection.outgoing,
+      acceptedTime: DateTime(2024),
+      displayName: 'Boris Klein',
+    );
+
+    Future<void> openTransferMenu(WidgetTester tester) async {
+      await tester.tap(find.byKey(callActionsTransferMenuKey));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('submit targets the consultation call when it is focused', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: consultation),
+      );
+
+      await openTransferMenu(tester);
+      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+      await tester.pumpAndSettle();
+
+      verify(
+        () =>
+            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
+      ).called(1);
+      await _teardown(tester);
+    });
+
+    testWidgets('submit still targets the consultation call when the held original call is focused', (tester) async {
+      // An incoming call grabs the selection at ring time and keeps it, so the
+      // held original call stays focused through the whole transfer flow. The
+      // replace target must be the consultation call regardless of focus - a
+      // self-referential transfer (referor == replace) is rejected by the
+      // backend.
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: original));
+
+      await openTransferMenu(tester);
+      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+      await tester.pumpAndSettle();
+
+      verify(
+        () =>
+            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
+      ).called(1);
+      await _teardown(tester);
+    });
+
+    testWidgets('attended item is absent while the consultation call is not yet accepted', (tester) async {
+      final ringingConsultation = _makeCall(
+        callId: 'consultation',
+        direction: CallDirection.outgoing,
+        displayName: 'Boris Klein',
+      );
+      await tester.pumpWidget(
+        _buildSubject(callBloc, activeCalls: [original, ringingConsultation], focusedCall: original),
+      );
+
+      await openTransferMenu(tester);
+
+      expect(find.byKey(callActionsTransferMenuNumberKey), findsNothing);
       await _teardown(tester);
     });
   });

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -270,40 +270,27 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    testWidgets('submit targets the consultation call when it is focused', (tester) async {
-      await tester.pumpWidget(
-        _buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: consultation),
-      );
+    // The replace target must always be the consultation call, regardless of
+    // which row is focused - an incoming call grabs the selection at ring
+    // time and keeps it, so the held original call may stay focused through
+    // the whole transfer flow. A self-referential transfer (referor ==
+    // replace) is rejected by the backend.
+    for (final focused in [consultation, original]) {
+      testWidgets('submit targets the consultation call when ${focused.callId} is focused', (tester) async {
+        await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: focused));
 
-      await openTransferMenu(tester);
-      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
-      await tester.pumpAndSettle();
+        await openTransferMenu(tester);
+        await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
+        await tester.pumpAndSettle();
 
-      verify(
-        () =>
-            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
-      ).called(1);
-      await _teardown(tester);
-    });
-
-    testWidgets('submit still targets the consultation call when the held original call is focused', (tester) async {
-      // An incoming call grabs the selection at ring time and keeps it, so the
-      // held original call stays focused through the whole transfer flow. The
-      // replace target must be the consultation call regardless of focus - a
-      // self-referential transfer (referor == replace) is rejected by the
-      // backend.
-      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [original, consultation], focusedCall: original));
-
-      await openTransferMenu(tester);
-      await tester.tap(find.byKey(callActionsTransferMenuNumberKey));
-      await tester.pumpAndSettle();
-
-      verify(
-        () =>
-            callBloc.add(CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation)),
-      ).called(1);
-      await _teardown(tester);
-    });
+        verify(
+          () => callBloc.add(
+            CallControlEvent.attendedTransferSubmitted(referorCall: original, replaceCall: consultation),
+          ),
+        ).called(1);
+        await _teardown(tester);
+      });
+    }
 
     testWidgets('attended item is absent while the consultation call is not yet accepted', (tester) async {
       final ringingConsultation = _makeCall(


### PR DESCRIPTION
## Overview

WT-1729. Stacked on #1513 (branch fix/attended-transfer-replace-call). Found while investigating and verifying WT-1728's attended transfer fix: the mobile signaling client does not recognize two backend-sent events related to `transfer` requests (both blind and attended), and treats any unrecognized event as fatal - tearing down the signaling connection.

- On a **failed** transfer, the backend sends `transfer_failed`. Because Janus replays the line's `call_logs` on every reconnect, and that replay still contains the same `transfer_failed` entry, the client re-throws and fails again immediately - a reconnect loop that continues for as long as the call stays alive.
- On a **successful** transfer, the backend sends `transfer_accepted` - same unrecognized-event crash, but since the call ends right after (hangup on both of the transferor's legs) the "poison" clears and a single reconnect recovers. Still, every successful attended/blind transfer currently pays a ~4s signaling drop at teardown.

## Changes

- `webtrit_signaling`: added `TransferAcceptedEvent` and `TransferFailedEvent` (both carry an optional `code` - confirmed on device: `transfer_accepted` sends `code:202`, `transfer_failed` sends `code:400`) and registered them in the call-event decoder map - so both are recognized instead of throwing `ArgumentError`.
- `CallBloc`: wired the two new events.
  - `transfer_accepted` -> defensively clears the transient `Transfer` state (the backend hangs up both legs right after, so there is nothing to roll back).
  - `transfer_failed` -> clears the `Transfer` state, un-holds the call, and shows a notification - mirroring how a blind transfer already recovers from a rejected REFER via `ReferFailed` (same notification, its wording is generic enough for both transfer flavors).
- Unit tests for the two new event classes (`fromJson`/`toJson` round-trip, with and without `code`).
- A `TODO` comment in `state_handshake.dart` documenting the deferred hardening described below, right at the code it applies to.

## Deferred: call_logs replay resilience (not included here)

This PR fixes the two specific event names actually observed - that alone fully closes the reported symptom (verified on device, see Testing). It does NOT make unrecognized events non-fatal in general, which would also protect against any *future* unrecognized event triggering the same reconnect-loop mechanism via the `call_logs` replay in `StateHandshake.fromJson` (as opposed to a live single-event occurrence, which only fails once, not in a loop - see the note below).

A branch/PR for that broader hardening was drafted (`fix/wt-1729-call-logs-resilience`, was PR #1518, now closed) and is being parked rather than merged, because it surfaced a real design problem during ultra-review:

- **Silently dropping an unparseable `call_logs` entry breaks a completeness invariant several consumers rely on.** `call_logs` is newest-first; `handshake_processor.dart`'s call-restoration logic and the push-notification `isolate_manager.dart` both read `callLogs.whereType<CallEventLog>().firstOrNull` to get "the latest call event" (used to decide `isTerminated`, whether to restore/hang-up an orphaned call, whether an incoming call is still ringing, etc.). If a *future* unrecognized event type happens to be the newest entry and gets silently dropped, `firstOrNull` resolves to the previous (stale) entry instead - a call the server already terminated could read as still active, or vice versa.
- **A bare `catch` also swallows genuine parsing bugs in already-known event types**, not just the intended forward-compat case, which reduces the ability to catch real bugs loudly during development/QA.
- A correct fix needs to either preserve position for unparseable entries (so a consumer can detect "the newest entry was unparseable" and treat its read as inconclusive) or otherwise propagate that entries were dropped, narrow the catch to the specific unrecognized-type case, and update every `call_logs`/`firstOrNull`/`lastOrNull` consumer to defend against it - a real cross-file design task, not a small addition to this PR.
- The parked branch does still contain one standalone, unambiguous correctness fix worth cherry-picking whenever this is picked back up: the original attempt had the `timestamp`/payload casts sitting *outside* the try/catch, so a malformed entry (not just an unrecognized type) still crashed uncaught - fixed there with a regression test.

Also still deliberately out of scope, unrelated to `call_logs`: making the *live* single-event path (`webtrit_signaling_client.dart` `_onMessage`) non-fatal for unrecognized events too. That path fails once per occurrence rather than looping, so it is not part of the "storm" mechanism - whether the app should ever silently ignore an unrecognized live event, versus treating it as a signal to catch protocol drift, is a broader product/architecture call, not made here.

## Testing

- `webtrit_signaling`: `flutter analyze` clean, `dart test` green for the new event tests (2 pre-existing unrelated failures in `line_error_event_test.dart` - broken `equals(isNotNull)` matcher usage, confirmed present on the base branch too, untouched by this PR).
- `webtrit_phone`: `flutter analyze` clean, `flutter test test/features/call` 496/496 green, full pre-push suite 1134/1134 green.
- **Device-verified** (3-emulator attended transfer, testenv): `transfer_accepted` now recognized end to end - 0 `ArgumentError`, 0 `SignalingClientStatus.failure` for the whole session (the only reconnect-scheduler activity in the log happened well before the transfer, unrelated warm-up). The ~4s signaling drop on a successful transfer is gone.