### PR TITLE
build: bump app version to 1.16.0+12

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2448,12 +2448,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
 
     if (callkeepError != null) {
-      if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
-        // Self-managed phone accounts cannot place emergency calls. Explain why
-        // and offer to hand the number off to the system dialer, instead of
-        // silently switching to it.
-        submitNotification(EmergencyNumberNotification(e.handle.value));
-      } else if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
+      if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
         CrashlyticsUtils.recordError(
           'CallBloc - __onMutationControlStart selfManagedPhoneAccountNotRegistered',
           information: ['callId: $callId', 'handle: ${e.handle.value}'],

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
@@ -176,32 +175,6 @@ final class GeneralUnableToCallNotification extends MessageNotification {
   @override
   String l10n(BuildContext context) {
     return context.l10n.notifications_errorSnackBar_generalUnableToCall;
-  }
-}
-
-/// Shown when callkeep rejects an outgoing call because the number is an
-/// emergency number. A self-managed phone account cannot place emergency
-/// calls, so we explain why and offer to hand the number off to the system
-/// dialer instead of silently switching apps.
-final class EmergencyNumberNotification extends MessageNotification {
-  const EmergencyNumberNotification(this.number);
-
-  final String number;
-
-  @override
-  String l10n(BuildContext context) {
-    return context.l10n.notifications_errorSnackBar_emergencyNumber(number);
-  }
-
-  @override
-  SnackBarAction? action(BuildContext context) {
-    return SnackBarAction(
-      label: context.l10n.notifications_errorSnackBarAction_emergencyNumber,
-      onPressed: () async {
-        final telUri = Uri(scheme: 'tel', path: number);
-        if (await canLaunchUrl(telUri)) launchUrl(telUri);
-      },
-    );
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2001,17 +2001,17 @@ packages:
     dependency: "direct main"
     description:
       path: webtrit_callkeep
-      ref: "1.3.0"
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
-    version: "1.3.0+1"
+    version: "1.3.0+2"
   webtrit_callkeep_android:
     dependency: transitive
     description:
       path: webtrit_callkeep_android
-      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2019,8 +2019,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_ios
-      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2028,8 +2028,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_linux
-      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"
@@ -2037,8 +2037,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_macos
-      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"
@@ -2046,8 +2046,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_platform_interface
-      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2055,8 +2055,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_web
-      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2064,8 +2064,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_windows
-      ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
-      resolved-ref: b7006b6522ae590ae29d1c1b41bc035034dfd411
+      ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
+      resolved-ref: "9752652fcde4798138cb16098d11aaf5d0c4bf5d"
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -129,7 +129,7 @@ dependencies:
     # Release branches pin callkeep to a published tag (see docs/release_versioning.md).
     git:
       url: https://github.com/WebTrit/webtrit_callkeep.git
-      ref: 1.3.0
+      ref: 9752652fcde4798138cb16098d11aaf5d0c4bf5d
       path: webtrit_callkeep
   webtrit_phone_number:
     path: ./packages/webtrit_phone_number

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ version: 0.0.0+0000000
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.0+11
+app_version: 1.16.0+12
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Overview

Patch for the active release/1.16.0 line delivering the emergency-number collision fix pair (WT-1730): the patched callkeep 1.3.0+2 (release-line PR #350, cherry-picked from callkeep develop PR #349) plus the matching app-side cleanup from develop PR #1522. Android classifies some ordinary PBX short numbers as emergency for certain carriers/regions, and self-managed outgoing calls to them were rejected; with the patched callkeep those calls go through, and the app-side handling of the now-removed emergency failure notification is dropped.

## Changes

- callkeep git pin moved from the `1.3.0` tag to the patched release/1.3.0 tip (`9752652`, version 1.3.0+2), same raw-sha delivery as the earlier 1.3.0+1 patch; lock re-resolved.
- Cherry-pick of #1522: dead emergency-number call-failure handling removed from CallBloc and the notifications model.
- `app_version` bumped to `1.16.0+12`.

## Testing

- `flutter analyze` clean, full suite green on this branch (pre-push).
- callkeep side verified on its patch branch: analyze clean, 207 Flutter tests, Kotlin unit tests green.