### PR TITLE
fix: name the phone service outage instead of blaming the connection (WT-1766)

### DIFF
--- a/lib/extensions/session_status.dart
+++ b/lib/extensions/session_status.dart
@@ -5,13 +5,20 @@ import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/theme/styles/styles.dart';
 
 extension SessionStatusL10n on SessionStatus {
+  /// A recognised refusal is only allowed to reword the state that actually
+  /// describes it. A connect error is the transport failing, and no network
+  /// outranks everything, so both keep their own wording even when the last
+  /// known refusal is still remembered.
   String l10n(BuildContext context) {
     if (hasPushTokenError) return context.l10n.sessionStatus_pushNotificationServiceProblem;
     return switch (signalingStatus) {
       CallStatus.connectivityNone => context.l10n.callStatus_connectivityNone,
       CallStatus.connectError => context.l10n.callStatus_connectError,
       CallStatus.appUnregistered => context.l10n.callStatus_appUnregistered,
-      CallStatus.connectIssue => context.l10n.callStatus_connectIssue,
+      CallStatus.connectIssue => switch (registrationRejection) {
+        RegistrationRejection.platformUnavailable => context.l10n.callStatus_serviceUnavailable,
+        RegistrationRejection.unspecified => context.l10n.callStatus_connectIssue,
+      },
       CallStatus.inProgress => context.l10n.callStatus_inProgress,
       CallStatus.ready => context.l10n.callStatus_ready,
     };
@@ -22,7 +29,11 @@ extension SessionStatusL10n on SessionStatus {
   String appBarl10n(BuildContext context) {
     return switch (signalingStatus) {
       CallStatus.connectivityNone => context.l10n.sessionStatus_AppBar_waitingForNetwork,
-      CallStatus.connectError || CallStatus.connectIssue => context.l10n.sessionStatus_AppBar_waitingForConnection,
+      CallStatus.connectError => context.l10n.sessionStatus_AppBar_waitingForConnection,
+      CallStatus.connectIssue => switch (registrationRejection) {
+        RegistrationRejection.platformUnavailable => context.l10n.sessionStatus_AppBar_serviceUnavailable,
+        RegistrationRejection.unspecified => context.l10n.sessionStatus_AppBar_waitingForConnection,
+      },
       CallStatus.appUnregistered => context.l10n.sessionStatus_AppBar_disconnected,
       CallStatus.inProgress => context.l10n.sessionStatus_AppBar_connecting,
       CallStatus.ready => '_',
@@ -43,7 +54,11 @@ extension SessionStatusSubtitleL10n on SessionStatus {
     if (hasPushTokenError) return context.l10n.sessionStatus_subtitle_diagnostic;
     return switch (signalingStatus) {
       CallStatus.connectivityNone => context.l10n.sessionStatus_subtitle_connectivityNone,
-      CallStatus.connectError || CallStatus.connectIssue => context.l10n.sessionStatus_subtitle_diagnostic,
+      CallStatus.connectError => context.l10n.sessionStatus_subtitle_diagnostic,
+      CallStatus.connectIssue => switch (registrationRejection) {
+        RegistrationRejection.platformUnavailable => context.l10n.sessionStatus_subtitle_serviceUnavailable,
+        RegistrationRejection.unspecified => context.l10n.sessionStatus_subtitle_diagnostic,
+      },
       CallStatus.appUnregistered when !registered => context.l10n.sessionStatus_subtitle_registrationOff,
       CallStatus.appUnregistered when updating => context.l10n.sessionStatus_subtitle_inProgress,
       CallStatus.appUnregistered => context.l10n.sessionStatus_subtitle_diagnostic,

--- a/lib/features/session_status/bloc/session_status_cubit.dart
+++ b/lib/features/session_status/bloc/session_status_cubit.dart
@@ -101,7 +101,11 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
         : null;
     _emitDebounced(
       state.copyWith(
-        status: SessionStatus(signalingStatus: call.status, pushTokenError: pushTokenError),
+        status: SessionStatus(
+          signalingStatus: call.status,
+          pushTokenError: pushTokenError,
+          registrationRejection: call.callServiceState.registrationRejection,
+        ),
         issues: _buildIssues(),
       ),
     );
@@ -157,7 +161,14 @@ class SessionStatusCubit extends Cubit<SessionStatusState> {
     final shownStatus = displayed == CallStatus.connectivityNone ? CallStatus.inProgress : displayed;
     emit(
       next.copyWith(
-        status: SessionStatus(signalingStatus: shownStatus, pushTokenError: next.status.pushTokenError),
+        status: SessionStatus(
+          signalingStatus: shownStatus,
+          pushTokenError: next.status.pushTokenError,
+          // The refusal explains the status being shown, so it stays with it:
+          // pairing a held-back status with the incoming reason would describe
+          // a state that is not on screen.
+          registrationRejection: state.status.registrationRejection,
+        ),
       ),
     );
   }

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -640,6 +640,12 @@ abstract class AppLocalizations {
   /// **'To resume making calls, a phone restart is required. This will resolve a temporary system error.'**
   String get call_SystemErrorDialog_description;
 
+  /// Shown when the phone system answered the registration attempt and refused to serve it, so the device and its network are working correctly and only the calling service is unavailable. Tell the user the outage is on the service side and expected to be temporary, and that no action on their device will speed it up.
+  ///
+  /// In en, this message translates to:
+  /// **'Service temporarily unavailable'**
+  String get callStatus_serviceUnavailable;
+
   /// No description provided for @call_SystemErrorDialog_title.
   ///
   /// In en, this message translates to:
@@ -3655,6 +3661,12 @@ abstract class AppLocalizations {
   /// **'Connecting...'**
   String get sessionStatus_AppBar_connecting;
 
+  /// App bar line shown while the phone system is refusing to register the account. Keep it short: it shares the bar with a progress indicator and is truncated on narrow screens.
+  ///
+  /// In en, this message translates to:
+  /// **'Service temporarily unavailable'**
+  String get sessionStatus_AppBar_serviceUnavailable;
+
   /// No description provided for @sessionStatus_pushNotificationServiceProblem.
   ///
   /// In en, this message translates to:
@@ -3690,6 +3702,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Registration is off'**
   String get sessionStatus_subtitle_registrationOff;
+
+  /// One-line explanation under the service-unavailable status. Reassures the user that their internet connection is not the cause, and points to the diagnostics screen for details.
+  ///
+  /// In en, this message translates to:
+  /// **'Your connection is fine, tap for details'**
+  String get sessionStatus_subtitle_serviceUnavailable;
 
   /// Status message displayed while the application is performing cleanup during the logout process.
   ///

--- a/lib/l10n/app_localizations.g.mapper.dart
+++ b/lib/l10n/app_localizations.g.mapper.dart
@@ -139,6 +139,7 @@ extension AppLocalizationsExtension on AppLocalizations {
       'callStatus_ready' => callStatus_ready,
       'call_SystemErrorDialog_description' =>
         call_SystemErrorDialog_description,
+      'callStatus_serviceUnavailable' => callStatus_serviceUnavailable,
       'call_SystemErrorDialog_title' => call_SystemErrorDialog_title,
       'call_ThumbnailAvatar_currentlyNoActiveCall' =>
         call_ThumbnailAvatar_currentlyNoActiveCall,
@@ -902,6 +903,8 @@ extension AppLocalizationsExtension on AppLocalizations {
         sessionStatus_AppBar_waitingForConnection,
       'sessionStatus_AppBar_disconnected' => sessionStatus_AppBar_disconnected,
       'sessionStatus_AppBar_connecting' => sessionStatus_AppBar_connecting,
+      'sessionStatus_AppBar_serviceUnavailable' =>
+        sessionStatus_AppBar_serviceUnavailable,
       'sessionStatus_pushNotificationServiceProblem' =>
         sessionStatus_pushNotificationServiceProblem,
       'sessionStatus_subtitle_connectivityNone' =>
@@ -911,6 +914,8 @@ extension AppLocalizationsExtension on AppLocalizations {
       'sessionStatus_subtitle_ready' => sessionStatus_subtitle_ready,
       'sessionStatus_subtitle_registrationOff' =>
         sessionStatus_subtitle_registrationOff,
+      'sessionStatus_subtitle_serviceUnavailable' =>
+        sessionStatus_subtitle_serviceUnavailable,
       'session_Teardown_progressText' => session_Teardown_progressText,
       'settings_AboutText_ApplicationEmbeddedLinks' =>
         settings_AboutText_ApplicationEmbeddedLinks,

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -343,6 +343,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'To resume making calls, a phone restart is required. This will resolve a temporary system error.';
 
   @override
+  String get callStatus_serviceUnavailable => 'Service temporarily unavailable';
+
+  @override
   String get call_SystemErrorDialog_title => 'System Error';
 
   @override
@@ -1990,6 +1993,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionStatus_AppBar_connecting => 'Connecting...';
 
   @override
+  String get sessionStatus_AppBar_serviceUnavailable => 'Service temporarily unavailable';
+
+  @override
   String get sessionStatus_pushNotificationServiceProblem => 'Problem with configuration push notification service';
 
   @override
@@ -2006,6 +2012,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sessionStatus_subtitle_registrationOff => 'Registration is off';
+
+  @override
+  String get sessionStatus_subtitle_serviceUnavailable => 'Your connection is fine, tap for details';
 
   @override
   String get session_Teardown_progressText => 'Signing out...';

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -347,6 +347,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Per riprendere a effettuare chiamate, è necessario riavviare il telefono. Questo risolverà un errore temporaneo di sistema.';
 
   @override
+  String get callStatus_serviceUnavailable => 'Servizio temporaneamente non disponibile';
+
+  @override
   String get call_SystemErrorDialog_title => 'Errore di sistema';
 
   @override
@@ -2014,6 +2017,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sessionStatus_AppBar_connecting => 'Connessione in corso...';
 
   @override
+  String get sessionStatus_AppBar_serviceUnavailable => 'Servizio temporaneamente non disponibile';
+
+  @override
   String get sessionStatus_pushNotificationServiceProblem =>
       'Problema con la configurazione del servizio di notifiche push';
 
@@ -2031,6 +2037,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get sessionStatus_subtitle_registrationOff => 'Registrazione disattivata';
+
+  @override
+  String get sessionStatus_subtitle_serviceUnavailable => 'La connessione è a posto, tocca per i dettagli';
 
   @override
   String get session_Teardown_progressText => 'Disconnessione in corso...';

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -342,6 +342,9 @@ class AppLocalizationsTh extends AppLocalizations {
       'หากต้องการโทรต่อ จำเป็นต้องรีสตาร์ทโทรศัพท์ ซึ่งจะแก้ไขข้อผิดพลาดชั่วคราวของระบบ';
 
   @override
+  String get callStatus_serviceUnavailable => 'บริการไม่พร้อมใช้งานชั่วคราว';
+
+  @override
   String get call_SystemErrorDialog_title => 'ข้อผิดพลาดของระบบ';
 
   @override
@@ -1986,6 +1989,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get sessionStatus_AppBar_connecting => 'กำลังเชื่อมต่อ...';
 
   @override
+  String get sessionStatus_AppBar_serviceUnavailable => 'บริการไม่พร้อมใช้งานชั่วคราว';
+
+  @override
   String get sessionStatus_pushNotificationServiceProblem => 'เกิดปัญหากับการตั้งค่าบริการ push notification';
 
   @override
@@ -2002,6 +2008,9 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get sessionStatus_subtitle_registrationOff => 'ปิดการลงทะเบียนแล้ว';
+
+  @override
+  String get sessionStatus_subtitle_serviceUnavailable => 'การเชื่อมต่อของคุณปกติ แตะเพื่อดูรายละเอียด';
 
   @override
   String get session_Teardown_progressText => 'กำลังออกจากระบบ...';

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -362,6 +362,9 @@ class AppLocalizationsUk extends AppLocalizations {
       'Щоб відновити можливість здійснювати дзвінки, необхідно перезавантажити телефон. Це виправить тимчасову системну помилку.';
 
   @override
+  String get callStatus_serviceUnavailable => 'Сервіс тимчасово недоступний';
+
+  @override
   String get call_SystemErrorDialog_title => 'Системна помилка';
 
   @override
@@ -2022,6 +2025,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get sessionStatus_AppBar_connecting => 'Підключення...';
 
   @override
+  String get sessionStatus_AppBar_serviceUnavailable => 'Сервіс тимчасово недоступний';
+
+  @override
   String get sessionStatus_pushNotificationServiceProblem => 'Проблема з налаштуванням служби пуш-сповіщень';
 
   @override
@@ -2038,6 +2044,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get sessionStatus_subtitle_registrationOff => 'Реєстрацію вимкнено';
+
+  @override
+  String get sessionStatus_subtitle_serviceUnavailable => 'Зі зʼєднанням усе гаразд, натисніть для деталей';
 
   @override
   String get session_Teardown_progressText => 'Вихід із системи...';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -270,6 +270,10 @@
   "callStatus_ready": "Connection established",
   "@callStatus_ready": {},
   "call_SystemErrorDialog_description": "To resume making calls, a phone restart is required. This will resolve a temporary system error.",
+  "callStatus_serviceUnavailable": "Service temporarily unavailable",
+  "@callStatus_serviceUnavailable": {
+    "description": "Shown when the phone system answered the registration attempt and refused to serve it, so the device and its network are working correctly and only the calling service is unavailable. Tell the user the outage is on the service side and expected to be temporary, and that no action on their device will speed it up."
+  },
   "@call_SystemErrorDialog_description": {},
   "call_SystemErrorDialog_title": "System Error",
   "@call_SystemErrorDialog_title": {},
@@ -1695,6 +1699,10 @@
   "@sessionStatus_AppBar_connecting": {
     "description": "Shown in the main app bar while the app is actively connecting to backend services."
   },
+  "sessionStatus_AppBar_serviceUnavailable": "Service temporarily unavailable",
+  "@sessionStatus_AppBar_serviceUnavailable": {
+    "description": "App bar line shown while the phone system is refusing to register the account. Keep it short: it shares the bar with a progress indicator and is truncated on narrow screens."
+  },
   "sessionStatus_pushNotificationServiceProblem": "Problem with configuration push notification service",
   "@sessionStatus_pushNotificationServiceProblem": {},
   "sessionStatus_subtitle_connectivityNone": "Check Wi-Fi or mobile data",
@@ -1716,6 +1724,10 @@
   "sessionStatus_subtitle_registrationOff": "Registration is off",
   "@sessionStatus_subtitle_registrationOff": {
     "description": "Subtitle of the connection status row when the account is unregistered because the user turned the registration setting off, as opposed to a connection problem."
+  },
+  "sessionStatus_subtitle_serviceUnavailable": "Your connection is fine, tap for details",
+  "@sessionStatus_subtitle_serviceUnavailable": {
+    "description": "One-line explanation under the service-unavailable status. Reassures the user that their internet connection is not the cause, and points to the diagnostics screen for details."
   },
   "session_Teardown_progressText": "Signing out...",
   "@session_Teardown_progressText": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -270,6 +270,10 @@
   "callStatus_ready": "Connessione stabilita",
   "@callStatus_ready": {},
   "call_SystemErrorDialog_description": "Per riprendere a effettuare chiamate, è necessario riavviare il telefono. Questo risolverà un errore temporaneo di sistema.",
+  "callStatus_serviceUnavailable": "Servizio temporaneamente non disponibile",
+  "@callStatus_serviceUnavailable": {
+    "description": "Shown when the phone system answered the registration attempt and refused to serve it, so the device and its network are working correctly and only the calling service is unavailable. Tell the user the outage is on the service side and expected to be temporary, and that no action on their device will speed it up."
+  },
   "@call_SystemErrorDialog_description": {},
   "call_SystemErrorDialog_title": "Errore di sistema",
   "@call_SystemErrorDialog_title": {},
@@ -1680,6 +1684,10 @@
   "@sessionStatus_AppBar_connecting": {
     "description": "Shown in the main app bar while the app is actively connecting to backend services."
   },
+  "sessionStatus_AppBar_serviceUnavailable": "Servizio temporaneamente non disponibile",
+  "@sessionStatus_AppBar_serviceUnavailable": {
+    "description": "App bar line shown while the phone system is refusing to register the account. Keep it short: it shares the bar with a progress indicator and is truncated on narrow screens."
+  },
   "sessionStatus_pushNotificationServiceProblem": "Problema con la configurazione del servizio di notifiche push",
   "@sessionStatus_pushNotificationServiceProblem": {},
   "sessionStatus_subtitle_connectivityNone": "Controlla Wi-Fi o dati mobili",
@@ -1692,6 +1700,10 @@
   "@sessionStatus_subtitle_ready": {},
   "sessionStatus_subtitle_registrationOff": "Registrazione disattivata",
   "@sessionStatus_subtitle_registrationOff": {},
+  "sessionStatus_subtitle_serviceUnavailable": "La connessione è a posto, tocca per i dettagli",
+  "@sessionStatus_subtitle_serviceUnavailable": {
+    "description": "One-line explanation under the service-unavailable status. Reassures the user that their internet connection is not the cause, and points to the diagnostics screen for details."
+  },
   "session_Teardown_progressText": "Disconnessione in corso...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -270,6 +270,10 @@
   "callStatus_ready": "เชื่อมต่อสำเร็จแล้ว",
   "@callStatus_ready": {},
   "call_SystemErrorDialog_description": "หากต้องการโทรต่อ จำเป็นต้องรีสตาร์ทโทรศัพท์ ซึ่งจะแก้ไขข้อผิดพลาดชั่วคราวของระบบ",
+  "callStatus_serviceUnavailable": "บริการไม่พร้อมใช้งานชั่วคราว",
+  "@callStatus_serviceUnavailable": {
+    "description": "Shown when the phone system answered the registration attempt and refused to serve it, so the device and its network are working correctly and only the calling service is unavailable. Tell the user the outage is on the service side and expected to be temporary, and that no action on their device will speed it up."
+  },
   "@call_SystemErrorDialog_description": {},
   "call_SystemErrorDialog_title": "ข้อผิดพลาดของระบบ",
   "@call_SystemErrorDialog_title": {},
@@ -1683,6 +1687,10 @@
   "@sessionStatus_AppBar_connecting": {
     "description": "Shown in the main app bar while the app is actively connecting to backend services."
   },
+  "sessionStatus_AppBar_serviceUnavailable": "บริการไม่พร้อมใช้งานชั่วคราว",
+  "@sessionStatus_AppBar_serviceUnavailable": {
+    "description": "App bar line shown while the phone system is refusing to register the account. Keep it short: it shares the bar with a progress indicator and is truncated on narrow screens."
+  },
   "sessionStatus_pushNotificationServiceProblem": "เกิดปัญหากับการตั้งค่าบริการ push notification",
   "@sessionStatus_pushNotificationServiceProblem": {},
   "sessionStatus_subtitle_connectivityNone": "ตรวจสอบ Wi-Fi หรือเน็ตมือถือ",
@@ -1695,6 +1703,10 @@
   "@sessionStatus_subtitle_ready": {},
   "sessionStatus_subtitle_registrationOff": "ปิดการลงทะเบียนแล้ว",
   "@sessionStatus_subtitle_registrationOff": {},
+  "sessionStatus_subtitle_serviceUnavailable": "การเชื่อมต่อของคุณปกติ แตะเพื่อดูรายละเอียด",
+  "@sessionStatus_subtitle_serviceUnavailable": {
+    "description": "One-line explanation under the service-unavailable status. Reassures the user that their internet connection is not the cause, and points to the diagnostics screen for details."
+  },
   "session_Teardown_progressText": "กำลังออกจากระบบ...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -270,6 +270,10 @@
   "callStatus_ready": "Підключення встановлено",
   "@callStatus_ready": {},
   "call_SystemErrorDialog_description": "Щоб відновити можливість здійснювати дзвінки, необхідно перезавантажити телефон. Це виправить тимчасову системну помилку.",
+  "callStatus_serviceUnavailable": "Сервіс тимчасово недоступний",
+  "@callStatus_serviceUnavailable": {
+    "description": "Shown when the phone system answered the registration attempt and refused to serve it, so the device and its network are working correctly and only the calling service is unavailable. Tell the user the outage is on the service side and expected to be temporary, and that no action on their device will speed it up."
+  },
   "@call_SystemErrorDialog_description": {},
   "call_SystemErrorDialog_title": "Системна помилка",
   "@call_SystemErrorDialog_title": {},
@@ -1680,6 +1684,10 @@
   "@sessionStatus_AppBar_connecting": {
     "description": "Shown in the main app bar while the app is actively connecting to backend services."
   },
+  "sessionStatus_AppBar_serviceUnavailable": "Сервіс тимчасово недоступний",
+  "@sessionStatus_AppBar_serviceUnavailable": {
+    "description": "App bar line shown while the phone system is refusing to register the account. Keep it short: it shares the bar with a progress indicator and is truncated on narrow screens."
+  },
   "sessionStatus_pushNotificationServiceProblem": "Проблема з налаштуванням служби пуш-сповіщень",
   "@sessionStatus_pushNotificationServiceProblem": {},
   "sessionStatus_subtitle_connectivityNone": "Перевірте Wi-Fi або мобільні дані",
@@ -1692,6 +1700,10 @@
   "@sessionStatus_subtitle_ready": {},
   "sessionStatus_subtitle_registrationOff": "Реєстрацію вимкнено",
   "@sessionStatus_subtitle_registrationOff": {},
+  "sessionStatus_subtitle_serviceUnavailable": "Зі зʼєднанням усе гаразд, натисніть для деталей",
+  "@sessionStatus_subtitle_serviceUnavailable": {
+    "description": "One-line explanation under the service-unavailable status. Reassures the user that their internet connection is not the cause, and points to the diagnostics screen for details."
+  },
   "session_Teardown_progressText": "Вихід із системи...",
   "@session_Teardown_progressText": {
     "description": "Status message displayed while the application is performing cleanup during the logout process."

--- a/lib/models/call/call.dart
+++ b/lib/models/call/call.dart
@@ -2,4 +2,5 @@ export 'call_entry.dart';
 export 'call_service_state.dart';
 export 'call_status.dart';
 export 'call_trigger_config.dart';
+export 'registration_rejection.dart';
 export 'signaling_client_status.dart';

--- a/lib/models/call/call_service_state.dart
+++ b/lib/models/call/call_service_state.dart
@@ -5,6 +5,7 @@ import 'package:webtrit_signaling/webtrit_signaling.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 
 import 'call_status.dart';
+import 'registration_rejection.dart';
 import 'signaling_client_status.dart';
 
 part 'call_service_state.freezed.dart';
@@ -49,6 +50,13 @@ class CallServiceState with _$CallServiceState {
 
   @override
   final int? lastSignalingDisconnectCode;
+
+  /// The recognised reason behind a failed registration, if the refusal is one
+  /// the app knows how to describe. Meaningful only while [status] reports a
+  /// registration problem; every other state leaves it unspecified.
+  RegistrationRejection get registrationRejection => registration?.status.isFailed == true
+      ? RegistrationRejection.of(registration?.code, registration?.reason)
+      : RegistrationRejection.unspecified;
 
   CallStatus get status {
     final lastSignalingDisconnectCode = this.lastSignalingDisconnectCode;

--- a/lib/models/call/registration_rejection.dart
+++ b/lib/models/call/registration_rejection.dart
@@ -1,0 +1,47 @@
+/// Why the phone system refused to register the account.
+///
+/// A refusal arrives as a numeric status plus a free-text phrase written by
+/// the registrar on the operator's side, so this vocabulary is ours rather
+/// than theirs: a value exists only where the refusal changes what is worth
+/// telling the user. Everything else stays [unspecified] and keeps the generic
+/// connection wording, which is the honest answer when we cannot do better.
+enum RegistrationRejection {
+  /// The registrar answered, and answered that it cannot serve the account
+  /// right now. Nothing is wrong with the device, its network, or the account.
+  platformUnavailable,
+
+  /// No refusal, or one we have nothing specific to say about.
+  unspecified;
+
+  /// Classifies the answer that came back with a failed registration.
+  ///
+  /// Both halves have to match. The status alone means little - 503 also
+  /// carries a busy line on an outgoing call - and the phrase is free text
+  /// from a third party rather than a contract, so it is compared in lower
+  /// case and by containment.
+  static RegistrationRejection of(int? code, String? reason) {
+    if (code == null || reason == null) return unspecified;
+
+    final phrase = reason.toLowerCase();
+    for (final known in _knownRefusals) {
+      if (known.code == code && phrase.contains(known.phrase)) return known.rejection;
+    }
+    return unspecified;
+  }
+}
+
+/// One refusal the app recognises.
+class _KnownRefusal {
+  const _KnownRefusal({required this.code, required this.phrase, required this.rejection});
+
+  final int code;
+  final String phrase;
+  final RegistrationRejection rejection;
+}
+
+/// Teaching the app a new refusal is a row here. A new value in
+/// [RegistrationRejection] is only needed when the advice to the user differs
+/// from every value already listed.
+const _knownRefusals = <_KnownRefusal>[
+  _KnownRefusal(code: 503, phrase: 'no target nodes', rejection: RegistrationRejection.platformUnavailable),
+];

--- a/lib/models/session_status.dart
+++ b/lib/models/session_status.dart
@@ -1,12 +1,23 @@
 import 'call/call_status.dart';
+import 'call/registration_rejection.dart';
 
 class SessionStatus {
-  const SessionStatus({required this.signalingStatus, this.pushTokenError});
+  const SessionStatus({
+    required this.signalingStatus,
+    this.pushTokenError,
+    this.registrationRejection = RegistrationRejection.unspecified,
+  });
 
   final CallStatus signalingStatus;
 
   /// Non-null when the push token registration failed. Independent of [signalingStatus].
   final String? pushTokenError;
+
+  /// Refines what [signalingStatus] is told to the user when the phone system
+  /// refused the registration for a reason we recognise. It never promotes or
+  /// demotes the status itself, so a harder state - no network above all -
+  /// keeps its own wording.
+  final RegistrationRejection registrationRejection;
 
   bool get hasPushTokenError => pushTokenError != null;
 
@@ -41,11 +52,16 @@ class SessionStatus {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is SessionStatus && signalingStatus == other.signalingStatus && pushTokenError == other.pushTokenError;
+      other is SessionStatus &&
+          signalingStatus == other.signalingStatus &&
+          pushTokenError == other.pushTokenError &&
+          registrationRejection == other.registrationRejection;
 
   @override
-  int get hashCode => Object.hash(signalingStatus, pushTokenError);
+  int get hashCode => Object.hash(signalingStatus, pushTokenError, registrationRejection);
 
   @override
-  String toString() => 'SessionStatus(signalingStatus: $signalingStatus, pushTokenError: $pushTokenError)';
+  String toString() =>
+      'SessionStatus(signalingStatus: $signalingStatus, pushTokenError: $pushTokenError, '
+      'registrationRejection: $registrationRejection)';
 }

--- a/test/extensions/session_status_test.dart
+++ b/test/extensions/session_status_test.dart
@@ -32,6 +32,28 @@ void main() {
     return caption;
   }
 
+  Future<({String title, String caption, String appBar})> textsOf(WidgetTester tester, SessionStatus status) async {
+    late String title;
+    late String caption;
+    late String appBar;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            l10n = AppLocalizations.of(context)!;
+            title = status.l10n(context);
+            caption = status.subtitleL10n(context, registered: true);
+            appBar = status.appBarl10n(context);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+    return (title: title, caption: caption, appBar: appBar);
+  }
+
   testWidgets('a session the user turned off names that reason', (tester) async {
     const status = SessionStatus(signalingStatus: CallStatus.appUnregistered);
 
@@ -60,6 +82,62 @@ void main() {
     const status = SessionStatus(signalingStatus: CallStatus.ready, pushTokenError: 'boom');
 
     expect(await captionOf(tester, status, registered: true), l10n.sessionStatus_subtitle_diagnostic);
+  });
+
+  group('a phone system that refuses to serve the account', () {
+    const refused = SessionStatus(
+      signalingStatus: CallStatus.connectIssue,
+      registrationRejection: RegistrationRejection.platformUnavailable,
+    );
+
+    testWidgets('is named as the service being down, not as a connection problem', (tester) async {
+      final texts = await textsOf(tester, refused);
+
+      expect(texts.title, l10n.callStatus_serviceUnavailable);
+      expect(texts.appBar, l10n.sessionStatus_AppBar_serviceUnavailable);
+    });
+
+    testWidgets('tells the user their own connection is not at fault', (tester) async {
+      final texts = await textsOf(tester, refused);
+
+      expect(texts.caption, l10n.sessionStatus_subtitle_serviceUnavailable);
+    });
+
+    testWidgets('an unrecognised refusal keeps the generic wording', (tester) async {
+      const status = SessionStatus(signalingStatus: CallStatus.connectIssue);
+
+      final texts = await textsOf(tester, status);
+
+      expect(texts.title, l10n.callStatus_connectIssue);
+      expect(texts.appBar, l10n.sessionStatus_AppBar_waitingForConnection);
+      expect(texts.caption, l10n.sessionStatus_subtitle_diagnostic);
+    });
+
+    // The refusal is remembered on the state, so it must not leak into a state
+    // that describes something else entirely.
+    testWidgets('a lost network still names the network', (tester) async {
+      const status = SessionStatus(
+        signalingStatus: CallStatus.connectivityNone,
+        registrationRejection: RegistrationRejection.platformUnavailable,
+      );
+
+      final texts = await textsOf(tester, status);
+
+      expect(texts.title, l10n.callStatus_connectivityNone);
+      expect(texts.appBar, l10n.sessionStatus_AppBar_waitingForNetwork);
+    });
+
+    testWidgets('a transport failure still reads as a connection error', (tester) async {
+      const status = SessionStatus(
+        signalingStatus: CallStatus.connectError,
+        registrationRejection: RegistrationRejection.platformUnavailable,
+      );
+
+      final texts = await textsOf(tester, status);
+
+      expect(texts.title, l10n.callStatus_connectError);
+      expect(texts.appBar, l10n.sessionStatus_AppBar_waitingForConnection);
+    });
   });
 
   test('only a missing network or a session still connecting rule out a server request', () {

--- a/test/features/session_status/bloc/session_status_cubit_test.dart
+++ b/test/features/session_status/bloc/session_status_cubit_test.dart
@@ -37,6 +37,16 @@ CallState _cs(CallStatus target) => switch (target) {
   ),
 };
 
+CallState _refused() => CallState(
+  callServiceState: const CallServiceState(
+    registration: ws.Registration(
+      status: ws.RegistrationStatus.registration_failed,
+      code: 503,
+      reason: 'No target nodes for callid abc',
+    ),
+  ),
+);
+
 void main() {
   group('SessionStatusCubit', () {
     late _MockCallBloc callBloc;
@@ -96,6 +106,44 @@ void main() {
 
         callController.add(_cs(CallStatus.ready));
         expect(cubit.state.status, _statusFor(CallStatus.ready));
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    test('a refused registration reaches the UI with its reason', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.inProgress), callStream: callController.stream);
+
+        callController.add(_refused());
+        async.elapse(kSignalingStatusDebounce);
+
+        expect(cubit.state.status.signalingStatus, CallStatus.connectIssue);
+        expect(cubit.state.status.registrationRejection, RegistrationRejection.platformUnavailable);
+
+        callController.close();
+        unawaited(cubit.close());
+      });
+    });
+
+    // While a transient episode is held back the previous status stays on
+    // screen; the reason has to stay with it, or the UI would pair the status
+    // it is showing with an explanation of a state it is not.
+    test('the reason travels with the status that is on screen, not the one held back', () {
+      fakeAsync((async) {
+        final callController = StreamController<CallState>(sync: true);
+
+        final cubit = buildCubit(initialCallState: _cs(CallStatus.ready), callStream: callController.stream);
+
+        callController.add(_refused());
+        expect(cubit.state.status.signalingStatus, CallStatus.ready, reason: 'the flip is still held back');
+        expect(cubit.state.status.registrationRejection, RegistrationRejection.unspecified);
+
+        async.elapse(kSignalingStatusDebounce);
+        expect(cubit.state.status.registrationRejection, RegistrationRejection.platformUnavailable);
 
         callController.close();
         unawaited(cubit.close());

--- a/test/models/call/registration_rejection_test.dart
+++ b/test/models/call/registration_rejection_test.dart
@@ -1,0 +1,72 @@
+/// The phrase is free text written by someone else's registrar, so these tests
+/// pin down how loosely it may be matched: loose enough to survive the call-id
+/// the platform appends and a change of casing, strict enough that a status
+/// reused elsewhere cannot be mistaken for a refusal to register.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_signaling/webtrit_signaling.dart';
+
+import 'package:webtrit_phone/models/models.dart';
+
+void main() {
+  group('classifying a refused registration', () {
+    test('a registrar with no node to serve the account is recognised', () {
+      expect(
+        RegistrationRejection.of(503, 'No target nodes for callid cb23792e-067b-1240-ab8d-02001700952a'),
+        RegistrationRejection.platformUnavailable,
+      );
+    });
+
+    test('the phrase is matched regardless of casing', () {
+      expect(RegistrationRejection.of(503, 'NO TARGET NODES'), RegistrationRejection.platformUnavailable);
+    });
+
+    test('the same status with another phrase is not that refusal', () {
+      expect(RegistrationRejection.of(503, 'busy line'), RegistrationRejection.unspecified);
+    });
+
+    test('the phrase alone, under another status, is not that refusal', () {
+      expect(RegistrationRejection.of(500, 'No target nodes'), RegistrationRejection.unspecified);
+    });
+
+    test('an unrecognised refusal stays unspecified', () {
+      expect(RegistrationRejection.of(500, 'Timeout from BE'), RegistrationRejection.unspecified);
+    });
+
+    test('a refusal that carries no detail stays unspecified', () {
+      expect(RegistrationRejection.of(null, null), RegistrationRejection.unspecified);
+      expect(RegistrationRejection.of(503, null), RegistrationRejection.unspecified);
+      expect(RegistrationRejection.of(null, 'No target nodes'), RegistrationRejection.unspecified);
+    });
+  });
+
+  group('what the call service reports', () {
+    const failure = Registration(
+      status: RegistrationStatus.registration_failed,
+      code: 503,
+      reason: 'No target nodes for callid abc',
+    );
+
+    test('a failed registration carries its recognised reason', () {
+      const state = CallServiceState(registration: failure);
+
+      expect(state.registrationRejection, RegistrationRejection.platformUnavailable);
+    });
+
+    test('a healthy registration reports no reason even with a stale code', () {
+      const state = CallServiceState(
+        registration: Registration(status: RegistrationStatus.registered, code: 503, reason: 'No target nodes'),
+      );
+
+      expect(state.registrationRejection, RegistrationRejection.unspecified);
+    });
+
+    test('no registration at all reports no reason', () {
+      const state = CallServiceState();
+
+      expect(state.registrationRejection, RegistrationRejection.unspecified);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

When the phone system answers a registration attempt and refuses to serve it, the app said exactly what it says when the device has no internet at all: "Waiting for connection..." in the toolbar and "Connection issue" in settings. Users take the only hint they are given and start fixing their network - switching Wi-Fi to mobile data, restarting the router, signing out and back in. None of it helps, because their connection was never the problem. This is what happened to the customer in WT-1766, who spent an hour fighting a network that was working perfectly.

The app now recognises this answer and says so: the service is temporarily unavailable, and the connection is fine. Any answer it does not recognise keeps the old wording, so nothing else on screen changes.

Nothing about the app's behaviour changes. It reconnects and retries exactly as before, makes no extra requests, and the colour and the "calls cannot be made" meaning of the state stay as they were. Only what the user is told changes.

Two states deliberately keep their own wording even while the refusal is remembered: no network at all, and a genuine transport failure. Neither is the service refusing anything, and saying otherwise would repeat the original mistake in the opposite direction.

## Verification

- Unit tests for the classification, including the cases that must NOT match: the same status carrying a different meaning elsewhere in the app, and the same phrase under a different status.
- Wording tests for all three places the state is shown, plus the two states that must keep their own wording.
- A test that the reason stays with the status actually on screen while a transient change is being smoothed out.
- Full analyze and the whole suite pass (1209 tests).
