### PR TITLE
build: bump app version to 1.16.1+5

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -997,6 +997,8 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       _CallSignalingEventPeerMediaState() => __onCallSignalingEventPeerMediaState(event, emit),
       _CallSignalingEventTransfer() => __onCallSignalingEventTransfer(event, emit),
       _CallSignalingEventTransferring() => __onCallSignalingEventTransfering(event, emit),
+      _CallSignalingEventTransferAccepted() => __onCallSignalingEventTransferAccepted(event, emit),
+      _CallSignalingEventTransferFailed() => __onCallSignalingEventTransferFailed(event, emit),
       _CallSignalingEventNotifyRefer() => __onCallSignalingEventNotifyRefer(event, emit),
       _CallSignalingEventNotifyUnknown() => __onCallSignalingEventNotifyUnknown(event, emit),
       _CallSignalingEventRegistration() => __onCallSignalingEventRegistration(event, emit),
@@ -1374,6 +1376,44 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
 
     final callUpdate = call.copyWith(transfer: transfer);
     emit(state.copyWithMappedActiveCall(event.callId, (_) => callUpdate));
+  }
+
+  /// The transfer completed - the backend hangs up both of the transferor's
+  /// legs right after this, so there is nothing to roll back here. Clears
+  /// the transient [Transfer] state defensively in case that hangup is
+  /// delayed, so the UI never gets stuck showing "Transferring...".
+  Future<void> __onCallSignalingEventTransferAccepted(
+    _CallSignalingEventTransferAccepted event,
+    Emitter<CallState> emit,
+  ) async {
+    final call = state.retrieveActiveCall(event.callId);
+    if (call == null || call.transfer == null) return;
+
+    emit(state.copyWithMappedActiveCall(event.callId, (activeCall) => activeCall.copyWith(transfer: null)));
+  }
+
+  /// The backend rejected the transfer (e.g. a self-referential REFER, or the
+  /// consultation party is unreachable). Unlike [TransferringEvent] the call
+  /// is NOT hung up automatically, so roll back the transient [Transfer]
+  /// state, un-hold the call so the user can keep talking or retry, and
+  /// surface a notification - mirroring how [ReferFailed] already recovers a
+  /// blind transfer rejected mid-flight.
+  Future<void> __onCallSignalingEventTransferFailed(
+    _CallSignalingEventTransferFailed event,
+    Emitter<CallState> emit,
+  ) async {
+    final call = state.retrieveActiveCall(event.callId);
+    if (call == null) return;
+
+    _logger.warning('__onCallSignalingEventTransferFailed: transfer failed (code=${event.code}) for ${event.callId}');
+
+    emit(state.copyWithMappedActiveCall(event.callId, (activeCall) => activeCall.copyWith(transfer: null)));
+    await callkeep.setHeld(event.callId, onHold: false);
+    // The wording ("Transfer failed, returning to active call") is generic
+    // enough for both flavors - `transfer_failed` fires the same way for
+    // blind and attended transfer, and a dedicated notification/l10n key
+    // isn't worth it just to rename this for the attended case.
+    submitNotification(BlindTransferFailedNotification());
   }
 
   Future<void> __onGlobalEventNumberPresenceUpdate(
@@ -4210,6 +4250,10 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
       add(const _CallSignalingEvent.registration(RegistrationStatus.unregistered));
     } else if (event is TransferringEvent) {
       add(_CallSignalingEvent.transferring(line: event.line, callId: event.callId));
+    } else if (event is TransferAcceptedEvent) {
+      add(_CallSignalingEvent.transferAccepted(line: event.line, callId: event.callId));
+    } else if (event is TransferFailedEvent) {
+      add(_CallSignalingEvent.transferFailed(line: event.line, callId: event.callId, code: event.code));
     } else if (event is GlobalEvent) {
       add(switch (event) {
         NumberPresenceUpdate event => _GlobalEvent.numberPresenceUpdate(

--- a/lib/features/call/bloc/call_event.dart
+++ b/lib/features/call/bloc/call_event.dart
@@ -210,6 +210,12 @@ sealed class _CallSignalingEvent extends CallEvent {
   const factory _CallSignalingEvent.transferring({required int? line, required String callId}) =
       _CallSignalingEventTransferring;
 
+  const factory _CallSignalingEvent.transferAccepted({required int? line, required String callId}) =
+      _CallSignalingEventTransferAccepted;
+
+  const factory _CallSignalingEvent.transferFailed({required int? line, required String callId, int? code}) =
+      _CallSignalingEventTransferFailed;
+
   const factory _CallSignalingEvent.notifyRefer({
     required int? line,
     required String callId,
@@ -464,6 +470,27 @@ class _CallSignalingEventTransferring extends _CallSignalingEvent {
 
   @override
   List<Object?> get props => [line, callId];
+}
+
+class _CallSignalingEventTransferAccepted extends _CallSignalingEvent {
+  const _CallSignalingEventTransferAccepted({required this.line, required this.callId});
+
+  final int? line;
+  final String callId;
+
+  @override
+  List<Object?> get props => [line, callId];
+}
+
+class _CallSignalingEventTransferFailed extends _CallSignalingEvent {
+  const _CallSignalingEventTransferFailed({required this.line, required this.callId, this.code});
+
+  final int? line;
+  final String callId;
+  final int? code;
+
+  @override
+  List<Object?> get props => [line, callId, code];
 }
 
 class _CallSignalingEventNotifyRefer extends _CallSignalingEvent {

--- a/packages/webtrit_signaling/lib/src/events/call/call_events.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/call_events.dart
@@ -15,6 +15,8 @@ export 'progress_event.dart';
 export 'resuming_event.dart';
 export 'ringing_event.dart';
 export 'subscription_state.dart';
+export 'transfer_accepted_event.dart';
+export 'transfer_failed_event.dart';
 export 'transferring_event.dart';
 export 'updated_event.dart';
 export 'updating_call_event.dart';

--- a/packages/webtrit_signaling/lib/src/events/call/transfer_accepted_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/transfer_accepted_event.dart
@@ -1,0 +1,29 @@
+import '../abstract_events.dart';
+
+class TransferAcceptedEvent extends CallEvent {
+  const TransferAcceptedEvent({super.transaction, required super.line, required super.callId, this.code});
+
+  static const typeValue = 'transfer_accepted';
+
+  final int? code;
+
+  @override
+  List<Object?> get props => [...super.props, code];
+
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(typeValue), if (code != null) 'code': code};
+
+  factory TransferAcceptedEvent.fromJson(Map<String, dynamic> json) {
+    final eventTypeValue = json[Event.typeKey];
+    if (eventTypeValue != typeValue) {
+      throw ArgumentError.value(eventTypeValue, Event.typeKey, 'Not equal $typeValue');
+    }
+
+    return TransferAcceptedEvent(
+      transaction: json['transaction'],
+      line: json['line'],
+      callId: json['call_id'],
+      code: json['code'],
+    );
+  }
+}

--- a/packages/webtrit_signaling/lib/src/events/call/transfer_failed_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call/transfer_failed_event.dart
@@ -1,0 +1,29 @@
+import '../abstract_events.dart';
+
+class TransferFailedEvent extends CallEvent {
+  const TransferFailedEvent({super.transaction, required super.line, required super.callId, this.code});
+
+  static const typeValue = 'transfer_failed';
+
+  final int? code;
+
+  @override
+  List<Object?> get props => [...super.props, code];
+
+  @override
+  Map<String, dynamic> toJson() => {...callBaseJson(typeValue), if (code != null) 'code': code};
+
+  factory TransferFailedEvent.fromJson(Map<String, dynamic> json) {
+    final eventTypeValue = json[Event.typeKey];
+    if (eventTypeValue != typeValue) {
+      throw ArgumentError.value(eventTypeValue, Event.typeKey, 'Not equal $typeValue');
+    }
+
+    return TransferFailedEvent(
+      transaction: json['transaction'],
+      line: json['line'],
+      callId: json['call_id'],
+      code: json['code'],
+    );
+  }
+}

--- a/packages/webtrit_signaling/lib/src/events/call_event.dart
+++ b/packages/webtrit_signaling/lib/src/events/call_event.dart
@@ -46,6 +46,8 @@ abstract class CallEvent extends LineEvent {
     ProgressEvent.typeValue: ProgressEvent.fromJson,
     ResumingEvent.typeValue: ResumingEvent.fromJson,
     RingingEvent.typeValue: RingingEvent.fromJson,
+    TransferAcceptedEvent.typeValue: TransferAcceptedEvent.fromJson,
+    TransferFailedEvent.typeValue: TransferFailedEvent.fromJson,
     TransferringEvent.typeValue: TransferringEvent.fromJson,
     UpdatedEvent.typeValue: UpdatedEvent.fromJson,
     UpdatingCallEvent.typeValue: UpdatingCallEvent.fromJson,

--- a/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
+++ b/packages/webtrit_signaling/lib/src/handshakes/state_handshake.dart
@@ -111,6 +111,23 @@ class StateHandshake extends Handshake {
       code: registrationMessage['code'],
       reason: registrationMessage['reason'],
     );
+    // TODO: an unrecognized/malformed entry in a line's or the guest line's
+    // call_logs below throws and fails this whole handshake. Since this
+    // handshake is replayed on every reconnect, one bad entry becomes a
+    // reconnect loop for as long as the call carrying it stays alive - not
+    // just a one-off failure. A prior attempt made per-entry parsing
+    // resilient (log + skip instead of throw), but that alone silently
+    // breaks a real invariant: consumers (e.g. the "latest call event"
+    // lookups in the call-restoration and push-isolate handshake handlers)
+    // assume call_logs is newest-first and complete, and use firstOrNull/
+    // lastOrNull to read the latest/earliest event - dropping an entry can
+    // make a server-terminated call look active or vice versa. A correct fix
+    // needs to either preserve position for unparseable entries (so
+    // consumers can detect "the newest entry was unparseable" and treat the
+    // read as inconclusive) or otherwise flag that entries were dropped, and
+    // should narrow the catch to the specific unrecognized-type case so a
+    // genuine parsing bug in an already-known type still fails loudly - not
+    // done here; see git history for a prior (closed) attempt.
     final linesJson = json['lines'] as List<dynamic>;
     final lines = linesJson
         .asMap()

--- a/packages/webtrit_signaling/test/src/events/call/transfer_accepted_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/transfer_accepted_event_test.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:webtrit_signaling/src/events/call/transfer_accepted_event.dart';
+
+void main() {
+  test('$TransferAcceptedEvent fromJson with code', () {
+    const transferAcceptedEventJson = '''
+    {
+      "event": "transfer_accepted",
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "code": 202
+    }
+    ''';
+
+    final event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 202);
+
+    expect(
+      TransferAcceptedEvent.fromJson(json.decode(transferAcceptedEventJson) as Map<String, dynamic>),
+      equals(event),
+    );
+  });
+
+  test('$TransferAcceptedEvent fromJson without code', () {
+    const transferAcceptedEventJson = '''
+    {
+      "event": "transfer_accepted",
+      "line": 0,
+      "call_id": "qwerty"
+    }
+    ''';
+
+    final event = TransferAcceptedEvent(line: 0, callId: 'qwerty');
+
+    expect(
+      TransferAcceptedEvent.fromJson(json.decode(transferAcceptedEventJson) as Map<String, dynamic>),
+      equals(event),
+    );
+  });
+
+  test('$TransferAcceptedEvent toJson round-trips', () {
+    const event = TransferAcceptedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 202);
+
+    expect(TransferAcceptedEvent.fromJson(event.toJson()), equals(event));
+  });
+}

--- a/packages/webtrit_signaling/test/src/events/call/transfer_failed_event_test.dart
+++ b/packages/webtrit_signaling/test/src/events/call/transfer_failed_event_test.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:webtrit_signaling/src/events/call/transfer_failed_event.dart';
+
+void main() {
+  test('$TransferFailedEvent fromJson with code', () {
+    const transferFailedEventJson = '''
+    {
+      "event": "transfer_failed",
+      "transaction": "transaction 1",
+      "line": 0,
+      "call_id": "qwerty",
+      "code": 400
+    }
+    ''';
+
+    final event = TransferFailedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 400);
+
+    expect(TransferFailedEvent.fromJson(json.decode(transferFailedEventJson) as Map<String, dynamic>), equals(event));
+  });
+
+  test('$TransferFailedEvent fromJson without code', () {
+    const transferFailedEventJson = '''
+    {
+      "event": "transfer_failed",
+      "line": 0,
+      "call_id": "qwerty"
+    }
+    ''';
+
+    final event = TransferFailedEvent(line: 0, callId: 'qwerty');
+
+    expect(TransferFailedEvent.fromJson(json.decode(transferFailedEventJson) as Map<String, dynamic>), equals(event));
+  });
+
+  test('$TransferFailedEvent toJson round-trips', () {
+    const event = TransferFailedEvent(transaction: 'transaction 1', line: 0, callId: 'qwerty', code: 400);
+
+    expect(TransferFailedEvent.fromJson(event.toJson()), equals(event));
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ version: 0.0.0+0
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.1+4
+app_version: 1.16.1+5
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Overview

Patch for the release/1.16.1 line (in QA): cherry-picks the signaling transfer-events fix from develop PR #1517 (WT-1729). The signaling client treated `transfer_accepted` and `transfer_failed` call events as unknown, which turned every attended transfer completion into a client error, a signaling disconnect and a reconnect cycle.

## Changes (cherry-picked from #1517)

- New `TransferAcceptedEvent` / `TransferFailedEvent` classes registered in the `webtrit_signaling` event decoder (with optional `code` support, confirmed against a real payload).
- CallBloc wiring: success defensively clears the `Transfer` state; failure clears it, un-holds the call and notifies via the existing blind-transfer failure notification (mirrors the `ReferFailed` recovery path).
- Unit tests for both events (fromJson/toJson, with and without `code`).
- `app_version` bumped to `1.16.1+5`.

## Testing

- `flutter analyze` clean, full suite green on this branch (pre-push).