### PR TITLE
refactor: centralize transient session status smoothing in the cubit (WT-1067)

### DIFF
--- a/lib/features/messaging/widgets/message_view/chat_message_view.dart
+++ b/lib/features/messaging/widgets/message_view/chat_message_view.dart
@@ -103,8 +103,6 @@ class _ChatMessageViewState extends State<ChatMessageView> {
         ? renderBox.localToGlobal(renderBox.size.bottomRight(Offset.zero) + offset, ancestor: overlay)
         : renderBox.localToGlobal(renderBox.size.bottomLeft(Offset.zero) + offset, ancestor: overlay);
 
-    print('RenderBox- a: $a, b: $b, renderBox.size: ${renderBox.size}, overlay.size: ${overlay.size}');
-
     return RelativeRect.fromRect(Rect.fromPoints(a, b), Offset.zero & overlay.size);
   }
 

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -37,8 +37,20 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   CallState? _lastCallState;
   CallkeepAndroidCallDeliveryMode _callDeliveryMode = CallkeepAndroidCallDeliveryMode.unknown;
 
+  /// Times the hold window of a transient episode (see [_emitDebounced]).
+  /// Scheduled once when the episode starts and cancelled by any hard state,
+  /// so oscillating reconnect attempts do not keep postponing the real status.
   final Debounce _transientDebounce = Debounce(kSignalingStatusDebounce);
+
+  /// The latest combined state withheld during a transient episode. Updated on
+  /// every transient change and emitted as-is when the window elapses; a hard
+  /// state discards it. Non-null exactly while an episode is in progress.
   SessionStatusState? _pendingTransient;
+
+  /// Whether the first combined state has been emitted. The constructor's
+  /// default state was never computed from the real sources, so the first
+  /// emission bypasses the smoothing instead of mistaking that default for
+  /// something already on screen.
   bool _bootstrapped = false;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -39,6 +39,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
 
   final Debounce _transientDebounce = Debounce(kSignalingStatusDebounce);
   SessionStatusState? _pendingTransient;
+  bool _bootstrapped = false;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
     _lastPushTokensState = pushTokens;
@@ -95,22 +96,35 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   }
 
   /// Smooths the transient reconnecting states so a reconnect cycle does not
-  /// flicker the UI. Hard states (ready, no network, unregistered) always show
-  /// immediately; a transient state is held back for [kSignalingStatusDebounce]
-  /// and only surfaces if the episode outlives the window:
+  /// flicker the UI. Only the signaling-status dimension is held back: the
+  /// push token error and the side issues are orthogonal to it and always ride
+  /// through immediately. Hard states (ready, no network, unregistered) show
+  /// immediately; a transient signaling status is held for
+  /// [kSignalingStatusDebounce] and only surfaces if the episode outlives the
+  /// window:
   ///
-  /// - from ready the previous status stays on screen, so the re-register blip
-  ///   after a recovery never reaches the UI;
-  /// - from a hard non-ready state (e.g. the network just came back) a calm
-  ///   "connecting" shows right away instead of the real derived state, which
-  ///   at that moment still carries a stale connect error from the outage;
+  /// - from ready and from unregistered the previous status stays on screen,
+  ///   so the re-register blip after a recovery (or a sub-second signaling
+  ///   hiccup) never reaches the UI;
+  /// - from no-network a calm "connecting" shows right away: the network just
+  ///   came back and deserves instant feedback, but the real derived state
+  ///   still carries a stale connect error recorded during the outage;
   /// - transient-to-transient changes only update the pending state.
   ///
   /// The window is scheduled once per transient episode (not reset by further
   /// transient changes): during a prolonged outage the reconnect cycle keeps
   /// oscillating between transient states, and re-scheduling on each of them
