### PR TITLE
fix(signaling): skip an unparseable call_log entry instead of failing the handshake

### DIFF
--- a/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
+++ b/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
@@ -1,9 +1,12 @@
 import 'package:equatable/equatable.dart';
+import 'package:logging/logging.dart';
 
 import '../events/events.dart';
 import '../requests/requests.dart';
 import '../responses/responses.dart';
 import 'handshake.dart';
+
+final _logger = Logger('StateHandshake');
 
 enum RegistrationStatus {
   registering,
@@ -131,33 +134,7 @@ class StateHandshake extends Handshake {
             return null;
           }
 
-          final callLogs = (lineJson['call_logs'] as List<dynamic>)
-              .map<CallLog>((callLogJson) {
-                final timestamp = callLogJson[0] as int;
-                final requestOrResponseOrEventJson = callLogJson[1];
-                requestOrResponseOrEventJson['line'] = lineIndex; // inject line to apply universal fromJson methods
-                requestOrResponseOrEventJson['call_id'] = callId; // inject call_id to apply universal fromJson methods
-                if (requestOrResponseOrEventJson.containsKey(Request.typeKey)) {
-                  return CallRequestLog(
-                    timestamp: timestamp,
-                    callRequest: CallRequest.fromJson(requestOrResponseOrEventJson),
-                  );
-                } else if (requestOrResponseOrEventJson.containsKey(Response.typeKey)) {
-                  return ResponseLog(timestamp: timestamp, response: Response.fromJson(requestOrResponseOrEventJson));
-                } else if (requestOrResponseOrEventJson.containsKey(Event.typeKey)) {
-                  return CallEventLog(
-                    timestamp: timestamp,
-                    callEvent: CallEvent.fromJson(requestOrResponseOrEventJson),
-                  );
-                } else {
-                  throw ArgumentError.value(
-                    requestOrResponseOrEventJson,
-                    'requestOrResponseOrEventJson',
-                    'Active call\'s logs incorrect',
-                  );
-                }
-              })
-              .toList(growable: false);
+          final callLogs = _parseCallLogs(lineJson['call_logs'] as List<dynamic>, line: lineIndex, callId: callId);
 
           return Line(callId: callId, callLogs: callLogs);
         })
