### PR TITLE
fix: recover a registration that keeps failing without a relogin (WT-1766)

### DIFF
--- a/docs/signaling_architecture_target.md
+++ b/docs/signaling_architecture_target.md
@@ -226,8 +226,36 @@ SignalingReconnectController({
   void Function(bool isAvailable)? onConnectionPresenceChanged,
   int notifyAfterConsecutiveFailures = 2,  // notify after this many consecutive failures
   bool reconnectEnabled = true,
+  Duration rebuildSessionAfter = const Duration(minutes: 5),  // see "Recovering a stuck registration"
+  int maxSessionRebuildsPerEpisode = 2,
 })
 ```
+
+### Recovering a stuck registration
+
+The server keeps one session per app and reads the SIP address and credentials
+into it once, when it creates it. If those change on the operator's side, the
+session keeps registering with the old ones and never succeeds again — and
+reconnecting does not help, because the socket re-attaches to that same session.
+Until now the only way out was for the user to log out and back in.
+
+The controller watches the registration status carried by the handshake and the
+session events. Once a failure has lasted `rebuildSessionAfter`, it schedules a
+reconnect itself — nothing else would, since a failed registration leaves the
+socket up — and that connect is made with `reregister: true`, which asks the
+server to build the session from scratch instead of attaching to it.
+
+Three things bound the damage: a call in progress always wins (a rebuild drops
+the session and the call with it, so the attempt is postponed), the flag is
+counted before the attempt rather than after a successful one, and only
+`maxSessionRebuildsPerEpisode` attempts are made until a registration succeeds,
+so a registrar-wide outage cannot turn every client into a session churner.
+Losing the network clears the failure clock: offline time says nothing about
+whether the credentials are still valid.
+
+The flag travels with the connect request and is not remembered anywhere:
+`SignalingModule.connect(reregister:)` → the platform's `start(..., reregister:)`
+→ the direct service or, on the Android hub path, `SignalingHubConnectCommand`.
 
 **Lifecycle / connectivity notification API:**
 

--- a/lib/features/call/services/signaling_reconnect_controller.dart
+++ b/lib/features/call/services/signaling_reconnect_controller.dart
@@ -66,7 +66,11 @@ class SignalingReconnectController {
     void Function(bool isAvailable)? onConnectionPresenceChanged,
     int notifyAfterConsecutiveFailures = 2,
     bool reconnectEnabled = true,
+    Duration rebuildSessionAfter = const Duration(minutes: 5),
+    int maxSessionRebuildsPerEpisode = 2,
   }) : assert(notifyAfterConsecutiveFailures >= 1, 'notifyAfterConsecutiveFailures must be >= 1'),
+       _rebuildSessionAfter = rebuildSessionAfter,
+       _maxSessionRebuilds = maxSessionRebuildsPerEpisode,
        _module = signalingModule,
        _onConnectionFailed = onConnectionFailed,
        _onConnectionPresenceChanged = onConnectionPresenceChanged,
@@ -81,6 +85,22 @@ class SignalingReconnectController {
   final int _notifyThreshold;
   final bool _reconnectEnabled;
 
+  /// How long the SIP registration must keep failing before a reconnect asks the
+  /// server to rebuild the session.
+  ///
+  /// Core reads the address and credentials it registers with once, when it
+  /// creates the session, and refreshes them only on its own reconnect. When an
+  /// operator changes them, the session keeps trying the old ones and never
+  /// registers again - and reconnecting does not help, because the socket
+  /// re-attaches to that same session. Asking for a rebuild is what a relogin
+  /// does, without the user having to know that (WT-1766).
+  final Duration _rebuildSessionAfter;
+
+  /// A rebuild drops the server-side session, so a registrar outage must not
+  /// turn every client into a session churner: give up after this many attempts
+  /// until the registration succeeds again.
+  final int _maxSessionRebuilds;
+
   late final StreamSubscription<SignalingModuleEvent> _subscription;
 
   /// Tracks whether a connection was successfully established in the current session.
@@ -93,6 +113,14 @@ class SignalingReconnectController {
   bool _networkActive = true;
   bool _hasActiveCalls = false;
   bool _disposed = false;
+
+  // The elapsed time is measured by the timer below rather than by comparing
+  // wall-clock stamps: a device clock correction must not make a fresh failure
+  // look old, or an old one look fresh.
+  bool _registrationFailing = false;
+  int _sessionRebuilds = 0;
+  bool _rebuildOnNextConnect = false;
+  Timer? _rebuildTimer;
 
   // Set to true by notifyNetworkAvailable and consumed by the first timer that
   // fires after it. Allows a one-shot opportunistic reconnect when the network
@@ -223,6 +251,9 @@ class SignalingReconnectController {
   void notifyNetworkUnavailable() {
     _logger.info('notifyNetworkUnavailable: isConnected=${_module.isConnected}');
     _networkActive = false;
+    // Time spent offline says nothing about the credentials - keep it out of the
+    // failure clock, or a subway ride would look like a broken registration.
+    _clearRegistrationFailure();
     _disconnect();
     _emitPresence(false);
   }
@@ -233,6 +264,16 @@ class SignalingReconnectController {
 
   void _onEvent(SignalingModuleEvent event) {
     switch (event) {
+      case SignalingHandshakeReceived(:final handshake):
+        _trackRegistration(handshake.registration.status);
+
+      case SignalingProtocolEvent(:final event):
+        if (event is RegisteredEvent) {
+          _trackRegistration(RegistrationStatus.registered);
+        } else if (event is RegistrationFailedEvent) {
+          _trackRegistration(RegistrationStatus.registration_failed);
+        }
+
       case SignalingConnected():
         _logger.fine('_onEvent: connected - resetting failure counter');
         _wasConnected = true;
@@ -341,9 +382,87 @@ class SignalingReconnectController {
         return;
       }
 
-      _logger.info('_scheduleReconnect: calling connect (force=$force isConnected=${_module.isConnected})');
-      _module.connect();
+      // Consumed and counted before the attempt: the server acts on the request
+      // as soon as it reads the URL, so a connect that then fails must not be
+      // free to ask again on the very next retry.
+      final reregister = _rebuildOnNextConnect && !_hasActiveCalls;
+      if (_rebuildOnNextConnect) {
+        _rebuildOnNextConnect = false;
+        if (reregister) _sessionRebuilds++;
+      }
+
+      _logger.info(
+        '_scheduleReconnect: calling connect (force=$force isConnected=${_module.isConnected} '
+        'reregister=$reregister)',
+      );
+      _module.connect(reregister: reregister);
     });
+  }
+
+  /// Follows how long the registration has been failing and, once that stops
+  /// looking transient, schedules the reconnect that carries the rebuild request.
+  ///
+  /// Nothing else would schedule it: a failed registration is a SIP-level
+  /// answer, the socket stays up, so without this the recovery would depend on
+  /// an unrelated disconnect happening to come along.
+  void _trackRegistration(RegistrationStatus status) {
+    switch (status) {
+      case RegistrationStatus.registration_failed:
+        if (_registrationFailing) return;
+        if (_sessionRebuilds >= _maxSessionRebuilds) {
+          _logger.info('registration still failing, but the session rebuild budget is spent');
+          return;
+        }
+        _logger.info('registration failed - arming the session rebuild in $_rebuildSessionAfter');
+        _registrationFailing = true;
+        _rebuildTimer?.cancel();
+        _rebuildTimer = Timer(_rebuildSessionAfter, _onRegistrationFailingTooLong);
+
+      case RegistrationStatus.registered:
+        if (_registrationFailing || _sessionRebuilds > 0) {
+          _logger.info('registration recovered - clearing the session rebuild state');
+        }
+        _clearRegistrationFailure();
+
+      // Registering / unregistering / unregistered are steps of their own, not a
+      // verdict on the credentials: leave whatever is armed as it is.
+      case RegistrationStatus.registering:
+      case RegistrationStatus.unregistering:
+      case RegistrationStatus.unregistered:
+        break;
+    }
+  }
+
+  void _clearRegistrationFailure() {
+    _registrationFailing = false;
+    _sessionRebuilds = 0;
+    _rebuildOnNextConnect = false;
+    _rebuildTimer?.cancel();
+    _rebuildTimer = null;
+  }
+
+  void _onRegistrationFailingTooLong() {
+    if (_disposed || !_registrationFailing) return;
+
+    // A rebuild tears the server-side session down, and any call it carries with
+    // it, so a call in progress always wins over the recovery.
+    if (_hasActiveCalls) {
+      _logger.info('session rebuild postponed - a call is in progress');
+      _rebuildTimer = Timer(_rebuildSessionAfter, _onRegistrationFailingTooLong);
+      return;
+    }
+    if (!_networkActive) {
+      _logger.info('session rebuild postponed - no network');
+      _rebuildTimer = Timer(_rebuildSessionAfter, _onRegistrationFailingTooLong);
+      return;
+    }
+
+    _logger.warning(
+      'registration has been failing for $_rebuildSessionAfter - '
+      'reconnecting with a session rebuild (attempt ${_sessionRebuilds + 1} of $_maxSessionRebuilds)',
+    );
+    _rebuildOnNextConnect = true;
+    _scheduleReconnect(Duration.zero, force: true);
   }
 
   void _disconnect() {
@@ -366,6 +485,7 @@ class SignalingReconnectController {
   void dispose() {
     _disposed = true;
     _reconnectTimer?.cancel();
+    _rebuildTimer?.cancel();
     _subscription.cancel().ignore();
   }
 }

--- a/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
+++ b/packages/webtrit_signaling/lib/src/webtrit_signaling_client.dart
@@ -25,6 +25,18 @@ class WebtritSignalingClient {
   static const _callIdChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
   @visibleForTesting
+  /// The signaling endpoint the client opens, including the connect flags.
+  ///
+  /// Kept separate from [connect] so the wire contract with the server can be
+  /// asserted without opening a socket.
+  static Uri buildSignalingUrl(Uri baseUrl, String tenantId, String token, bool force, {bool reregister = false}) {
+    final tenantUrl = buildTenantUrl(baseUrl, tenantId);
+    return tenantUrl.replace(
+      pathSegments: [...tenantUrl.pathSegments, 'signaling', 'v1'],
+      queryParameters: {'token': token, 'force': force.toString(), if (reregister) 'reregister': 'true'},
+    );
+  }
+
   static Uri buildTenantUrl(Uri baseUrl, String tenantId) {
     if (tenantId.isEmpty) {
       return baseUrl;
@@ -79,21 +91,27 @@ class WebtritSignalingClient {
 
   final _transactions = <String, Transaction>{};
 
+  /// Opens a signaling connection.
+  ///
+  /// [force] takes the session over from another socket of the same app.
+  ///
+  /// [reregister] additionally asks the server to rebuild the session from
+  /// scratch instead of attaching to the one it already keeps for this app.
+  /// Everything the server cached for that session - among it the address and
+  /// credentials it registers with - is read anew, which is the only way a
+  /// client can recover from a session that keeps failing to register with
+  /// data that has since changed on the operator's side. It costs a full
+  /// re-registration, so use it as a last resort, never as the normal path.
   static Future<WebtritSignalingClient> connect(
     Uri baseUrl,
     String tenantId,
     String token,
     bool force, {
+    bool reregister = false,
     Duration? connectionTimeout,
     TrustedCertificates certs = TrustedCertificates.empty,
   }) async {
-    final tenantUrl = buildTenantUrl(baseUrl, tenantId);
-    final signalingUrl = tenantUrl
-        .replace(
-          pathSegments: [...tenantUrl.pathSegments, 'signaling', 'v1'],
-          queryParameters: {'token': token, 'force': force.toString()},
-        )
-        .toString();
+    final signalingUrl = buildSignalingUrl(baseUrl, tenantId, token, force, reregister: reregister).toString();
 
     final ws = await connectWebSocket(
       signalingUrl,

--- a/packages/webtrit_signaling/test/src/signaling_url_test.dart
+++ b/packages/webtrit_signaling/test/src/signaling_url_test.dart
@@ -1,0 +1,31 @@
+/// The connect URL is the whole contract with the server for the connect flags:
+/// if a parameter name drifts, the app silently keeps attaching to a session it
+/// asked to have rebuilt, and nothing else in the suite would notice (WT-1766).
+library;
+
+import 'package:test/test.dart';
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+
+void main() {
+  final baseUrl = Uri.parse('https://core.example.com');
+
+  test('a plain connect carries the token and force, and nothing more', () {
+    final url = WebtritSignalingClient.buildSignalingUrl(baseUrl, '', 'tok', true);
+
+    expect(url.path, endsWith('/signaling/v1'));
+    expect(url.queryParameters, {'token': 'tok', 'force': 'true'});
+  });
+
+  test('a session rebuild is requested as reregister=true', () {
+    final url = WebtritSignalingClient.buildSignalingUrl(baseUrl, '', 'tok', true, reregister: true);
+
+    expect(url.queryParameters['reregister'], 'true');
+  });
+
+  test('a tenant is kept in the path', () {
+    final url = WebtritSignalingClient.buildSignalingUrl(baseUrl, 'acme', 'tok', false);
+
+    expect(url.path, contains('acme'));
+    expect(url.path, endsWith('/signaling/v1'));
+  });
+}

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/lib/src/signaling_service.dart
@@ -124,7 +124,7 @@ class WebtritSignalingService implements SignalingModule {
   /// The timer is cancelled immediately when a terminal event arrives, so it
   /// has no effect during normal operation.
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_isDisposed || _startPending || _isConnected) return;
     _startPending = true;
     _startPendingTimer?.cancel();
@@ -134,7 +134,10 @@ class WebtritSignalingService implements SignalingModule {
       _startPendingTimer = null;
       connect();
     });
-    SignalingServicePlatform.instance.start(_config, mode: _mode).catchError((Object e, StackTrace s) {
+    SignalingServicePlatform.instance.start(_config, mode: _mode, reregister: reregister).catchError((
+      Object e,
+      StackTrace s,
+    ) {
       _logger.severe('connect: start() failed', e, s);
       _clearStartPending();
     });

--- a/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service/test/signaling_service_test.dart
@@ -25,7 +25,7 @@ class _FakeModule implements SignalingModule {
   bool get isConnected => _connected;
 
   @override
-  void connect() {}
+  void connect({bool reregister = false}) {}
 
   @override
   Future<void> disconnect() async {}
@@ -71,6 +71,7 @@ class _FakePlatform extends Fake implements SignalingServicePlatform {
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
   }) async {
     startedConfigs.add(config);
     startedModes.add(mode);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub.dart
@@ -244,8 +244,8 @@ class SignalingHub {
           _logger.warning('Hub connect: unknown subscriber ${cmd.consumerId}');
           return;
         }
-        _logger.fine('Hub received connect command from ${cmd.consumerId}');
-        _signalingModule.connect();
+        _logger.fine('Hub received connect command from ${cmd.consumerId} (reregister=${cmd.reregister})');
+        _signalingModule.connect(reregister: cmd.reregister);
       case SignalingHubDisconnectCommand():
         if (!_subscribers.containsKey(cmd.consumerId)) {
           _logger.warning('Hub disconnect: unknown subscriber ${cmd.consumerId}');

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_client.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_client.dart
@@ -163,8 +163,8 @@ class SignalingHubClient {
   /// Fire-and-forget: the hub will call [SignalingModule.connect] in the
   /// background isolate. The resulting [SignalingConnected] event will arrive
   /// on [events] once the connection is established.
-  void sendConnect() {
-    _hubPort.send(SignalingHubConnectCommand(consumerId: consumerId).encode());
+  void sendConnect({bool reregister = false}) {
+    _hubPort.send(SignalingHubConnectCommand(consumerId: consumerId, reregister: reregister).encode());
   }
 
   /// Asks the hub to disconnect the background WebSocket.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_command.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_command.dart
@@ -43,7 +43,11 @@ sealed class SignalingHubCommand {
           );
         case _tagConnect:
           if (wire.length < 2) return null;
-          return SignalingHubConnectCommand(consumerId: wire[1] as String);
+          return SignalingHubConnectCommand(
+            consumerId: wire[1] as String,
+            // Older senders omit the flag; absent means a plain connect.
+            reregister: wire.length > 2 && wire[2] == true,
+          );
         case _tagDisconnect:
           if (wire.length < 2) return null;
           return SignalingHubDisconnectCommand(consumerId: wire[1] as String);
@@ -127,10 +131,15 @@ class SignalingHubExecuteCommand extends SignalingHubCommand {
 /// Sent by [SignalingHubModule.connect] so the main isolate can trigger a
 /// connection attempt without owning the WebSocket directly.
 class SignalingHubConnectCommand extends SignalingHubCommand {
-  const SignalingHubConnectCommand({required String consumerId}) : super(consumerId);
+  const SignalingHubConnectCommand({required String consumerId, this.reregister = false}) : super(consumerId);
+
+  /// Ask the server to rebuild the session instead of attaching to the existing
+  /// one. Decided by the reconnect policy in the main isolate; the hub only
+  /// carries it across.
+  final bool reregister;
 
   @override
-  List<Object?> encode() => [_tagConnect, consumerId];
+  List<Object?> encode() => [_tagConnect, consumerId, reregister];
 }
 
 /// Asks the hub to call [SignalingModule.disconnect] on the background WebSocket.

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_module.dart
@@ -73,7 +73,7 @@ class SignalingHubModule implements SignalingModule {
   /// The resulting [SignalingConnected] event arrives on [events] once the
   /// connection is established.
   @override
-  void connect() => _hubClient.sendConnect();
+  void connect({bool reregister = false}) => _hubClient.sendConnect(reregister: reregister);
 
   /// Asks the hub to disconnect the background WebSocket.
   ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub_connection_manager.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub_connection_manager.dart
@@ -86,6 +86,12 @@ class HubConnectionManager {
 
   Future<void> disconnect() => _module?.disconnect() ?? Future.value();
 
+  /// Asks the background isolate to (re)connect.
+  ///
+  /// Only used when the reconnect policy needs the session rebuilt; the plain
+  /// reconnect path is driven by the isolate itself.
+  void connect({bool reregister = false}) => _module?.connect(reregister: reregister);
+
   /// Starts or restarts the hub-init polling loop.
   ///
   /// No-op if a module is already wired up. Increments the generation so

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/plugin.dart
@@ -124,6 +124,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
   }) async {
     _isStopped = false;
     _currentConfig = config;
@@ -132,7 +133,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
 
     _logger.info('start effectiveMode=$effectiveMode tenantId=${config.tenantId}');
 
-    await _startService(config, effectiveMode);
+    await _startService(config, effectiveMode, reregister: reregister);
   }
 
   @override
@@ -296,7 +297,11 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
     }
   }
 
-  Future<void> _startService(SignalingServiceConfig config, SignalingServiceMode mode) async {
+  Future<void> _startService(
+    SignalingServiceConfig config,
+    SignalingServiceMode mode, {
+    bool reregister = false,
+  }) async {
     if (mode == SignalingServiceMode.pushBound) {
       _logger.fine('_startService mode=pushBound -- delegating to direct service');
       final myToken = _startServiceToken = Object();
@@ -309,7 +314,7 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
       // Start the direct service first so SignalingConnecting is emitted and
       // buffered before we subscribe -- this clears any stale events from a
       // previous session and guarantees the replay on subscribe is fresh.
-      await _directService.start(config, mode: mode);
+      await _directService.start(config, mode: mode, reregister: reregister);
 
       if (_isStopped) {
         _logger.fine('_startService: aborted — stopped during direct start');
@@ -331,6 +336,15 @@ class WebtritSignalingServiceAndroid extends SignalingServicePlatform {
           if (!_eventsController.isClosed) _eventsController.addError(e, st);
         },
       );
+      return;
+    }
+
+    // A running hub already owns a session, so the rebuild request has to reach
+    // the isolate as a command; a hub that is still starting builds a fresh
+    // session anyway and needs nothing.
+    if (reregister && _hubManager.isConnected) {
+      _logger.info('_startService: asking the hub to reconnect with a session rebuild');
+      _hubManager.connect(reregister: true);
       return;
     }
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/hub/signaling_hub_module_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/hub/signaling_hub_module_test.dart
@@ -30,7 +30,7 @@ class _FakeHubClient extends Fake implements SignalingHubClient {
   void start() => started = true;
 
   @override
-  void sendConnect() => connectSent = true;
+  void sendConnect({bool reregister = false}) => connectSent = true;
 
   @override
   void sendDisconnect() => disconnectSent = true;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/isolate/signaling_foreground_isolate_manager_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/fgs/isolate/signaling_foreground_isolate_manager_test.dart
@@ -26,7 +26,7 @@ class _FakeSignalingModule extends Fake implements SignalingModule {
   Stream<SignalingModuleEvent> get events => _controller.stream;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     connectCount++;
     _connected = true;
     _controller.add(SignalingConnected());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/attach_pattern_integration_test.dart
@@ -34,6 +34,7 @@ typedef _SignalingClientFactory =
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     });
 
 // ---------------------------------------------------------------------------
@@ -79,7 +80,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }
@@ -133,6 +134,7 @@ class _SignalingModule implements SignalingModule {
         connectionTimeout: const Duration(seconds: 10),
         certs: trustedCertificates,
         force: true,
+        reregister: false,
       );
       if (_disposed) {
         try {
@@ -330,6 +332,7 @@ _SignalingClientFactory _fakeFactory(_FakeSignalingClient client) =>
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     }) async => client;
 
 /// Builds and starts the "background service side":
@@ -420,6 +423,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async => fakeClient,
       );
       await manager.handleStatus(enabled: true);
@@ -830,6 +834,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async => cycle == 0 ? fakeClient1 : fakeClient2,
       );
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/bloc_flow_integration_test.dart
@@ -30,6 +30,7 @@ typedef _SignalingClientFactory =
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     });
 
 // ---------------------------------------------------------------------------
@@ -75,7 +76,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }
@@ -129,6 +130,7 @@ class _SignalingModule implements SignalingModule {
         connectionTimeout: const Duration(seconds: 10),
         certs: trustedCertificates,
         force: true,
+        reregister: false,
       );
       if (_disposed) {
         try {
@@ -367,6 +369,7 @@ _SignalingClientFactory _fakeFactory(_FakeSignalingClient client) =>
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     }) async => client;
 
 /// Builds the "server side": module + hub, connects, and returns both.
@@ -609,6 +612,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async {
               callCount++;
               return callCount == 1 ? _FakeSignalingClient() : fakeClient2;
@@ -867,6 +871,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async {
               connectCount.add(1);
               return fakeClient;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_client_integration_test.dart
@@ -31,6 +31,7 @@ typedef _SignalingClientFactory =
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     });
 
 // ---------------------------------------------------------------------------
@@ -76,7 +77,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }
@@ -130,6 +131,7 @@ class _SignalingModule implements SignalingModule {
         connectionTimeout: const Duration(seconds: 10),
         certs: trustedCertificates,
         force: true,
+        reregister: false,
       );
       if (_disposed) {
         try {
@@ -273,6 +275,7 @@ _SignalingClientFactory _fakeFactory(_FakeSignalingClient client) =>
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     }) async => client;
 
 _SignalingModule _buildModule(_FakeSignalingClient client) => _SignalingModule(

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/hub_connection_manager_integration_test.dart
@@ -43,7 +43,7 @@ class _FakeSignalingModule implements SignalingModule {
   bool get isConnected => _connected;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     _connected = true;
     _emit(SignalingConnecting());
     _emit(SignalingConnected());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/integration/stress_integration_test.dart
@@ -33,6 +33,7 @@ typedef _SignalingClientFactory =
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     });
 
 // ---------------------------------------------------------------------------
@@ -78,7 +79,7 @@ class _SignalingModule implements SignalingModule {
   bool get isConnected => _client != null;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     unawaited(_connectAsync());
   }
@@ -132,6 +133,7 @@ class _SignalingModule implements SignalingModule {
         connectionTimeout: const Duration(seconds: 10),
         certs: trustedCertificates,
         force: true,
+        reregister: false,
       );
       if (_disposed) {
         try {
@@ -308,6 +310,7 @@ _SignalingClientFactory _fakeFactory(_FakeSignalingClient client) =>
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     }) async => client;
 
 Future<({_SignalingModule module, SignalingHub hub, _FakeSignalingClient fakeClient})> _buildServerSide() async {
@@ -562,6 +565,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async => _FakeSignalingClient(),
       );
       addTearDown(module.dispose);
@@ -597,6 +601,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async {
               final c = _FakeSignalingClient();
               lastCreated = c;
@@ -633,6 +638,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async {
               final c = _FakeSignalingClient();
               clients.add(c);
@@ -693,6 +699,7 @@ void main() {
               required Duration connectionTimeout,
               required TrustedCertificates certs,
               required bool force,
+              required bool reregister,
             }) async => _fakeClientToggle == 0 ? fakeClient1 : fakeClient2,
       );
 

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/test/plugin_test.dart
@@ -30,6 +30,7 @@ class _FakeDirectService extends WebtritSignalingServiceDirect {
   Future<void> start(
     SignalingServiceConfig config, {
     SignalingServiceMode mode = SignalingServiceMode.pushBound,
+    bool reregister = false,
   }) async {
     // Only the first call is gated; subsequent calls pass through immediately.
     if (!_gateConsumed && _gate != null) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_ios/test/plugin_test.dart
@@ -73,7 +73,7 @@ class _FakeSignalingModule implements SignalingModule {
   bool get isConnected => _isConnected;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     _buffer.clear();
     _emit(SignalingConnecting());
@@ -188,7 +188,7 @@ class _FailingSignalingModule implements SignalingModule {
   bool get isConnected => false;
 
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) return;
     _buffer.clear();
     _emit(SignalingConnecting());

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_module.dart
@@ -27,7 +27,14 @@ abstract interface class SignalingModule {
   /// Initiates a new connection attempt. Fire-and-forget.
   ///
   /// On [SignalingHubModule] this is a no-op -- the hub owns the connection.
-  void connect();
+  /// Opens a connection.
+  ///
+  /// [reregister] additionally asks the server to rebuild the session it keeps
+  /// for this app instead of attaching to the existing one, which is the only
+  /// way a client can recover from a session whose registration data went stale
+  /// on the server. It costs a full re-registration, so the decision belongs to
+  /// the reconnect policy, never to this layer.
+  void connect({bool reregister = false});
 
   /// Gracefully closes the current connection.
   ///

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_module_impl.dart
@@ -24,6 +24,7 @@ typedef SignalingClientFactory =
       required Duration connectionTimeout,
       required TrustedCertificates certs,
       required bool force,
+      required bool reregister,
     });
 
 Uri _coreUrlToSignalingUrl(String coreUrl) {
@@ -38,12 +39,14 @@ Future<WebtritSignalingClient> _defaultClientFactory({
   required Duration connectionTimeout,
   required TrustedCertificates certs,
   required bool force,
+  required bool reregister,
 }) {
   return WebtritSignalingClient.connect(
     url,
     tenantId,
     token,
     force,
+    reregister: reregister,
     connectionTimeout: connectionTimeout,
     certs: certs,
   );
@@ -211,7 +214,7 @@ class SignalingModuleImpl implements SignalingModule {
   /// Initiates a connection. Fire-and-forget -- result arrives via [events].
   /// Clears the session buffer on each call.
   @override
-  void connect() {
+  void connect({bool reregister = false}) {
     if (_disposed) {
       _logger.fine('connect: skipped — disposed');
       return;
@@ -220,10 +223,10 @@ class SignalingModuleImpl implements SignalingModule {
       _logger.info('connect: skipped — already connecting or connected (connectToken set)');
       return;
     }
-    _logger.info('connect: starting new connect attempt (isConnected=$isConnected)');
+    _logger.info('connect: starting new connect attempt (isConnected=$isConnected reregister=$reregister)');
     final token = _connectToken = Object();
     _eventBuffer.clear();
-    unawaited(_connectAsync(token));
+    unawaited(_connectAsync(token, reregister: reregister));
   }
 
   @override
@@ -277,7 +280,7 @@ class SignalingModuleImpl implements SignalingModule {
   // Internal
   // ---------------------------------------------------------------------------
 
-  Future<void> _connectAsync(Object connectToken) async {
+  Future<void> _connectAsync(Object connectToken, {bool reregister = false}) async {
     try {
       final existing = _client;
       if (existing != null) {
@@ -306,6 +309,7 @@ class SignalingModuleImpl implements SignalingModule {
           connectionTimeout: connectionTimeout,
           certs: trustedCertificates,
           force: true,
+          reregister: reregister,
         );
 
         if (_connectToken != connectToken || _disposed) {

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -98,6 +98,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
     SignalingServiceConfig config, {
     // ignore: avoid_unused_parameters
     SignalingServiceMode mode = SignalingServiceMode.pushBound,
+    bool reregister = false,
   }) async {
     _isStopped = false;
     final myToken = _startToken = Object();
@@ -141,7 +142,7 @@ class WebtritSignalingServiceDirect extends SignalingServicePlatform {
       },
     );
     _module = module;
-    module.connect();
+    module.connect(reregister: reregister);
   }
 
   @override

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_platform.dart
@@ -39,7 +39,11 @@ abstract class SignalingServicePlatform extends PlatformInterface {
   ///   in the main isolate and is not persistent.
   /// - [SignalingServiceMode.pushBound] -- service stops when the app Activity
   ///   is closed, allowing the next push to start a fresh instance.
-  Future<void> start(SignalingServiceConfig config, {SignalingServiceMode mode = SignalingServiceMode.persistent});
+  Future<void> start(
+    SignalingServiceConfig config, {
+    SignalingServiceMode mode = SignalingServiceMode.persistent,
+    bool reregister = false,
+  });
 
   /// Sends [request] to the server via the active connection.
   Future<void> execute(Request request);

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/test/signaling_module_impl_test.dart
@@ -101,6 +101,7 @@ class _ControlledFactory {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) {
         final c = Completer<WebtritSignalingClient>();
         _calls.add(c);
@@ -137,6 +138,7 @@ SignalingModuleImpl _buildModuleFromClients(List<WebtritSignalingClient> clients
           required Duration connectionTimeout,
           required TrustedCertificates certs,
           required bool force,
+          required bool reregister,
         }) async => clients[index++],
   );
 }

--- a/test/features/call/services/signaling_module_test.dart
+++ b/test/features/call/services/signaling_module_test.dart
@@ -95,6 +95,7 @@ SignalingClientFactory _successFactory(_FakeSignalingClient client) {
     required Duration connectionTimeout,
     required TrustedCertificates certs,
     required bool force,
+    required bool reregister,
   }) async => client;
 }
 
@@ -107,6 +108,7 @@ SignalingClientFactory _failingFactory(Object error) {
     required Duration connectionTimeout,
     required TrustedCertificates certs,
     required bool force,
+    required bool reregister,
   }) async => throw error;
 }
 
@@ -122,6 +124,7 @@ class _ControlledFactory {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) {
         _completer = Completer<WebtritSignalingClient>();
         return _completer!.future;
@@ -260,6 +263,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         return callCount == 1 ? firstClient : secondClient;
@@ -625,6 +629,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         if (callCount == 1) throw error;
@@ -788,6 +793,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         callCount++;
         return callCount == 1 ? client1 : client2;
@@ -1229,6 +1235,7 @@ void main() {
         required Duration connectionTimeout,
         required TrustedCertificates certs,
         required bool force,
+        required bool reregister,
       }) async {
         call++;
         return call == 1 ? client1 : client2;
@@ -1401,6 +1408,7 @@ void main() {
           required Duration connectionTimeout,
           required TrustedCertificates certs,
           required bool force,
+          required bool reregister,
         }) async => client,
       );
 

--- a/test/features/call/services/signaling_reconnect_controller_test.dart
+++ b/test/features/call/services/signaling_reconnect_controller_test.dart
@@ -17,6 +17,7 @@ class _FakeSignalingModule implements SignalingModule {
 
   int connectCalls = 0;
   int disconnectCalls = 0;
+  final List<bool> reregisterFlags = [];
 
   @override
   bool isConnected = false;
@@ -27,7 +28,10 @@ class _FakeSignalingModule implements SignalingModule {
   void emit(SignalingModuleEvent event) => _controller.add(event);
 
   @override
-  void connect() => connectCalls++;
+  void connect({bool reregister = false}) {
+    connectCalls++;
+    reregisterFlags.add(reregister);
+  }
 
   @override
   Future<void> disconnect() async => disconnectCalls++;
@@ -1167,6 +1171,120 @@ void main() {
         module.emit(_lost());
 
         expect(presence, [false, true, false]);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Recovering a registration that will never succeed on its own (WT-1766)
+  // -------------------------------------------------------------------------
+
+  group('session rebuild after a persistent registration failure', () {
+    StateHandshake handshakeWith(RegistrationStatus status) => StateHandshake(
+      keepaliveInterval: const Duration(seconds: 30),
+      timestamp: 0,
+      registration: Registration(status: status),
+      lines: const [null],
+      presenceInfos: const [],
+      dialogInfos: const [],
+      guestLine: null,
+    );
+
+    SignalingReconnectController build(_FakeSignalingModule module) =>
+        SignalingReconnectController(signalingModule: module, rebuildSessionAfter: const Duration(minutes: 5));
+
+    test('a failure that outlasts the threshold reconnects and asks for a rebuild', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        final controller = build(module);
+        addTearDown(controller.dispose);
+
+        module.emit(SignalingHandshakeReceived(handshake: handshakeWith(RegistrationStatus.registration_failed)));
+        async.elapse(const Duration(minutes: 5, seconds: 1));
+
+        expect(module.reregisterFlags, [true], reason: 'nothing else reconnects on a registration failure');
+      });
+    });
+
+    test('a failure shorter than the threshold is left alone', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        final controller = build(module);
+        addTearDown(controller.dispose);
+
+        module.emit(SignalingHandshakeReceived(handshake: handshakeWith(RegistrationStatus.registration_failed)));
+        async.elapse(const Duration(minutes: 4));
+
+        expect(module.reregisterFlags, isEmpty);
+      });
+    });
+
+    test('a registration that recovers cancels the rebuild', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        final controller = build(module);
+        addTearDown(controller.dispose);
+
+        module.emit(SignalingHandshakeReceived(handshake: handshakeWith(RegistrationStatus.registration_failed)));
+        async.elapse(const Duration(minutes: 4));
+        module.emit(SignalingProtocolEvent(event: RegisteredEvent()));
+        async.elapse(const Duration(minutes: 10));
+
+        expect(module.reregisterFlags, isEmpty);
+      });
+    });
+
+    test('a call in progress postpones the rebuild instead of dropping the call', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        final controller = build(module);
+        addTearDown(controller.dispose);
+
+        controller.notifyHasActiveCalls(hasActiveCalls: true);
+        module.emit(SignalingHandshakeReceived(handshake: handshakeWith(RegistrationStatus.registration_failed)));
+        async.elapse(const Duration(minutes: 6));
+
+        expect(module.reregisterFlags.where((flag) => flag), isEmpty, reason: 'a live call outranks the recovery');
+      });
+    });
+
+    test('losing the network does not age the failure clock', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        final controller = build(module);
+        addTearDown(controller.dispose);
+
+        module.emit(SignalingHandshakeReceived(handshake: handshakeWith(RegistrationStatus.registration_failed)));
+        async.elapse(const Duration(minutes: 2));
+        controller.notifyNetworkUnavailable();
+        async.elapse(const Duration(minutes: 30));
+        controller.notifyNetworkAvailable();
+        async.elapse(const Duration(minutes: 1));
+
+        expect(
+          module.reregisterFlags.where((flag) => flag),
+          isEmpty,
+          reason: 'offline time is not a failing registration',
+        );
+      });
+    });
+
+    test('the rebuild budget is spent, not repeated forever', () {
+      fakeAsync((async) {
+        final module = _FakeSignalingModule();
+        final controller = SignalingReconnectController(
+          signalingModule: module,
+          rebuildSessionAfter: const Duration(minutes: 5),
+          maxSessionRebuildsPerEpisode: 1,
+        );
+        addTearDown(controller.dispose);
+
+        for (var i = 0; i < 4; i++) {
+          module.emit(SignalingHandshakeReceived(handshake: handshakeWith(RegistrationStatus.registration_failed)));
+          async.elapse(const Duration(minutes: 6));
+        }
+
+        expect(module.reregisterFlags.where((flag) => flag).length, 1);
       });
     });
   });


### PR DESCRIPTION
## Overview

When the phone system an account registers to is changed on the operator's side
(a different address, different credentials), the session the app is attached to
keeps trying the old ones and never registers again. The app sits on
"Waiting for connection..." indefinitely, and reconnecting does not help,
because it re-attaches to that very session. Until now the only way out was for
the user to log out and log back in.

The app now watches how long registration has been failing. Once it has been
broken for a few minutes, the app asks the server to build the session from
scratch instead of reattaching to it, so the current settings are picked up and
the account registers again on its own.

Three things keep this from making a bad situation worse:

- a call in progress always wins - the attempt is postponed until the call ends,
  since rebuilding the session would drop the call;
- losing the network does not count as a registration failure, so a tunnel or a
  flaky connection does not trigger anything;
- the number of attempts per outage is capped, so an outage affecting the whole
  phone system cannot turn every client into a source of extra load.

## Verification

- Reproduced on a local stack: the account's phone system address was changed
  underneath a running app. Before the change the app stayed stuck until a
  relogin; now it recovers on its own within the expected window.
- Unit tests cover the timing (fires after the threshold, ignores short
  failures, a recovery cancels it), the safety rules (an active call postpones
  it, offline time does not age the clock, the attempt budget is spent once),
  and that the request actually reaches the server as expected.
- Full analyze plus the root and package test suites pass.

WT-1766
