### PR TITLE
chore: add BrowserStack App Live upload script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ CONFIGURATOR_TOKEN=your-configurator-token
 
 # Localizely API token (used by `melos run l10n:push` and `melos run l10n:pull`)
 LOCALIZELY_TOKEN=your-localizely-token
+
+# BrowserStack App Live credentials (used by `melos run browserstack:upload`)
+# Get them at https://www.browserstack.com/accounts/profile/details
+BROWSERSTACK_USERNAME=your-browserstack-username
+BROWSERSTACK_ACCESS_KEY=your-browserstack-access-key

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Integration tests are located in the `patrol_test` folder.
 
 - **Coverage**: See [Integration Test Coverage](docs/integration_test_coverage.md) for a description of every test file and its steps.
 
+### Manual testing on real devices
+
+- **BrowserStack App Live**: See [BrowserStack App Live Upload](docs/browserstack_upload.md) for uploading builds to BrowserStack and testing them manually on real devices.
+
 ## Contributing
 
 We welcome contributions from the community! Please follow our contribution guidelines when submitting pull requests.

--- a/docs/browserstack_upload.md
+++ b/docs/browserstack_upload.md
@@ -1,0 +1,84 @@
+# BrowserStack App Live Upload
+
+Upload app builds to [BrowserStack App Live](https://app-live.browserstack.com/) for
+manual testing on real devices. This is the way to check behavior on hardware we do not
+have on hand (for example OEM Android phones such as Xiaomi, Oppo, or Vivo with their
+vendor-specific battery and background restrictions).
+
+The tooling consists of `tool/scripts/browserstack_upload.sh` and the
+`melos run browserstack:upload` wrapper.
+
+## One-time setup
+
+1. Sign in at [browserstack.com](https://www.browserstack.com/) and copy your username
+   and access key from
+   [Account settings](https://www.browserstack.com/accounts/profile/details).
+2. Put them into the repo-root `.env` (see `.env.example`):
+
+   ```bash
+   BROWSERSTACK_USERNAME=your-browserstack-username
+   BROWSERSTACK_ACCESS_KEY=your-browserstack-access-key
+   ```
+
+## Usage
+
+Build a debug apk and upload it in one step (default flavor
+`deeplinksDisabledSmsReceiverDisabled`):
+
+```bash
+tool/scripts/browserstack_upload.sh --build
+```
+
+Build with a specific flavor, or in release mode:
+
+```bash
+tool/scripts/browserstack_upload.sh --build someFlavor
+tool/scripts/browserstack_upload.sh --build --release
+```
+
+Upload without building - the script picks the newest apk from
+`build/app/outputs/flutter-apk`:
+
+```bash
+tool/scripts/browserstack_upload.sh
+```
+
+Upload a specific file (apk, aab, or ipa):
+
+```bash
+tool/scripts/browserstack_upload.sh path/to/app.apk
+```
+
+List recent App Live uploads:
+
+```bash
+tool/scripts/browserstack_upload.sh --list
+```
+
+Via melos, pass flags through `BS_ARGS`:
+
+```bash
+BS_ARGS="--build" melos run browserstack:upload
+```
+
+## How builds show up in App Live
+
+- Every upload carries a custom id, `webtrit_phone` by default (override with
+  `--custom-id <id>`). In the App Live app picker, choose the app with that id -
+  App Live automatically selects the newest build uploaded under it.
+- When building with `--build`, the apk is stamped with the `app_version` from
+  `pubspec.yaml` as the version name and an hourly UTC date code (`yymmddhh`) as the
+  build number, so uploads are distinguishable in the App Live UI. (The committed
+  standard `version:` field stays `0.0.0+0` by convention.)
+
+## Practical notes
+
+- Android apks are installed as-is (not re-signed), so Firebase push notifications
+  work in the App Live session.
+- iOS ipas are re-signed by BrowserStack, which breaks the push entitlement - push
+  notifications and CallKit incoming calls do not work there. Use App Live iOS
+  sessions for UI checks only.
+- Uploads are kept for 30 days, then deleted automatically.
+- Device logs (logcat) are available in the DevTools panel of a running App Live
+  session and can be saved with its download button. There is no API for App Live
+  session logs - the download button is the only way to get them.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -396,6 +396,13 @@ melos:
       description: Configure Xcode project without building.
       run: flutter build ios --dart-define-from-file=dart_define.json --no-tree-shake-icons --config-only
 
+    browserstack:upload:
+      description: >-
+        Upload an apk to BrowserStack App Live for manual testing on real devices.
+        Reads BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY from .env.
+        Set BS_ARGS for extra flags (e.g. --build, --list, a file path).
+      run: tool/scripts/browserstack_upload.sh ${BS_ARGS:-}
+
     # ===========================
     # Clean - melos run clean | clean:git
     # ===========================

--- a/tool/scripts/browserstack_upload.sh
+++ b/tool/scripts/browserstack_upload.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Upload an app build (apk/aab/ipa) to BrowserStack App Live for manual testing
+# on real devices.
+#
+# Usage:
+#   tool/scripts/browserstack_upload.sh <path-to-app>    upload the given file
+#   tool/scripts/browserstack_upload.sh                  upload the newest apk from build output
+#   tool/scripts/browserstack_upload.sh --build [flavor] build a debug apk first, then upload
+#                                                        (default flavor: deeplinksDisabledSmsReceiverDisabled)
+#   tool/scripts/browserstack_upload.sh --list           list recent App Live uploads and exit
+#
+# Options:
+#   --custom-id <id>   App Live custom_id (default: webtrit_phone);
+#                      App Live auto-picks the latest build uploaded with this id
+#   --release          with --build: build release instead of debug
+#
+# Credentials: BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY in the repo .env
+# (see .env.example). Get them at https://www.browserstack.com/accounts/profile/details
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+API="https://api-cloud.browserstack.com/app-live"
+APK_DIR="$REPO_ROOT/build/app/outputs/flutter-apk"
+CUSTOM_ID="webtrit_phone"
+DEFAULT_FLAVOR="deeplinksDisabledSmsReceiverDisabled"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+env_var() {
+  grep -E "^(export[[:space:]]+)?$1=" "$ENV_FILE" | head -1 | cut -d '=' -f2- | tr -d '"'
+}
+
+[ -f "$ENV_FILE" ] || die ".env not found at $ENV_FILE (copy .env.example and fill in credentials)"
+BS_USER="$(env_var BROWSERSTACK_USERNAME)"
+BS_KEY="$(env_var BROWSERSTACK_ACCESS_KEY)"
+[ -n "$BS_USER" ] && [ -n "$BS_KEY" ] \
+  || die "BROWSERSTACK_USERNAME / BROWSERSTACK_ACCESS_KEY not set in $ENV_FILE"
+AUTH="$BS_USER:$BS_KEY"
+
+pretty() { python3 -m json.tool 2>/dev/null || cat; }
+
+APP_FILE=""
+DO_BUILD=0
+FLAVOR="$DEFAULT_FLAVOR"
+BUILD_MODE="--debug"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --list)
+      curl -su "$AUTH" "$API/recent_apps" | pretty
+      exit 0
+      ;;
+    --build)
+      DO_BUILD=1
+      if [ $# -gt 1 ] && [[ "$2" != --* ]]; then FLAVOR="$2"; shift; fi
+      ;;
+    --release) BUILD_MODE="--release" ;;
+    --custom-id)
+      [ $# -gt 1 ] || die "--custom-id needs a value"
+      CUSTOM_ID="$2"; shift
+      ;;
+    --help|-h) sed -n '2,19p' "$0"; exit 0 ;;
+    -*) die "unknown option: $1" ;;
+    *) APP_FILE="$1" ;;
+  esac
+  shift
+done
+
+if [ "$DO_BUILD" = 1 ]; then
+  echo "building $BUILD_MODE apk, flavor $FLAVOR ..."
+  (cd "$REPO_ROOT" && flutter build apk --dart-define-from-file=dart_define.json \
+    --no-tree-shake-icons "$BUILD_MODE" --flavor "$FLAVOR")
+fi
+
+if [ -z "$APP_FILE" ]; then
+  [ -d "$APK_DIR" ] || die "no build output at $APK_DIR (pass a file path or use --build)"
+  APP_FILE="$(ls -t "$APK_DIR"/*.apk 2>/dev/null | head -1)"
+  [ -n "$APP_FILE" ] || die "no apk found in $APK_DIR"
+fi
+[ -f "$APP_FILE" ] || die "file not found: $APP_FILE"
+
+echo "uploading: $APP_FILE"
+echo "custom_id: $CUSTOM_ID"
+RESPONSE="$(curl -su "$AUTH" -X POST "$API/upload" \
+  -F "file=@$APP_FILE" \
+  -F "data={\"custom_id\": \"$CUSTOM_ID\"}")"
+echo "$RESPONSE" | pretty
+
+echo "$RESPONSE" | grep -q '"app_url"' \
+  || die "upload failed (no app_url in response)"
+echo
+echo "done: open https://app-live.browserstack.com/ and pick the app '$CUSTOM_ID' (latest build)"

