### PR TITLE
feat: pseudorandom avatar colors (WT-782)

### DIFF
--- a/assets/themes/original.widget.dark.config.json
+++ b/assets/themes/original.widget.dark.config.json
@@ -117,6 +117,10 @@
         "availableColor": null,
         "unavailableColor": null,
         "sizeFactor": 0.325
+      },
+      "nameColors": {
+        "enabled": true,
+        "palette": null
       }
     }
   },

--- a/assets/themes/original.widget.light.config.json
+++ b/assets/themes/original.widget.light.config.json
@@ -121,6 +121,10 @@
         "availableColor": null,
         "unavailableColor": null,
         "sizeFactor": 0.325
+      },
+      "nameColors": {
+        "enabled": true,
+        "palette": null
       }
     }
   },

--- a/docs/widgets_configuration.md
+++ b/docs/widgets_configuration.md
@@ -183,6 +183,12 @@ smart badges, and registration status markers.
 - **Loading overlay** — loader visibility, padding, stroke width.
 - **Smart indicator** — top-left badge with background color, icon, and size factor.
 - **Registered badge** — bottom-right badge with colors for registered/unregistered and size factor.
+- **Name colors** — pseudorandom, name-derived colors for avatars without a photo:
+    - **enabled** — when `true` (default), the circle background and initials color are derived
+      deterministically from the displayed name, so the same contact/chat/group always gets the
+      same color; set to `false` to keep the static `backgroundColor` / `initialsTextStyle.color`.
+    - **palette** — optional list of hex colors to pick from; when `null` or empty the color is
+      generated from the name hash (unbounded number of hues, tuned per light/dark theme).
 
 **Example:**
 
@@ -227,6 +233,10 @@ smart badges, and registration status markers.
       "registeredColor": null,
       "unregisteredColor": null,
       "sizeFactor": 0.2
+    },
+    "nameColors": {
+      "enabled": true,
+      "palette": null
     }
   }
 }

--- a/lib/features/messaging/widgets/group_avatar.dart
+++ b/lib/features/messaging/widgets/group_avatar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/theme/styles/styles.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 
 class GroupAvatar extends StatelessWidget {
   const GroupAvatar({super.key, required this.name, this.size = 24, this.style});
@@ -15,8 +16,19 @@ class GroupAvatar extends StatelessWidget {
     final themeStyle = theme.extension<LeadingAvatarStyles>()?.primary;
     final effectiveStyle = LeadingAvatarStyle.merge(themeStyle, style);
 
-    final backgroundColor = effectiveStyle.backgroundColor ?? theme.colorScheme.secondaryContainer;
-    final initialsStyle = effectiveStyle.initialsTextStyle;
+    // Absent config means on: only an explicit `enabled: false` opts out.
+    final nameColors = effectiveStyle.nameColors ?? const NameColorsStyle();
+    final nameBackgroundColor = nameColors.enabled
+        ? AvatarColors.background(name, theme.brightness, palette: nameColors.palette)
+        : null;
+
+    final backgroundColor =
+        nameBackgroundColor ?? effectiveStyle.backgroundColor ?? theme.colorScheme.secondaryContainer;
+    final initialsStyle = nameBackgroundColor != null
+        ? effectiveStyle.initialsTextStyle?.copyWith(
+            color: AvatarColors.foreground(nameBackgroundColor, theme.brightness),
+          )
+        : effectiveStyle.initialsTextStyle;
 
     return SizedBox(
       width: size * 2,

--- a/lib/theme/factory/styles/leading_avatar_style_factory.dart
+++ b/lib/theme/factory/styles/leading_avatar_style_factory.dart
@@ -25,6 +25,7 @@ class LeadingAvatarStyleFactory implements ThemeStyleFactory<LeadingAvatarStyles
         smartIndicator: _mapSmart(config?.smartIndicator),
         registeredBadge: _mapRegistered(config?.registeredBadge),
         presenceBadge: _mapPresence(config?.presenceBadge),
+        nameColors: _mapNameColors(config?.nameColors),
       ),
     );
   }
@@ -64,6 +65,13 @@ class LeadingAvatarStyleFactory implements ThemeStyleFactory<LeadingAvatarStyles
       unregisteredColor: c.unregisteredColor?.toColor(),
       sizeFactor: c.sizeFactor,
     );
