### PR TITLE
build: update WebRTC engine to the latest upstream release

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -807,11 +807,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "main_ext_rebase_06.05.26"
-      resolved-ref: "2c1964a0c96470ef67771983e775b7648fab8257"
+      ref: "main_ext_rebase_11.08.26"
+      resolved-ref: "42b105ddab9db3859decf649c4cb49e91b926261"
       url: "https://github.com/WebTrit/flutter-webrtc.git"
     source: git
-    version: "1.4.1"
+    version: "1.6.0"
   formz:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -159,7 +159,7 @@ dependencies:
   flutter_webrtc:
     git:
       url: https://github.com/WebTrit/flutter-webrtc.git
-      ref: main_ext_rebase_06.05.26
+      ref: main_ext_rebase_11.08.26
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
## Overview

The bundled WebRTC engine fork was rebased onto the latest upstream release (1.6.0), picking up its recent call audio and stability fixes while keeping our own patches on top. The app now points to the refreshed fork branch; nothing else changes.

Analyze and the full test suite pass locally. Basic calls were verified locally on real iOS and Android devices.