### PR TITLE
fix: remove dead emergency-number call-failure handling (WT-1730)

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2501,12 +2501,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
 
     if (callkeepError != null) {
-      if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
-        // Self-managed phone accounts cannot place emergency calls. Explain why
-        // and offer to hand the number off to the system dialer, instead of
-        // silently switching to it.
-        submitNotification(EmergencyNumberNotification(e.handle.value));
-      } else if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
+      if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
         CrashlyticsUtils.recordError(
           'CallBloc - __onMutationControlStart selfManagedPhoneAccountNotRegistered',
           information: ['callId: $callId', 'handle: ${e.handle.value}'],

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
@@ -176,32 +175,6 @@ final class GeneralUnableToCallNotification extends MessageNotification {
   @override
   String l10n(BuildContext context) {
     return context.l10n.notifications_errorSnackBar_generalUnableToCall;
-  }
-}
-
-/// Shown when callkeep rejects an outgoing call because the number is an
-/// emergency number. A self-managed phone account cannot place emergency
-/// calls, so we explain why and offer to hand the number off to the system
-/// dialer instead of silently switching apps.
-final class EmergencyNumberNotification extends MessageNotification {
-  const EmergencyNumberNotification(this.number);
-
-  final String number;
-
-  @override
-  String l10n(BuildContext context) {
-    return context.l10n.notifications_errorSnackBar_emergencyNumber(number);
-  }
-
-  @override
-  SnackBarAction? action(BuildContext context) {
-    return SnackBarAction(
-      label: context.l10n.notifications_errorSnackBarAction_emergencyNumber,
-      onPressed: () async {
-        final telUri = Uri(scheme: 'tel', path: number);
-        if (await canLaunchUrl(telUri)) launchUrl(telUri);
-      },
-    );
   }
 }
 


### PR DESCRIPTION
## Overview

webtrit_callkeep no longer produces `CallkeepCallRequestError.emergencyNumber`: the outgoing
call Uri is now always built with a `sip:` scheme (see the companion callkeep PR), so Android's
Telecom emergency-number matching never triggers for a self-managed call in the first place.
This removes the now-unreachable handling on the phone side:

- `CallBloc.__onMutationControlStart` no longer branches on `CallkeepCallRequestError.emergencyNumber`;
  it falls through to the generic failure path.
- `EmergencyNumberNotification` (the snackbar offering to hand the number to the system dialer)
  is deleted from `lib/features/call/models/notification.dart`.

`CallkeepCallRequestError.emergencyNumber` and the `notifications_errorSnackBar_emergencyNumber` /
`notifications_errorSnackBarAction_emergencyNumber` l10n keys are intentionally left in place
(pigeon wire enum, Localizely-managed strings) - they are dead but harmless; removing them needs
an upstream Localizely change, out of scope here.

Depends on the callkeep sip-scheme fix (path dependency, already picked up on develop).