@@ -174,30 +151,7 @@ class StateHandshake extends Handshake {
     if (guestLineJson != null) {
       final callId = guestLineJson['call_id'] as String?;
       if (callId != null) {
-        final callLogs = (guestLineJson['call_logs'] as List<dynamic>)
-            .map<CallLog>((callLogJson) {
-              final timestamp = callLogJson[0] as int;
-              final requestOrResponseOrEventJson = callLogJson[1];
-              requestOrResponseOrEventJson['line'] = null; // inject line to apply universal fromJson methods
-              requestOrResponseOrEventJson['call_id'] = callId; // inject call_id to apply universal fromJson methods
-              if (requestOrResponseOrEventJson.containsKey(Request.typeKey)) {
-                return CallRequestLog(
-                  timestamp: timestamp,
-                  callRequest: CallRequest.fromJson(requestOrResponseOrEventJson),
-                );
-              } else if (requestOrResponseOrEventJson.containsKey(Response.typeKey)) {
-                return ResponseLog(timestamp: timestamp, response: Response.fromJson(requestOrResponseOrEventJson));
-              } else if (requestOrResponseOrEventJson.containsKey(Event.typeKey)) {
-                return CallEventLog(timestamp: timestamp, callEvent: CallEvent.fromJson(requestOrResponseOrEventJson));
-              } else {
-                throw ArgumentError.value(
-                  requestOrResponseOrEventJson,
-                  'requestOrResponseOrEventJson',
-                  'Guest line\'s logs incorrect',
-                );
-              }
-            })
-            .toList(growable: false);
+        final callLogs = _parseCallLogs(guestLineJson['call_logs'] as List<dynamic>, line: null, callId: callId);
 
         guestLine = Line(callId: callId, callLogs: callLogs);
       }
@@ -213,4 +167,38 @@ class StateHandshake extends Handshake {
       guestLine: guestLine,
     );
   }
+}
+
+/// Parses one line's `call_logs` array into [CallLog] entries, skipping (and
+/// logging) any entry this client version cannot parse - most commonly an
+/// event type the server added after this client shipped. A single
+/// unparseable entry must not fail the whole handshake: [StateHandshake] is
+/// replayed on every reconnect, so letting one bad entry throw here would
+/// turn into a reconnect loop for as long as the call carrying it stays
+/// alive, instead of just losing that one log entry.
+List<CallLog> _parseCallLogs(List<dynamic> callLogsJson, {required int? line, required String callId}) {
+  final callLogs = <CallLog>[];
+  for (final callLogJson in callLogsJson) {
+    final timestamp = callLogJson[0] as int;
+    final requestOrResponseOrEventJson = callLogJson[1] as Map<String, dynamic>;
+    requestOrResponseOrEventJson['line'] = line; // inject line to apply universal fromJson methods
+    requestOrResponseOrEventJson['call_id'] = callId; // inject call_id to apply universal fromJson methods
+
+    try {
+      if (requestOrResponseOrEventJson.containsKey(Request.typeKey)) {
+        callLogs.add(
+          CallRequestLog(timestamp: timestamp, callRequest: CallRequest.fromJson(requestOrResponseOrEventJson)),
+        );
+      } else if (requestOrResponseOrEventJson.containsKey(Response.typeKey)) {
+        callLogs.add(ResponseLog(timestamp: timestamp, response: Response.fromJson(requestOrResponseOrEventJson)));
+      } else if (requestOrResponseOrEventJson.containsKey(Event.typeKey)) {
+        callLogs.add(CallEventLog(timestamp: timestamp, callEvent: CallEvent.fromJson(requestOrResponseOrEventJson)));
+      } else {
+        throw ArgumentError.value(requestOrResponseOrEventJson, 'requestOrResponseOrEventJson', 'call_log incorrect');
+      }
+    } catch (error, stackTrace) {
+      _logger.warning('_parseCallLogs: skipping unparseable call_log entry for call $callId', error, stackTrace);
+    }
+  }
+  return callLogs;
 }

