### PR TITLE
build: bump app_version build iteration to 1.15.4+9

### DIFF
--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -1758,7 +1758,7 @@ abstract class AppLocalizations {
   /// No description provided for @login_Button_qrSigninAllowCameraAccess.
   ///
   /// In en, this message translates to:
-  /// **'Allow camera access'**
+  /// **'Continue'**
   String get login_Button_qrSigninAllowCameraAccess;
 
   /// No description provided for @login_Button_qrSigninOpenSettings.

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -946,7 +946,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Camera access is needed to scan a QR code. Enable it to continue.';
 
   @override
-  String get login_Button_qrSigninAllowCameraAccess => 'Allow camera access';
+  String get login_Button_qrSigninAllowCameraAccess => 'Continue';
 
   @override
   String get login_Button_qrSigninOpenSettings => 'Open settings';

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -952,7 +952,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'L\'accesso alla fotocamera è necessario per scansionare un codice QR. Attivalo per continuare.';
 
   @override
-  String get login_Button_qrSigninAllowCameraAccess => 'Consenti l\'accesso alla fotocamera';
+  String get login_Button_qrSigninAllowCameraAccess => 'Continua';
 
   @override
   String get login_Button_qrSigninOpenSettings => 'Apri le impostazioni';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -955,7 +955,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Для сканування QR-коду потрібен доступ до камери. Увімкніть його, щоб продовжити.';
 
   @override
-  String get login_Button_qrSigninAllowCameraAccess => 'Надати доступ до камери';
+  String get login_Button_qrSigninAllowCameraAccess => 'Продовжити';
 
   @override
   String get login_Button_qrSigninOpenSettings => 'Відкрити налаштування';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -792,7 +792,7 @@
   "@login_Text_qrSigninCameraPermissionTitle": {},
   "login_Text_qrSigninCameraPermissionDescription": "Camera access is needed to scan a QR code. Enable it to continue.",
   "@login_Text_qrSigninCameraPermissionDescription": {},
-  "login_Button_qrSigninAllowCameraAccess": "Allow camera access",
+  "login_Button_qrSigninAllowCameraAccess": "Continue",
   "@login_Button_qrSigninAllowCameraAccess": {},
   "login_Button_qrSigninOpenSettings": "Open settings",
   "@login_Button_qrSigninOpenSettings": {},

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -792,7 +792,7 @@
   "@login_Text_qrSigninCameraPermissionTitle": {},
   "login_Text_qrSigninCameraPermissionDescription": "L'accesso alla fotocamera è necessario per scansionare un codice QR. Attivalo per continuare.",
   "@login_Text_qrSigninCameraPermissionDescription": {},
-  "login_Button_qrSigninAllowCameraAccess": "Consenti l'accesso alla fotocamera",
+  "login_Button_qrSigninAllowCameraAccess": "Continua",
   "@login_Button_qrSigninAllowCameraAccess": {},
   "login_Button_qrSigninOpenSettings": "Apri le impostazioni",
   "@login_Button_qrSigninOpenSettings": {},

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -792,7 +792,7 @@
   "@login_Text_qrSigninCameraPermissionTitle": {},
   "login_Text_qrSigninCameraPermissionDescription": "Для сканування QR-коду потрібен доступ до камери. Увімкніть його, щоб продовжити.",
   "@login_Text_qrSigninCameraPermissionDescription": {},
-  "login_Button_qrSigninAllowCameraAccess": "Надати доступ до камери",
+  "login_Button_qrSigninAllowCameraAccess": "Продовжити",
   "@login_Button_qrSigninAllowCameraAccess": {},
   "login_Button_qrSigninOpenSettings": "Відкрити налаштування",
   "@login_Button_qrSigninOpenSettings": {},

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.15.4+8
+app_version: 1.15.4+9
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Overview

Patch for the client line release/1.15.4-develop-untested: cherry-picks the QR sign-in camera-permission button wording fix from develop PR #1519. The button on the QR sign-in camera permission screen said "Allow camera access", which reads as if tapping it grants the permission; it actually proceeds to the system prompt (or settings), so the wording is now the neutral "Continue" / "Continua" / "Продовжити".

## Changes (cherry-picked from #1519)

- `login_Button_qrSigninAllowCameraAccess` reworded in en/it/uk arb files and the generated localizations (the th locale does not exist on this line, dropped from the pick).
- `app_version` bumped to `1.15.4+9`.

## Testing

- `flutter analyze` clean, full suite green on this branch (pre-push).