### PR TITLE
feat: call screen avatar (WT-1197)

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -26,6 +26,7 @@ class CallActiveScaffold extends StatefulWidget {
     required this.callConfig,
     required this.localePlaceholderBuilder,
     required this.remotePlaceholderBuilder,
+    this.contactResolver,
   });
 
   final CallStatus callStatus;
@@ -39,6 +40,10 @@ class CallActiveScaffold extends StatefulWidget {
   final CallCapabilitiesConfig callConfig;
   final WidgetBuilder? localePlaceholderBuilder;
   final WidgetBuilder? remotePlaceholderBuilder;
+
+  /// Resolves the remote number to a contact so the avatar shown in place of the
+  /// video can use the contact photo; without it the avatar falls back to initials.
+  final ContactResolver? contactResolver;
 
   @override
   CallActiveScaffoldState createState() => CallActiveScaffoldState();
@@ -298,6 +303,16 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                                                 style: style?.callInfo,
                                                 processingStatus: focusedCall.processingStatus,
                                               ),
+                                            // Nothing to render in the video area (audio-only call,
+                                            // remote camera off, or a held call): the remote party's
+                                            // avatar takes its place, between the info block and the
+                                            // action area.
+                                            if (!_hasRenderableRemoteFrame)
+                                              CallRemoteAvatar(
+                                                activeCall: activeCall,
+                                                radius: _avatarRadius(mediaQueryData),
+                                                contactResolver: widget.contactResolver,
+                                              ),
                                             if (!focusedIsRinging)
                                               ActiveCallActions(
                                                 style: style?.actions,
@@ -466,6 +481,12 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
         ),
       ),
     );
+  }
+
+  /// Radius of the avatar shown in place of the remote video, derived from the screen:
+  /// the call layout sits inside a `FittedBox`, so local constraints are unbounded there.
+  double _avatarRadius(MediaQueryData mediaQueryData) {
+    return (mediaQueryData.size.shortestSide * 0.30).clamp(24.0, 150.0);
   }
 
   /// Generates the list of menu items for the call options popup.

