### PR TITLE
feat: name call row actions for assistive technology (WT-1745)

### DIFF
--- a/lib/app/keys.dart
+++ b/lib/app/keys.dart
@@ -93,6 +93,10 @@ const callActionsTransferMenuNumberKey = Key(callActionsTransferMenuNumberId);
 const String callFrontCameraPreviewId = 'callFrontCameraPreview';
 const callFrontCameraPreviewKey = Key(callFrontCameraPreviewId);
 
+// Identifier-only entries: controls that have no widget-test key.
+const String callTileDialId = 'callTileDial';
+const String callTileMenuId = 'callTileMenu';
+
 const String contactsExtContactTileId = 'contactsExtContactTile';
 const contactsExtContactTileKey = Key(contactsExtContactTileId);
 const String contactsLocalContactTileId = 'contactsLocalContactTile';

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -232,6 +232,18 @@ abstract class AppLocalizations {
   /// **'More'**
   String get callTileActions_more;
 
+  /// Accessibility name of the call button in a call history or contact row.
+  ///
+  /// In en, this message translates to:
+  /// **'Call {name}'**
+  String callTile_SemanticsLabel_call(String name);
+
+  /// Accessibility name of the video call button in a call history or contact row.
+  ///
+  /// In en, this message translates to:
+  /// **'Video call {name}'**
+  String callTile_SemanticsLabel_videoCall(String name);
+
   /// No description provided for @call_CallActionsTooltip_accept.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -123,6 +123,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get callTileActions_more => 'More';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'Call $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'Video call $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'Accept';
 
   @override

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -124,6 +124,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get callTileActions_more => 'Altro';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'Chiama $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'Videochiamata a $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'Accetta chiamata';
 
   @override

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -123,6 +123,16 @@ class AppLocalizationsTh extends AppLocalizations {
   String get callTileActions_more => 'เพิ่มเติม';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'โทรหา $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'วิดีโอคอลหา $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'รับสาย';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -139,6 +139,16 @@ class AppLocalizationsUk extends AppLocalizations {
   String get callTileActions_more => 'Більше';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'Подзвонити $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'Відеодзвінок $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'Прийняти';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "Call {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "Video call {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "Accept",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Accept transfer",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "Chiama {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "Videochiamata a {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "Accetta chiamata",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Accetta trasferimento",

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "โทรหา {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "วิดีโอคอลหา {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "รับสาย",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "รับการโอนสาย",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "Подзвонити {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "Відеодзвінок {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "Прийняти",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Прийняти переадресацію",

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
-import 'package:webtrit_phone/widgets/call/number_actions.dart';
-import 'package:webtrit_phone/widgets/semantic_action.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
 
 class TileMenuButton extends StatelessWidget {
   const TileMenuButton({super.key, required this.onTap});

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -2,8 +2,10 @@
 
 import 'package:flutter/material.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/call/number_actions.dart';
+import 'package:webtrit_phone/widgets/semantic_action.dart';
 
 class TileMenuButton extends StatelessWidget {
   const TileMenuButton({super.key, required this.onTap});
@@ -13,16 +15,21 @@ class TileMenuButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        height: 32,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: themeData.colorScheme.surface.withAlpha(1),
-          borderRadius: BorderRadius.circular(16),
+    return SemanticAction(
+      label: context.l10n.callTileActions_more,
+      identifier: callTileMenuId,
+      button: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          height: 32,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: themeData.colorScheme.surface.withAlpha(1),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Icon(Icons.more_vert, size: 20, color: themeData.textTheme.labelMedium?.color),
         ),
-        child: Icon(Icons.more_vert, size: 20, color: themeData.textTheme.labelMedium?.color),
       ),
     );
   }
@@ -65,18 +72,21 @@ class _CallTileAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 6),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(icon, size: 22, color: themeData.colorScheme.primary),
-            const SizedBox(height: 2),
-            Text(label, maxLines: 1, overflow: TextOverflow.ellipsis, style: themeData.textTheme.labelSmall),
-          ],
+    return SemanticAction(
+      button: true,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 22, color: themeData.colorScheme.primary),
+              const SizedBox(height: 2),
+              Text(label, maxLines: 1, overflow: TextOverflow.ellipsis, style: themeData.textTheme.labelSmall),
+            ],
+          ),
         ),
       ),
     );