+  }
+
+  /// Name-derived colors are on by default: a theme without a `nameColors` block still gets them,
+  /// only an explicit `"enabled": false` turns them off.
+  NameColorsStyle _mapNameColors(NameColorsStyleConfig? c) {
+    if (c == null) return const NameColorsStyle();
+    return NameColorsStyle(enabled: c.enabled, palette: c.palette?.map((hex) => hex.toColor()).toList());
   }
 
   PresenceBadgeStyle? _mapPresence(PresenceBadgeStyleConfig? c) {

--- a/lib/theme/styles/leading_avatar_style.dart
+++ b/lib/theme/styles/leading_avatar_style.dart
@@ -17,6 +17,7 @@ class LeadingAvatarStyle with Diagnosticable {
     this.smartIndicator,
     this.registeredBadge,
     this.presenceBadge,
+    this.nameColors,
   });
 
   /// Circle background; falls back to ColorScheme.secondaryContainer when null.
@@ -43,6 +44,9 @@ class LeadingAvatarStyle with Diagnosticable {
   /// Presence badge (bottom-right).
   final PresenceBadgeStyle? presenceBadge;
 
+  /// Pseudorandom, name-derived background/initials colors.
+  final NameColorsStyle? nameColors;
+
   static LeadingAvatarStyle merge(LeadingAvatarStyle? base, LeadingAvatarStyle? override) {
     if (base == null && override == null) return const LeadingAvatarStyle();
     base ??= const LeadingAvatarStyle();
@@ -60,6 +64,7 @@ class LeadingAvatarStyle with Diagnosticable {
       smartIndicator: SmartIndicatorStyle.merge(base.smartIndicator, override.smartIndicator),
       registeredBadge: RegisteredBadgeStyle.merge(base.registeredBadge, override.registeredBadge),
       presenceBadge: PresenceBadgeStyle.merge(base.presenceBadge, override.presenceBadge),
+      nameColors: NameColorsStyle.merge(base.nameColors, override.nameColors),
     );
   }
 
@@ -76,6 +81,7 @@ class LeadingAvatarStyle with Diagnosticable {
       smartIndicator: SmartIndicatorStyle.lerp(a?.smartIndicator, b?.smartIndicator, t),
       registeredBadge: RegisteredBadgeStyle.lerp(a?.registeredBadge, b?.registeredBadge, t),
       presenceBadge: PresenceBadgeStyle.lerp(a?.presenceBadge, b?.presenceBadge, t),
+      nameColors: t < 0.5 ? (a?.nameColors ?? b?.nameColors) : (b?.nameColors ?? a?.nameColors),
     );
   }
 
@@ -90,7 +96,35 @@ class LeadingAvatarStyle with Diagnosticable {
       ..add(DiagnosticsProperty<LoadingOverlayStyle?>('loadingOverlay', loadingOverlay))
       ..add(DiagnosticsProperty<SmartIndicatorStyle?>('smartIndicator', smartIndicator))
       ..add(DiagnosticsProperty<RegisteredBadgeStyle?>('registeredBadge', registeredBadge))
-      ..add(DiagnosticsProperty<PresenceBadgeStyle?>('presenceBadge', presenceBadge));
+      ..add(DiagnosticsProperty<PresenceBadgeStyle?>('presenceBadge', presenceBadge))
+      ..add(DiagnosticsProperty<NameColorsStyle?>('nameColors', nameColors));
+  }
+}
+
+/// Pseudorandom, name-derived avatar colors (see `AvatarColors`).
+class NameColorsStyle with Diagnosticable {
+  const NameColorsStyle({this.enabled = true, this.palette});
+
+  /// Whether the background/initials colors are derived from the name.
+  final bool enabled;
+
+  /// Optional fixed palette; when null/empty the color is generated from the name hash.
+  final List<Color>? palette;
+
+  static NameColorsStyle? merge(NameColorsStyle? base, NameColorsStyle? override) {
+    if (base == null && override == null) return null;
+    if (base == null) return override;
+    if (override == null) return base;
+
+    return NameColorsStyle(enabled: override.enabled, palette: override.palette ?? base.palette);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(FlagProperty('enabled', value: enabled, ifTrue: 'enabled'))
+      ..add(IterableProperty<Color>('palette', palette));
   }
 }
 