--- a/lib/features/call/view/call_screen.dart
+++ b/lib/features/call/view/call_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/repositories/repositories.dart';
 import 'package:webtrit_phone/theme/theme.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -45,6 +46,11 @@ class _CallScreenState extends State<CallScreen> with AutoRouteAwareStateMixin {
   Widget build(BuildContext context) {
     final callBloc = context.read<CallBloc>();
 
+    final contactResolver = DefaultContactResolver(
+      contactsRepository: context.read<ContactsRepository>(),
+      userRepository: context.read<UserRepository>(),
+    );
+
     final style = Theme.of(context).extension<CallScreenStyles>()?.primary?.systemUiOverlayStyle;
 
     final scaffold = BlocConsumer<CallBloc, CallState>(
@@ -76,6 +82,7 @@ class _CallScreenState extends State<CallScreen> with AutoRouteAwareStateMixin {
             callConfig: widget.callConfig,
             localePlaceholderBuilder: widget.localePlaceholderBuilder,
             remotePlaceholderBuilder: widget.remotePlaceholderBuilder,
+            contactResolver: contactResolver,
           );
         } else {
           return const CallInitScaffold();

--- a/lib/features/call/widgets/call_remote_avatar.dart
+++ b/lib/features/call/widgets/call_remote_avatar.dart
@@ -1,0 +1,169 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+
+import 'package:webtrit_phone/extensions/extensions.dart';
+import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/utils/utils.dart';
+
+import '../bloc/call_bloc.dart';
+import '../utils/utils.dart';
+
+/// Remote party avatar rendered in the area the remote video normally occupies.
+///
+/// Shown while there is nothing to render there - an audio-only call, the remote camera
+/// switched off, or a held call - so the screen is not just an empty background.
+///
+/// Deliberately not `LeadingAvatar`: that widget is built for list-row sized icons and
+/// carries presence/registration badges, a loading overlay and per-theme styling that
+/// this screen has no use for. Only the pseudorandom name color ([AvatarColors]) is
+/// shared, so a contact looks the same here as in the lists.
+class CallRemoteAvatar extends StatefulWidget {
+  const CallRemoteAvatar({super.key, required this.activeCall, required this.radius, this.contactResolver});
+
+  /// Radius of the avatar. The caller derives it from the screen (not from the local
+  /// constraints): the call layout sits inside a `FittedBox`, so the incoming
+  /// constraints there are unbounded.
+  final double radius;
+
+  final ActiveCall activeCall;
+  final ContactResolver? contactResolver;
+
+  @override
+  State<CallRemoteAvatar> createState() => _CallRemoteAvatarState();
+}
+
+class _CallRemoteAvatarState extends State<CallRemoteAvatar> {
+  /// Resolved once per number: the call screen rebuilds on every bloc state change,
+  /// so resolving inside `build` would hit the contacts repository continuously.
+  late Future<Contact?> _contact;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveContact();
+  }
+
+  @override
+  void didUpdateWidget(covariant CallRemoteAvatar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.activeCall.handle.value != widget.activeCall.handle.value ||
+        oldWidget.contactResolver != widget.contactResolver) {
+      _resolveContact();
+    }
+  }
+
+  void _resolveContact() {
+    _contact = widget.contactResolver?.resolve(widget.activeCall.handle.value) ?? Future.value(null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final diameter = widget.radius * 2;
+
+    // Taps belong to the call screen behind it, which toggles the controls.
+    return IgnorePointer(
+      child: FutureBuilder<Contact?>(
+        future: _contact,
+        builder: (context, snapshot) {
+          final contact = snapshot.data;
+          final name = contact?.maybeName ?? widget.activeCall.displayName ?? widget.activeCall.handle.value;
+
+          final background = AvatarColors.background(name, theme.brightness) ?? theme.colorScheme.secondaryContainer;
+
+          return SizedBox.square(
+            dimension: diameter,
+            child: ClipOval(
+              child: ColoredBox(
+                color: background,
+                child: _CallRemoteAvatarContent(
+                  name: name,
+                  thumbnail: contact?.thumbnail,
+                  thumbnailUrl: contact?.thumbnailUrl,
+                  diameter: diameter,
+                  foregroundColor: AvatarColors.foreground(background, theme.brightness),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CallRemoteAvatarContent extends StatelessWidget {
+  const _CallRemoteAvatarContent({
+    required this.name,
+    required this.thumbnail,
+    required this.thumbnailUrl,
+    required this.diameter,
+    required this.foregroundColor,
+  });
+
+  final String name;
+  final Uint8List? thumbnail;
+  final Uri? thumbnailUrl;
+  final double diameter;
+  final Color foregroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final initials = _Initials(name: name, diameter: diameter, color: foregroundColor);
+
+    if (thumbnailUrl != null) {
+      // Ask the remote for the resolution actually painted; the list-sized default
+      // would be upscaled to a blur at this diameter.
+      final devicePixels = (diameter * MediaQuery.devicePixelRatioOf(context)).round();
+      final url = gravatarUrlWithSize(thumbnailUrl, devicePixels) ?? thumbnailUrl!;
+
+      return Image.network(
+        url.toString(),
+        fit: BoxFit.cover,
+        width: diameter,
+        height: diameter,
+        filterQuality: FilterQuality.medium,
+        errorBuilder: (context, error, stackTrace) => _localImage ?? initials,
+        loadingBuilder: (context, child, progress) => progress == null ? child : (_localImage ?? initials),
+      );
+    }
+
+    return _localImage ?? initials;
+  }
+
+  Widget? get _localImage {
+    final thumbnail = this.thumbnail;
+    if (thumbnail == null) return null;
+
+    return Image.memory(
+      thumbnail,
+      fit: BoxFit.cover,
+      width: diameter,
+      height: diameter,
+      filterQuality: FilterQuality.medium,
+      errorBuilder: (context, error, stackTrace) => _Initials(name: name, diameter: diameter, color: foregroundColor),
+    );
+  }
+}
+
+class _Initials extends StatelessWidget {
+  const _Initials({required this.name, required this.diameter, required this.color});
+
+  final String name;
+  final double diameter;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        name.initialism,
+        softWrap: false,
+        overflow: TextOverflow.fade,
+        textAlign: TextAlign.center,
+        style: TextStyle(fontSize: diameter * 0.35, fontWeight: FontWeight.bold, color: color),
+      ),
+    );
+  }
+}

--- a/lib/features/call/widgets/widgets.dart
+++ b/lib/features/call/widgets/widgets.dart
@@ -2,6 +2,7 @@ export 'incoming_call_actions.dart';
 export 'active_call_actions.dart';
 export 'call_active_thumbnail.dart';
 export 'call_info.dart';
+export 'call_remote_avatar.dart';
 export 'call_list.dart';
 export 'focused_action_hint.dart';
 export 'call_network_quality_meter.dart';

--- a/lib/utils/gravatar.dart
+++ b/lib/utils/gravatar.dart
@@ -3,3 +3,15 @@ import 'package:gravatar_utils/gravatar_utils.dart';
 Uri? gravatarThumbnailUrl(String? email, {DefaultImage defaultImage = DefaultImage.fileNotFound}) {
   return email != null ? Gravatar(email).image(scheme: 'https', defaultImage: defaultImage) : null;
 }
+
+/// Re-requests a Gravatar URL at [sizePx] pixels.
+///
+/// Gravatar serves 80x80 by default, which is enough for a list row but visibly soft on
+/// a large avatar, so consumers that render big ask for the size they actually need.
+/// Non-Gravatar URLs are returned unchanged.
+Uri? gravatarUrlWithSize(Uri? url, int sizePx) {
+  if (url == null || !url.host.endsWith('gravatar.com')) return url;
+
+  final size = sizePx.clamp(1, 2048);
+  return url.replace(queryParameters: {...url.queryParameters, 's': '$size'});
+}

--- a/lib/widgets/leading_avatar.dart
+++ b/lib/widgets/leading_avatar.dart
@@ -147,6 +147,14 @@ class _LeadingAvatarState extends State<LeadingAvatar> {
               switchInCurve: Curves.easeInOut,
               switchOutCurve: Curves.easeInOut,
               transitionBuilder: (child, animation) => FadeTransition(opacity: animation, child: child),
+              // The default layout builder stacks the children loosely, which lets an image
+              // size itself to its intrinsic pixels and float in the middle of the circle
+              // instead of covering it; expand so the content always fills the avatar.
+              layoutBuilder: (currentChild, previousChildren) => Stack(
+                fit: StackFit.expand,
+                alignment: Alignment.center,
+                children: [...previousChildren, ?currentChild],
+              ),
               child: _buildAvatarContent(_diameter, _style),
             ),
           ),

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -309,6 +309,24 @@ void main() {
     });
   });
 
+  group('CallActiveScaffold - avatar in the video area', () {
+    testWidgets('audio-only call shows the remote avatar instead of the video overlay', (tester) async {
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [active], focusedCall: active));
+
+      expect(find.byType(CallRemoteAvatar), findsOneWidget);
+      expect(find.byType(RemoteVideoViewOverlay), findsNothing);
+      await _teardown(tester);
+    });
+
+    testWidgets('falls back to the initials of the remote display name', (tester) async {
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [active], focusedCall: active));
+      await tester.pump();
+
+      expect(find.descendant(of: find.byType(CallRemoteAvatar), matching: find.text('BK')), findsOneWidget);
+      await _teardown(tester);
+    });
+  });
+
   group('CallActiveScaffold - 3 calls (held + active + incoming)', () {
     testWidgets('three rows, ringing focus keeps two buttons and the hint', (tester) async {
       final held = _makeCall(callId: 'held', acceptedTime: DateTime(2024), held: true, displayName: 'Clara Diaz');


### PR DESCRIPTION
This pull request adds support for displaying a remote party's avatar in the call screen when there is no remote video available (e.g., in audio-only calls, when the remote camera is off, or during a held call). The avatar attempts to use the contact's photo if available, otherwise it falls back to showing initials. The implementation includes a new `CallRemoteAvatar` widget, updates to the call screen logic to use it, and new tests to cover the avatar display.

**New avatar display in call screen:**

* Introduced the `CallRemoteAvatar` widget, which displays the remote party's avatar or initials in place of the video when appropriate. It resolves the contact using an optional `ContactResolver` and handles both local images and Gravatar URLs, requesting the correct image size for large displays. (`lib/features/call/widgets/call_remote_avatar.dart`)
* Updated `CallActiveScaffold` and `CallScreen` to accept and pass a `contactResolver`, and to render `CallRemoteAvatar` when no remote video frame is available. (`lib/features/call/view/call_active_scaffold.dart`, `lib/features/call/view/call_screen.dart`) [[1]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR29) [[2]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR44-R47) [[3]](diffhunk://#diff-b7cab609412b9ae4a944b36b22c2b5373aee007a33bfc247fd79a837c91c095dR306-R315) [[4]](diffhunk://#diff-ee44a71ca4264eeb817fb3867633136fec2c114b8d7d67c43b9c7db0b914f389R49-R53) [[5]](diffhunk://#diff-ee44a71ca4264eeb817fb3867633136fec2c114b8d7d67c43b9c7db0b914f389R85)
* Exported the new widget for use elsewhere. (`lib/features/call/widgets/widgets.dart`)

**Avatar image handling improvements:**

* Added a utility to request Gravatar images at a specified size, ensuring avatars are crisp at any display size. (`lib/utils/gravatar.dart`)
* Improved the layout builder for `LeadingAvatar` to ensure images always fill the avatar circle. (`lib/widgets/leading_avatar.dart`)

**Testing:**

* Added widget tests to verify that the avatar displays correctly in audio-only calls and falls back to initials when no image is available. (`test/features/call/view/call_active_scaffold_test.dart`)