### PR TITLE
fix: keep the app bar blur only while the bar is translucent (WT-1781)

### DIFF
--- a/assets/themes/original.widget.dark.config.json
+++ b/assets/themes/original.widget.dark.config.json
@@ -55,8 +55,7 @@
         "fontSize": 18,
         "fontWeight": {
           "weight": 600
-        },
-        "color": "#E2E2E2"
+        }
       }
     },
     "__tabBarConfig": "Tab bar styling including indicator, labels, alignment, and animation.",

--- a/assets/themes/original.widget.light.config.json
+++ b/assets/themes/original.widget.light.config.json
@@ -55,8 +55,7 @@
         "fontSize": 18,
         "fontWeight": {
           "weight": 600
-        },
-        "color": "#30302F"
+        }
       },
       "systemOverlayStyle": {
         "statusBarIconBrightness": "dark",

--- a/lib/features/call/view/call_init_scaffold.dart
+++ b/lib/features/call/view/call_init_scaffold.dart
@@ -23,8 +23,10 @@ class CallInitScaffold extends StatelessWidget {
           SafeArea(
             child: AppBar(
               leading: style?.appBar?.showBackButton == false ? null : const ExtBackButton(),
-              backgroundColor: style?.appBar?.backgroundColor,
-              foregroundColor: style?.appBar?.foregroundColor,
+              // Fallbacks keep the bar transparent with a light foreground over
+              // the dark call gradient even when the call style is absent.
+              backgroundColor: style?.appBar?.backgroundColor ?? Colors.transparent,
+              foregroundColor: style?.appBar?.foregroundColor ?? surfaceColor,
               primary: style?.appBar?.primary ?? false,
             ),
           ),

--- a/lib/features/call/view/call_init_scaffold.dart
+++ b/lib/features/call/view/call_init_scaffold.dart
@@ -22,10 +22,10 @@ class CallInitScaffold extends StatelessWidget {
         children: [
           SafeArea(
             child: AppBar(
-              leading: const ExtBackButton(),
-              backgroundColor: Colors.transparent,
-              foregroundColor: surfaceColor,
-              primary: false,
+              leading: style?.appBar?.showBackButton == false ? null : const ExtBackButton(),
+              backgroundColor: style?.appBar?.backgroundColor,
+              foregroundColor: style?.appBar?.foregroundColor,
+              primary: style?.appBar?.primary ?? false,
             ),
           ),
           Center(

--- a/lib/features/cdrs/features/number_cdrs_log/view/number_cdrs_screen.dart
+++ b/lib/features/cdrs/features/number_cdrs_log/view/number_cdrs_screen.dart
@@ -74,7 +74,9 @@ class _NumberCdrsScreenState extends State<NumberCdrsScreen> {
 
     return Scaffold(
       extendBodyBehindAppBar: true,
-      appBar: AppBar(),
+      // Deliberately chrome-less: the bar only floats the back button over the
+      // number header card, so it must not paint the themed bar color.
+      appBar: AppBar(backgroundColor: Colors.transparent),
       body: Stack(
         children: [
           BlocBuilder<NumberCdrsLogCubit, CdrsListState>(

--- a/lib/features/cdrs/features/number_cdrs_log/view/number_cdrs_screen.dart
+++ b/lib/features/cdrs/features/number_cdrs_log/view/number_cdrs_screen.dart
@@ -74,7 +74,7 @@ class _NumberCdrsScreenState extends State<NumberCdrsScreen> {
 
     return Scaffold(
       extendBodyBehindAppBar: true,
-      appBar: AppBar(backgroundColor: theme.canvasColor.withAlpha(0)),
+      appBar: AppBar(),
       body: Stack(
         children: [
           BlocBuilder<NumberCdrsLogCubit, CdrsListState>(

--- a/lib/features/contact/view/contact_screen.dart
+++ b/lib/features/contact/view/contact_screen.dart
@@ -116,7 +116,7 @@ class _ContactScreenState extends State<ContactScreen> {
                         actions: [
                           if (widget.enableAppBarChat && contact.canMessage)
                             IconButton(
-                              icon: Icon(Icons.message, color: colorScheme.onSurface),
+                              icon: const Icon(Icons.message),
                               onPressed: () => _navigateToChatConversation(contact),
                             ),
                         ],

--- a/lib/features/log_records_console/view/log_records_console_screen.dart
+++ b/lib/features/log_records_console/view/log_records_console_screen.dart
@@ -35,7 +35,6 @@ class LogRecordsConsoleScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.logRecordsConsole_AppBarTitle),
@@ -48,11 +47,10 @@ class LogRecordsConsoleScreen extends StatelessWidget {
                     ? SizedCircularProgressIndicator(
                         size: 20,
                         outerSize: 24,
-                        color: colorScheme.onSurface,
+                        color: IconTheme.of(context).color,
                         strokeWidth: 2,
                       )
                     : const Icon(Icons.share),
-                style: IconButton.styleFrom(foregroundColor: colorScheme.onSurface),
                 onPressed: switch (state) {
                   LogRecordsConsoleStateSuccess(:final logRecords, isSharing: false) when logRecords.isNotEmpty => () {
                     context.read<LogRecordsConsoleCubit>().share();
@@ -68,7 +66,6 @@ class LogRecordsConsoleScreen extends StatelessWidget {
               final hasRecords = state is LogRecordsConsoleStateSuccess && state.logRecords.isNotEmpty;
               return PopupMenuButton<_LogConsoleMenuAction>(
                 icon: const Icon(Icons.more_vert),
-                iconColor: colorScheme.onSurface,
                 position: PopupMenuPosition.under,
                 enabled: canInteract,
                 onSelected: (action) => _onMenuSelected(context, action, state as LogRecordsConsoleStateSuccess),

--- a/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
+++ b/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
@@ -81,7 +81,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
           return Scaffold(
             extendBodyBehindAppBar: true,
             appBar: AppBar(
-              flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
+              flexibleSpace: BlurredSurface.adaptive(context),
               centerTitle: true,
               title: FadeIn(
                 child: Builder(

--- a/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
+++ b/lib/features/messaging/features/chat_conversation/view/conversation_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
@@ -68,8 +66,6 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return BlocProvider(
       create: (context) => ChatTypingCubit(messagingBloc.state.client),
       child: BlocConsumer<ConversationCubit, ConversationState>(
@@ -85,13 +81,7 @@ class _ChatConversationScreenState extends State<ChatConversationScreen> {
           return Scaffold(
             extendBodyBehindAppBar: true,
             appBar: AppBar(
-              backgroundColor: theme.canvasColor.withAlpha(150),
-              flexibleSpace: ClipRect(
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                  child: Container(color: theme.canvasColor.withAlpha(150)),
-                ),
-              ),
+              flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
               centerTitle: true,
               title: FadeIn(
                 child: Builder(

--- a/lib/features/messaging/features/sms_conversation/view/sms_conversation_screen.dart
+++ b/lib/features/messaging/features/sms_conversation/view/sms_conversation_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
@@ -9,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/features/features.dart';
 import 'package:webtrit_phone/repositories/repositories.dart';
+import 'package:webtrit_phone/widgets/blurred_surface.dart';
 import 'package:webtrit_phone/widgets/fade_id.dart';
 import 'package:webtrit_phone/widgets/no_data_placeholder.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
@@ -42,8 +41,6 @@ class _SmsConversationScreenState extends State<SmsConversationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return BlocProvider(
       create: (context) => SmsTypingCubit(messagingBloc.state.client),
       child: BlocConsumer<SmsConversationCubit, SmsConversationState>(
@@ -71,13 +68,7 @@ class _SmsConversationScreenState extends State<SmsConversationScreen> {
                 extendBodyBehindAppBar: true,
                 appBar: AppBar(
                   centerTitle: true,
-                  backgroundColor: theme.canvasColor.withAlpha(150),
-                  flexibleSpace: ClipRect(
-                    child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                      child: Container(color: theme.canvasColor.withAlpha(150)),
-                    ),
-                  ),
+                  flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
                   title: Builder(
                     builder: (context) {
                       if (recipientNumber != null) {

--- a/lib/features/messaging/features/sms_conversation/view/sms_conversation_screen.dart
+++ b/lib/features/messaging/features/sms_conversation/view/sms_conversation_screen.dart
@@ -68,7 +68,7 @@ class _SmsConversationScreenState extends State<SmsConversationScreen> {
                 extendBodyBehindAppBar: true,
                 appBar: AppBar(
                   centerTitle: true,
-                  flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
+                  flexibleSpace: BlurredSurface.adaptive(context),
                   title: Builder(
                     builder: (context) {
                       if (recipientNumber != null) {

--- a/lib/features/messaging/features/sms_conversation_builder/view/sms_conversation_builder_view.dart
+++ b/lib/features/messaging/features/sms_conversation_builder/view/sms_conversation_builder_view.dart
@@ -147,24 +147,22 @@ class _SmsConversationBuilderViewState extends State<SmsConversationBuilderView>
   }
 
   AppBar buildAppBar(bool isValidNumberInField) {
-    final colorScheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final actionColor = theme.appBarTheme.foregroundColor ?? theme.colorScheme.primary;
 
     return AppBar(
       title: Text(context.l10n.messaging_ConversationBuilders_title_new),
       automaticallyImplyLeading: false,
       leading: TextButton(
         onPressed: () => Navigator.of(context).pop(),
-        child: Text(context.l10n.messaging_ConversationBuilders_cancel, style: TextStyle(color: colorScheme.primary)),
+        child: Text(context.l10n.messaging_ConversationBuilders_cancel, style: TextStyle(color: actionColor)),
       ),
       leadingWidth: 100,
       actions: [
         if (isValidNumberInField)
           TextButton(
             onPressed: builderCubit.onConfirmByParsedNumber,
-            child: Text(
-              context.l10n.messaging_ConversationBuilders_create,
-              style: TextStyle(color: colorScheme.primary),
-            ),
+            child: Text(context.l10n.messaging_ConversationBuilders_create, style: TextStyle(color: actionColor)),
           ),
       ],
     );

--- a/lib/features/settings/features/media_settings/view/media_settings_screen.dart
+++ b/lib/features/settings/features/media_settings/view/media_settings_screen.dart
@@ -25,7 +25,6 @@ class _MediaSettingsScreenState extends State<MediaSettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
     final l10n = context.l10n;
 
     final localStyle = theme.extension<AboutScreenStyles>()?.primary;
@@ -54,7 +53,6 @@ class _MediaSettingsScreenState extends State<MediaSettingsScreen> {
             icon: const Icon(Icons.settings_backup_restore),
             tooltip: l10n.settings_encoding_AppBar_reset_tooltip,
             onPressed: () => cubit.reset(),
-            color: colorScheme.onSurface,
           ),
         ],
       ),

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -29,7 +29,6 @@ class SettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    final colorScheme = themeData.colorScheme;
     final effectiveStyle = style ?? themeData.extension<SettingsScreenStyles>()?.primary;
 
     final showSeparators = effectiveStyle?.showSeparators ?? true;
@@ -46,13 +45,7 @@ class SettingsScreen extends StatelessWidget {
         leading: const AutoLeadingButton(),
         title: Text(context.l10n.settings_AppBarTitle_myAccount),
         flexibleSpace: BlurredSurface.fromStyle(effectiveStyle?.appBarBlurredSurface),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            style: IconButton.styleFrom(foregroundColor: colorScheme.onSurface),
-            onPressed: () => _onRefreshTap(context),
-          ),
-        ],
+        actions: [IconButton(icon: const Icon(Icons.refresh), onPressed: () => _onRefreshTap(context))],
       ),
       body: BlocBuilder<SettingsBloc, SettingsState>(
         builder: (context, state) {

--- a/lib/features/system_notifications/view/system_notifications_screen.dart
+++ b/lib/features/system_notifications/view/system_notifications_screen.dart
@@ -50,13 +50,10 @@ class _SystemNotificationsScreenState extends State<SystemNotificationsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Scaffold(
       extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text(context.l10n.system_notifications_screen_title),
-        backgroundColor: theme.canvasColor.withAlpha(150),
         flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
       ),
       body: BlocBuilder<SystemNotificationsScreenCubit, SystemNotificationScreenState>(

--- a/lib/features/system_notifications/view/system_notifications_screen.dart
+++ b/lib/features/system_notifications/view/system_notifications_screen.dart
@@ -54,7 +54,7 @@ class _SystemNotificationsScreenState extends State<SystemNotificationsScreen> {
       extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text(context.l10n.system_notifications_screen_title),
-        flexibleSpace: const BlurredSurface(sigmaX: 10, sigmaY: 10),
+        flexibleSpace: BlurredSurface.adaptive(context),
       ),
       body: BlocBuilder<SystemNotificationsScreenCubit, SystemNotificationScreenState>(
         builder: (context, state) {

--- a/lib/theme/factory/theme_data/app_bar_theme_data_factory.dart
+++ b/lib/theme/factory/theme_data/app_bar_theme_data_factory.dart
@@ -5,13 +5,11 @@ import 'package:webtrit_phone/theme/theme.dart';
 import '../theme_style_factory.dart';
 
 class AppBarThemeDataFactory implements ThemeStyleFactory<AppBarTheme> {
-  const AppBarThemeDataFactory(this.config, this.defaultFontFamily, this.brightness);
+  const AppBarThemeDataFactory(this.colorScheme, this.config, this.defaultFontFamily);
 
+  final ColorScheme colorScheme;
   final AppBarConfig config;
   final String? defaultFontFamily;
-
-  /// Theme brightness, used to complete the app bar's system overlay style.
-  final Brightness brightness;
 
   @override
   AppBarTheme create() {
@@ -28,13 +26,23 @@ class AppBarThemeDataFactory implements ThemeStyleFactory<AppBarTheme> {
       centerTitle: config.centerTitle,
       iconTheme: config.iconTheme?.toIconThemeData(),
       actionsIconTheme: config.actionsIconTheme?.toIconThemeData(),
-      titleTextStyle: config.titleTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+      titleTextStyle: _titleTextStyle(),
       toolbarTextStyle: config.toolbarTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
       // Always non-null: an AppBar wraps itself in an AnnotatedRegion, and the engine
       // keeps the previously set value for every null field, so a partial style would
       // leave the bars looking like the screen shown before this one.
       systemOverlayStyle:
-          config.systemOverlayStyle?.toSystemUiOverlayStyle(brightness) ?? systemOverlayStyleOf(brightness),
+          config.systemOverlayStyle?.toSystemUiOverlayStyle(colorScheme.brightness) ??
+          systemOverlayStyleOf(colorScheme.brightness),
     );
+  }
+
+  // Once the config carries a title style, AppBar takes it verbatim and never
+  // falls back to foregroundColor, so the color chain has to be completed here:
+  // explicit title color -> configured foreground -> scheme default.
+  TextStyle? _titleTextStyle() {
+    final titleTextStyle = config.titleTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
+    if (titleTextStyle == null || titleTextStyle.color != null) return titleTextStyle;
+    return titleTextStyle.copyWith(color: config.foregroundColor?.toColor() ?? colorScheme.onSurface);
   }
 }

--- a/lib/theme/factory/theme_data/app_bar_theme_data_factory.dart
+++ b/lib/theme/factory/theme_data/app_bar_theme_data_factory.dart
@@ -24,10 +24,10 @@ class AppBarThemeDataFactory implements ThemeStyleFactory<AppBarTheme> {
       leadingWidth: config.leadingWidth,
       toolbarHeight: config.toolbarHeight,
       centerTitle: config.centerTitle,
-      iconTheme: config.iconTheme?.toIconThemeData(),
-      actionsIconTheme: config.actionsIconTheme?.toIconThemeData(),
-      titleTextStyle: _titleTextStyle(),
-      toolbarTextStyle: config.toolbarTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily),
+      iconTheme: _iconTheme(config.iconTheme, colorScheme.onSurface),
+      actionsIconTheme: _iconTheme(config.actionsIconTheme, colorScheme.onSurfaceVariant),
+      titleTextStyle: _textStyle(config.titleTextStyle),
+      toolbarTextStyle: _textStyle(config.toolbarTextStyle),
       // Always non-null: an AppBar wraps itself in an AnnotatedRegion, and the engine
       // keeps the previously set value for every null field, so a partial style would
       // leave the bars looking like the screen shown before this one.
@@ -37,12 +37,20 @@ class AppBarThemeDataFactory implements ThemeStyleFactory<AppBarTheme> {
     );
   }
 
-  // Once the config carries a title style, AppBar takes it verbatim and never
-  // falls back to foregroundColor, so the color chain has to be completed here:
-  // explicit title color -> configured foreground -> scheme default.
-  TextStyle? _titleTextStyle() {
-    final titleTextStyle = config.titleTextStyle?.toTextStyle(defaultFontFamily: defaultFontFamily);
-    if (titleTextStyle == null || titleTextStyle.color != null) return titleTextStyle;
-    return titleTextStyle.copyWith(color: config.foregroundColor?.toColor() ?? colorScheme.onSurface);
+  // Once the config carries a style, AppBar takes it verbatim and never falls
+  // back to foregroundColor, so the color chain has to be completed here:
+  // explicit color -> configured foreground -> scheme default.
+  TextStyle? _textStyle(TextStyleConfig? styleConfig) {
+    final style = styleConfig?.toTextStyle(defaultFontFamily: defaultFontFamily);
+    if (style == null || style.color != null) return style;
+    return style.copyWith(color: config.foregroundColor?.toColor() ?? colorScheme.onSurface);
+  }
+
+  // Same chain for icon themes; the scheme default mirrors the framework's
+  // (onSurface for leading, onSurfaceVariant for actions).
+  IconThemeData? _iconTheme(IconThemeDataConfig? iconConfig, Color schemeDefault) {
+    final iconTheme = iconConfig?.toIconThemeData();
+    if (iconTheme == null || iconTheme.color != null) return iconTheme;
+    return iconTheme.copyWith(color: config.foregroundColor?.toColor() ?? schemeDefault);
   }
 }

--- a/lib/theme/factory/theme_style_factory_provider.dart
+++ b/lib/theme/factory/theme_style_factory_provider.dart
@@ -226,9 +226,9 @@ class ThemeStyleFactoryProvider {
 
   AppBarTheme createAppBarTheme() {
     return AppBarThemeDataFactory(
+      colorScheme,
       widgetConfig.bar.appBarConfig,
       defaultTextTheme.bodyMedium?.fontFamily,
-      colorScheme.brightness,
     ).create();
   }
 

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -27,10 +27,20 @@ class BlurredSurface extends StatelessWidget {
   /// i.e. while content actually shows through the bar. On an opaque bar a
   /// backdrop blur has nothing to reveal and only smears the bar edges with
   /// the colors around it, so `null` is returned and the bar stays solid.
+  ///
+  /// The overlay carries a semi-opaque surface tint - the same recipe the
+  /// shipped page styles use for the tab bars - because on a transparent bar
+  /// the tint is what makes the bar visible at all: a pure blur vanishes over
+  /// a uniform background.
   static BlurredSurface? adaptive(BuildContext context, {double sigmaX = 10, double sigmaY = 10}) {
-    final barColor = Theme.of(context).appBarTheme.backgroundColor;
+    final theme = Theme.of(context);
+    final barColor = theme.appBarTheme.backgroundColor;
     if (barColor != null && barColor.a >= 1.0) return null;
-    return BlurredSurface(sigmaX: sigmaX, sigmaY: sigmaY);
+    return BlurredSurface(
+      color: theme.colorScheme.surface.withValues(alpha: 0x96 / 255),
+      sigmaX: sigmaX,
+      sigmaY: sigmaY,
+    );
   }
 
   final Color? color;

--- a/lib/widgets/blurred_surface.dart
+++ b/lib/widgets/blurred_surface.dart
@@ -21,6 +21,18 @@ class BlurredSurface extends StatelessWidget {
     return BlurredSurface(color: style.color, sigmaX: style.sigmaX ?? 10, sigmaY: style.sigmaY ?? 10);
   }
 
+  /// Frosted-glass fallback for app bars that have no configured blur style.
+  ///
+  /// Returns the blur only while the themed app bar background is translucent,
+  /// i.e. while content actually shows through the bar. On an opaque bar a
+  /// backdrop blur has nothing to reveal and only smears the bar edges with
+  /// the colors around it, so `null` is returned and the bar stays solid.
+  static BlurredSurface? adaptive(BuildContext context, {double sigmaX = 10, double sigmaY = 10}) {
+    final barColor = Theme.of(context).appBarTheme.backgroundColor;
+    if (barColor != null && barColor.a >= 1.0) return null;
+    return BlurredSurface(sigmaX: sigmaX, sigmaY: sigmaY);
+  }
+
   final Color? color;
   final double sigmaX;
   final double sigmaY;

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -62,7 +62,12 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
                       Flexible(
                         child: Text(
                           status.appBarl10n(context),
-                          style: theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
+                          // Colored as a title: the status line replaces the title, so it has
+                          // to follow the app bar's configured title color, not the typography.
+                          style: theme.textTheme.bodyMedium!.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: DefaultTextStyle.of(context).style.color,
+                          ),
                           overflow: TextOverflow.ellipsis,
                           maxLines: 1,
                         ),
@@ -120,49 +125,61 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
                         height: kMinInteractiveDimension,
                       ),
                       padding: const EdgeInsets.all(2),
-                      icon: Stack(
-                        clipBehavior: Clip.none,
-                        children: <Widget>[
-                          LeadingAvatar(
-                            username: info?.name ?? info?.numbers.main,
-                            thumbnailUrl: gravatarThumbnailUrl(info?.email),
-                            radius: kMinInteractiveDimension / 2,
-                            showLoading: true,
-                          ),
-                          BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
-                            builder: (context, microphoneStatusState) {
-                              return Visibility(
-                                visible:
-                                    microphoneStatusState.microphonePermissionGranted != null &&
-                                    !microphoneStatusState.microphonePermissionGranted!,
-                                child: Positioned(
-                                  right: -8,
-                                  top: -2,
-                                  child: Container(
-                                    padding: EdgeInsets.all(3),
-                                    decoration: BoxDecoration(
-                                      color: Theme.of(context).colorScheme.error,
-                                      shape: BoxShape.circle,
+                      // The avatar keeps its own palette: without this reset the app bar
+                      // pushes its foreground color into the subtree and tints it.
+                      icon: IconTheme(
+                        data: theme.iconTheme,
+                        child: DefaultTextStyle(
+                          style: theme.textTheme.bodyMedium!,
+                          child: Stack(
+                            clipBehavior: Clip.none,
+                            children: <Widget>[
+                              LeadingAvatar(
+                                username: info?.name ?? info?.numbers.main,
+                                thumbnailUrl: gravatarThumbnailUrl(info?.email),
+                                radius: kMinInteractiveDimension / 2,
+                                showLoading: true,
+                              ),
+                              BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
+                                builder: (context, microphoneStatusState) {
+                                  return Visibility(
+                                    visible:
+                                        microphoneStatusState.microphonePermissionGranted != null &&
+                                        !microphoneStatusState.microphonePermissionGranted!,
+                                    child: Positioned(
+                                      right: -8,
+                                      top: -2,
+                                      child: Container(
+                                        padding: EdgeInsets.all(3),
+                                        decoration: BoxDecoration(
+                                          color: Theme.of(context).colorScheme.error,
+                                          shape: BoxShape.circle,
+                                        ),
+                                        child: Icon(
+                                          Icons.mic_off,
+                                          color: Theme.of(context).colorScheme.onError,
+                                          size: 14,
+                                        ),
+                                      ),
                                     ),
-                                    child: Icon(Icons.mic_off, color: Colors.white, size: 14),
-                                  ),
-                                ),
-                              );
-                            },
+                                  );
+                                },
+                              ),
+                              BlocBuilder<SessionStatusCubit, SessionStatusState>(
+                                buildWhen: (previous, current) => previous.topIssue != current.topIssue,
+                                builder: (context, sessionState) {
+                                  final topIssue = sessionState.topIssue;
+                                  if (topIssue == null) return const SizedBox.shrink();
+                                  return Positioned(
+                                    right: -2,
+                                    bottom: -2,
+                                    child: SessionIssueBadge(color: topIssue.color(context), size: 12),
+                                  );
+                                },
+                              ),
+                            ],
                           ),
-                          BlocBuilder<SessionStatusCubit, SessionStatusState>(
-                            buildWhen: (previous, current) => previous.topIssue != current.topIssue,
-                            builder: (context, sessionState) {
-                              final topIssue = sessionState.topIssue;
-                              if (topIssue == null) return const SizedBox.shrink();
-                              return Positioned(
-                                right: -2,
-                                bottom: -2,
-                                child: SessionIssueBadge(color: topIssue.color(context), size: 12),
-                              );
-                            },
-                          ),
-                        ],
+                        ),
                       ),
                       onPressed: () {
                         FocusScope.of(context).unfocus();

--- a/test/theme/app_bar_theme_data_factory_test.dart
+++ b/test/theme/app_bar_theme_data_factory_test.dart
@@ -43,4 +43,59 @@ void main() {
       expect(theme.foregroundColor, const Color(0xFF445566));
     });
   });
+
+  group('AppBarThemeDataFactory toolbarTextStyle color', () {
+    test('toolbar style without color falls back to foreground', () {
+      final theme = create(
+        const AppBarConfig(foregroundColor: '#445566', toolbarTextStyle: TextStyleConfig(fontSize: 14)),
+      );
+
+      expect(theme.toolbarTextStyle?.color, const Color(0xFF445566));
+    });
+  });
+
+  group('AppBarThemeDataFactory icon theme colors', () {
+    test('explicit icon colors win over foreground', () {
+      final theme = create(
+        const AppBarConfig(
+          foregroundColor: '#445566',
+          iconTheme: IconThemeDataConfig(color: '#112233'),
+          actionsIconTheme: IconThemeDataConfig(color: '#223344'),
+        ),
+      );
+
+      expect(theme.iconTheme?.color, const Color(0xFF112233));
+      expect(theme.actionsIconTheme?.color, const Color(0xFF223344));
+    });
+
+    test('icon themes without color fall back to foreground', () {
+      final theme = create(
+        const AppBarConfig(
+          foregroundColor: '#445566',
+          iconTheme: IconThemeDataConfig(size: 20),
+          actionsIconTheme: IconThemeDataConfig(size: 22),
+        ),
+      );
+
+      expect(theme.iconTheme?.color, const Color(0xFF445566));
+      expect(theme.iconTheme?.size, 20);
+      expect(theme.actionsIconTheme?.color, const Color(0xFF445566));
+    });
+
+    test('icon themes without color and foreground fall back to scheme roles', () {
+      final theme = create(
+        const AppBarConfig(iconTheme: IconThemeDataConfig(size: 20), actionsIconTheme: IconThemeDataConfig(size: 22)),
+      );
+
+      expect(theme.iconTheme?.color, colorScheme.onSurface);
+      expect(theme.actionsIconTheme?.color, colorScheme.onSurfaceVariant);
+    });
+
+    test('absent icon themes stay null so the framework default applies', () {
+      final theme = create(const AppBarConfig(foregroundColor: '#445566'));
+
+      expect(theme.iconTheme, isNull);
+      expect(theme.actionsIconTheme, isNull);
+    });
+  });
 }

--- a/test/theme/app_bar_theme_data_factory_test.dart
+++ b/test/theme/app_bar_theme_data_factory_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_appearance_theme/models/models.dart';
+import 'package:webtrit_phone/theme/factory/theme_data/app_bar_theme_data_factory.dart';
+
+void main() {
+  final colorScheme = ColorScheme.fromSeed(seedColor: Colors.blue);
+
+  AppBarTheme create(AppBarConfig config) => AppBarThemeDataFactory(colorScheme, config, null).create();
+
+  group('AppBarThemeDataFactory titleTextStyle color', () {
+    test('explicit title color wins over foreground', () {
+      final theme = create(
+        const AppBarConfig(
+          foregroundColor: '#445566',
+          titleTextStyle: TextStyleConfig(fontSize: 18, color: '#112233'),
+        ),
+      );
+
+      expect(theme.titleTextStyle?.color, const Color(0xFF112233));
+    });
+
+    test('title style without color falls back to foreground', () {
+      final theme = create(
+        const AppBarConfig(foregroundColor: '#445566', titleTextStyle: TextStyleConfig(fontSize: 18)),
+      );
+
+      expect(theme.titleTextStyle?.color, const Color(0xFF445566));
+      expect(theme.titleTextStyle?.fontSize, 18);
+    });
+
+    test('title style without color and foreground falls back to scheme onSurface', () {
+      final theme = create(const AppBarConfig(titleTextStyle: TextStyleConfig(fontSize: 18)));
+
+      expect(theme.titleTextStyle?.color, colorScheme.onSurface);
+    });
+
+    test('absent title style stays null so the framework default applies', () {
+      final theme = create(const AppBarConfig(foregroundColor: '#445566'));
+
+      expect(theme.titleTextStyle, isNull);
+      expect(theme.foregroundColor, const Color(0xFF445566));
+    });
+  });
+}

--- a/test/widgets/blurred_surface_test.dart
+++ b/test/widgets/blurred_surface_test.dart
@@ -59,6 +59,12 @@ void main() {
       expect(await adaptiveFor(tester, null), isNotNull);
     });
 
+    testWidgets('carries a semi-opaque surface tint so a transparent bar stays visible', (tester) async {
+      final surface = await adaptiveFor(tester, const Color(0x00000000));
+      expect(surface?.color, isNotNull);
+      expect(surface!.color!.a, closeTo(0x96 / 255, 0.01));
+    });
+
     testWidgets('stays solid when the themed bar background is opaque', (tester) async {
       expect(await adaptiveFor(tester, const Color(0xFF14284B)), isNull);
     });

--- a/test/widgets/blurred_surface_test.dart
+++ b/test/widgets/blurred_surface_test.dart
@@ -29,4 +29,38 @@ void main() {
       expect(widget!.color, Colors.red);
     });
   });
+
+  group('BlurredSurface.adaptive', () {
+    Future<BlurredSurface?> adaptiveFor(WidgetTester tester, Color? appBarBackground) async {
+      BlurredSurface? result;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(appBarTheme: AppBarTheme(backgroundColor: appBarBackground)),
+          home: Builder(
+            builder: (context) {
+              result = BlurredSurface.adaptive(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      return result;
+    }
+
+    testWidgets('blurs when the themed bar background is fully transparent', (tester) async {
+      expect(await adaptiveFor(tester, const Color(0x00000000)), isNotNull);
+    });
+
+    testWidgets('blurs when the themed bar background is semi-transparent', (tester) async {
+      expect(await adaptiveFor(tester, const Color(0x9614284B)), isNotNull);
+    });
+
+    testWidgets('blurs when no bar background is configured', (tester) async {
+      expect(await adaptiveFor(tester, null), isNotNull);
+    });
+
+    testWidgets('stays solid when the themed bar background is opaque', (tester) async {
+      expect(await adaptiveFor(tester, const Color(0xFF14284B)), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Overview

A few screens - chat, SMS and notifications - always blur the content behind their top bar. With a translucent bar that gives the intended frosted-glass look, but on themes that configure a solid bar color there is nothing to show through, and the blur only smeared the bar edges into the surrounding colors: the bar looked like a fuzzy gradient instead of matching the crisp solid bar of every other screen.

The blur is now adaptive: it applies only while the configured bar color actually lets content show through, and it carries the same semi-opaque surface tint the default tab styles use - on a transparent bar the tint is what makes the bar visible at all, so the default themes keep their familiar frosted bar. Solid bars stay crisp and identical to the rest of the app. Screens whose blur comes from the theme configuration, including all the root tabs, are on a separate path and are not affected.

Stacked on #1542 - only the last two commits belong to this PR; it becomes a two-commit diff after #1542 merges.

## Verification

Widget tests cover the adaptive rule (transparent, semi-transparent, unset and opaque bar colors) and the tint. Full analyze and test suite pass.