@@ -301,9 +311,15 @@ class _CallTileState extends State<CallTile> {
                     const SizedBox(width: 4),
                     if (widget.gesturesEnabled)
                       if (widget.onDialPressed != null)
-                        IconButton(
-                          onPressed: widget.onDialPressed,
-                          icon: Icon(widget.dialIcon ?? Icons.call, color: colorScheme.primary),
+                        SemanticAction(
+                          label: widget.dialIcon == Icons.videocam
+                              ? context.l10n.callTile_SemanticsLabel_videoCall(widget.name)
+                              : context.l10n.callTile_SemanticsLabel_call(widget.name),
+                          identifier: callTileDialId,
+                          child: IconButton(
+                            onPressed: widget.onDialPressed,
+                            icon: Icon(widget.dialIcon ?? Icons.call, color: colorScheme.primary),
+                          ),
                         )
                       else if (actions.isNotEmpty)
                         TileMenuButton(onTap: () => showMenuPopup()),

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -14,10 +14,9 @@ class TileMenuButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return SemanticAction(
+    return SemanticAction.button(
       label: context.l10n.callTileActions_more,
       identifier: callTileMenuId,
-      button: true,
       child: GestureDetector(
         onTap: onTap,
         child: Container(
@@ -71,8 +70,7 @@ class _CallTileAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return SemanticAction(
-      button: true,
+    return SemanticAction.button(
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
         onTap: onTap,

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -2,8 +2,11 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/l10n/app_localizations.g.dart';
 import 'package:webtrit_phone/widgets/call/call_tile.dart';
+
+import '../../helpers/helpers.dart';
 
 void main() {
   Widget buildTestable(Widget child) {
@@ -249,6 +252,75 @@ void main() {
 
       expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Audio call'), findsOneWidget);
       expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Copy number'), findsOneWidget);
+    });
+  });
+
+  group('CallTile accessibility', () {
+    testWidgets('dial button is announced as "Call <name>" and is targetable by id', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.bySemanticsIdentifier(callTileDialId),
+        label: 'Call John Doe',
+        identifier: callTileDialId,
+        isButton: true,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('video dial button is announced as "Video call <name>"', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () {}, dialIcon: Icons.videocam)));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.bySemanticsIdentifier(callTileDialId),
+        label: 'Video call John Doe',
+        identifier: callTileDialId,
+        isButton: true,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('trailing menu button is announced as "More"', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(onAudioCallPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.bySemanticsIdentifier(callTileMenuId),
+        label: 'More',
+        identifier: callTileMenuId,
+        isButton: true,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('inline actions expose their visible label on the tappable node', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(expanded: true, onVideoCallPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.descendant(of: find.byType(CallTileActionsBar), matching: find.text('Video call')),
+        label: 'Video call',
+        isButton: true,
+      );
+
+      handle.dispose();
     });
   });
 }


### PR DESCRIPTION
## Overview

The call and video call buttons in call history, contacts and favorites rows, the row menu button and the inline row actions were nameless for screen readers and untargetable for UI test automation - on a call history screen every one of them showed up as an anonymous tappable area.

They now announce themselves properly: the dial button as "Call <name>" (or "Video call <name>") with the row's contact name, the menu button as "More", and each inline action reads its visible caption as a single control. The dial and menu buttons also expose stable automation ids. Labels are localized in all four app languages; the Italian and Thai strings are drafts to be refined by translators.

Stacked on #1562, which provides the shared wrapper and test harness this change uses.

## Verification

Widget tests cover the announced names, the automation ids and the merged-node contract for all three control kinds; full analyze and test suite pass.