### PR TITLE
fix: report register status request failures to the user (WT-1067)

### DIFF
--- a/lib/features/register_status/cubit/register_status_cubit.dart
+++ b/lib/features/register_status/cubit/register_status_cubit.dart
@@ -23,7 +23,7 @@ class RegisterStatus {
 class RegisterStatusCubit extends Cubit<RegisterStatus> {
   RegisterStatusCubit(this.appRepository, this.registerStatusRepository, {this.handleError})
     : super(RegisterStatus(value: registerStatusRepository.getRegisterStatus())) {
-    fetchStatus(silently: true);
+    fetchStatus();
     _connectivitySub = Connectivity().onConnectivityChanged.listen(_handleConnectivity);
   }
 
@@ -34,34 +34,44 @@ class RegisterStatusCubit extends Cubit<RegisterStatus> {
   late final StreamSubscription _connectivitySub;
 
   void _handleConnectivity(List<ConnectivityResult> results) {
-    if (results.any((result) => result != ConnectivityResult.none)) fetchStatus(silently: true);
+    if (results.any((result) => result != ConnectivityResult.none)) fetchStatus();
   }
 
-  Future<void> fetchStatus({bool silently = false}) async {
+  /// Returns whether the fetch succeeded, so an explicit user-triggered
+  /// refresh can report a failure instead of silently keeping the stale value.
+  ///
+  /// [handleError] is called on every failure: it routes a 401 to the app
+  /// logout flow and ignores everything else, so it stays silent for the
+  /// automatic fetches (startup, connectivity regained).
+  Future<bool> fetchStatus() async {
     try {
       final status = await appRepository.getRegisterStatus();
-      registerStatusRepository.setRegisterStatus(status);
+      await registerStatusRepository.setRegisterStatus(status);
       emit(RegisterStatus(value: status));
+      return true;
     } catch (e, s) {
       _logger.warning('Failed to get register status', e, s);
       handleError?.call(e, s);
-
       if (!_isTransientNetworkError(e)) {
-        if (!silently) handleError?.call(e, s);
         CrashlyticsUtils.recordError(e, stack: s, reason: 'RegisterStatusCubit.fetchStatus');
       }
+      return false;
     }
   }
 
   bool _isTransientNetworkError(Object error) =>
       error is SocketException || error is TimeoutException || error is TlsException;
 
-  Future<void> setStatus(bool value) async {
+  /// Returns whether the change was accepted by the server. On failure the
+  /// previous value is restored, so the caller must tell the user why the
+  /// switch snapped back.
+  Future<bool> setStatus(bool value) async {
     emit(RegisterStatus(value: value, isUpdating: true));
     try {
       await appRepository.setRegisterStatus(value);
       await registerStatusRepository.setRegisterStatus(value);
       emit(RegisterStatus(value: value, isUpdating: false));
+      return true;
     } catch (e, stackTrace) {
       _logger.warning('_onRegisterStatusChanged', e, stackTrace);
       emit(RegisterStatus(value: !value, isUpdating: false));
@@ -69,6 +79,7 @@ class RegisterStatusCubit extends Cubit<RegisterStatus> {
       if (!_isTransientNetworkError(e)) {
         CrashlyticsUtils.recordError(e, stack: stackTrace, reason: 'RegisterStatusCubit.setStatus');
       }
+      return false;
     }
   }
 


### PR DESCRIPTION
## Overview

Second in the WT-1067 merge queue: after #1540, before the UI changes in #1539.

Failures around the account registration setting were handled inconsistently: an expired session could trigger the forced logout twice, an explicit refresh could fail with no feedback at all, and a failed change quietly rolled the switch back as if the tap had been ignored.

Now every failure is reported exactly once, and both operations tell their caller whether they succeeded - so the screen (updated in #1539) can explain a failure instead of staying silent.

## Verification

Full test suite green.
