### PR TITLE
docs: spell out the default signaling path and where events are serialized

### DIFF
--- a/lib/features/settings/features/network/bloc/network_cubit.dart
+++ b/lib/features/settings/features/network/bloc/network_cubit.dart
@@ -49,6 +49,11 @@ class NetworkCubit extends Cubit<NetworkState> {
     return IncomingCallType.values.map((type) => IncomingCallTypeModel(type, type == currentType)).toList();
   }
 
+  // The socket type relies on a foreground service holding a persistent
+  // WebSocket, which the OS only lets us run reliably under the Android 14+
+  // foreground-service type rules - so the option simply is not offered below
+  // that. Everywhere else the list is empty and the app stays on the default
+  // push-notification type.
   List<IncomingCallType> _buildIncomingCallTypesRemainder() {
     return _isAndroid14OrAbove() ? [IncomingCallType.socket] : <IncomingCallType>[];
   }

--- a/lib/models/incoming_call_type.dart
+++ b/lib/models/incoming_call_type.dart
@@ -1,7 +1,31 @@
 import 'package:webtrit_signaling_service/webtrit_signaling_service.dart';
 
+/// How the app learns about an incoming call - and, as a consequence, where the
+/// signaling connection lives on Android.
+///
+/// The two values are NOT equal alternatives:
+///
+/// - [pushNotification] is the DEFAULT on every platform
+///   (`NetworkState.incomingCallType` falls back to it when nothing is
+///   selected). The signaling client runs inside the application process, and
+///   its events reach the call logic directly - no serialization is involved.
+/// - [socket] is an OPT-IN chosen by the user in Settings > Network, offered on
+///   Android 14+ only (see `NetworkCubit._buildIncomingCallTypesRemainder`).
+///   A foreground service owns a persistent WebSocket in a separate isolate,
+///   and every signaling event crosses the isolate boundary through the hub
+///   codec as JSON - the only configuration where signaling events are
+///   serialized at all.
+///
+/// Keep the distinction in mind when reasoning about the signaling pipeline:
+/// conclusions drawn from the hub/FGS code path apply only to the opt-in
+/// [socket] mode, not to the app at large.
 enum IncomingCallType {
+  /// Incoming calls arrive via push notifications; the signaling client lives
+  /// in the application process. The default on every platform.
   pushNotification,
+
+  /// Incoming calls arrive over a persistent WebSocket owned by a foreground
+  /// service in its own isolate. User opt-in, Android 14+ only.
   socket;
 
   bool get isPushNotification => this == pushNotification;

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_codec.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_android/lib/src/fgs/hub/signaling_hub_codec.dart
@@ -1,3 +1,18 @@
+/// Wire codec of the FGS signaling hub.
+///
+/// Used ONLY in the persistent/`socket` mode (a user opt-in, Android 14+): the
+/// foreground service owns the signaling connection in its own isolate, and
+/// every [SignalingModuleEvent] - including each protocol [Event] - crosses the
+/// isolate boundary through this codec as JSON. In the default push-bound mode
+/// signaling events never pass through here.
+///
+/// Consequence for the event types themselves: an event MUST round-trip through
+/// its own `toJson`/`fromJson` without losing information, including fields
+/// that are resolved client-side rather than received from the wire - anything
+/// dropped here silently disappears in this mode only, which makes such a bug
+/// easy to miss on every other configuration.
+library;
+
 import 'package:logging/logging.dart';
 import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_signaling_service_platform_interface/webtrit_signaling_service_platform_interface.dart';

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_service_mode.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/models/signaling_service_mode.dart
@@ -5,6 +5,11 @@ enum SignalingServiceMode {
   ///
   /// The service survives app backgrounding and is restarted after device
   /// reboot. Use this when a permanent signaling connection is required.
+  ///
+  /// This is the user OPT-IN path (the `socket` incoming-call type, offered on
+  /// Android 14+ only): a foreground service owns the WebSocket in its own
+  /// isolate, and every signaling event crosses the isolate boundary through
+  /// the hub codec as JSON - the only mode where events are serialized.
   persistent,
 
   /// The service is tied to the application's Activity lifecycle.
@@ -12,5 +17,9 @@ enum SignalingServiceMode {
   /// Started by the push-notification isolate when a call arrives. The service
   /// stops automatically when the user closes the app ([onTaskRemoved]), which
   /// allows the next incoming push to start a fresh service instance.
+  ///
+  /// This is the DEFAULT path (the `pushNotification` incoming-call type):
+  /// signaling runs inside the application process and its events reach
+  /// consumers directly, with no serialization involved.
   pushBound,
 }

--- a/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
+++ b/packages/webtrit_signaling_service/webtrit_signaling_service_platform_interface/lib/src/signaling_service_direct.dart
@@ -20,7 +20,10 @@ final _logger = Logger('WebtritSignalingServiceDirect');
 ///
 /// Manages the [SignalingModule] lifecycle entirely in the calling isolate —
 /// no Foreground Service, no background isolate. Used as-is on iOS and as
-/// the pushBound delegate on Android.
+/// the pushBound delegate on Android — i.e. this is the DEFAULT signaling
+/// path; events reach consumers as live objects, with no serialization
+/// (unlike the opt-in persistent/FGS mode, where every event crosses the
+/// isolate boundary through the hub codec as JSON).
 ///
 /// ## Module rotation
 ///


### PR DESCRIPTION
## Overview

The relationship between the two incoming-call types is easy to misread from the code alone: the persistent foreground-service path with its JSON event codec looks like the main Android pipeline, while in reality it is a user opt-in offered on Android 14+ only, and the default push-bound path never serializes signaling events at all. A recent automated review drew exactly that wrong conclusion, so the next reader - human or tool - deserves to find the answer where they enter the code.

Documentation only, no behavior change. The distinction is now stated at every likely entry point: the incoming-call type enum, the service mode enum, the hub codec header (including the lossless round-trip requirement it imposes on event types), the Android 14 gate in the network settings and the direct service.
