### PR TITLE
feat: groundwork for naming controls to assistive technology (WT-1745)

### DIFF
--- a/lib/app/keys.dart
+++ b/lib/app/keys.dart
@@ -1,61 +1,113 @@
 import 'package:flutter/foundation.dart';
 
-const loginModeScreenSignUpButtonKey = Key('loginModeScreenSignUpButton');
-const loginModeScreenUrlButtonKey = Key('loginModeScreenUrlButton');
+// Each widget key is paired with a String constant that doubles as the
+// accessibility identifier (`Semantics.identifier`) of the same control.
+// The key is always built from the constant, so the widget-test anchor and
+// the accessibility tree anchor cannot drift apart.
 
-const coreUrlInputKey = Key('coreUrlInput');
-const coreUrlButtonKey = Key('coreUrlButton');
+const String loginModeScreenSignUpButtonId = 'loginModeScreenSignUpButton';
+const loginModeScreenSignUpButtonKey = Key(loginModeScreenSignUpButtonId);
+const String loginModeScreenUrlButtonId = 'loginModeScreenUrlButton';
+const loginModeScreenUrlButtonKey = Key(loginModeScreenUrlButtonId);
 
-const signupEmailInputKey = Key('signupEmailInput');
-const signupVerifyInputKey = Key('signupVerifyInput');
-const signupEmailButtonKey = Key('signupEmailButton');
-const signupVerifyButtonKey = Key('signupVerifyButton');
+const String coreUrlInputId = 'coreUrlInput';
+const coreUrlInputKey = Key(coreUrlInputId);
+const String coreUrlButtonId = 'coreUrlButton';
+const coreUrlButtonKey = Key(coreUrlButtonId);
 
-const optInputKey = Key('otpInput');
-const otpVerifyInputKey = Key('otpVerifyInput');
-const otpButtonKey = Key('otpButton');
-const otpVerifyButtonKey = Key('otpVerifyButton');
+const String signupEmailInputId = 'signupEmailInput';
+const signupEmailInputKey = Key(signupEmailInputId);
+const String signupVerifyInputId = 'signupVerifyInput';
+const signupVerifyInputKey = Key(signupVerifyInputId);
+const String signupEmailButtonId = 'signupEmailButton';
+const signupEmailButtonKey = Key(signupEmailButtonId);
+const String signupVerifyButtonId = 'signupVerifyButton';
+const signupVerifyButtonKey = Key(signupVerifyButtonId);
 
-const passwordUserInputKey = Key('passwordUserInput');
-const passwordPasswordInputKey = Key('passwordPasswordInput');
-const passwordButtonKey = Key('passwordButton');
+const String optInputId = 'otpInput';
+const optInputKey = Key(optInputId);
+const String otpVerifyInputId = 'otpVerifyInput';
+const otpVerifyInputKey = Key(otpVerifyInputId);
+const String otpButtonId = 'otpButton';
+const otpButtonKey = Key(otpButtonId);
+const String otpVerifyButtonId = 'otpVerifyButton';
+const otpVerifyButtonKey = Key(otpVerifyButtonId);
 
-const contactsAgreementCheckboxKey = Key('contactsAgreementCheckbox');
-const contactsAgreementAcceptButtonKey = Key('contactsAgreementAcceptButton');
+const String passwordUserInputId = 'passwordUserInput';
+const passwordUserInputKey = Key(passwordUserInputId);
+const String passwordPasswordInputId = 'passwordPasswordInput';
+const passwordPasswordInputKey = Key(passwordPasswordInputId);
+const String passwordButtonId = 'passwordButton';
+const passwordButtonKey = Key(passwordButtonId);
 
