### PR TITLE
fix: package_rename use new app id (WT-1795)

### DIFF
--- a/docs/application_properties.md
+++ b/docs/application_properties.md
@@ -54,7 +54,7 @@ If you prefer to use `package_rename` manually, follow these steps:
      android:
        app_name: "New App"
        package_name: com.webtrit.newapp
-       override_old_package: com.webtrit.app # N
+       override_old_package: com.webtrit.phone # N
        lang: kotlin
      ios:
        app_name: "New App"

--- a/makefile
+++ b/makefile
@@ -123,7 +123,7 @@ generate-package-config:
 	@echo "  android:" >>$(FLUTTER_RENAME_PACKAGE_CONFIG)
 	@echo "    app_name: $(ANDROID_APP_NAME)" >> $(FLUTTER_RENAME_PACKAGE_CONFIG)
 	@echo "    package_name: $(PACKAGE_NAME)" >> $(FLUTTER_RENAME_PACKAGE_CONFIG)
-	@echo "    override_old_package: com.webtrit.app" >> $(FLUTTER_RENAME_PACKAGE_CONFIG)
+	@echo "    override_old_package: com.webtrit.phone" >> $(FLUTTER_RENAME_PACKAGE_CONFIG)
 	@echo "    lang: kotlin" >> $(FLUTTER_RENAME_PACKAGE_CONFIG)
 	@echo "  ios:" >> $(FLUTTER_RENAME_PACKAGE_CONFIG)
 	@echo "    app_name: $(IOS_APP_NAME)" >> $(FLUTTER_RENAME_PACKAGE_CONFIG)


### PR DESCRIPTION
This pull request updates the default value for the `override_old_package` property from `com.webtrit.app` to `com.webtrit.phone` in both the documentation and the package configuration generation process. 