### PR TITLE
fix(voicemail): sort voicemail list newest first (WT-719)

### DIFF
--- a/packages/data/app_database/lib/src/daos/voicemail_dao.dart
+++ b/packages/data/app_database/lib/src/daos/voicemail_dao.dart
@@ -134,10 +134,11 @@ class VoicemailDao extends DatabaseAccessor<AppDatabase> with _$VoicemailDaoMixi
               transcriptions.mediaId.equalsExp(voicemail.id),
         ),
       ])
-      // The trailing source-priority term is a per-voicemail tie-break so a
-      // sender number shared by a local and an external (PBX) contact
-      // resolves to the external one (the first row kept by the collapse).
-      ..orderBy([OrderingTerm.asc(voicemail.rowId), ...contacts.sourcePriorityOrder()]);
+      // Newest voicemail first; the trailing source-priority term is a
+      // per-voicemail tie-break so a sender number shared by a local and an
+      // external (PBX) contact resolves to the external one (the first row
+      // kept by the collapse).
+      ..orderBy([OrderingTerm.desc(voicemail.date), ...contacts.sourcePriorityOrder()]);
   }
 
   /// The contact join yields one row per matching contact; keep exactly one

--- a/packages/data/app_database/test/voicemail_dao_test.dart
+++ b/packages/data/app_database/test/voicemail_dao_test.dart
@@ -48,6 +48,18 @@ void main() {
     });
   });
 
+  group('ordering', () {
+    test('returns voicemails newest first', () async {
+      await db.voicemailDao.insertOrUpdateVoicemail(createVoicemail(id: 'vm-old', date: '2026-01-01T00:00:00Z'));
+      await db.voicemailDao.insertOrUpdateVoicemail(createVoicemail(id: 'vm-new', date: '2026-01-03T00:00:00Z'));
+      await db.voicemailDao.insertOrUpdateVoicemail(createVoicemail(id: 'vm-mid', date: '2026-01-02T00:00:00Z'));
+
+      final rows = await db.voicemailDao.getVoicemailsWithContacts();
+
+      expect(rows.map((row) => row.voicemail.id), ['vm-new', 'vm-mid', 'vm-old']);
+    });
+  });
+
   group('contact resolution', () {
     test('collapses colliding contacts to one deterministic row per voicemail', () async {
       await db.contactsDao.insertOnUniqueConflictUpdateContact(


### PR DESCRIPTION
## Overview
Voicemail list was ordered by local insertion row id (ascending), not by the
message timestamp, so newly synced voicemails could appear anywhere in the
list. Order by the voicemail `date` column descending instead, so the newest
voicemail is always first. Contact tie-break for a shared sender number is
unchanged.

## Test plan
- [x] `dart test` in `packages/data/app_database` (added a dedicated ordering test)
- [x] full `flutter test` via pre-push hook (1171 passed)