-const userAgreementCheckboxKey = Key('userAgreementCheckbox');
-const userAgreementAcceptButtonKey = Key('userAgreementAcceptButton');
+const String contactsAgreementCheckboxId = 'contactsAgreementCheckbox';
+const contactsAgreementCheckboxKey = Key(contactsAgreementCheckboxId);
+const String contactsAgreementAcceptButtonId = 'contactsAgreementAcceptButton';
+const contactsAgreementAcceptButtonKey = Key(contactsAgreementAcceptButtonId);
 
-const permissionsInitButtonKey = Key('permissionsProcessButton');
-const permissionTipsButtonKey = Key('permissionTipsButton');
+const String userAgreementCheckboxId = 'userAgreementCheckbox';
+const userAgreementCheckboxKey = Key(userAgreementCheckboxId);
+const String userAgreementAcceptButtonId = 'userAgreementAcceptButton';
+const userAgreementAcceptButtonKey = Key(userAgreementAcceptButtonId);
 
-const mainAppBarKey = Key('mainAppBar');
-const settingsLogoutButtonKey = Key('settingsLogoutButton');
+const String permissionsInitButtonId = 'permissionsProcessButton';
+const permissionsInitButtonKey = Key(permissionsInitButtonId);
+const String permissionTipsButtonId = 'permissionTipsButton';
+const permissionTipsButtonKey = Key(permissionTipsButtonId);
 
-const confirmDialogYesButtonKey = Key('confirmDialogYesButton');
-const confirmDialogNoButtonKey = Key('confirmDialogNoButton');
+const String mainAppBarId = 'mainAppBar';
+const mainAppBarKey = Key(mainAppBarId);
+const String settingsLogoutButtonId = 'settingsLogoutButton';
+const settingsLogoutButtonKey = Key(settingsLogoutButtonId);
 
-const actionPadVideoCallKey = Key('actionPadVideoCall');
-const actionPadBackspaceKey = Key('actionPadBackspace');
+const String confirmDialogYesButtonId = 'confirmDialogYesButton';
+const confirmDialogYesButtonKey = Key(confirmDialogYesButtonId);
+const String confirmDialogNoButtonId = 'confirmDialogNoButton';
+const confirmDialogNoButtonKey = Key(confirmDialogNoButtonId);
 
-const callActionsMuteKey = Key('callActionsMute');
-const callActionsVideoCallKey = Key('callActionsVideoCall');
-const callActionsSpeakerKey = Key('callActionsSpeaker');
-const callActionsHoldKey = Key('callActionsHold');
-const callActionsKeypadKey = Key('callActionsKeypad');
-const callActionsHangupKey = Key('callActionsHangup');
-const callActionsTransferMenuKey = Key('callActionsTransferMenu');
-const callActionsTransferMenuBlindInitKey = Key('callActionsTransferMenuBlindInit');
-const callActionsTransferMenuAttendedInitKey = Key('callActionsTransferMenuAttendedInit');
-const callActionsTransferMenuNumberKey = Key('callActionsTransferAttendedNumber');
-const callFrontCameraPreviewKey = Key('callFrontCameraPreview');
+const String actionPadVideoCallId = 'actionPadVideoCall';
+const actionPadVideoCallKey = Key(actionPadVideoCallId);
+const String actionPadBackspaceId = 'actionPadBackspace';
+const actionPadBackspaceKey = Key(actionPadBackspaceId);
 