-  /// would postpone the real status forever.
+  /// would postpone the real status forever. The very first combined state
+  /// bypasses the smoothing entirely - the default constructor state was never
+  /// computed from the real sources and must not be mistaken for something
+  /// already on screen.
   void _emitDebounced(SessionStatusState next) {
+    if (!_bootstrapped) {
+      _bootstrapped = true;
+      emit(next);
+      return;
+    }
+
     if (!next.status.signalingStatus.isTransientReconnecting) {
       _pendingTransient = null;
       _transientDebounce.cancel();
@@ -128,11 +142,10 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     _pendingTransient = next;
 
     final displayed = state.status.signalingStatus;
-    if (displayed == CallStatus.ready || displayed.isTransientReconnecting) return;
-
+    final shownStatus = displayed == CallStatus.connectivityNone ? CallStatus.inProgress : displayed;
     emit(
       next.copyWith(
-        status: SessionStatus(signalingStatus: CallStatus.inProgress, pushTokenError: next.status.pushTokenError),
+        status: SessionStatus(signalingStatus: shownStatus, pushTokenError: next.status.pushTokenError),
       ),
     );
   }

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -6,21 +6,17 @@ import 'package:logging/logging.dart';
 
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
+import 'package:webtrit_phone/app/constants.dart';
+import 'package:webtrit_phone/extensions/call_status.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/models/models.dart';
+import 'package:webtrit_phone/utils/utils.dart';
 
 part 'session_status_state.dart';
 
 part 'session_status_cubit.freezed.dart';
 
 final _logger = Logger('SessionStatusCubit');
-
-/// How long a downgrade from [CallStatus.ready] is held back before it is
-/// shown. Reconnects re-register the session, which drops the derived status
-/// to a transient non-ready state for well under this window; without the
-/// hold the whole account screen flickers established -> connecting ->
-/// established on every network recovery.
-const kSessionStatusDowngradeDebounce = Duration(seconds: 2);
 
 class SessionStatusCubit extends Cubit<SessionStatusState> {
   SessionStatusCubit({required PushTokensBloc pushTokensBloc, required CallBloc callBloc})
@@ -41,7 +37,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   CallState? _lastCallState;
   CallkeepAndroidCallDeliveryMode _callDeliveryMode = CallkeepAndroidCallDeliveryMode.unknown;
 
-  Timer? _downgradeTimer;
+  final Debounce _downgradeDebounce = Debounce(kSignalingStatusDebounce);
   SessionStatusState? _pendingDowngrade;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
@@ -98,36 +94,40 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     );
   }
 
