### PR TITLE
fix: sms typing handler

### DIFF
--- a/lib/features/messaging/cubits/message_typing/sms_typing_cubit.dart
+++ b/lib/features/messaging/cubits/message_typing/sms_typing_cubit.dart
@@ -78,7 +78,7 @@ class SmsTypingCubit extends Cubit<TypingNumbers> {
         final channel = client.getSmsConversationChannel(conversationId);
         if (channel == null || channel.state != PhoenixChannelState.joined) throw Exception('Channel not ready yet');
 
-        await for (var event in channel.chatEvents) {
+        await for (var event in channel.smsEvents) {
           switch (event) {
             case SmsChannelTyping event:
               _addTypingNumber((event).number);

--- a/lib/features/messaging/extensions/phoenix_socket.dart
+++ b/lib/features/messaging/extensions/phoenix_socket.dart
@@ -998,6 +998,12 @@ sealed class SmsChannelEvent {
         return SmsChannelMessageUpdate(SmsMessagePhxMapper.fromMap(m.payload as Map<String, dynamic>));
       case 'sms_conversation_cursor_set':
         return SmsChannelCursorSet(SmsMessageReadCursorPhxMapper.fromMap(m.payload as Map<String, dynamic>));
+      case 'typing':
+        final number = m.payload?['number'];
+        if (number is String) {
+          return SmsChannelTyping(number: number);
+        }
+        return SmsChannelUnknown(event: m.event.value);
       case 'phx_error':
         return SmsChannelDisconnect();
       default:
@@ -1042,8 +1048,8 @@ class SmsChannelCursorSet extends SmsChannelEvent with EquatableMixin {
   bool get stringify => true;
 }
 
-class SmsChannelTyping extends ChatChannelEvent with EquatableMixin {
-  SmsChannelTyping(this.number);
+class SmsChannelTyping extends SmsChannelEvent with EquatableMixin {
+  SmsChannelTyping({required this.number});
 
   final String number;
 


### PR DESCRIPTION
This pull request updates the SMS typing indicator functionality to correctly handle typing events in SMS conversations. The main changes involve switching the event stream to `smsEvents`, properly decoding the "typing" event, and correcting the event class hierarchy.

**Typing event handling improvements:**

* Changed the event stream in `SmsTypingCubit` to use `channel.smsEvents` instead of `channel.chatEvents`, ensuring SMS typing events are received correctly.
* Updated the event decoding logic in `phoenix_socket.dart` to handle the "typing" event, extracting the `number` from the payload and returning an `SmsChannelTyping` event.

**Code structure corrections:**

* Changed `SmsChannelTyping` to extend `SmsChannelEvent` (instead of `ChatChannelEvent`), and updated its constructor to use a named parameter.