--- a/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
+++ b/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
@@ -179,12 +179,12 @@ class StateHandshake extends Handshake {
 List<CallLog> _parseCallLogs(List<dynamic> callLogsJson, {required int? line, required String callId}) {
   final callLogs = <CallLog>[];
   for (final callLogJson in callLogsJson) {
-    final timestamp = callLogJson[0] as int;
-    final requestOrResponseOrEventJson = callLogJson[1] as Map<String, dynamic>;
-    requestOrResponseOrEventJson['line'] = line; // inject line to apply universal fromJson methods
-    requestOrResponseOrEventJson['call_id'] = callId; // inject call_id to apply universal fromJson methods
-
     try {
+      final timestamp = callLogJson[0] as int;
+      final requestOrResponseOrEventJson = callLogJson[1] as Map<String, dynamic>;
+      requestOrResponseOrEventJson['line'] = line; // inject line to apply universal fromJson methods
+      requestOrResponseOrEventJson['call_id'] = callId; // inject call_id to apply universal fromJson methods
+
       if (requestOrResponseOrEventJson.containsKey(Request.typeKey)) {
         callLogs.add(
           CallRequestLog(timestamp: timestamp, callRequest: CallRequest.fromJson(requestOrResponseOrEventJson)),

--- a/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
+++ b/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
@@ -153,4 +153,34 @@ void main() {
     final result = StateHandshake.fromJson(jsonWithNull);
     expect(result.dialogInfos.first.state, equals(SignalingDialogState.unknown));
   });
+
+  test('$StateHandshake fromJson skips an unparseable call_log entry instead of throwing', () {
+    final jsonWithUnknownCallLogEvent =
+        json.decode('''
+    {
+      "handshake": "state",
+      "keepalive_interval": 30000,
+      "timestamp": 1662114679648,
+      "registration": {"status": "registered"},
+      "lines": [
+        {
+          "call_id": "qwertyuiopasdfghjklzxcvbnm",
+          "call_logs": [
+            [1662114479751, {"event": "incoming_call", "transaction": "transaction-1", "callee": "123", "caller": "456"}],
+            [1662114479999, {"event": "some_future_event", "transaction": "transaction-2"}]
+          ]
+        },
+        null
+      ]
+    }
+    ''')
+            as Map<String, dynamic>;
+
+    expect(() => StateHandshake.fromJson(jsonWithUnknownCallLogEvent), returnsNormally);
+
+    final result = StateHandshake.fromJson(jsonWithUnknownCallLogEvent);
+    final callLogs = result.lines.first!.callLogs;
+    expect(callLogs.length, equals(1));
+    expect((callLogs.first as CallEventLog).callEvent, isA<IncomingCallEvent>());
+  });
 }

--- a/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
+++ b/packages/webtrit_signaling/test/src/handshakes/handshake_state_test.dart
@@ -183,4 +183,34 @@ void main() {
     expect(callLogs.length, equals(1));
     expect((callLogs.first as CallEventLog).callEvent, isA<IncomingCallEvent>());
   });
+
+  test('$StateHandshake fromJson skips a call_log entry with a malformed envelope (not just an unknown type)', () {
+    final jsonWithMalformedCallLogEnvelope =
+        json.decode('''
+    {
+      "handshake": "state",
+      "keepalive_interval": 30000,
+      "timestamp": 1662114679648,
+      "registration": {"status": "registered"},
+      "lines": [
+        {
+          "call_id": "qwertyuiopasdfghjklzxcvbnm",
+          "call_logs": [
+            [1662114479751, {"event": "incoming_call", "transaction": "transaction-1", "callee": "123", "caller": "456"}],
+            [null, {"event": "ringing", "transaction": "transaction-2"}]
+          ]
+        },
+        null
+      ]
+    }
+    ''')
+            as Map<String, dynamic>;
+
+    expect(() => StateHandshake.fromJson(jsonWithMalformedCallLogEnvelope), returnsNormally);
+
+    final result = StateHandshake.fromJson(jsonWithMalformedCallLogEnvelope);
+    final callLogs = result.lines.first!.callLogs;
+    expect(callLogs.length, equals(1));
+    expect((callLogs.first as CallEventLog).callEvent, isA<IncomingCallEvent>());
+  });
 }


### PR DESCRIPTION
## Overview

WT-1729. Stacked on #1517 (the narrow transfer_accepted/transfer_failed fix). This is the broader hardening step that PR called out as deliberately out of scope: `StateHandshake.fromJson` throws for any `call_logs` entry it cannot parse (any event type this client version does not recognize). Since the state handshake is replayed on every reconnect, one bad entry doesn't just fail once - it fails identically on every subsequent reconnect attempt for as long as the call carrying it stays alive. This was the actual mechanism behind the transfer_failed crash-loop before #1517 taught the client to recognize that specific event; this PR makes the mechanism itself resilient, so the same thing can't happen again for any other future/unrecognized event type.

## Changes

- Extracted the near-identical main-line/guest-line `call_logs` parsing (previously duplicated inline, ~25 lines each) into one `_parseCallLogs` helper - net code reduction alongside the fix.
- Each `call_logs` entry's parse is now wrapped in try/catch: an unparseable entry is logged and skipped, not thrown - it only loses that one log entry instead of failing the whole handshake (and, on reconnect, doing that again forever).

## Deliberately out of scope

Only the `call_logs` replay path in `webtrit_signaling` (`state_handshake.dart`) is touched - this is what turns a single bad event into a *loop*, which is the actual "storm" symptom. The live single-event path (`webtrit_signaling_client.dart` `_onMessage`) still treats an unrecognized event as fatal for a single occurrence; changing that too would be a broader behavioral call (does the app want to silently ignore any future unrecognized live event, or is treating it as a connection problem the right signal to catch protocol drift quickly) - not made here.

## Testing

- New test: a `call_logs` array with one valid entry and one entry with an unrecognized event type - `StateHandshake.fromJson` returns normally and the result contains only the valid entry. Verified this test fails against the pre-fix code (temporarily swapped in the base branch's version of the file) with the exact `ArgumentError: Unknown call event type` that caused the original crash-loop.
- `webtrit_signaling`: `flutter analyze` clean, `dart test` 104/106 (2 pre-existing unrelated failures in `line_error_event_test.dart`, confirmed present on the base branch too).
- `webtrit_phone`: `flutter analyze` clean, full pre-push suite 1134/1134 green.