### PR TITLE
build: bump app version to 1.16.1+6

### DIFF
--- a/lib/features/call/bloc/call_bloc.dart
+++ b/lib/features/call/bloc/call_bloc.dart
@@ -2555,12 +2555,7 @@ class CallBloc extends Bloc<CallEvent, CallState> with WidgetsBindingObserver im
     );
 
     if (callkeepError != null) {
-      if (callkeepError == CallkeepCallRequestError.emergencyNumber) {
-        // Self-managed phone accounts cannot place emergency calls. Explain why
-        // and offer to hand the number off to the system dialer, instead of
-        // silently switching to it.
-        submitNotification(EmergencyNumberNotification(e.handle.value));
-      } else if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
+      if (callkeepError == CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered) {
         CrashlyticsUtils.recordError(
           'CallBloc - __onMutationControlStart selfManagedPhoneAccountNotRegistered',
           information: ['callId: $callId', 'handle: ${e.handle.value}'],

--- a/lib/features/call/models/notification.dart
+++ b/lib/features/call/models/notification.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 
@@ -176,32 +175,6 @@ final class GeneralUnableToCallNotification extends MessageNotification {
   @override
   String l10n(BuildContext context) {
     return context.l10n.notifications_errorSnackBar_generalUnableToCall;
-  }
-}
-
-/// Shown when callkeep rejects an outgoing call because the number is an
-/// emergency number. A self-managed phone account cannot place emergency
-/// calls, so we explain why and offer to hand the number off to the system
-/// dialer instead of silently switching apps.
-final class EmergencyNumberNotification extends MessageNotification {
-  const EmergencyNumberNotification(this.number);
-
-  final String number;
-
-  @override
-  String l10n(BuildContext context) {
-    return context.l10n.notifications_errorSnackBar_emergencyNumber(number);
-  }
-
-  @override
-  SnackBarAction? action(BuildContext context) {
-    return SnackBarAction(
-      label: context.l10n.notifications_errorSnackBarAction_emergencyNumber,
-      onPressed: () async {
-        final telUri = Uri(scheme: 'tel', path: number);
-        if (await canLaunchUrl(telUri)) launchUrl(telUri);
-      },
-    );
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2003,16 +2003,16 @@ packages:
     description:
       path: webtrit_callkeep
       ref: "1.3.1"
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
-    version: "1.3.1+0"
+    version: "1.3.1+1"
   webtrit_callkeep_android:
     dependency: transitive
     description:
       path: webtrit_callkeep_android
-      ref: bbf48ce41c652da02db883945f43f2661e02bcde
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2020,8 +2020,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_ios
-      ref: bbf48ce41c652da02db883945f43f2661e02bcde
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2029,8 +2029,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_linux
-      ref: bbf48ce41c652da02db883945f43f2661e02bcde
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"
@@ -2038,8 +2038,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_macos
-      ref: bbf48ce41c652da02db883945f43f2661e02bcde
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"
@@ -2047,8 +2047,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_platform_interface
-      ref: bbf48ce41c652da02db883945f43f2661e02bcde
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2056,8 +2056,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_web
-      ref: bbf48ce41c652da02db883945f43f2661e02bcde
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.0.0+0"
@@ -2065,8 +2065,8 @@ packages:
     dependency: transitive
     description:
       path: webtrit_callkeep_windows
-      ref: bbf48ce41c652da02db883945f43f2661e02bcde
-      resolved-ref: bbf48ce41c652da02db883945f43f2661e02bcde
+      ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
+      resolved-ref: e49efe6605ed75a02b171ddf7c8bb906d5241a73
       url: "https://github.com/WebTrit/webtrit_callkeep.git"
     source: git
     version: "0.1.0+1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ version: 0.0.0+0
 # Where:
 #   - <Major>, <Minor>, <Patch>: non-negative integers, decided by the developer
 # app_version represents tasks and fixed bugs, which is different from the build version that is specific to each client
-app_version: 1.16.1+5
+app_version: 1.16.1+6
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Overview

Patch for the release/1.16.1 line (in QA) delivering the emergency-number collision fix pair (WT-1730): the patched callkeep 1.3.1+1 (release-line PR #351, cherry-picked from callkeep develop PR #349) plus the matching app-side cleanup from develop PR #1522. Android classifies some ordinary PBX short numbers as emergency for certain carriers/regions, and self-managed outgoing calls to them were rejected; with the patched callkeep those calls go through, and the app-side handling of the now-removed emergency failure notification is dropped.

## Changes

- The temporary `1.3.1` tag was moved to the patched release/1.3.1 tip (`e49efe6`, version 1.3.1+1); the pubspec ref stays `1.3.1`, lock re-resolved to the new tip.
- Cherry-pick of #1522: dead emergency-number call-failure handling removed from CallBloc and the notifications model.
- `app_version` bumped to `1.16.1+6`.

## Testing

- `flutter analyze` clean, full suite green on this branch (pre-push).
- callkeep side verified on its patch branch: analyze clean, 207 Flutter tests, Kotlin unit tests green.