--- a/lib/utils/avatar_colors.dart
+++ b/lib/utils/avatar_colors.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// Deterministic ("pseudorandom") avatar colors derived from a name.
+///
+/// The same seed always produces the same color, so a contact/chat/group keeps
+/// its color across rebuilds, screens, sessions and devices - no persistence needed.
+///
+/// Two modes:
+/// - no explicit palette: the seed hash picks a hue and the color is built in HSL with a
+///   fixed saturation/lightness pair per [Brightness], which guarantees readable initials
+///   for every possible hue;
+/// - explicit palette (from the appearance theme): the seed hash picks an entry, and the
+///   foreground falls back to a luminance-based black/white choice.
+class AvatarColors {
+  const AvatarColors._();
+
+  /// Saturation/lightness of the generated background and of the initials on top of it.
+  static const _backgroundSaturation = 0.7;
+  static const _foregroundSaturation = 0.2;
+  static const _lightBackgroundLightness = 0.25;
+  static const _lightForegroundLightness = 0.95;
+  static const _darkBackgroundLightness = 0.8;
+  static const _darkForegroundLightness = 0.05;
+
+  /// Background color for [seed]; returns null for an empty/blank seed so callers
+  /// can keep their static fallback.
+  static Color? background(String? seed, Brightness brightness, {List<Color>? palette}) {
+    final hash = _hash(seed);
+    if (hash == null) return null;
+
+    if (palette != null && palette.isNotEmpty) return palette[hash % palette.length];
+
+    final lightness = brightness == Brightness.dark ? _darkBackgroundLightness : _lightBackgroundLightness;
+    return HSLColor.fromAHSL(1, (hash % 360).toDouble(), _backgroundSaturation, lightness).toColor();
+  }
+
+  /// Initials color to place on top of [background].
+  static Color foreground(Color background, Brightness brightness) {
+    final hsl = HSLColor.fromColor(background);
+
+    // A grey/near-grey palette entry has no usable hue - fall back to plain contrast.
+    if (hsl.saturation < 0.1) {
+      return background.computeLuminance() > 0.5 ? Colors.black87 : Colors.white;
+    }
+
+    final lightness = brightness == Brightness.dark ? _darkForegroundLightness : _lightForegroundLightness;
+    return HSLColor.fromAHSL(1, hsl.hue, _foregroundSaturation, lightness).toColor();
+  }
+
+  /// FNV-1a over the normalized seed; null when there is nothing to hash.
+  static int? _hash(String? seed) {
+    final normalized = seed?.trim().toLowerCase() ?? '';
+    if (normalized.isEmpty) return null;
+
+    var hash = 0x811c9dc5;
+    for (final rune in normalized.runes) {
+      hash = (hash ^ rune) & 0xFFFFFFFF;
+      hash = (hash * 0x01000193) & 0xFFFFFFFF;
+    }
+    return hash;
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,3 +1,4 @@
+export 'avatar_colors.dart';
 export 'backoff_retries.dart';
 export 'badge_layout.dart';
 export 'bloc_concurrency.dart';

--- a/lib/widgets/leading_avatar.dart
+++ b/lib/widgets/leading_avatar.dart
@@ -112,15 +112,30 @@ class _LeadingAvatarState extends State<LeadingAvatar> {
     );
   }
 
+  /// Name-derived background, or null when disabled / not applicable (photo shown, no name).
+  Color? _nameBackgroundColor(BuildContext context) {
+    // Absent config means on: only an explicit `enabled: false` opts out.
+    final nameColors = _style.nameColors ?? const NameColorsStyle();
+    if (!nameColors.enabled) return null;
+    if (widget.thumbnail != null || widget.thumbnailUrl != null) return null;
+
+    return AvatarColors.background(widget.username, Theme.of(context).brightness, palette: nameColors.palette);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
     final presenceParams = PresenceViewParams.of(context);
+    final nameBackgroundColor = _nameBackgroundColor(context);
 
     return Container(
       width: _diameter,
       height: _diameter,
-      decoration: BoxDecoration(shape: BoxShape.circle, color: _style.backgroundColor ?? scheme.secondaryContainer),
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: nameBackgroundColor ?? _style.backgroundColor ?? scheme.secondaryContainer,
+      ),
       child: Stack(
         alignment: Alignment.center,
         fit: StackFit.loose,
@@ -208,7 +223,11 @@ class _LeadingAvatarState extends State<LeadingAvatar> {
   Widget _placeholder(double diameter, LeadingAvatarStyle style) {
     final username = widget.username;
     final icon = style.placeholderIcon ?? widget.placeholderIcon;
-    final color = style.initialsTextStyle?.color;
+    final brightness = Theme.of(context).brightness;
+    final nameBackgroundColor = _nameBackgroundColor(context);
+    final color = nameBackgroundColor != null
+        ? AvatarColors.foreground(nameBackgroundColor, brightness)
+        : style.initialsTextStyle?.color;
 
     if (username != null) {
       final defaultTs = TextStyle(fontSize: diameter * 0.35, fontWeight: FontWeight.bold);
@@ -219,7 +238,7 @@ class _LeadingAvatarState extends State<LeadingAvatar> {
           softWrap: false,
           overflow: TextOverflow.fade,
           textAlign: TextAlign.center,
-          style: defaultTs.merge(style.initialsTextStyle),
+          style: defaultTs.merge(style.initialsTextStyle).copyWith(color: color),
         ),
       );
     }

--- a/packages/webtrit_appearance_theme/lib/models/common/leading_avatar_style_config.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/leading_avatar_style_config.dart
@@ -39,6 +39,9 @@ class LeadingAvatarStyleConfig with _$LeadingAvatarStyleConfig {
 
     /// Presence badge appearance.
     this.presenceBadge,
+
+    /// Per-name pseudorandom color appearance.
+    this.nameColors,
   });
 
   /// Circle background color. Defaults to theme.secondaryContainer when null.
@@ -73,9 +76,44 @@ class LeadingAvatarStyleConfig with _$LeadingAvatarStyleConfig {
   @override
   final PresenceBadgeStyleConfig? presenceBadge;
 
+  /// Per-name pseudorandom color appearance.
+  @override
+  final NameColorsStyleConfig? nameColors;
+
   factory LeadingAvatarStyleConfig.fromJson(Map<String, Object?> json) => _$LeadingAvatarStyleConfigFromJson(json);
 
   Map<String, Object?> toJson() => _$LeadingAvatarStyleConfigToJson(this);
+}
+
+/// Pseudorandom, name-derived avatar colors.
+///
+/// When enabled, an avatar without a photo gets a background deterministically derived from
+/// the displayed name instead of the static [LeadingAvatarStyleConfig.backgroundColor].
+@freezed
+@JsonSerializable()
+class NameColorsStyleConfig with _$NameColorsStyleConfig {
+  /// Creates a [NameColorsStyleConfig].
+  const NameColorsStyleConfig({
+    /// Whether name-derived colors are used at all.
+    this.enabled = true,
+
+    /// Optional fixed palette to pick from; when null/empty the color is generated from the
+    /// name hash (hue) so the number of distinct colors is unbounded.
+    this.palette,
+  });
+
+  /// Whether name-derived colors are used at all.
+  @override
+  final bool enabled;
+
+  /// Optional fixed palette to pick from; when null/empty the color is generated from the
+  /// name hash (hue) so the number of distinct colors is unbounded.
+  @override
+  final List<String>? palette;
+
+  factory NameColorsStyleConfig.fromJson(Map<String, Object?> json) => _$NameColorsStyleConfigFromJson(json);
+
+  Map<String, Object?> toJson() => _$NameColorsStyleConfigToJson(this);
 }
 
 /// Loading overlay style shown while avatar data is unavailable.

--- a/packages/webtrit_appearance_theme/lib/models/common/leading_avatar_style_config.freezed.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/leading_avatar_style_config.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$LeadingAvatarStyleConfig {
 
- String? get backgroundColor; double? get radius; TextStyleConfig? get initialsTextStyle; IconDataConfig? get placeholderIcon; LoadingOverlayStyleConfig? get loading; SmartIndicatorStyleConfig? get smartIndicator; RegisteredBadgeStyleConfig? get registeredBadge; PresenceBadgeStyleConfig? get presenceBadge;
+ String? get backgroundColor; double? get radius; TextStyleConfig? get initialsTextStyle; IconDataConfig? get placeholderIcon; LoadingOverlayStyleConfig? get loading; SmartIndicatorStyleConfig? get smartIndicator; RegisteredBadgeStyleConfig? get registeredBadge; PresenceBadgeStyleConfig? get presenceBadge; NameColorsStyleConfig? get nameColors;
 /// Create a copy of LeadingAvatarStyleConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $LeadingAvatarStyleConfigCopyWith<LeadingAvatarStyleConfig> get copyWith => _$Le
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LeadingAvatarStyleConfig&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.radius, radius) || other.radius == radius)&&(identical(other.initialsTextStyle, initialsTextStyle) || other.initialsTextStyle == initialsTextStyle)&&(identical(other.placeholderIcon, placeholderIcon) || other.placeholderIcon == placeholderIcon)&&(identical(other.loading, loading) || other.loading == loading)&&(identical(other.smartIndicator, smartIndicator) || other.smartIndicator == smartIndicator)&&(identical(other.registeredBadge, registeredBadge) || other.registeredBadge == registeredBadge)&&(identical(other.presenceBadge, presenceBadge) || other.presenceBadge == presenceBadge));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LeadingAvatarStyleConfig&&(identical(other.backgroundColor, backgroundColor) || other.backgroundColor == backgroundColor)&&(identical(other.radius, radius) || other.radius == radius)&&(identical(other.initialsTextStyle, initialsTextStyle) || other.initialsTextStyle == initialsTextStyle)&&(identical(other.placeholderIcon, placeholderIcon) || other.placeholderIcon == placeholderIcon)&&(identical(other.loading, loading) || other.loading == loading)&&(identical(other.smartIndicator, smartIndicator) || other.smartIndicator == smartIndicator)&&(identical(other.registeredBadge, registeredBadge) || other.registeredBadge == registeredBadge)&&(identical(other.presenceBadge, presenceBadge) || other.presenceBadge == presenceBadge)&&(identical(other.nameColors, nameColors) || other.nameColors == nameColors));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,backgroundColor,radius,initialsTextStyle,placeholderIcon,loading,smartIndicator,registeredBadge,presenceBadge);
+int get hashCode => Object.hash(runtimeType,backgroundColor,radius,initialsTextStyle,placeholderIcon,loading,smartIndicator,registeredBadge,presenceBadge,nameColors);
 
 @override
 String toString() {
-  return 'LeadingAvatarStyleConfig(backgroundColor: $backgroundColor, radius: $radius, initialsTextStyle: $initialsTextStyle, placeholderIcon: $placeholderIcon, loading: $loading, smartIndicator: $smartIndicator, registeredBadge: $registeredBadge, presenceBadge: $presenceBadge)';
+  return 'LeadingAvatarStyleConfig(backgroundColor: $backgroundColor, radius: $radius, initialsTextStyle: $initialsTextStyle, placeholderIcon: $placeholderIcon, loading: $loading, smartIndicator: $smartIndicator, registeredBadge: $registeredBadge, presenceBadge: $presenceBadge, nameColors: $nameColors)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $LeadingAvatarStyleConfigCopyWith<$Res>  {
   factory $LeadingAvatarStyleConfigCopyWith(LeadingAvatarStyleConfig value, $Res Function(LeadingAvatarStyleConfig) _then) = _$LeadingAvatarStyleConfigCopyWithImpl;
 @useResult
 $Res call({
- String? backgroundColor, double? radius, TextStyleConfig? initialsTextStyle, IconDataConfig? placeholderIcon, LoadingOverlayStyleConfig? loading, SmartIndicatorStyleConfig? smartIndicator, RegisteredBadgeStyleConfig? registeredBadge, PresenceBadgeStyleConfig? presenceBadge
+ String? backgroundColor, double? radius, TextStyleConfig? initialsTextStyle, IconDataConfig? placeholderIcon, LoadingOverlayStyleConfig? loading, SmartIndicatorStyleConfig? smartIndicator, RegisteredBadgeStyleConfig? registeredBadge, PresenceBadgeStyleConfig? presenceBadge, NameColorsStyleConfig? nameColors
 });
 
 
@@ -63,7 +63,7 @@ class _$LeadingAvatarStyleConfigCopyWithImpl<$Res>
 
 /// Create a copy of LeadingAvatarStyleConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? backgroundColor = freezed,Object? radius = freezed,Object? initialsTextStyle = freezed,Object? placeholderIcon = freezed,Object? loading = freezed,Object? smartIndicator = freezed,Object? registeredBadge = freezed,Object? presenceBadge = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? backgroundColor = freezed,Object? radius = freezed,Object? initialsTextStyle = freezed,Object? placeholderIcon = freezed,Object? loading = freezed,Object? smartIndicator = freezed,Object? registeredBadge = freezed,Object? presenceBadge = freezed,Object? nameColors = freezed,}) {
   return _then(LeadingAvatarStyleConfig(
 backgroundColor: freezed == backgroundColor ? _self.backgroundColor : backgroundColor // ignore: cast_nullable_to_non_nullable
 as String?,radius: freezed == radius ? _self.radius : radius // ignore: cast_nullable_to_non_nullable
@@ -73,7 +73,8 @@ as IconDataConfig?,loading: freezed == loading ? _self.loading : loading // igno
 as LoadingOverlayStyleConfig?,smartIndicator: freezed == smartIndicator ? _self.smartIndicator : smartIndicator // ignore: cast_nullable_to_non_nullable
 as SmartIndicatorStyleConfig?,registeredBadge: freezed == registeredBadge ? _self.registeredBadge : registeredBadge // ignore: cast_nullable_to_non_nullable
 as RegisteredBadgeStyleConfig?,presenceBadge: freezed == presenceBadge ? _self.presenceBadge : presenceBadge // ignore: cast_nullable_to_non_nullable
-as PresenceBadgeStyleConfig?,
+as PresenceBadgeStyleConfig?,nameColors: freezed == nameColors ? _self.nameColors : nameColors // ignore: cast_nullable_to_non_nullable
+as NameColorsStyleConfig?,
   ));
 }
 