-const contactsExtContactTileKey = Key('contactsExtContactTile');
-const contactsLocalContactTileKey = Key('contactsLocalContactTile');
-const contactsTabExtKey = Key('contactsTabExt');
-const contactsTabLocalKey = Key('contactsTabLocal');
-const contactsSerchInputKey = Key('contactsSearchInput');
-const contactsSerchInputClearKey = Key('contactsSearchInputClear');
-const contactPhoneTileKey = Key('contactPhoneTile');
-const contactPhoneTileFavIconKey = Key('contactPhoneTileFavIcon');
-const contactEmailTileKey = Key('contactEmailTile');
+const String callActionsMuteId = 'callActionsMute';
+const callActionsMuteKey = Key(callActionsMuteId);
+const String callActionsVideoCallId = 'callActionsVideoCall';
+const callActionsVideoCallKey = Key(callActionsVideoCallId);
+const String callActionsSpeakerId = 'callActionsSpeaker';
+const callActionsSpeakerKey = Key(callActionsSpeakerId);
+const String callActionsHoldId = 'callActionsHold';
+const callActionsHoldKey = Key(callActionsHoldId);
+const String callActionsKeypadId = 'callActionsKeypad';
+const callActionsKeypadKey = Key(callActionsKeypadId);
+const String callActionsHangupId = 'callActionsHangup';
+const callActionsHangupKey = Key(callActionsHangupId);
+const String callActionsTransferMenuId = 'callActionsTransferMenu';
+const callActionsTransferMenuKey = Key(callActionsTransferMenuId);
+const String callActionsTransferMenuBlindInitId = 'callActionsTransferMenuBlindInit';
+const callActionsTransferMenuBlindInitKey = Key(callActionsTransferMenuBlindInitId);
+const String callActionsTransferMenuAttendedInitId = 'callActionsTransferMenuAttendedInit';
+const callActionsTransferMenuAttendedInitKey = Key(callActionsTransferMenuAttendedInitId);
+const String callActionsTransferMenuNumberId = 'callActionsTransferAttendedNumber';
+const callActionsTransferMenuNumberKey = Key(callActionsTransferMenuNumberId);
+const String callFrontCameraPreviewId = 'callFrontCameraPreview';
+const callFrontCameraPreviewKey = Key(callFrontCameraPreviewId);
+
+const String contactsExtContactTileId = 'contactsExtContactTile';
+const contactsExtContactTileKey = Key(contactsExtContactTileId);
+const String contactsLocalContactTileId = 'contactsLocalContactTile';
+const contactsLocalContactTileKey = Key(contactsLocalContactTileId);
+const String contactsTabExtId = 'contactsTabExt';
+const contactsTabExtKey = Key(contactsTabExtId);
+const String contactsTabLocalId = 'contactsTabLocal';
+const contactsTabLocalKey = Key(contactsTabLocalId);
+const String contactsSerchInputId = 'contactsSearchInput';
+const contactsSerchInputKey = Key(contactsSerchInputId);
+const String contactsSerchInputClearId = 'contactsSearchInputClear';
+const contactsSerchInputClearKey = Key(contactsSerchInputClearId);
+const String contactPhoneTileId = 'contactPhoneTile';
+const contactPhoneTileKey = Key(contactPhoneTileId);
+const String contactPhoneTileFavIconId = 'contactPhoneTileFavIcon';
+const contactPhoneTileFavIconKey = Key(contactPhoneTileFavIconId);
+const String contactEmailTileId = 'contactEmailTile';
+const contactEmailTileKey = Key(contactEmailTileId);

--- a/lib/widgets/semantic_action.dart
+++ b/lib/widgets/semantic_action.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Attaches an accessibility [label] and a stable [identifier] to the single
+/// interactive control in [child].
+///
+/// The whole subtree is merged into one semantics node, so the label, the
+/// identifier and the activation action are guaranteed to end up on the same
+/// node. A plain `Semantics(identifier: ...)` wrapper must never be used for
+/// this: an identifier forces its own semantics boundary, which produces a
+/// node that carries the identifier but no action, while the action stays on
+/// an inner nameless node (screen readers then announce a bare "button" and
+/// UI automation cannot target the control by its id).
+///
+/// [child] must contain exactly one interactive control: merging a subtree
+/// with several tappable descendants would collapse them into a single node.
+///
+/// Set [button] for tap targets that are not built from button widgets
+/// (`GestureDetector`, `InkWell`), so assistive technology announces a role;
+/// controls that already are buttons keep their role through the merge.
+class SemanticAction extends StatelessWidget {
+  const SemanticAction({super.key, this.label, this.identifier, this.button = false, required this.child});
+
+  /// Spoken name of the control; omit when the control already exposes a
+  /// proper visible or semantic label of its own.
+  final String? label;
+
+  /// Stable, non-localized automation id (exposed as the platform resource
+  /// id); use the `...Id` constant paired with the control's widget key.
+  final String? identifier;
+
+  /// Whether to add the button role to the merged node.
+  final bool button;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MergeSemantics(
+      child: Semantics(label: label, identifier: identifier, button: button ? true : null, child: child),
+    );
+  }
+}

