### PR TITLE
build: stop the configurator generation step from looking like it failed

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -442,14 +442,22 @@ melos:
         APP_ID=$(grep -E '^(export[[:space:]]+)?APP_ID=' .env | cut -d '=' -f2-)
         CONFIGURATOR_TOKEN=$(grep -E '^(export[[:space:]]+)?CONFIGURATOR_TOKEN=' .env | cut -d '=' -f2-)
         KEYSTORE_APP_PATH="../webtrit_phone_keystores/applications/${APP_ID:?APP_ID not found in .env}"
-        dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
+        # `dart run` streams a "Running build hooks..." progress fragment on stderr, and melos
+        # labels everything a script writes to stderr as ERROR - which reads as a failed run even
+        # though the command succeeded. Strip just that fragment; any other stderr text, the exit
+        # code and stdout pass through untouched.
+        phone_tools() {
+          { dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart "$@" 2>&1 1>&3 \
+            | sed -e 's/Running build hooks\.\.\.//g' -e '/^[[:space:]]*$/d' >&2; } 3>&1
+        }
+        phone_tools \
           configurator-resources \
           --applicationId="$APP_ID" \
           --keystores-path=../webtrit_phone_keystores/applications \
           --token="${CONFIGURATOR_TOKEN:?CONFIGURATOR_TOKEN not found in .env}"
-        dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
+        phone_tools \
           configurator-generate
-        dart run ../webtrit_phone_tools/bin/webtrit_phone_tools.dart \
+        phone_tools \
           configurator-setup \
           --platform ios \
           --platform android \


### PR DESCRIPTION
## Overview

Preparing a white-label build with `melos run configurator:generate` finished
successfully, but the run printed error lines along the way. Every step had
worked, yet the output said otherwise, so it read as a broken run and cost time
double-checking that nothing was actually wrong.

The cause was cosmetic: the toolchain writes a harmless progress note to the
error channel, and the task runner reports anything on that channel as an error.
That note is now kept out of the error output.

## Verification

- `melos run configurator:generate` no longer prints error lines on a successful run.
- A genuinely failing step still prints its real error, stops the script and
  returns a failure status, so nothing is swallowed.
- Command output of each step is unchanged.