### PR TITLE
fix(login): use neutral wording on qr sign-in camera permission button

### DIFF
--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -2005,7 +2005,7 @@ abstract class AppLocalizations {
   /// No description provided for @login_Button_qrSigninAllowCameraAccess.
   ///
   /// In en, this message translates to:
-  /// **'Allow camera access'**
+  /// **'Continue'**
   String get login_Button_qrSigninAllowCameraAccess;
 
   /// No description provided for @login_Button_qrSigninOpenSettings.

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -1096,7 +1096,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Camera access is needed to scan a QR code. Enable it to continue.';
 
   @override
-  String get login_Button_qrSigninAllowCameraAccess => 'Allow camera access';
+  String get login_Button_qrSigninAllowCameraAccess => 'Continue';
 
   @override
   String get login_Button_qrSigninOpenSettings => 'Open settings';

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -1104,7 +1104,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'L\'accesso alla fotocamera è necessario per scansionare un codice QR. Attivalo per continuare.';
 
   @override
-  String get login_Button_qrSigninAllowCameraAccess => 'Consenti l\'accesso alla fotocamera';
+  String get login_Button_qrSigninAllowCameraAccess => 'Continua';
 
   @override
   String get login_Button_qrSigninOpenSettings => 'Apri le impostazioni';

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -1088,7 +1088,7 @@ class AppLocalizationsTh extends AppLocalizations {
       'ต้องการสิทธิ์เข้าถึงกล้องเพื่อสแกนคิวอาร์โค้ด โปรดเปิดใช้งานเพื่อดำเนินการต่อ';
 
   @override
-  String get login_Button_qrSigninAllowCameraAccess => 'อนุญาตการเข้าถึงกล้อง';
+  String get login_Button_qrSigninAllowCameraAccess => 'ดำเนินการต่อ';
 
   @override
   String get login_Button_qrSigninOpenSettings => 'เปิดการตั้งค่า';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -1116,7 +1116,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Для сканування QR-коду потрібен доступ до камери. Увімкніть його, щоб продовжити.';
 
   @override
-  String get login_Button_qrSigninAllowCameraAccess => 'Надати доступ до камери';
+  String get login_Button_qrSigninAllowCameraAccess => 'Продовжити';
 
   @override
   String get login_Button_qrSigninOpenSettings => 'Відкрити налаштування';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -936,7 +936,7 @@
   "@login_Text_qrSigninCameraPermissionTitle": {},
   "login_Text_qrSigninCameraPermissionDescription": "Camera access is needed to scan a QR code. Enable it to continue.",
   "@login_Text_qrSigninCameraPermissionDescription": {},
-  "login_Button_qrSigninAllowCameraAccess": "Allow camera access",
+  "login_Button_qrSigninAllowCameraAccess": "Continue",
   "@login_Button_qrSigninAllowCameraAccess": {},
   "login_Button_qrSigninOpenSettings": "Open settings",
   "@login_Button_qrSigninOpenSettings": {},

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -936,7 +936,7 @@
   "@login_Text_qrSigninCameraPermissionTitle": {},
   "login_Text_qrSigninCameraPermissionDescription": "L'accesso alla fotocamera è necessario per scansionare un codice QR. Attivalo per continuare.",
   "@login_Text_qrSigninCameraPermissionDescription": {},
-  "login_Button_qrSigninAllowCameraAccess": "Consenti l'accesso alla fotocamera",
+  "login_Button_qrSigninAllowCameraAccess": "Continua",
   "@login_Button_qrSigninAllowCameraAccess": {},
   "login_Button_qrSigninOpenSettings": "Apri le impostazioni",
   "@login_Button_qrSigninOpenSettings": {},

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -936,7 +936,7 @@
   "@login_Text_qrSigninCameraPermissionTitle": {},
   "login_Text_qrSigninCameraPermissionDescription": "ต้องการสิทธิ์เข้าถึงกล้องเพื่อสแกนคิวอาร์โค้ด โปรดเปิดใช้งานเพื่อดำเนินการต่อ",
   "@login_Text_qrSigninCameraPermissionDescription": {},
-  "login_Button_qrSigninAllowCameraAccess": "อนุญาตการเข้าถึงกล้อง",
+  "login_Button_qrSigninAllowCameraAccess": "ดำเนินการต่อ",
   "@login_Button_qrSigninAllowCameraAccess": {},
   "login_Button_qrSigninOpenSettings": "เปิดการตั้งค่า",
   "@login_Button_qrSigninOpenSettings": {},

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -936,7 +936,7 @@
   "@login_Text_qrSigninCameraPermissionTitle": {},
   "login_Text_qrSigninCameraPermissionDescription": "Для сканування QR-коду потрібен доступ до камери. Увімкніть його, щоб продовжити.",
   "@login_Text_qrSigninCameraPermissionDescription": {},
-  "login_Button_qrSigninAllowCameraAccess": "Надати доступ до камери",
+  "login_Button_qrSigninAllowCameraAccess": "Продовжити",
   "@login_Button_qrSigninAllowCameraAccess": {},
   "login_Button_qrSigninOpenSettings": "Відкрити налаштування",
   "@login_Button_qrSigninOpenSettings": {},


### PR DESCRIPTION
## Overview
- App Store review flagged the QR sign-in camera permission priming screen (guideline 5.1.1(iv)): the button shown before the system camera permission dialog was labeled "Allow camera access", which reads as granting the permission from within the app rather than proceeding to the system prompt.
- Renamed the button to the neutral "Continue" across all four locales (en/it/uk/th), matching the wording already used on the generic onboarding permissions screen (`permission_Button_request`).
- Title/description copy above the button is unchanged; only the action-word button label was in scope.

## Test plan
- [x] `flutter gen-l10n` regenerated, only the targeted string changed in `app_localizations*.g.dart`
- [x] `melos run check` (analyze) clean
- [x] Manual check on device: QR sign-in permission screen shows "Continue" and still triggers the system camera prompt