--- a/lib/widgets/semantic_action.dart
+++ b/lib/widgets/semantic_action.dart
@@ -14,11 +14,16 @@ import 'package:flutter/material.dart';
 /// [child] must contain exactly one interactive control: merging a subtree
 /// with several tappable descendants would collapse them into a single node.
 ///
-/// Set [button] for tap targets that are not built from button widgets
-/// (`GestureDetector`, `InkWell`), so assistive technology announces a role;
-/// controls that already are buttons keep their role through the merge.
+/// Pick the constructor by what [child] is built from: the default one for
+/// controls that already announce their own role (`IconButton`, `TextButton`,
+/// ...), [SemanticAction.button] for tap targets that carry no semantic role
+/// of their own (`GestureDetector`, `InkWell`) so the role gets added.
 class SemanticAction extends StatelessWidget {
-  const SemanticAction({super.key, this.label, this.identifier, this.button = false, required this.child});
+  /// Names a control that already announces its own role.
+  const SemanticAction({super.key, this.label, this.identifier, required this.child}) : _button = false;
+
+  /// Names a bare tap target and adds the button role to the merged node.
+  const SemanticAction.button({super.key, this.label, this.identifier, required this.child}) : _button = true;
 
   /// Spoken name of the control; omit when the control already exposes a
   /// proper visible or semantic label of its own.
@@ -28,15 +33,14 @@ class SemanticAction extends StatelessWidget {
   /// id); use the `...Id` constant paired with the control's widget key.
   final String? identifier;
 
-  /// Whether to add the button role to the merged node.
-  final bool button;
+  final bool _button;
 
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     return MergeSemantics(
-      child: Semantics(label: label, identifier: identifier, button: button ? true : null, child: child),
+      child: Semantics(label: label, identifier: identifier, button: _button ? true : null, child: child),
     );
   }
 }

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -30,6 +30,7 @@ export 'progress_overlay.dart';
 export 'safe_network_image.dart';
 export 'scroll_to_bottom.dart';
 export 'scroll_to_top.dart';
+export 'semantic_action.dart';
 export 'shimmer.dart';
 export 'sip_presence_indicator.dart';
 export 'sized_circular_progress_indicator.dart';

--- a/test/helpers/helpers.dart
+++ b/test/helpers/helpers.dart
@@ -1,1 +1,2 @@
 export 'feature_access_factories.dart';
+export 'semantics.dart';

--- a/test/helpers/semantics.dart
+++ b/test/helpers/semantics.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Asserts that the control found by [finder] is exposed to assistive
+/// technology as a single semantics node that carries the tap action
+/// together with the given [label] and/or [identifier].
+///
+/// This is the accessibility contract every interactive control must meet:
+/// name, automation id and action on the same node. A control whose label or
+/// id lives on a different node than its action fails this matcher even
+/// though it may look correct on screen.
+///
+/// Call within a `tester.ensureSemantics()` scope.
+void expectTapTargetSemantics(WidgetTester tester, Finder finder, {String? label, String? identifier, bool? isButton}) {
+  expect(
+    tester.getSemantics(finder),
+    isSemantics(label: label, identifier: identifier, hasTapAction: true, isButton: isButton),
+  );
+}