@@ -82,6 +83,193 @@ as PresenceBadgeStyleConfig?,
 
 /// Adds pattern-matching-related methods to [LeadingAvatarStyleConfig].
 extension LeadingAvatarStyleConfigPatterns on LeadingAvatarStyleConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$NameColorsStyleConfig {
+
+ bool get enabled; List<String>? get palette;
+/// Create a copy of NameColorsStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NameColorsStyleConfigCopyWith<NameColorsStyleConfig> get copyWith => _$NameColorsStyleConfigCopyWithImpl<NameColorsStyleConfig>(this as NameColorsStyleConfig, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NameColorsStyleConfig&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other.palette, palette));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(palette));
+
+@override
+String toString() {
+  return 'NameColorsStyleConfig(enabled: $enabled, palette: $palette)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NameColorsStyleConfigCopyWith<$Res>  {
+  factory $NameColorsStyleConfigCopyWith(NameColorsStyleConfig value, $Res Function(NameColorsStyleConfig) _then) = _$NameColorsStyleConfigCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled, List<String>? palette
+});
+
+
+
+
+}
+/// @nodoc
+class _$NameColorsStyleConfigCopyWithImpl<$Res>
+    implements $NameColorsStyleConfigCopyWith<$Res> {
+  _$NameColorsStyleConfigCopyWithImpl(this._self, this._then);
+
+  final NameColorsStyleConfig _self;
+  final $Res Function(NameColorsStyleConfig) _then;
+
+/// Create a copy of NameColorsStyleConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? palette = freezed,}) {
+  return _then(NameColorsStyleConfig(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,palette: freezed == palette ? _self.palette : palette // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [NameColorsStyleConfig].
+extension NameColorsStyleConfigPatterns on NameColorsStyleConfig {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:

--- a/packages/webtrit_appearance_theme/lib/models/common/leading_avatar_style_config.g.dart
+++ b/packages/webtrit_appearance_theme/lib/models/common/leading_avatar_style_config.g.dart
@@ -41,6 +41,11 @@ LeadingAvatarStyleConfig _$LeadingAvatarStyleConfigFromJson(
       : PresenceBadgeStyleConfig.fromJson(
           json['presenceBadge'] as Map<String, dynamic>,
         ),
+  nameColors: json['nameColors'] == null
+      ? null
+      : NameColorsStyleConfig.fromJson(
+          json['nameColors'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$LeadingAvatarStyleConfigToJson(
@@ -54,6 +59,23 @@ Map<String, dynamic> _$LeadingAvatarStyleConfigToJson(
   'smartIndicator': instance.smartIndicator?.toJson(),
   'registeredBadge': instance.registeredBadge?.toJson(),
   'presenceBadge': instance.presenceBadge?.toJson(),
+  'nameColors': instance.nameColors?.toJson(),
+};
+
+NameColorsStyleConfig _$NameColorsStyleConfigFromJson(
+  Map<String, dynamic> json,
+) => NameColorsStyleConfig(
+  enabled: json['enabled'] as bool? ?? true,
+  palette: (json['palette'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+);
+
+Map<String, dynamic> _$NameColorsStyleConfigToJson(
+  NameColorsStyleConfig instance,
+) => <String, dynamic>{
+  'enabled': instance.enabled,
+  'palette': instance.palette,
 };
 
 LoadingOverlayStyleConfig _$LoadingOverlayStyleConfigFromJson(

--- a/test/utils/avatar_colors_test.dart
+++ b/test/utils/avatar_colors_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/utils/avatar_colors.dart';
+
+void main() {
+  group('AvatarColors.background', () {
+    test('is deterministic for the same seed', () {
+      expect(
+        AvatarColors.background('John Doe', Brightness.light),
+        AvatarColors.background('John Doe', Brightness.light),
+      );
+    });
+
+    test('ignores case and surrounding whitespace', () {
+      expect(
+        AvatarColors.background('  john doe ', Brightness.light),
+        AvatarColors.background('John Doe', Brightness.light),
+      );
+    });
+
+    test('returns null for null/blank seeds', () {
+      expect(AvatarColors.background(null, Brightness.light), isNull);
+      expect(AvatarColors.background('', Brightness.light), isNull);
+      expect(AvatarColors.background('   ', Brightness.light), isNull);
+    });
+
+    test('differs between light and dark brightness', () {
+      expect(
+        AvatarColors.background('John Doe', Brightness.light),
+        isNot(AvatarColors.background('John Doe', Brightness.dark)),
+      );
+    });
+
+    test('spreads distinct seeds over multiple colors', () {
+      final seeds = List.generate(30, (i) => 'Contact $i');
+      final colors = seeds.map((s) => AvatarColors.background(s, Brightness.light)).toSet();
+
+      expect(colors.length, greaterThan(15));
+    });
+
+    test('picks from an explicit palette', () {
+      const palette = [Colors.red, Colors.green, Colors.blue];
+
+      for (final seed in ['a', 'bb', 'ccc', 'John Doe']) {
+        expect(palette, contains(AvatarColors.background(seed, Brightness.light, palette: palette)));
+      }
+    });
+
+    test('falls back to generated colors for an empty palette', () {
+      expect(
+        AvatarColors.background('John Doe', Brightness.light, palette: const []),
+        AvatarColors.background('John Doe', Brightness.light),
+      );
+    });
+  });
+
+  group('AvatarColors.foreground', () {
+    test('contrasts with the generated background', () {
+      for (final brightness in Brightness.values) {
+        final background = AvatarColors.background('John Doe', brightness)!;
+        final foreground = AvatarColors.foreground(background, brightness);
+
+        expect((background.computeLuminance() - foreground.computeLuminance()).abs(), greaterThan(0.2));
+      }
+    });
+
+    test('uses plain black/white on greyscale palette entries', () {
+      expect(AvatarColors.foreground(Colors.white, Brightness.light), Colors.black87);
+      expect(AvatarColors.foreground(Colors.black, Brightness.light), Colors.white);
+    });
+  });
+}

--- a/test/widgets/leading_avatar_test.dart
+++ b/test/widgets/leading_avatar_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/theme/styles/styles.dart';
+import 'package:webtrit_phone/utils/utils.dart';
+import 'package:webtrit_phone/widgets/leading_avatar.dart';
+
+void main() {
+  Widget wrap(Widget child, {NameColorsStyle? nameColors}) {
+    return MaterialApp(
+      theme: ThemeData(
+        extensions: [
+          LeadingAvatarStyles(
+            primary: LeadingAvatarStyle(
+              backgroundColor: const Color(0xFFEEF3F6),
+              initialsTextStyle: const TextStyle(color: Color(0xFF1F618F)),
+              nameColors: nameColors,
+            ),
+          ),
+        ],
+      ),
+      home: Scaffold(
+        body: PresenceViewParams(
+          hybridPresenceSupport: false,
+          blfViaSipSupport: false,
+          presenceViaSipSupport: false,
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  Color backgroundOf(WidgetTester tester) {
+    final container = tester.widget<Container>(
+      find.descendant(of: find.byType(LeadingAvatar), matching: find.byType(Container)).first,
+    );
+    return (container.decoration! as BoxDecoration).color!;
+  }
+
+  Color initialsColorOf(WidgetTester tester) {
+    return tester
+        .widget<Text>(find.descendant(of: find.byType(LeadingAvatar), matching: find.byType(Text)))
+        .style!
+        .color!;
+  }
+
+  group('LeadingAvatar name colors', () {
+    testWidgets('derives the background from the username', (tester) async {
+      await tester.pumpWidget(wrap(const LeadingAvatar(username: 'John Doe'), nameColors: const NameColorsStyle()));
+
+      expect(backgroundOf(tester), AvatarColors.background('John Doe', Brightness.light));
+    });
+
+    testWidgets('gives different names different backgrounds', (tester) async {
+      await tester.pumpWidget(wrap(const LeadingAvatar(username: 'John Doe'), nameColors: const NameColorsStyle()));
+      final first = backgroundOf(tester);
+
+      await tester.pumpWidget(wrap(const LeadingAvatar(username: 'Jane Roe'), nameColors: const NameColorsStyle()));
+
+      expect(backgroundOf(tester), isNot(first));
+    });
+
+    testWidgets('contrasts the initials with the derived background', (tester) async {
+      await tester.pumpWidget(wrap(const LeadingAvatar(username: 'John Doe'), nameColors: const NameColorsStyle()));
+
+      expect(initialsColorOf(tester), AvatarColors.foreground(backgroundOf(tester), Brightness.light));
+    });
+
+    testWidgets('keeps the themed colors when disabled', (tester) async {
+      await tester.pumpWidget(
+        wrap(const LeadingAvatar(username: 'John Doe'), nameColors: const NameColorsStyle(enabled: false)),
+      );
+
+      expect(backgroundOf(tester), const Color(0xFFEEF3F6));
+      expect(initialsColorOf(tester), const Color(0xFF1F618F));
+    });
+
+    testWidgets('is on when the theme has no nameColors block', (tester) async {
+      await tester.pumpWidget(wrap(const LeadingAvatar(username: 'John Doe')));
+
+      expect(backgroundOf(tester), AvatarColors.background('John Doe', Brightness.light));
+    });
+
+    testWidgets('keeps the themed background when there is no name', (tester) async {
+      await tester.pumpWidget(wrap(const LeadingAvatar(username: null), nameColors: const NameColorsStyle()));
+
+      expect(backgroundOf(tester), const Color(0xFFEEF3F6));
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces support for deterministic, name-derived avatar colors (sometimes called "pseudorandom" avatar colors) for contacts, chats, and groups without a photo. This feature ensures that each name gets a consistent background and initials color across sessions and devices, improving visual distinction and user experience. The implementation is theme-configurable, with options to enable/disable the feature and provide a custom palette. The changes affect theme configuration, style handling, and avatar rendering.

The most important changes are:

**Feature: Name-derived avatar colors**
* Added a new `nameColors` configuration block to theme files (e.g., `original.widget.light.config.json`, `original.widget.dark.config.json`) and documented it in `widgets_configuration.md`. This block enables/disables the feature and allows specifying a palette of colors. [[1]](diffhunk://#diff-a01ab9065d888e90cabc3a75a4f5cccdf810d14ae0a7d937f4a5befe71a36e94R120-R123) [[2]](diffhunk://#diff-5010fcc9aab1aecf6e4929b1ebd783bf72610cb47b471601d56f1c1d021fb963R124-R127) [[3]](diffhunk://#diff-c1261702e431480a20fee65731a95e9d23339ad3cfb8cbbb41834edca72bf029R186-R191) [[4]](diffhunk://#diff-c1261702e431480a20fee65731a95e9d23339ad3cfb8cbbb41834edca72bf029R236-R239)
* Implemented the `AvatarColors` utility class to generate deterministic colors from names, supporting both palette-based and hue-based color generation. [[1]](diffhunk://#diff-3572a4597ff582a3ea91e522e518b67ff08006167fc05defedd31370ebb34f6aR1-R62) [[2]](diffhunk://#diff-76223fa74af4301fe190c81f9d3fc27fc16dcffe4de170518572b5e442e2aea8R1)
* Updated `LeadingAvatarStyle`, its factory, and related config models to support the new `NameColorsStyle` and `NameColorsStyleConfig`, including merging, serialization, and diagnostics. [[1]](diffhunk://#diff-bff756b4b38ce56137b27d0694675b1a6067fb3a225d5b31d5034e385f885676R28) [[2]](diffhunk://#diff-bff756b4b38ce56137b27d0694675b1a6067fb3a225d5b31d5034e385f885676R70-R76) [[3]](diffhunk://#diff-4839cb84d3b3c28db2e369d6a75b2d1cf3243648004d83a8aa73e8650b8457d4R20) [[4]](diffhunk://#diff-4839cb84d3b3c28db2e369d6a75b2d1cf3243648004d83a8aa73e8650b8457d4R47-R49) [[5]](diffhunk://#diff-4839cb84d3b3c28db2e369d6a75b2d1cf3243648004d83a8aa73e8650b8457d4R67) [[6]](diffhunk://#diff-4839cb84d3b3c28db2e369d6a75b2d1cf3243648004d83a8aa73e8650b8457d4R84) [[7]](diffhunk://#diff-4839cb84d3b3c28db2e369d6a75b2d1cf3243648004d83a8aa73e8650b8457d4L93-R127) [[8]](diffhunk://#diff-31e3b850d2546ee2224cbf6d6167921ddf5aebab1ab9e148e026250f5d252416R42-R44) [[9]](diffhunk://#diff-31e3b850d2546ee2224cbf6d6167921ddf5aebab1ab9e148e026250f5d252416R79-R118) [[10]](diffhunk://#diff-fc4678a2775746716a71f57db8a28e2b877cd4edda60028cb5f6f9d853747a81L18-R18) [[11]](diffhunk://#diff-fc4678a2775746716a71f57db8a28e2b877cd4edda60028cb5f6f9d853747a81L29-R38)
* Modified avatar rendering in `LeadingAvatar` and `GroupAvatar` to use name-derived colors for the background and initials when enabled and no photo is present. [[1]](diffhunk://#diff-1b185d36f8a4cd6bea52ea801243b449ea5b55acd17eb1a210b5d00c35b9d0ccR115-R138) [[2]](diffhunk://#diff-1b185d36f8a4cd6bea52ea801243b449ea5b55acd17eb1a210b5d00c35b9d0ccL211-R230) [[3]](diffhunk://#diff-1b185d36f8a4cd6bea52ea801243b449ea5b55acd17eb1a210b5d00c35b9d0ccL222-R241) [[4]](diffhunk://#diff-9dba79cafdf6ae08bed2e4fd7346da8ae4a79e5d7c07f0d99ca630ed42f3eebeR4) [[5]](diffhunk://#diff-9dba79cafdf6ae08bed2e4fd7346da8ae4a79e5d7c07f0d99ca630ed42f3eebeL18-R31)

**Documentation:**
* Updated `widgets_configuration.md` to describe the new `nameColors` option, its behavior, and configuration examples. [[1]](diffhunk://#diff-c1261702e431480a20fee65731a95e9d23339ad3cfb8cbbb41834edca72bf029R186-R191) [[2]](diffhunk://#diff-c1261702e431480a20fee65731a95e9d23339ad3cfb8cbbb41834edca72bf029R236-R239)

These changes provide a more visually consistent and customizable avatar experience, especially for users and groups without profile photos.