-  /// Holds back a downgrade from ready to a transient state for
-  /// [kSessionStatusDowngradeDebounce]: a reconnect blip returns to ready
-  /// before the timer fires and never reaches the UI. Losing the network
-  /// entirely and every other transition show immediately.
+  /// Holds back a downgrade from ready to a transient reconnecting state for
+  /// [kSignalingStatusDebounce]: the re-register blip after a network recovery
+  /// returns to ready before the window elapses and never reaches the UI.
+  /// Losing the network entirely, an unregistered session and every transition
+  /// not starting from ready show immediately.
+  ///
+  /// The window is scheduled once per downgrade episode (not reset by further
+  /// transient changes): during a prolonged outage the reconnect cycle keeps
+  /// oscillating between transient states, and re-scheduling on each of them
+  /// would keep the stale ready on screen forever.
   void _emitDebounced(SessionStatusState next) {
     final isTransientDowngrade =
-        state.status.signalingStatus == CallStatus.ready &&
-        next.status.signalingStatus != CallStatus.ready &&
-        next.status.signalingStatus != CallStatus.connectivityNone;
+        state.status.signalingStatus == CallStatus.ready && next.status.signalingStatus.isTransientReconnecting;
 
     if (isTransientDowngrade) {
+      if (_pendingDowngrade == null) {
+        _downgradeDebounce.schedule(() {
+          final pending = _pendingDowngrade;
+          _pendingDowngrade = null;
+          if (pending != null && !isClosed) emit(pending);
+        });
+      }
       _pendingDowngrade = next;
-      _downgradeTimer ??= Timer(kSessionStatusDowngradeDebounce, () {
-        _downgradeTimer = null;
-        final pending = _pendingDowngrade;
-        _pendingDowngrade = null;
-        if (pending != null && !isClosed) emit(pending);
-      });
       return;
     }
 
-    _downgradeTimer?.cancel();
-    _downgradeTimer = null;
     _pendingDowngrade = null;
+    _downgradeDebounce.cancel();
     emit(next);
   }
 
   @override
   Future<void> close() {
-    _downgradeTimer?.cancel();
+    _downgradeDebounce.dispose();
     _callSubscription.cancel();
     _pushTokensSubscription.cancel();
     return super.close();

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -15,6 +15,13 @@ part 'session_status_cubit.freezed.dart';
 
 final _logger = Logger('SessionStatusCubit');
 
+/// How long a downgrade from [CallStatus.ready] is held back before it is
+/// shown. Reconnects re-register the session, which drops the derived status
+/// to a transient non-ready state for well under this window; without the
+/// hold the whole account screen flickers established -> connecting ->
+/// established on every network recovery.
+const kSessionStatusDowngradeDebounce = Duration(seconds: 2);
+
 class SessionStatusCubit extends Cubit<SessionStatusState> {
   SessionStatusCubit({required PushTokensBloc pushTokensBloc, required CallBloc callBloc})
     : super(const SessionStatusState()) {
@@ -33,6 +40,9 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   PushTokensState? _lastPushTokensState;
   CallState? _lastCallState;
   CallkeepAndroidCallDeliveryMode _callDeliveryMode = CallkeepAndroidCallDeliveryMode.unknown;
+
+  Timer? _downgradeTimer;
+  SessionStatusState? _pendingDowngrade;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
     _lastPushTokensState = pushTokens;
@@ -80,7 +90,7 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     final pushTokenError = (pushTokens.pushToken == null && pushTokens.errorMessage != null)
         ? pushTokens.errorMessage
         : null;
-    emit(
+    _emitDebounced(
       state.copyWith(
         status: SessionStatus(signalingStatus: call.status, pushTokenError: pushTokenError),
         issues: _buildIssues(),
@@ -88,8 +98,36 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     );
   }
 
+  /// Holds back a downgrade from ready to a transient state for
+  /// [kSessionStatusDowngradeDebounce]: a reconnect blip returns to ready
+  /// before the timer fires and never reaches the UI. Losing the network
+  /// entirely and every other transition show immediately.
+  void _emitDebounced(SessionStatusState next) {
+    final isTransientDowngrade =
+        state.status.signalingStatus == CallStatus.ready &&
+        next.status.signalingStatus != CallStatus.ready &&
+        next.status.signalingStatus != CallStatus.connectivityNone;
+
+    if (isTransientDowngrade) {
+      _pendingDowngrade = next;
+      _downgradeTimer ??= Timer(kSessionStatusDowngradeDebounce, () {
+        _downgradeTimer = null;
+        final pending = _pendingDowngrade;
+        _pendingDowngrade = null;
+        if (pending != null && !isClosed) emit(pending);
+      });
+      return;
+    }
+
+    _downgradeTimer?.cancel();
+    _downgradeTimer = null;
+    _pendingDowngrade = null;
+    emit(next);
+  }
+
   @override
   Future<void> close() {
+    _downgradeTimer?.cancel();
     _callSubscription.cancel();
     _pushTokensSubscription.cancel();
     return super.close();

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -37,8 +37,8 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
   CallState? _lastCallState;
   CallkeepAndroidCallDeliveryMode _callDeliveryMode = CallkeepAndroidCallDeliveryMode.unknown;
 
-  final Debounce _downgradeDebounce = Debounce(kSignalingStatusDebounce);
-  SessionStatusState? _pendingDowngrade;
+  final Debounce _transientDebounce = Debounce(kSignalingStatusDebounce);
+  SessionStatusState? _pendingTransient;
 
   void _onPushTokensChanged(PushTokensState pushTokens) {
     _lastPushTokensState = pushTokens;
@@ -94,40 +94,52 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     );
   }
 
-  /// Holds back a downgrade from ready to a transient reconnecting state for
-  /// [kSignalingStatusDebounce]: the re-register blip after a network recovery
-  /// returns to ready before the window elapses and never reaches the UI.
-  /// Losing the network entirely, an unregistered session and every transition
-  /// not starting from ready show immediately.
+  /// Smooths the transient reconnecting states so a reconnect cycle does not
+  /// flicker the UI. Hard states (ready, no network, unregistered) always show
+  /// immediately; a transient state is held back for [kSignalingStatusDebounce]
+  /// and only surfaces if the episode outlives the window:
   ///
-  /// The window is scheduled once per downgrade episode (not reset by further
+  /// - from ready the previous status stays on screen, so the re-register blip
+  ///   after a recovery never reaches the UI;
+  /// - from a hard non-ready state (e.g. the network just came back) a calm
+  ///   "connecting" shows right away instead of the real derived state, which
+  ///   at that moment still carries a stale connect error from the outage;
+  /// - transient-to-transient changes only update the pending state.
+  ///
+  /// The window is scheduled once per transient episode (not reset by further
   /// transient changes): during a prolonged outage the reconnect cycle keeps
   /// oscillating between transient states, and re-scheduling on each of them
-  /// would keep the stale ready on screen forever.
+  /// would postpone the real status forever.
   void _emitDebounced(SessionStatusState next) {
-    final isTransientDowngrade =
-        state.status.signalingStatus == CallStatus.ready && next.status.signalingStatus.isTransientReconnecting;
-
-    if (isTransientDowngrade) {
-      if (_pendingDowngrade == null) {
-        _downgradeDebounce.schedule(() {
-          final pending = _pendingDowngrade;
-          _pendingDowngrade = null;
-          if (pending != null && !isClosed) emit(pending);
-        });
-      }
-      _pendingDowngrade = next;
+    if (!next.status.signalingStatus.isTransientReconnecting) {
+      _pendingTransient = null;
+      _transientDebounce.cancel();
+      emit(next);
       return;
     }
 
-    _pendingDowngrade = null;
-    _downgradeDebounce.cancel();
-    emit(next);
+    if (_pendingTransient == null) {
+      _transientDebounce.schedule(() {
+        final pending = _pendingTransient;
+        _pendingTransient = null;
+        if (pending != null && !isClosed) emit(pending);
+      });
+    }
+    _pendingTransient = next;
+
+    final displayed = state.status.signalingStatus;
+    if (displayed == CallStatus.ready || displayed.isTransientReconnecting) return;
+
+    emit(
+      next.copyWith(
+        status: SessionStatus(signalingStatus: CallStatus.inProgress, pushTokenError: next.status.pushTokenError),
+      ),
+    );
   }
 
   @override
   Future<void> close() {
-    _downgradeDebounce.dispose();
+    _transientDebounce.dispose();
     _callSubscription.cancel();
     _pushTokensSubscription.cancel();
     return super.close();

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -5,16 +5,14 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
-import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
-class MainAppBar extends StatefulWidget implements PreferredSizeWidget {
+class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
   const MainAppBar({
     super.key,
     this.title,
@@ -39,169 +37,145 @@ class MainAppBar extends StatefulWidget implements PreferredSizeWidget {
   }
 
   @override
-  State<MainAppBar> createState() => _MainAppBarState();
-}
-
-class _MainAppBarState extends State<MainAppBar> {
-  late final TransientDebouncer<SessionStatus> _debouncer;
-
-  @override
-  void initState() {
-    super.initState();
-    final initial = context.read<SessionStatusCubit>().state.status;
-    _debouncer = TransientDebouncer<SessionStatus>(
-      initial: initial,
-      duration: kSignalingStatusDebounce,
-      isTransient: (s) => s.signalingStatus.isTransientReconnecting && !s.hasPushTokenError,
-      getLatest: () => context.read<SessionStatusCubit>().state.status,
-    );
-  }
-
-  @override
-  void dispose() {
-    _debouncer.dispose();
-    super.dispose();
-  }
-
-  void _updateDisplayedStatus(SessionStatus newStatus) {
-    if (!mounted) return;
-    _debouncer.update(newStatus, () => setState(() {}));
-  }
-
-  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    // The smoothing of transient signaling states lives in SessionStatusCubit,
+    // so the status is consumed directly: a second debouncer here would stack
+    // an identical window on top and lag the app bar behind the rest of the UI.
     return RepaintBoundary(
-      child: BlocListener<SessionStatusCubit, SessionStatusState>(
-        listener: (context, state) => _updateDisplayedStatus(state.status),
-        child: AppBar(
-          title: Builder(
-            builder: (context) {
-              Widget? widgetToShow;
-              if (_debouncer.displayed.isEstablishing) {
-                widgetToShow = Row(
-                  key: _debouncer.displayed.key,
-                  mainAxisSize: MainAxisSize.max,
-                  children: [
-                    SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
-                    SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        _debouncer.displayed.appBarl10n(context),
-                        style: theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
+      child: BlocBuilder<SessionStatusCubit, SessionStatusState>(
+        buildWhen: (previous, current) => previous.status != current.status,
+        builder: (context, sessionStatusState) {
+          final status = sessionStatusState.status;
+          return AppBar(
+            title: Builder(
+              builder: (context) {
+                Widget? widgetToShow;
+                if (status.isEstablishing) {
+                  widgetToShow = Row(
+                    key: status.key,
+                    mainAxisSize: MainAxisSize.max,
+                    children: [
+                      SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
+                      SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          status.appBarl10n(context),
+                          style: theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                        ),
                       ),
-                    ),
-                  ],
-                );
-              }
-              widgetToShow ??= Row(mainAxisSize: MainAxisSize.max, children: [widget.title ?? SizedBox.shrink()]);
+                    ],
+                  );
+                }
+                widgetToShow ??= Row(mainAxisSize: MainAxisSize.max, children: [title ?? SizedBox.shrink()]);
 
-              return AnimatedSwitcher(
-                duration: const Duration(milliseconds: 500),
-                transitionBuilder: (child, animation) {
-                  final r = animation.status == AnimationStatus.reverse;
-                  return FadeTransition(
-                    opacity: animation.drive(CurveTween(curve: Curves.easeInOut)),
-                    child: SlideTransition(
-                      position: animation.drive(
-                        Tween<Offset>(
-                          begin: Offset(0, r ? -1 : 1),
-                          end: Offset.zero,
-                        ).chain(CurveTween(curve: Curves.easeOut)),
+                return AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 500),
+                  transitionBuilder: (child, animation) {
+                    final r = animation.status == AnimationStatus.reverse;
+                    return FadeTransition(
+                      opacity: animation.drive(CurveTween(curve: Curves.easeInOut)),
+                      child: SlideTransition(
+                        position: animation.drive(
+                          Tween<Offset>(
+                            begin: Offset(0, r ? -1 : 1),
+                            end: Offset.zero,
+                          ).chain(CurveTween(curve: Curves.easeOut)),
+                        ),
+                        child: child,
                       ),
-                      child: child,
-                    ),
-                  );
-                },
-                switchInCurve: Curves.easeInExpo,
-                switchOutCurve: Curves.easeOutExpo,
-                child: widgetToShow,
-              );
-            },
-          ),
-          bottom: widget.bottom,
-          backgroundColor: widget.backgroundColor,
-          flexibleSpace: widget.flexibleSpace,
-          elevation: widget.elevation,
-          centerTitle: false,
-          actions: [
-            if (_debouncer.displayed.isReady) ...[
-              if (AppBarParams.of(context).pullableCallDialogs.isNotEmpty)
-                CallPullBadge(pullableCallDialogs: AppBarParams.of(context).pullableCallDialogs),
-              if (AppBarParams.of(context).systemNotificationsEnabled) SystemNotificationsBadge(),
-            ],
-            Ink(
-              decoration: ShapeDecoration(
-                shape: CircleBorder(side: BorderSide(color: _debouncer.displayed.color(context))),
-              ),
-              child: BlocBuilder<UserInfoCubit, UserInfoState>(
-                builder: (context, userinfoState) {
-                  final info = userinfoState.userInfo;
-                  return IconButton(
-                    key: mainAppBarKey,
-                    constraints: const BoxConstraints.tightFor(
-                      width: kMinInteractiveDimension,
-                      height: kMinInteractiveDimension,
-                    ),
-                    padding: const EdgeInsets.all(2),
-                    icon: Stack(
-                      clipBehavior: Clip.none,
-                      children: <Widget>[
-                        LeadingAvatar(
-                          username: info?.name ?? info?.numbers.main,
-                          thumbnailUrl: gravatarThumbnailUrl(info?.email),
-                          radius: kMinInteractiveDimension / 2,
-                          showLoading: true,
-                        ),
-                        BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
-                          builder: (context, microphoneStatusState) {
-                            return Visibility(
-                              visible:
-                                  microphoneStatusState.microphonePermissionGranted != null &&
-                                  !microphoneStatusState.microphonePermissionGranted!,
-                              child: Positioned(
-                                right: -8,
-                                top: -2,
-                                child: Container(
-                                  padding: EdgeInsets.all(3),
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(context).colorScheme.error,
-                                    shape: BoxShape.circle,
-                                  ),
-                                  child: Icon(Icons.mic_off, color: Colors.white, size: 14),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                        BlocBuilder<SessionStatusCubit, SessionStatusState>(
-                          buildWhen: (previous, current) => previous.topIssue != current.topIssue,
-                          builder: (context, sessionState) {
-                            final topIssue = sessionState.topIssue;
-                            if (topIssue == null) return const SizedBox.shrink();
-                            return Positioned(
-                              right: -2,
-                              bottom: -2,
-                              child: SessionIssueBadge(color: topIssue.color(context), size: 12),
-                            );
-                          },
-                        ),
-                      ],
-                    ),
-                    onPressed: () {
-                      FocusScope.of(context).unfocus();
-                      context.router.navigate(const SettingsRouterPageRoute());
-                    },
-                  );
-                },
-              ),
+                    );
+                  },
+                  switchInCurve: Curves.easeInExpo,
+                  switchOutCurve: Curves.easeOutExpo,
+                  child: widgetToShow,
+                );
+              },
             ),
-            const SizedBox(width: NavigationToolbar.kMiddleSpacing),
-          ],
-        ),
+            bottom: bottom,
+            backgroundColor: backgroundColor,
+            flexibleSpace: flexibleSpace,
+            elevation: elevation,
+            centerTitle: false,
+            actions: [
+              if (status.isReady) ...[
+                if (AppBarParams.of(context).pullableCallDialogs.isNotEmpty)
+                  CallPullBadge(pullableCallDialogs: AppBarParams.of(context).pullableCallDialogs),
+                if (AppBarParams.of(context).systemNotificationsEnabled) SystemNotificationsBadge(),
+              ],
+              Ink(
+                decoration: ShapeDecoration(
+                  shape: CircleBorder(side: BorderSide(color: status.color(context))),
+                ),
+                child: BlocBuilder<UserInfoCubit, UserInfoState>(
+                  builder: (context, userinfoState) {
+                    final info = userinfoState.userInfo;
+                    return IconButton(
+                      key: mainAppBarKey,
+                      constraints: const BoxConstraints.tightFor(
+                        width: kMinInteractiveDimension,
+                        height: kMinInteractiveDimension,
+                      ),
+                      padding: const EdgeInsets.all(2),
+                      icon: Stack(
+                        clipBehavior: Clip.none,
+                        children: <Widget>[
+                          LeadingAvatar(
+                            username: info?.name ?? info?.numbers.main,
+                            thumbnailUrl: gravatarThumbnailUrl(info?.email),
+                            radius: kMinInteractiveDimension / 2,
+                            showLoading: true,
+                          ),
+                          BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
+                            builder: (context, microphoneStatusState) {
+                              return Visibility(
+                                visible:
+                                    microphoneStatusState.microphonePermissionGranted != null &&
+                                    !microphoneStatusState.microphonePermissionGranted!,
+                                child: Positioned(
+                                  right: -8,
+                                  top: -2,
+                                  child: Container(
+                                    padding: EdgeInsets.all(3),
+                                    decoration: BoxDecoration(
+                                      color: Theme.of(context).colorScheme.error,
+                                      shape: BoxShape.circle,
+                                    ),
+                                    child: Icon(Icons.mic_off, color: Colors.white, size: 14),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                          BlocBuilder<SessionStatusCubit, SessionStatusState>(
+                            buildWhen: (previous, current) => previous.topIssue != current.topIssue,
+                            builder: (context, sessionState) {
+                              final topIssue = sessionState.topIssue;
+                              if (topIssue == null) return const SizedBox.shrink();
+                              return Positioned(
+                                right: -2,
+                                bottom: -2,
+                                child: SessionIssueBadge(color: topIssue.color(context), size: 12),
+                              );
+                            },
+                          ),
+                        ],
+                      ),
+                      onPressed: () {
+                        FocusScope.of(context).unfocus();
+                        context.router.navigate(const SettingsRouterPageRoute());
+                      },
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(width: NavigationToolbar.kMiddleSpacing),
+            ],
+          );
+        },
       ),
     );
   }

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -6,9 +6,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart' as ws;
 
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/push_tokens/bloc/push_tokens_bloc.dart';
-import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/features/session_status/bloc/session_status_cubit.dart';
 import 'package:webtrit_phone/models/models.dart';
 
@@ -65,6 +65,19 @@ void main() {
         final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: const Stream.empty());
 
         expect(cubit.state.status, _statusFor(CallStatus.ready));
+        unawaited(cubit.close());
+      });
+    });
+
+    test('the first combined state bypasses the smoothing even when transient', () {
+      fakeAsync((async) {
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.connectError), callStream: const Stream.empty());
+
+        expect(
+          cubit.state.status,
+          _statusFor(CallStatus.connectError),
+          reason: 'the default state was never on screen, so there is nothing to hold',
+        );
         unawaited(cubit.close());
       });
     });
@@ -186,6 +199,51 @@ void main() {
         expect(cubit.state.status, _statusFor(CallStatus.connectError));
 
         callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('a signaling hiccup while unregistered is held back, not amplified', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.appUnregistered), callStream: callController.stream);
+
+        // A sub-second blip: connectIssue and back. Nothing may reach the UI.
+        callController.add(_cs(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.appUnregistered));
+
+        callController.add(_cs(CallStatus.appUnregistered));
+        expect(cubit.state.status, _statusFor(CallStatus.appUnregistered));
+
+        async.elapse(kSignalingStatusDebounce * 2);
+        expect(cubit.state.status, _statusFor(CallStatus.appUnregistered));
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('a push token error rides through immediately while a transient is held', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+        final pushController = StreamController<PushTokensState>(sync: true);
+
+        final cubit = buildCubit(
+          initialCallState: _cs(CallStatus.ready),
+          callStream: callController.stream,
+          pushStream: pushController.stream,
+        );
+
+        callController.add(_cs(CallStatus.inProgress));
+        expect(cubit.state.status, _statusFor(CallStatus.ready), reason: 'the downgrade itself is held');
+
+        pushController.add(const PushTokensState(errorMessage: 'token failed'));
+        expect(cubit.state.status.hasPushTokenError, isTrue, reason: 'orthogonal fields must not wait for the window');
+        expect(cubit.state.status.signalingStatus, CallStatus.ready);
+
+        callController.close();
+        pushController.close();
         unawaited(cubit.close());
       });
     });

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -69,20 +69,64 @@ void main() {
       });
     });
 
-    test('emits status on every callStatus change while not ready', () {
+    test('debounces changes between transient states and shows ready immediately', () {
       fakeAsync((async) {
         final callController = StreamController<CallState>(sync: true);
 
         final cubit = buildCubit(initialCallState: _cs(CallStatus.inProgress), callStream: callController.stream);
 
         callController.add(_cs(CallStatus.connectIssue));
-        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.inProgress), reason: 'transient flips are held back');
 
-        callController.add(_cs(CallStatus.connectError));
-        expect(cubit.state.status, _statusFor(CallStatus.connectError));
+        async.elapse(kSignalingStatusDebounce);
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         callController.add(_cs(CallStatus.ready));
         expect(cubit.state.status, _statusFor(CallStatus.ready));
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('recovering the network shows connecting at once, never the stale connect error', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.connectivityNone), callStream: callController.stream);
+
+        // The network is back, but the derived state still carries the connect
+        // error recorded during the outage (DNS failure on the last attempt).
+        callController.add(_cs(CallStatus.connectError));
+        expect(
+          cubit.state.status,
+          _statusFor(CallStatus.inProgress),
+          reason: 'the stale error must be shown as connecting, not flashed',
+        );
+
+        callController.add(_cs(CallStatus.inProgress));
+        callController.add(_cs(CallStatus.ready));
+        expect(cubit.state.status, _statusFor(CallStatus.ready));
+
+        async.elapse(kSignalingStatusDebounce * 2);
+        expect(cubit.state.status, _statusFor(CallStatus.ready), reason: 'nothing pending may fire later');
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('a connect error that persists past the window does surface', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.connectivityNone), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.connectError));
+        expect(cubit.state.status, _statusFor(CallStatus.inProgress));
+
+        async.elapse(kSignalingStatusDebounce);
+        expect(cubit.state.status, _statusFor(CallStatus.connectError));
 
         callController.close();
         unawaited(cubit.close());

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:webtrit_signaling/webtrit_signaling.dart' as ws;
 
 import 'package:webtrit_phone/features/call/call.dart';
 import 'package:webtrit_phone/features/push_tokens/bloc/push_tokens_bloc.dart';
+import 'package:webtrit_phone/app/constants.dart';
 import 'package:webtrit_phone/features/session_status/bloc/session_status_cubit.dart';
 import 'package:webtrit_phone/models/models.dart';
 
@@ -98,11 +99,11 @@ void main() {
         callController.add(_cs(CallStatus.inProgress));
         expect(cubit.state.status, _statusFor(CallStatus.ready), reason: 'the downgrade must be held back');
 
-        async.elapse(kSessionStatusDowngradeDebounce ~/ 2);
+        async.elapse(kSignalingStatusDebounce ~/ 2);
         callController.add(_cs(CallStatus.ready));
         expect(cubit.state.status, _statusFor(CallStatus.ready));
 
-        async.elapse(kSessionStatusDowngradeDebounce * 2);
+        async.elapse(kSignalingStatusDebounce * 2);
         expect(cubit.state.status, _statusFor(CallStatus.ready), reason: 'the dropped blip must not fire later');
 
         callController.close();
@@ -119,7 +120,7 @@ void main() {
         callController.add(_cs(CallStatus.connectIssue));
         expect(cubit.state.status, _statusFor(CallStatus.ready));
 
-        async.elapse(kSessionStatusDowngradeDebounce);
+        async.elapse(kSignalingStatusDebounce);
         expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
 
         callController.close();
@@ -137,7 +138,7 @@ void main() {
         callController.add(_cs(CallStatus.connectError));
         expect(cubit.state.status, _statusFor(CallStatus.ready));
 
-        async.elapse(kSessionStatusDowngradeDebounce);
+        async.elapse(kSignalingStatusDebounce);
         expect(cubit.state.status, _statusFor(CallStatus.connectError));
 
         callController.close();

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -68,23 +68,91 @@ void main() {
       });
     });
 
-    test('emits status on every callStatus change', () {
+    test('emits status on every callStatus change while not ready', () {
       fakeAsync((async) {
         final callController = StreamController<CallState>(sync: true);
 
-        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.inProgress), callStream: callController.stream);
 
         callController.add(_cs(CallStatus.connectIssue));
         expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
-
-        callController.add(_cs(CallStatus.inProgress));
-        expect(cubit.state.status, _statusFor(CallStatus.inProgress));
 
         callController.add(_cs(CallStatus.connectError));
         expect(cubit.state.status, _statusFor(CallStatus.connectError));
 
         callController.add(_cs(CallStatus.ready));
         expect(cubit.state.status, _statusFor(CallStatus.ready));
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('drops a downgrade blip that returns to ready within the debounce window', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        // The re-register blip after a reconnect: ready -> inProgress -> ready.
+        callController.add(_cs(CallStatus.inProgress));
+        expect(cubit.state.status, _statusFor(CallStatus.ready), reason: 'the downgrade must be held back');
+
+        async.elapse(kSessionStatusDowngradeDebounce ~/ 2);
+        callController.add(_cs(CallStatus.ready));
+        expect(cubit.state.status, _statusFor(CallStatus.ready));
+
+        async.elapse(kSessionStatusDowngradeDebounce * 2);
+        expect(cubit.state.status, _statusFor(CallStatus.ready), reason: 'the dropped blip must not fire later');
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('shows a downgrade that outlives the debounce window', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.connectIssue));
+        expect(cubit.state.status, _statusFor(CallStatus.ready));
+
+        async.elapse(kSessionStatusDowngradeDebounce);
+        expect(cubit.state.status, _statusFor(CallStatus.connectIssue));
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('shows the latest downgrade when several arrive within one window', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.inProgress));
+        callController.add(_cs(CallStatus.connectError));
+        expect(cubit.state.status, _statusFor(CallStatus.ready));
+
+        async.elapse(kSessionStatusDowngradeDebounce);
+        expect(cubit.state.status, _statusFor(CallStatus.connectError));
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('shows losing the network immediately, without the debounce', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_cs(CallStatus.connectivityNone));
+        expect(cubit.state.status, _statusFor(CallStatus.connectivityNone));
 
         callController.close();
         unawaited(cubit.close());


### PR DESCRIPTION
## Overview

First in the WT-1067 merge queue; #1541 (error reporting) and #1539 (UI) are stacked on top, in that order.

Every reconnect made the account screen flicker: within a second or two the status jumped between "established", "connection error" and "connecting", and parts of the UI reacted in step. The app bar did not flicker only because it had its own smoothing - each screen was deciding on its own, inconsistently.

This PR moves that smoothing into the single place that produces the session status, so the whole app shows one calm, consistent picture: short reconnect blips never reach the screen, turning the network back on shows "connecting" right away instead of flashing a stale error, and a problem that actually persists still surfaces after a few seconds.

## Also included

Removed a leftover debug print on develop that broke `flutter analyze`, and with it the pre-push hook for every branch cut from develop.

## Verification

Full test suite green; the tests reproduce the exact flicker scenarios captured in a device log.