### PR TITLE
feat: ios push mode specify (WT-1782)

### DIFF
--- a/lib/repositories/push_tokens/push_tokens_repository.dart
+++ b/lib/repositories/push_tokens/push_tokens_repository.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+
 import 'package:webtrit_api/webtrit_api.dart';
 
 import 'package:webtrit_phone/app/session/session.dart';
@@ -15,7 +17,19 @@ class PushTokensRepository {
   final SessionGuard _sessionGuard;
 
   Future<void> insertOrUpdatePushToken(AppPushTokenType type, String value) async {
-    var appPushToken = AppPushToken(type: type, value: value);
+    // If you launch the app in debug mode, then you definetely want to use dev environment for push tokens
+    // Alternatively you can use ios entitlements from native part, but use kDebugMode is just simpler and cover 99% dev cases
+    //
+    // fcm on ios handles dev/prod automatically, so we don't need to worry about that
+    final env = switch ((type, kDebugMode)) {
+      (AppPushTokenType.apkvoip, true) => AppPushTokenEnv.dev,
+      (AppPushTokenType.apkvoip, false) => AppPushTokenEnv.prod,
+      (AppPushTokenType.apns, true) => AppPushTokenEnv.dev,
+      (AppPushTokenType.apns, false) => AppPushTokenEnv.prod,
+      _ => null,
+    };
+
+    var appPushToken = AppPushToken(type: type, value: value, env: env);
 
     try {
       return await _webtritApiClient.createAppPushToken(_token, appPushToken);

--- a/packages/webtrit_api/lib/src/models/app_push_token.dart
+++ b/packages/webtrit_api/lib/src/models/app_push_token.dart
@@ -8,16 +8,22 @@ part 'app_push_token.freezed.dart';
 
 part 'app_push_token.g.dart';
 
+@JsonEnum(fieldRename: FieldRename.snake)
+enum AppPushTokenEnv { dev, prod }
+
 @freezed
 @JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
 class AppPushToken with _$AppPushToken {
-  const AppPushToken({required this.type, required this.value});
+  const AppPushToken({required this.type, required this.value, this.env});
 
   @override
   final AppPushTokenType type;
 
   @override
   final String value;
+
+  @override
+  final AppPushTokenEnv? env;
 
   factory AppPushToken.fromJson(Map<String, dynamic> json) => _$AppPushTokenFromJson(json);
 

--- a/packages/webtrit_api/lib/src/models/app_push_token.freezed.dart
+++ b/packages/webtrit_api/lib/src/models/app_push_token.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AppPushToken {
 
- AppPushTokenType get type; String get value;
+ AppPushTokenType get type; String get value; AppPushTokenEnv? get env;
 /// Create a copy of AppPushToken
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $AppPushTokenCopyWith<AppPushToken> get copyWith => _$AppPushTokenCopyWithImpl<A
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppPushToken&&(identical(other.type, type) || other.type == type)&&(identical(other.value, value) || other.value == value));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppPushToken&&(identical(other.type, type) || other.type == type)&&(identical(other.value, value) || other.value == value)&&(identical(other.env, env) || other.env == env));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,value);
+int get hashCode => Object.hash(runtimeType,type,value,env);
 
 @override
 String toString() {
-  return 'AppPushToken(type: $type, value: $value)';
+  return 'AppPushToken(type: $type, value: $value, env: $env)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $AppPushTokenCopyWith<$Res>  {
   factory $AppPushTokenCopyWith(AppPushToken value, $Res Function(AppPushToken) _then) = _$AppPushTokenCopyWithImpl;
 @useResult
 $Res call({
- AppPushTokenType type, String value
+ AppPushTokenType type, String value, AppPushTokenEnv? env
 });
 
 
@@ -63,11 +63,12 @@ class _$AppPushTokenCopyWithImpl<$Res>
 
 /// Create a copy of AppPushToken
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? value = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? value = null,Object? env = freezed,}) {
   return _then(AppPushToken(
 type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as AppPushTokenType,value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
-as String,
+as String,env: freezed == env ? _self.env : env // ignore: cast_nullable_to_non_nullable
+as AppPushTokenEnv?,
   ));
 }
 

--- a/packages/webtrit_api/lib/src/models/app_push_token.g.dart
+++ b/packages/webtrit_api/lib/src/models/app_push_token.g.dart
@@ -9,12 +9,14 @@ part of 'app_push_token.dart';
 AppPushToken _$AppPushTokenFromJson(Map<String, dynamic> json) => AppPushToken(
   type: $enumDecode(_$AppPushTokenTypeEnumMap, json['type']),
   value: json['value'] as String,
+  env: $enumDecodeNullable(_$AppPushTokenEnvEnumMap, json['env']),
 );
 
 Map<String, dynamic> _$AppPushTokenToJson(AppPushToken instance) =>
     <String, dynamic>{
       'type': _$AppPushTokenTypeEnumMap[instance.type]!,
       'value': instance.value,
+      'env': _$AppPushTokenEnvEnumMap[instance.env],
     };
 
 const _$AppPushTokenTypeEnumMap = {
@@ -22,4 +24,9 @@ const _$AppPushTokenTypeEnumMap = {
   AppPushTokenType.hms: 'hms',
   AppPushTokenType.apns: 'apns',
   AppPushTokenType.apkvoip: 'apkvoip',
+};
+
+const _$AppPushTokenEnvEnumMap = {
+  AppPushTokenEnv.dev: 'dev',
+  AppPushTokenEnv.prod: 'prod',
 };


### PR DESCRIPTION
This pull request updates how push tokens are handled by introducing a new optional `env` (environment) field to the `AppPushToken` model. This field allows the system to distinguish between development and production environments when registering push tokens, which helps prevent mix-ups between dev and prod tokens, especially during development and testing. The repository logic is updated to set this field automatically based on the build mode, and all relevant model, serialization, and copy logic is extended to support this new field.

**Push token environment support:**

* Added a new `AppPushTokenEnv` enum (`dev`, `prod`) and an optional `env` field to the `AppPushToken` model, including serialization and copy logic updates. [[1]](diffhunk://#diff-b895b26717790d486ebca833eccf0393061e97c1106997550749b6e9ac592e8fR11-R27) [[2]](diffhunk://#diff-95fdb73171c0477ff7c18534f1268915e459e36a96873a34d5d5177615744768L18-R18) [[3]](diffhunk://#diff-95fdb73171c0477ff7c18534f1268915e459e36a96873a34d5d5177615744768L29-R38) [[4]](diffhunk://#diff-95fdb73171c0477ff7c18534f1268915e459e36a96873a34d5d5177615744768L49-R49) [[5]](diffhunk://#diff-95fdb73171c0477ff7c18534f1268915e459e36a96873a34d5d5177615744768L66-R71) [[6]](diffhunk://#diff-1cdee3044a30561c3b5017959bddf0cb2c1a99d2e47386a59cf36a519720349fR12-R19) [[7]](diffhunk://#diff-1cdee3044a30561c3b5017959bddf0cb2c1a99d2e47386a59cf36a519720349fR28-R32)
* Updated `PushTokensRepository.insertOrUpdatePushToken` to automatically assign the correct `env` based on the token type and whether the app is running in debug mode, using `kDebugMode`. [[1]](diffhunk://#diff-e1809aa3744fa58494c9c43301c6ac360ea311d2b52d2136f33fba1d30e4b619R3-R4) [[2]](diffhunk://#diff-e1809aa3744fa58494c9c43301c6ac360ea311d2b52d2136f33fba1d30e4b619L18-R32)

These changes help ensure that push tokens are registered in the correct environment, reducing the risk of development tokens being used in production and vice versa.