--- a/test/widgets/semantic_action_test.dart
+++ b/test/widgets/semantic_action_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/widgets/semantic_action.dart';
+
+import '../helpers/helpers.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  testWidgets('names a bare gesture target and merges label, identifier and tap into one node', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    var tapped = false;
+    await tester.pumpWidget(
+      wrap(
+        SemanticAction(
+          label: 'Play',
+          identifier: 'voicemailPlay',
+          button: true,
+          child: GestureDetector(
+            onTap: () => tapped = true,
+            child: const SizedBox(width: 48, height: 48, child: Icon(Icons.play_arrow)),
+          ),
+        ),
+      ),
+    );
+
+    final finder = find.bySemanticsIdentifier('voicemailPlay');
+    expectTapTargetSemantics(tester, finder, label: 'Play', identifier: 'voicemailPlay', isButton: true);
+
+    await tester.tap(finder);
+    expect(tapped, isTrue);
+
+    handle.dispose();
+  });
+
+  testWidgets('keeps identifier on the same node as a button that forms its own semantics boundary', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      wrap(
+        SemanticAction(
+          label: 'Search',
+          identifier: 'contactsSearch',
+          child: IconButton(icon: const Icon(Icons.search), onPressed: () {}),
+        ),
+      ),
+    );
+
+    // The identifier must resolve to the node that also carries the label and
+    // the tap action - not to an empty wrapper node above the button.
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier('contactsSearch'),
+      label: 'Search',
+      identifier: 'contactsSearch',
+      isButton: true,
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('identifier-only usage preserves the existing visible label', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      wrap(
+        SemanticAction(
+          identifier: 'agreementAccept',
+          child: TextButton(onPressed: () {}, child: const Text('Accept')),
+        ),
+      ),
+    );
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier('agreementAccept'),
+      label: 'Accept',
+      identifier: 'agreementAccept',
+      isButton: true,
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('labeled controls meet the labeled tap target guideline', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      wrap(
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SemanticAction(
+              label: 'Play',
+              identifier: 'voicemailPlay',
+              button: true,
+              child: GestureDetector(
+                onTap: () {},
+                child: const SizedBox(width: 48, height: 48, child: Icon(Icons.play_arrow)),
+              ),
+            ),
+            SemanticAction(
+              label: 'Search',
+              identifier: 'contactsSearch',
+              child: IconButton(icon: const Icon(Icons.search), onPressed: () {}),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+
+    handle.dispose();
+  });
+}

--- a/test/widgets/semantic_action_test.dart
+++ b/test/widgets/semantic_action_test.dart
@@ -18,10 +18,9 @@ void main() {
     var tapped = false;
     await tester.pumpWidget(
       wrap(
-        SemanticAction(
+        SemanticAction.button(
           label: 'Play',
           identifier: 'voicemailPlay',
-          button: true,
           child: GestureDetector(
             onTap: () => tapped = true,
             child: const SizedBox(width: 48, height: 48, child: Icon(Icons.play_arrow)),
@@ -96,10 +95,9 @@ void main() {
         Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            SemanticAction(
+            SemanticAction.button(
               label: 'Play',
               identifier: 'voicemailPlay',
-              button: true,
               child: GestureDetector(
                 onTap: () {},
                 child: const SizedBox(width: 48, height: 48, child: Icon(Icons.play_arrow)),


### PR DESCRIPTION
## Overview

Screen readers and UI test automation currently see many of the app's controls as nameless: icon-only buttons expose no spoken name, and no control in the app exposes a stable automation id, so automated tests have to fall back to tapping by screen coordinates.

This lays the groundwork for fixing that across the app: a shared wrapper that puts the name, the id and the tap action on the same accessibility node; automation ids paired with the existing widget-test keys so the two anchors cannot drift apart; and the first accessibility tests guarding that contract.

No visible or behavioral changes. Follow-up changes will apply the wrapper to the affected controls screen by screen.

## Verification

New widget tests cover the merged-node contract (including the case where a button forms its own semantics boundary) and the labeled tap target guideline; full analyze and test suite pass.