### PR TITLE
feat(voicemail): default transcription source to local instead of disabled (WT-719)

### DIFF
--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -1404,6 +1404,10 @@ extension AppLocalizationsExtension on AppLocalizations {
       'transcriptionSettings_Model_fastTitle' =>
         transcriptionSettings_Model_fastTitle,
       'transcriptionSettings_Model_note' => transcriptionSettings_Model_note,
+      'transcriptionSettings_Model_offSubtitle' =>
+        transcriptionSettings_Model_offSubtitle,
+      'transcriptionSettings_Model_offTitle' =>
+        transcriptionSettings_Model_offTitle,
       'transcriptionSettings_Widget_screenTitle' =>
         transcriptionSettings_Widget_screenTitle,
       'voicemail_Widget_screenTitle' => voicemail_Widget_screenTitle,

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.dart
@@ -747,7 +747,7 @@ class ChatContactInfo with _$ChatContactInfo {
 @JsonSerializable(explicitToJson: true)
 class AppConfigTranscription with _$AppConfigTranscription {
   const AppConfigTranscription({
-    this.mode = 'disabled',
+    this.mode = 'local',
     this.language,
     this.local = const AppConfigTranscriptionLocal(),
     this.remote = const AppConfigTranscriptionRemote(),

--- a/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/features_config/app_config.g.dart
@@ -601,7 +601,7 @@ Map<String, dynamic> _$ChatContactInfoToJson(ChatContactInfo instance) =>
 AppConfigTranscription _$AppConfigTranscriptionFromJson(
   Map<String, dynamic> json,
 ) => AppConfigTranscription(
-  mode: json['mode'] as String? ?? 'disabled',
+  mode: json['mode'] as String? ?? 'local',
   language: json['language'] as String?,
   local: json['local'] == null
       ? const AppConfigTranscriptionLocal()

--- a/test/mappers/transcription_mapper_test.dart
+++ b/test/mappers/transcription_mapper_test.dart
@@ -25,10 +25,10 @@ void main() {
       expect(config.remoteModel, 'large-v3');
     });
 
-    test('defaults to the disabled mode with no local model selected', () {
+    test('defaults to the local mode with no local model selected', () {
       final config = TranscriptionMapper.map(const AppConfig());
 
-      expect(TranscriptionMode.fromName(config.mode), TranscriptionMode.disabled);
+      expect(TranscriptionMode.fromName(config.mode), TranscriptionMode.local);
       expect(config.language, isNull);
       expect(config.localModel, const LocalTranscriptionModelOff());
       expect(config.remoteUrl, isNull);


### PR DESCRIPTION
## Overview
A brand-new theme (in the configurator, or any config that omits the
`transcription` section entirely) currently defaults `AppConfigTranscription.mode`
to `disabled`. Changes the default to `local`; the local model itself still
defaults to `off` (unchanged), so nothing downloads or transcribes until the
user opts in from the app's own transcription settings screen. Also
regenerates the stale l10n mapper entries for the `Off` tier
title/subtitle (added by #1521, but missing from the generated mapper on
develop).

## Test plan
- [x] `flutter analyze` - no issues
- [x] `flutter test` (full suite, via pre-push hook) - 1184 passed