### PR TITLE
feat: name the app bar account and notifications buttons for assistive technology (WT-1745)

### DIFF
--- a/lib/app/keys.dart
+++ b/lib/app/keys.dart
@@ -96,6 +96,7 @@ const callFrontCameraPreviewKey = Key(callFrontCameraPreviewId);
 // Identifier-only entries: controls that have no widget-test key.
 const String callTileDialId = 'callTileDial';
 const String callTileMenuId = 'callTileMenu';
+const String systemNotificationsBadgeId = 'systemNotificationsBadge';
 
 const String contactsExtContactTileId = 'contactsExtContactTile';
 const contactsExtContactTileKey = Key(contactsExtContactTileId);

--- a/lib/features/system_notifications/widgets/system_notification_badge.dart
+++ b/lib/features/system_notifications/widgets/system_notification_badge.dart
@@ -5,7 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../system_notifications.dart';
 
@@ -49,45 +52,50 @@ class _SystemNotificationsBadgeState extends State<SystemNotificationsBadge> wit
           final colorScheme = theme.colorScheme;
           final hasUnseen = unseenCount > 0;
 
-          return SizedBox(
-            width: kMinInteractiveDimension,
-            height: kMinInteractiveDimension,
-            child: ClipOval(
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  onTap: () {
-                    controller.reset();
-                    FocusScope.of(context).unfocus();
-                    context.router.navigate(const SystemNotificationsPageRoute());
-                  },
-                  child: SizedBox(
-                    child: Stack(
-                      children: [
-                        RotationTransition(
-                          turns: controller.drive(
-                            Tween<double>(begin: 0, end: 1).chain(CurveTween(curve: Curves.elasticInOut)),
-                          ),
-                          child: Center(
-                            child: Icon(
-                              hasUnseen ? Icons.notifications : Icons.notifications_outlined,
-                              color: hasUnseen ? colorScheme.tertiary : colorScheme.secondary,
+          return SemanticAction(
+            label: context.l10n.system_notifications_screen_title,
+            identifier: systemNotificationsBadgeId,
+            button: true,
+            child: SizedBox(
+              width: kMinInteractiveDimension,
+              height: kMinInteractiveDimension,
+              child: ClipOval(
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    onTap: () {
+                      controller.reset();
+                      FocusScope.of(context).unfocus();
+                      context.router.navigate(const SystemNotificationsPageRoute());
+                    },
+                    child: SizedBox(
+                      child: Stack(
+                        children: [
+                          RotationTransition(
+                            turns: controller.drive(
+                              Tween<double>(begin: 0, end: 1).chain(CurveTween(curve: Curves.elasticInOut)),
                             ),
-                          ),
-                        ),
-                        if (hasUnseen)
-                          Center(
-                            child: Text(
-                              unseenCount.toString(),
-                              style: TextStyle(
-                                color: colorScheme.onPrimary,
-                                fontSize: 8,
-                                fontWeight: FontWeight.bold,
-                                height: 1,
+                            child: Center(
+                              child: Icon(
+                                hasUnseen ? Icons.notifications : Icons.notifications_outlined,
+                                color: hasUnseen ? colorScheme.tertiary : colorScheme.secondary,
                               ),
                             ),
                           ),
-                      ],
+                          if (hasUnseen)
+                            Center(
+                              child: Text(
+                                unseenCount.toString(),
+                                style: TextStyle(
+                                  color: colorScheme.onPrimary,
+                                  fontSize: 8,
+                                  fontWeight: FontWeight.bold,
+                                  height: 1,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/lib/features/system_notifications/widgets/system_notification_badge.dart
+++ b/lib/features/system_notifications/widgets/system_notification_badge.dart
@@ -52,10 +52,9 @@ class _SystemNotificationsBadgeState extends State<SystemNotificationsBadge> wit
           final colorScheme = theme.colorScheme;
           final hasUnseen = unseenCount > 0;
 
-          return SemanticAction(
+          return SemanticAction.button(
             label: context.l10n.system_notifications_screen_title,
             identifier: systemNotificationsBadgeId,
-            button: true,
             child: SizedBox(
               width: kMinInteractiveDimension,
               height: kMinInteractiveDimension,

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -9,6 +9,7 @@ import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -118,73 +119,81 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
                 child: BlocBuilder<UserInfoCubit, UserInfoState>(
                   builder: (context, userinfoState) {
                     final info = userinfoState.userInfo;
-                    return IconButton(
-                      key: mainAppBarKey,
-                      constraints: const BoxConstraints.tightFor(
-                        width: kMinInteractiveDimension,
-                        height: kMinInteractiveDimension,
-                      ),
-                      padding: const EdgeInsets.all(2),
-                      // The avatar keeps its own palette: without this reset the app bar
-                      // pushes its foreground color into the subtree and tints it.
-                      icon: IconTheme(
-                        data: theme.iconTheme,
-                        child: DefaultTextStyle(
-                          style: theme.textTheme.bodyMedium!,
-                          child: Stack(
-                            clipBehavior: Clip.none,
-                            children: <Widget>[
-                              LeadingAvatar(
-                                username: info?.name ?? info?.numbers.main,
-                                thumbnailUrl: gravatarThumbnailUrl(info?.email),
-                                radius: kMinInteractiveDimension / 2,
-                                showLoading: true,
-                              ),
-                              BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
-                                builder: (context, microphoneStatusState) {
-                                  return Visibility(
-                                    visible:
-                                        microphoneStatusState.microphonePermissionGranted != null &&
-                                        !microphoneStatusState.microphonePermissionGranted!,
-                                    child: Positioned(
-                                      right: -8,
-                                      top: -2,
-                                      child: Container(
-                                        padding: EdgeInsets.all(3),
-                                        decoration: BoxDecoration(
-                                          color: Theme.of(context).colorScheme.error,
-                                          shape: BoxShape.circle,
+                    return SemanticAction(
+                      label: context.l10n.settings_AppBarTitle_myAccount,
+                      identifier: mainAppBarId,
+                      child: IconButton(
+                        key: mainAppBarKey,
+                        constraints: const BoxConstraints.tightFor(
+                          width: kMinInteractiveDimension,
+                          height: kMinInteractiveDimension,
+                        ),
+                        padding: const EdgeInsets.all(2),
+                        // The avatar's initials and status badges are visual-only here; the
+                        // button announces itself with a fixed name instead.
+                        icon: ExcludeSemantics(
+                          // The avatar keeps its own palette: without this reset the app bar
+                          // pushes its foreground color into the subtree and tints it.
+                          child: IconTheme(
+                            data: theme.iconTheme,
+                            child: DefaultTextStyle(
+                              style: theme.textTheme.bodyMedium!,
+                              child: Stack(
+                                clipBehavior: Clip.none,
+                                children: <Widget>[
+                                  LeadingAvatar(
+                                    username: info?.name ?? info?.numbers.main,
+                                    thumbnailUrl: gravatarThumbnailUrl(info?.email),
+                                    radius: kMinInteractiveDimension / 2,
+                                    showLoading: true,
+                                  ),
+                                  BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
+                                    builder: (context, microphoneStatusState) {
+                                      return Visibility(
+                                        visible:
+                                            microphoneStatusState.microphonePermissionGranted != null &&
+                                            !microphoneStatusState.microphonePermissionGranted!,
+                                        child: Positioned(
+                                          right: -8,
+                                          top: -2,
+                                          child: Container(
+                                            padding: EdgeInsets.all(3),
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context).colorScheme.error,
+                                              shape: BoxShape.circle,
+                                            ),
+                                            child: Icon(
+                                              Icons.mic_off,
+                                              color: Theme.of(context).colorScheme.onError,
+                                              size: 14,
+                                            ),
+                                          ),
                                         ),
-                                        child: Icon(
-                                          Icons.mic_off,
-                                          color: Theme.of(context).colorScheme.onError,
-                                          size: 14,
-                                        ),
-                                      ),
-                                    ),
-                                  );
-                                },
+                                      );
+                                    },
+                                  ),
+                                  BlocBuilder<SessionStatusCubit, SessionStatusState>(
+                                    buildWhen: (previous, current) => previous.topIssue != current.topIssue,
+                                    builder: (context, sessionState) {
+                                      final topIssue = sessionState.topIssue;
+                                      if (topIssue == null) return const SizedBox.shrink();
+                                      return Positioned(
+                                        right: -2,
+                                        bottom: -2,
+                                        child: SessionIssueBadge(color: topIssue.color(context), size: 12),
+                                      );
+                                    },
+                                  ),
+                                ],
                               ),
-                              BlocBuilder<SessionStatusCubit, SessionStatusState>(
-                                buildWhen: (previous, current) => previous.topIssue != current.topIssue,
-                                builder: (context, sessionState) {
-                                  final topIssue = sessionState.topIssue;
-                                  if (topIssue == null) return const SizedBox.shrink();
-                                  return Positioned(
-                                    right: -2,
-                                    bottom: -2,
-                                    child: SessionIssueBadge(color: topIssue.color(context), size: 12),
-                                  );
-                                },
-                              ),
-                            ],
+                            ),
                           ),
                         ),
+                        onPressed: () {
+                          FocusScope.of(context).unfocus();
+                          context.router.navigate(const SettingsRouterPageRoute());
+                        },
                       ),
-                      onPressed: () {
-                        FocusScope.of(context).unfocus();
-                        context.router.navigate(const SettingsRouterPageRoute());
-                      },
                     );
                   },
                 ),

--- a/test/features/system_notifications/system_notification_badge_test.dart
+++ b/test/features/system_notifications/system_notification_badge_test.dart
@@ -1,0 +1,51 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/app/keys.dart';
+import 'package:webtrit_phone/features/system_notifications/system_notifications.dart';
+import 'package:webtrit_phone/l10n/app_localizations.g.dart';
+
+import '../../helpers/helpers.dart';
+
+class _MockCounterCubit extends MockCubit<int> implements SystemNotificationsCounterCubit {}
+
+void main() {
+  Widget buildTestable(SystemNotificationsCounterCubit cubit) {
+    return MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: BlocProvider<SystemNotificationsCounterCubit>.value(
+          value: cubit,
+          child: const SystemNotificationsBadge(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('bell is announced as "Notifications" and is targetable by id', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    final cubit = _MockCounterCubit();
+    whenListen(cubit, const Stream<int>.empty(), initialState: 0);
+    await tester.pumpWidget(buildTestable(cubit));
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier(systemNotificationsBadgeId),
+      label: 'Notifications',
+      identifier: systemNotificationsBadgeId,
+      isButton: true,
+    );
+
+    handle.dispose();
+
+    // Let the widget's unseen-count polling loop notice the disposal and stop,
+    // so no timer outlives the test.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(seconds: 2));
+  });
+}


### PR DESCRIPTION
## Overview

The two buttons in the main app bar were exposed badly to screen readers and UI test automation. The notifications bell had no name at all, and the account button announced itself as the bare initial of the user's name - for numeric accounts that is a lone digit, clashing with the keypad keys (as reported by QA).

The bell now announces itself as "Notifications" and the account button as "My account", both with stable automation ids. The labels reuse the titles of the screens each button opens, so no new translations were needed and the wording stays consistent in all four app languages. The avatar's initials and status badges remain purely visual.

Stacked on #1563. Together with it, the call history screen now has zero nameless tappable controls in the accessibility tree (checked on a real device).

## Verification

A widget test covers the bell's announced name and automation id; the account button is verified in the on-device accessibility dump; full analyze and test suite pass.