--- a/tool/scripts/browserstack_upload.sh
+++ b/tool/scripts/browserstack_upload.sh
@@ -69,9 +69,14 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "$DO_BUILD" = 1 ]; then
-  echo "building $BUILD_MODE apk, flavor $FLAVOR ..."
+  # The committed version: stays 0.0.0+0 by convention; stamp the apk with
+  # app_version + an hourly date code so uploads are distinguishable in App Live.
+  BUILD_NAME="$(grep -E '^app_version:' "$REPO_ROOT/pubspec.yaml" | cut -d ' ' -f2 | cut -d '+' -f1)"
+  BUILD_NUMBER="$(date -u +%y%m%d%H)"
+  echo "building $BUILD_MODE apk, flavor $FLAVOR, version ${BUILD_NAME:-0.0.0}+$BUILD_NUMBER ..."
   (cd "$REPO_ROOT" && flutter build apk --dart-define-from-file=dart_define.json \
-    --no-tree-shake-icons "$BUILD_MODE" --flavor "$FLAVOR")
+    --no-tree-shake-icons "$BUILD_MODE" --flavor "$FLAVOR" \
+    ${BUILD_NAME:+--build-name="$BUILD_NAME"} --build-number="$BUILD_NUMBER")
 fi
 
 if [ -z "$APP_FILE" ]; then


### PR DESCRIPTION
## Overview

Testing fixes on OEM devices we do not have on hand (Oppo, Realme and similar ColorOS phones) required uploading builds to BrowserStack through the web UI by hand. This adds a small script that uploads the current apk to App Live in one command, optionally building it first, so the latest build is always ready to pick on a real device.

Credentials live in the local `.env` (documented in `.env.example`); a `melos run browserstack:upload` target wraps the script.

## Verification

Uploaded a debug apk both directly and via the melos target and confirmed it appears in App Live as the latest build under the shared app id.