### PR TITLE
feat: name the call history, app bar and keypad controls for assistive technology (WT-1745)

### DIFF
--- a/lib/app/keys.dart
+++ b/lib/app/keys.dart
@@ -93,6 +93,10 @@ const callActionsTransferMenuNumberKey = Key(callActionsTransferMenuNumberId);
 const String callFrontCameraPreviewId = 'callFrontCameraPreview';
 const callFrontCameraPreviewKey = Key(callFrontCameraPreviewId);
 
+// Identifier-only entries: controls that have no widget-test key.
+const String callTileDialId = 'callTileDial';
+const String callTileMenuId = 'callTileMenu';
+
 const String contactsExtContactTileId = 'contactsExtContactTile';
 const contactsExtContactTileKey = Key(contactsExtContactTileId);
 const String contactsLocalContactTileId = 'contactsLocalContactTile';

--- a/lib/app/keys.dart
+++ b/lib/app/keys.dart
@@ -94,6 +94,9 @@ const String callFrontCameraPreviewId = 'callFrontCameraPreview';
 const callFrontCameraPreviewKey = Key(callFrontCameraPreviewId);
 
 // Identifier-only entries: controls that have no widget-test key.
+const String actionPadOverflowId = 'actionPadOverflow';
+const String actionPadTransferId = 'actionPadTransfer';
+const String actionPadVoiceCallId = 'actionPadVoiceCall';
 const String callTileDialId = 'callTileDial';
 const String callTileMenuId = 'callTileMenu';
 const String systemNotificationsBadgeId = 'systemNotificationsBadge';

--- a/lib/app/keys.dart
+++ b/lib/app/keys.dart
@@ -96,6 +96,7 @@ const callFrontCameraPreviewKey = Key(callFrontCameraPreviewId);
 // Identifier-only entries: controls that have no widget-test key.
 const String callTileDialId = 'callTileDial';
 const String callTileMenuId = 'callTileMenu';
+const String systemNotificationsBadgeId = 'systemNotificationsBadge';
 
 const String contactsExtContactTileId = 'contactsExtContactTile';
 const contactsExtContactTileKey = Key(contactsExtContactTileId);

--- a/lib/features/keypad/widgets/actionpad.dart
+++ b/lib/features/keypad/widgets/actionpad.dart
@@ -58,30 +58,24 @@ class Actionpad extends StatelessWidget {
             visible: onInitiatedTransferPressed == null,
             child: Transform.scale(
               scale: localStyle?.secondary?.scale ?? 1.0,
-              child: SemanticAction(
-                identifier: actionPadOverflowId,
-                child: TextButton(
-                  onPressed: actionsEnabled ? () {} : null,
-                  style: localStyle?.secondary?.style,
-                  child: PopupMenuButton(
-                    enabled: actionsEnabled,
-                    child: Icon(Icons.more_vert, size: iconSize),
-                    itemBuilder: (context) {
-                      return [
-                        if (onVideoCallPressed != null)
-                          PopupMenuItem(onTap: onVideoCallPressed, child: Text(context.l10n.numberActions_videoCall)),
-                        if (onTransferPressed != null)
-                          PopupMenuItem(onTap: onTransferPressed, child: Text(context.l10n.numberActions_transfer)),
-                        if (callNumbers.length > 1)
-                          for (final number in callNumbers)
-                            PopupMenuItem(
-                              onTap: () => onCallFrom?.call(number),
-                              child: Text(context.l10n.numberActions_callFrom(number)),
-                            ),
-                      ];
-                    },
-                  ),
-                ),
+              child: _OverflowMenuButton(
+                enabled: actionsEnabled,
+                style: localStyle?.secondary?.style,
+                iconSize: iconSize,
+                itemBuilder: (context) {
+                  return [
+                    if (onVideoCallPressed != null)
+                      PopupMenuItem(onTap: onVideoCallPressed, child: Text(context.l10n.numberActions_videoCall)),
+                    if (onTransferPressed != null)
+                      PopupMenuItem(onTap: onTransferPressed, child: Text(context.l10n.numberActions_transfer)),
+                    if (callNumbers.length > 1)
+                      for (final number in callNumbers)
+                        PopupMenuItem(
+                          onTap: () => onCallFrom?.call(number),
+                          child: Text(context.l10n.numberActions_callFrom(number)),
+                        ),
+                  ];
+                },
               ),
             ),
           )
@@ -143,6 +137,48 @@ class Actionpad extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// The overflow trigger merges its styling TextButton and the popup control
+/// into one semantics node, and after the merge the TextButton's handler is
+/// the node's tap action - so the button must open the menu itself, or
+/// assistive-technology activation would hit a decorative no-op.
+class _OverflowMenuButton extends StatefulWidget {
+  const _OverflowMenuButton({
+    required this.enabled,
+    required this.style,
+    required this.iconSize,
+    required this.itemBuilder,
+  });
+
+  final bool enabled;
+  final ButtonStyle? style;
+  final double? iconSize;
+  final PopupMenuItemBuilder<dynamic> itemBuilder;
+
+  @override
+  State<_OverflowMenuButton> createState() => _OverflowMenuButtonState();
+}
+
+class _OverflowMenuButtonState extends State<_OverflowMenuButton> {
+  final _menuKey = GlobalKey<PopupMenuButtonState<dynamic>>();
+
+  @override
+  Widget build(BuildContext context) {
+    return SemanticAction(
+      identifier: actionPadOverflowId,
+      child: TextButton(
+        onPressed: widget.enabled ? () => _menuKey.currentState?.showButtonMenu() : null,
+        style: widget.style,
+        child: PopupMenuButton(
+          key: _menuKey,
+          enabled: widget.enabled,
+          itemBuilder: widget.itemBuilder,
+          child: Icon(Icons.more_vert, size: widget.iconSize),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/keypad/widgets/actionpad.dart
+++ b/lib/features/keypad/widgets/actionpad.dart
@@ -58,26 +58,29 @@ class Actionpad extends StatelessWidget {
             visible: onInitiatedTransferPressed == null,
             child: Transform.scale(
               scale: localStyle?.secondary?.scale ?? 1.0,
-              child: TextButton(
-                onPressed: actionsEnabled ? () {} : null,
-                style: localStyle?.secondary?.style,
-                child: PopupMenuButton(
-                  enabled: actionsEnabled,
-                  child: Icon(Icons.more_vert, size: iconSize),
-                  itemBuilder: (context) {
-                    return [
-                      if (onVideoCallPressed != null)
-                        PopupMenuItem(onTap: onVideoCallPressed, child: Text(context.l10n.numberActions_videoCall)),
-                      if (onTransferPressed != null)
-                        PopupMenuItem(onTap: onTransferPressed, child: Text(context.l10n.numberActions_transfer)),
-                      if (callNumbers.length > 1)
-                        for (final number in callNumbers)
-                          PopupMenuItem(
-                            onTap: () => onCallFrom?.call(number),
-                            child: Text(context.l10n.numberActions_callFrom(number)),
-                          ),
-                    ];
-                  },
+              child: SemanticAction(
+                identifier: actionPadOverflowId,
+                child: TextButton(
+                  onPressed: actionsEnabled ? () {} : null,
+                  style: localStyle?.secondary?.style,
+                  child: PopupMenuButton(
+                    enabled: actionsEnabled,
+                    child: Icon(Icons.more_vert, size: iconSize),
+                    itemBuilder: (context) {
+                      return [
+                        if (onVideoCallPressed != null)
+                          PopupMenuItem(onTap: onVideoCallPressed, child: Text(context.l10n.numberActions_videoCall)),
+                        if (onTransferPressed != null)
+                          PopupMenuItem(onTap: onTransferPressed, child: Text(context.l10n.numberActions_transfer)),
+                        if (callNumbers.length > 1)
+                          for (final number in callNumbers)
+                            PopupMenuItem(
+                              onTap: () => onCallFrom?.call(number),
+                              child: Text(context.l10n.numberActions_callFrom(number)),
+                            ),
+                      ];
+                    },
+                  ),
                 ),
               ),
             ),
@@ -87,40 +90,56 @@ class Actionpad extends StatelessWidget {
             visible: onInitiatedTransferPressed == null && onVideoCallPressed != null,
             child: Transform.scale(
               scale: localStyle?.secondary?.scale ?? 1.0,
-              child: TextButton(
-                key: actionPadVideoCallKey,
-                onPressed: actionsEnabled ? onVideoCallPressed : null,
-                style: localStyle?.secondary?.style,
-                child: Icon(Icons.videocam, size: iconSize),
+              child: SemanticAction(
+                label: context.l10n.numberActions_videoCall,
+                identifier: actionPadVideoCallId,
+                child: TextButton(
+                  key: actionPadVideoCallKey,
+                  onPressed: actionsEnabled ? onVideoCallPressed : null,
+                  style: localStyle?.secondary?.style,
+                  child: Icon(Icons.videocam, size: iconSize),
+                ),
               ),
             ),
           ),
         if (onInitiatedTransferPressed != null)
           Transform.scale(
             scale: localStyle?.primary?.scale ?? 1.0,
-            child: TextButton(
-              onPressed: actionsEnabled ? onInitiatedTransferPressed : null,
-              style: localStyle?.primary?.style,
-              child: Icon(Icons.phone_forwarded, size: iconSize),
+            child: SemanticAction(
+              label: context.l10n.numberActions_transfer,
+              identifier: actionPadTransferId,
+              child: TextButton(
+                onPressed: actionsEnabled ? onInitiatedTransferPressed : null,
+                style: localStyle?.primary?.style,
+                child: Icon(Icons.phone_forwarded, size: iconSize),
+              ),
             ),
           )
         else
           Transform.scale(
             scale: localStyle?.primary?.scale ?? 1.0,
-            child: TextButton(
-              onPressed: actionsEnabled ? onAudioCallPressed : null,
-              style: localStyle?.primary?.style,
-              child: Icon(Icons.call, size: iconSize),
+            child: SemanticAction(
+              label: context.l10n.numberActions_audioCall,
+              identifier: actionPadVoiceCallId,
+              child: TextButton(
+                onPressed: actionsEnabled ? onAudioCallPressed : null,
+                style: localStyle?.primary?.style,
+                child: Icon(Icons.call, size: iconSize),
+              ),
             ),
           ),
         Transform.scale(
           scale: localStyle?.backspace?.scale ?? 1.0,
-          child: TextButton(
-            key: actionPadBackspaceKey,
-            onPressed: actionsEnabled ? onBackspacePressed : null,
-            onLongPress: actionsEnabled ? onBackspaceLongPress : null,
-            style: localStyle?.backspace?.style,
-            child: const Icon(Icons.backspace_outlined),
+          child: SemanticAction(
+            label: context.l10n.actionpad_SemanticsLabel_backspace,
+            identifier: actionPadBackspaceId,
+            child: TextButton(
+              key: actionPadBackspaceKey,
+              onPressed: actionsEnabled ? onBackspacePressed : null,
+              onLongPress: actionsEnabled ? onBackspaceLongPress : null,
+              style: localStyle?.backspace?.style,
+              child: const Icon(Icons.backspace_outlined),
+            ),
           ),
         ),
       ],

--- a/lib/features/recents/widgets/recent_tile.dart
+++ b/lib/features/recents/widgets/recent_tile.dart
@@ -103,6 +103,7 @@ class RecentTile extends StatelessWidget {
       expanded: expanded,
       onDialPressed: onDialPressed,
       dialIcon: (callLogEntry.video && videoEnabled) ? Icons.videocam : Icons.call,
+      dialIsVideo: callLogEntry.video && videoEnabled,
       callNumbers: callNumbers,
       onAudioCallPressed: onAudioCallPressed,
       onVideoCallPressed: onVideoCallPressed,

--- a/lib/features/system_notifications/widgets/system_notification_badge.dart
+++ b/lib/features/system_notifications/widgets/system_notification_badge.dart
@@ -5,7 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
 
 import '../system_notifications.dart';
 
@@ -49,45 +52,50 @@ class _SystemNotificationsBadgeState extends State<SystemNotificationsBadge> wit
           final colorScheme = theme.colorScheme;
           final hasUnseen = unseenCount > 0;
 
-          return SizedBox(
-            width: kMinInteractiveDimension,
-            height: kMinInteractiveDimension,
-            child: ClipOval(
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  onTap: () {
-                    controller.reset();
-                    FocusScope.of(context).unfocus();
-                    context.router.navigate(const SystemNotificationsPageRoute());
-                  },
-                  child: SizedBox(
-                    child: Stack(
-                      children: [
-                        RotationTransition(
-                          turns: controller.drive(
-                            Tween<double>(begin: 0, end: 1).chain(CurveTween(curve: Curves.elasticInOut)),
-                          ),
-                          child: Center(
-                            child: Icon(
-                              hasUnseen ? Icons.notifications : Icons.notifications_outlined,
-                              color: hasUnseen ? colorScheme.tertiary : colorScheme.secondary,
+          return SemanticAction(
+            label: context.l10n.system_notifications_screen_title,
+            identifier: systemNotificationsBadgeId,
+            button: true,
+            child: SizedBox(
+              width: kMinInteractiveDimension,
+              height: kMinInteractiveDimension,
+              child: ClipOval(
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    onTap: () {
+                      controller.reset();
+                      FocusScope.of(context).unfocus();
+                      context.router.navigate(const SystemNotificationsPageRoute());
+                    },
+                    child: SizedBox(
+                      child: Stack(
+                        children: [
+                          RotationTransition(
+                            turns: controller.drive(
+                              Tween<double>(begin: 0, end: 1).chain(CurveTween(curve: Curves.elasticInOut)),
                             ),
-                          ),
-                        ),
-                        if (hasUnseen)
-                          Center(
-                            child: Text(
-                              unseenCount.toString(),
-                              style: TextStyle(
-                                color: colorScheme.onPrimary,
-                                fontSize: 8,
-                                fontWeight: FontWeight.bold,
-                                height: 1,
+                            child: Center(
+                              child: Icon(
+                                hasUnseen ? Icons.notifications : Icons.notifications_outlined,
+                                color: hasUnseen ? colorScheme.tertiary : colorScheme.secondary,
                               ),
                             ),
                           ),
-                      ],
+                          if (hasUnseen)
+                            Center(
+                              child: Text(
+                                unseenCount.toString(),
+                                style: TextStyle(
+                                  color: colorScheme.onPrimary,
+                                  fontSize: 8,
+                                  fontWeight: FontWeight.bold,
+                                  height: 1,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/lib/features/system_notifications/widgets/system_notification_badge.dart
+++ b/lib/features/system_notifications/widgets/system_notification_badge.dart
@@ -52,10 +52,9 @@ class _SystemNotificationsBadgeState extends State<SystemNotificationsBadge> wit
           final colorScheme = theme.colorScheme;
           final hasUnseen = unseenCount > 0;
 
-          return SemanticAction(
+          return SemanticAction.button(
             label: context.l10n.system_notifications_screen_title,
             identifier: systemNotificationsBadgeId,
-            button: true,
             child: SizedBox(
               width: kMinInteractiveDimension,
               height: kMinInteractiveDimension,

--- a/lib/features/system_notifications/widgets/system_notification_badge.dart
+++ b/lib/features/system_notifications/widgets/system_notification_badge.dart
@@ -52,8 +52,9 @@ class _SystemNotificationsBadgeState extends State<SystemNotificationsBadge> wit
           final colorScheme = theme.colorScheme;
           final hasUnseen = unseenCount > 0;
 
+          final title = context.l10n.system_notifications_screen_title;
           return SemanticAction.button(
-            label: context.l10n.system_notifications_screen_title,
+            label: hasUnseen ? '$title, $unseenCount' : title,
             identifier: systemNotificationsBadgeId,
             child: SizedBox(
               width: kMinInteractiveDimension,
@@ -83,13 +84,17 @@ class _SystemNotificationsBadgeState extends State<SystemNotificationsBadge> wit
                           ),
                           if (hasUnseen)
                             Center(
-                              child: Text(
-                                unseenCount.toString(),
-                                style: TextStyle(
-                                  color: colorScheme.onPrimary,
-                                  fontSize: 8,
-                                  fontWeight: FontWeight.bold,
-                                  height: 1,
+                              // The raw digit is visual-only; the count is
+                              // spoken as part of the button's label.
+                              child: ExcludeSemantics(
+                                child: Text(
+                                  unseenCount.toString(),
+                                  style: TextStyle(
+                                    color: colorScheme.onPrimary,
+                                    fontSize: 8,
+                                    fontWeight: FontWeight.bold,
+                                    height: 1,
+                                  ),
                                 ),
                               ),
                             ),

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -232,6 +232,18 @@ abstract class AppLocalizations {
   /// **'More'**
   String get callTileActions_more;
 
+  /// Accessibility name of the call button in a call history or contact row.
+  ///
+  /// In en, this message translates to:
+  /// **'Call {name}'**
+  String callTile_SemanticsLabel_call(String name);
+
+  /// Accessibility name of the video call button in a call history or contact row.
+  ///
+  /// In en, this message translates to:
+  /// **'Video call {name}'**
+  String callTile_SemanticsLabel_videoCall(String name);
+
   /// No description provided for @call_CallActionsTooltip_accept.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.g.dart
+++ b/lib/l10n/app_localizations.g.dart
@@ -100,6 +100,12 @@ abstract class AppLocalizations {
   /// **'Your self-care password has expired. Please update it using your self-care.\nUntil the password is changed, access to the service will be limited.'**
   String get account_selfCarePasswordExpired_message;
 
+  /// Accessibility name of the keypad backspace button.
+  ///
+  /// In en, this message translates to:
+  /// **'Backspace'**
+  String get actionpad_SemanticsLabel_backspace;
+
   /// Elapsed time relative to now, shown in days.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -123,6 +123,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get callTileActions_more => 'More';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'Call $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'Video call $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'Accept';
 
   @override

--- a/lib/l10n/app_localizations_en.g.dart
+++ b/lib/l10n/app_localizations_en.g.dart
@@ -13,6 +13,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your self-care password has expired. Please update it using your self-care.\nUntil the password is changed, access to the service will be limited.';
 
   @override
+  String get actionpad_SemanticsLabel_backspace => 'Backspace';
+
+  @override
   String agoTicker_daysAgo(int days) {
     String _temp0 = intl.Intl.pluralLogic(
       days,

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -13,6 +13,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'La tua password di self-care è scaduta. Ti preghiamo di aggiornarla utilizzando il self-care.\nFino a quando la password non sarà cambiata, l\'accesso al servizio sarà limitato.';
 
   @override
+  String get actionpad_SemanticsLabel_backspace => 'Cancella';
+
+  @override
   String agoTicker_daysAgo(int days) {
     String _temp0 = intl.Intl.pluralLogic(
       days,

--- a/lib/l10n/app_localizations_it.g.dart
+++ b/lib/l10n/app_localizations_it.g.dart
@@ -124,6 +124,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get callTileActions_more => 'Altro';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'Chiama $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'Videochiamata a $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'Accetta chiamata';
 
   @override

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -13,6 +13,9 @@ class AppLocalizationsTh extends AppLocalizations {
       'รหัสผ่าน self-care ของคุณหมดอายุแล้ว กรุณาอัปเดตผ่าน self-care ของคุณ\nจนกว่าจะเปลี่ยนรหัสผ่าน การเข้าถึงบริการจะถูกจำกัด';
 
   @override
+  String get actionpad_SemanticsLabel_backspace => 'ลบ';
+
+  @override
   String agoTicker_daysAgo(int days) {
     String _temp0 = intl.Intl.pluralLogic(
       days,

--- a/lib/l10n/app_localizations_th.g.dart
+++ b/lib/l10n/app_localizations_th.g.dart
@@ -123,6 +123,16 @@ class AppLocalizationsTh extends AppLocalizations {
   String get callTileActions_more => 'เพิ่มเติม';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'โทรหา $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'วิดีโอคอลหา $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'รับสาย';
 
   @override

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -13,6 +13,9 @@ class AppLocalizationsUk extends AppLocalizations {
       'Термін дії вашого пароля самообслуговування минув. Оновіть його за допомогою самообслуговування.\nДоки пароль не буде змінено, доступ до служби буде обмежено.';
 
   @override
+  String get actionpad_SemanticsLabel_backspace => 'Стерти';
+
+  @override
   String agoTicker_daysAgo(int days) {
     String _temp0 = intl.Intl.pluralLogic(
       days,

--- a/lib/l10n/app_localizations_uk.g.dart
+++ b/lib/l10n/app_localizations_uk.g.dart
@@ -139,6 +139,16 @@ class AppLocalizationsUk extends AppLocalizations {
   String get callTileActions_more => 'Більше';
 
   @override
+  String callTile_SemanticsLabel_call(String name) {
+    return 'Подзвонити $name';
+  }
+
+  @override
+  String callTile_SemanticsLabel_videoCall(String name) {
+    return 'Відеодзвінок $name';
+  }
+
+  @override
   String get call_CallActionsTooltip_accept => 'Прийняти';
 
   @override

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "Call {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "Video call {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "Accept",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Accept transfer",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -4,6 +4,10 @@
   "@account_selfCarePasswordExpired_message": {
     "description": "Shown when a web self-care password is expired. By default, such passwords may be created in an expired state or set to expire after a period of time. The user must log in to the self-care portal and set a new password. Until refreshed, access to related services is restricted."
   },
+  "actionpad_SemanticsLabel_backspace": "Backspace",
+  "@actionpad_SemanticsLabel_backspace": {
+    "description": "Accessibility name of the keypad backspace button."
+  },
   "agoTicker_daysAgo": "{days, plural, zero{} one{{days} day ago} other{{days} days ago}}",
   "@agoTicker_daysAgo": {
     "description": "Elapsed time relative to now, shown in days.",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4,6 +4,10 @@
   "@account_selfCarePasswordExpired_message": {
     "description": "Shown when a web self-care password is expired. By default, such passwords may be created in an expired state or set to expire after a period of time. The user must log in to the self-care portal and set a new password. Until refreshed, access to related services is restricted."
   },
+  "actionpad_SemanticsLabel_backspace": "Cancella",
+  "@actionpad_SemanticsLabel_backspace": {
+    "description": "Accessibility name of the keypad backspace button."
+  },
   "agoTicker_daysAgo": "{days, plural, zero{} one{{days} giorno fa} other{{days} giorni fa}}",
   "@agoTicker_daysAgo": {
     "description": "Elapsed time relative to now, shown in days.",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "Chiama {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "Videochiamata a {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "Accetta chiamata",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Accetta trasferimento",

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "โทรหา {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "วิดีโอคอลหา {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "รับสาย",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "รับการโอนสาย",

--- a/lib/l10n/arb/app_th.arb
+++ b/lib/l10n/arb/app_th.arb
@@ -4,6 +4,10 @@
   "@account_selfCarePasswordExpired_message": {
     "description": "Shown when a web self-care password is expired. By default, such passwords may be created in an expired state or set to expire after a period of time. The user must log in to the self-care portal and set a new password. Until refreshed, access to related services is restricted."
   },
+  "actionpad_SemanticsLabel_backspace": "ลบ",
+  "@actionpad_SemanticsLabel_backspace": {
+    "description": "Accessibility name of the keypad backspace button."
+  },
   "agoTicker_daysAgo": "{days, plural, zero{} one{{days} วันที่แล้ว} other{{days} วันที่แล้ว}}",
   "@agoTicker_daysAgo": {
     "description": "Elapsed time relative to now, shown in days.",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -87,6 +87,16 @@
   "@callTileActions_more": {
     "description": "Label of the expanded call tile action that opens the full actions menu."
   },
+  "callTile_SemanticsLabel_call": "Подзвонити {name}",
+  "@callTile_SemanticsLabel_call": {
+    "description": "Accessibility name of the call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
+  "callTile_SemanticsLabel_videoCall": "Відеодзвінок {name}",
+  "@callTile_SemanticsLabel_videoCall": {
+    "description": "Accessibility name of the video call button in a call history or contact row.",
+    "placeholders": {"name": {"type": "String"}}
+  },
   "call_CallActionsTooltip_accept": "Прийняти",
   "@call_CallActionsTooltip_accept": {},
   "call_CallActionsTooltip_accept_inviteToAttendedTransfer": "Прийняти переадресацію",

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -4,6 +4,10 @@
   "@account_selfCarePasswordExpired_message": {
     "description": "Shown when a web self-care password is expired. By default, such passwords may be created in an expired state or set to expire after a period of time. The user must log in to the self-care portal and set a new password. Until refreshed, access to related services is restricted."
   },
+  "actionpad_SemanticsLabel_backspace": "Стерти",
+  "@actionpad_SemanticsLabel_backspace": {
+    "description": "Accessibility name of the keypad backspace button."
+  },
   "agoTicker_daysAgo": "{days, plural, zero{} one{{days} день тому} few{{days} дні тому} many{{days} днів тому} other{{days} днів тому}}",
   "@agoTicker_daysAgo": {
     "description": "Elapsed time relative to now, shown in days.",

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -104,6 +104,7 @@ class CallTile extends StatefulWidget {
     this.expanded = false,
     this.onDialPressed,
     this.dialIcon,
+    this.dialIsVideo = false,
     this.gesturesEnabled = true,
     this.dismissible = false,
     this.dismissibleObject,
@@ -135,6 +136,11 @@ class CallTile extends StatefulWidget {
   final bool expanded;
   final VoidCallback? onDialPressed;
   final IconData? dialIcon;
+
+  /// Whether the trailing dial shortcut places a video call; drives both the
+  /// spoken name of the button and which inline call action it supersedes.
+  final bool dialIsVideo;
+
   final bool gesturesEnabled;
 
   final bool dismissible;
@@ -217,7 +223,7 @@ class _CallTileState extends State<CallTile> {
     // duplicate it; the dial button stays visible and keeps that action.
     final suppressedInlineIcon = widget.onDialPressed == null
         ? null
-        : (widget.dialIcon == Icons.videocam ? Icons.videocam_outlined : Icons.call_outlined);
+        : (widget.dialIsVideo ? Icons.videocam_outlined : Icons.call_outlined);
     final primaryActions = actions
         .where((action) => action.primary)
         .where((action) => !(widget.expanded && action.icon == suppressedInlineIcon))
@@ -309,7 +315,7 @@ class _CallTileState extends State<CallTile> {
                     if (widget.gesturesEnabled)
                       if (widget.onDialPressed != null)
                         SemanticAction(
-                          label: widget.dialIcon == Icons.videocam
+                          label: widget.dialIsVideo
                               ? context.l10n.callTile_SemanticsLabel_videoCall(widget.name)
                               : context.l10n.callTile_SemanticsLabel_call(widget.name),
                           identifier: callTileDialId,

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
-import 'package:webtrit_phone/widgets/call/number_actions.dart';
-import 'package:webtrit_phone/widgets/semantic_action.dart';
+import 'package:webtrit_phone/widgets/widgets.dart';
 
 class TileMenuButton extends StatelessWidget {
   const TileMenuButton({super.key, required this.onTap});

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -2,8 +2,10 @@
 
 import 'package:flutter/material.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/widgets/call/number_actions.dart';
+import 'package:webtrit_phone/widgets/semantic_action.dart';
 
 class TileMenuButton extends StatelessWidget {
   const TileMenuButton({super.key, required this.onTap});
@@ -13,16 +15,21 @@ class TileMenuButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        height: 32,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: themeData.colorScheme.surface.withAlpha(1),
-          borderRadius: BorderRadius.circular(16),
+    return SemanticAction(
+      label: context.l10n.callTileActions_more,
+      identifier: callTileMenuId,
+      button: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          height: 32,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: themeData.colorScheme.surface.withAlpha(1),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Icon(Icons.more_vert, size: 20, color: themeData.textTheme.labelMedium?.color),
         ),
-        child: Icon(Icons.more_vert, size: 20, color: themeData.textTheme.labelMedium?.color),
       ),
     );
   }
@@ -65,18 +72,21 @@ class _CallTileAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 6),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(icon, size: 22, color: themeData.colorScheme.primary),
-            const SizedBox(height: 2),
-            Text(label, maxLines: 1, overflow: TextOverflow.ellipsis, style: themeData.textTheme.labelSmall),
-          ],
+    return SemanticAction(
+      button: true,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 22, color: themeData.colorScheme.primary),
+              const SizedBox(height: 2),
+              Text(label, maxLines: 1, overflow: TextOverflow.ellipsis, style: themeData.textTheme.labelSmall),
+            ],
+          ),
         ),
       ),
     );
@@ -301,9 +311,15 @@ class _CallTileState extends State<CallTile> {
                     const SizedBox(width: 4),
                     if (widget.gesturesEnabled)
                       if (widget.onDialPressed != null)
-                        IconButton(
-                          onPressed: widget.onDialPressed,
-                          icon: Icon(widget.dialIcon ?? Icons.call, color: colorScheme.primary),
+                        SemanticAction(
+                          label: widget.dialIcon == Icons.videocam
+                              ? context.l10n.callTile_SemanticsLabel_videoCall(widget.name)
+                              : context.l10n.callTile_SemanticsLabel_call(widget.name),
+                          identifier: callTileDialId,
+                          child: IconButton(
+                            onPressed: widget.onDialPressed,
+                            icon: Icon(widget.dialIcon ?? Icons.call, color: colorScheme.primary),
+                          ),
                         )
                       else if (actions.isNotEmpty)
                         TileMenuButton(onTap: () => showMenuPopup()),

--- a/lib/widgets/call/call_tile.dart
+++ b/lib/widgets/call/call_tile.dart
@@ -14,10 +14,9 @@ class TileMenuButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return SemanticAction(
+    return SemanticAction.button(
       label: context.l10n.callTileActions_more,
       identifier: callTileMenuId,
-      button: true,
       child: GestureDetector(
         onTap: onTap,
         child: Container(
@@ -71,8 +70,7 @@ class _CallTileAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    return SemanticAction(
-      button: true,
+    return SemanticAction.button(
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
         onTap: onTap,

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -9,6 +9,7 @@ import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/app/router/app_router.dart';
 import 'package:webtrit_phone/extensions/extensions.dart';
 import 'package:webtrit_phone/features/features.dart';
+import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/utils/utils.dart';
 import 'package:webtrit_phone/widgets/widgets.dart';
 
@@ -118,73 +119,81 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
                 child: BlocBuilder<UserInfoCubit, UserInfoState>(
                   builder: (context, userinfoState) {
                     final info = userinfoState.userInfo;
-                    return IconButton(
-                      key: mainAppBarKey,
-                      constraints: const BoxConstraints.tightFor(
-                        width: kMinInteractiveDimension,
-                        height: kMinInteractiveDimension,
-                      ),
-                      padding: const EdgeInsets.all(2),
-                      // The avatar keeps its own palette: without this reset the app bar
-                      // pushes its foreground color into the subtree and tints it.
-                      icon: IconTheme(
-                        data: theme.iconTheme,
-                        child: DefaultTextStyle(
-                          style: theme.textTheme.bodyMedium!,
-                          child: Stack(
-                            clipBehavior: Clip.none,
-                            children: <Widget>[
-                              LeadingAvatar(
-                                username: info?.name ?? info?.numbers.main,
-                                thumbnailUrl: gravatarThumbnailUrl(info?.email),
-                                radius: kMinInteractiveDimension / 2,
-                                showLoading: true,
-                              ),
-                              BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
-                                builder: (context, microphoneStatusState) {
-                                  return Visibility(
-                                    visible:
-                                        microphoneStatusState.microphonePermissionGranted != null &&
-                                        !microphoneStatusState.microphonePermissionGranted!,
-                                    child: Positioned(
-                                      right: -8,
-                                      top: -2,
-                                      child: Container(
-                                        padding: EdgeInsets.all(3),
-                                        decoration: BoxDecoration(
-                                          color: Theme.of(context).colorScheme.error,
-                                          shape: BoxShape.circle,
+                    return SemanticAction(
+                      label: context.l10n.settings_AppBarTitle_myAccount,
+                      identifier: mainAppBarId,
+                      child: IconButton(
+                        key: mainAppBarKey,
+                        constraints: const BoxConstraints.tightFor(
+                          width: kMinInteractiveDimension,
+                          height: kMinInteractiveDimension,
+                        ),
+                        padding: const EdgeInsets.all(2),
+                        // The avatar's initials and status badges are visual-only here; the
+                        // button announces itself with a fixed name instead.
+                        icon: ExcludeSemantics(
+                          // The avatar keeps its own palette: without this reset the app bar
+                          // pushes its foreground color into the subtree and tints it.
+                          child: IconTheme(
+                            data: theme.iconTheme,
+                            child: DefaultTextStyle(
+                              style: theme.textTheme.bodyMedium!,
+                              child: Stack(
+                                clipBehavior: Clip.none,
+                                children: <Widget>[
+                                  LeadingAvatar(
+                                    username: info?.name ?? info?.numbers.main,
+                                    thumbnailUrl: gravatarThumbnailUrl(info?.email),
+                                    radius: kMinInteractiveDimension / 2,
+                                    showLoading: true,
+                                  ),
+                                  BlocBuilder<MicrophoneStatusBloc, MicrophoneStatusState>(
+                                    builder: (context, microphoneStatusState) {
+                                      return Visibility(
+                                        visible:
+                                            microphoneStatusState.microphonePermissionGranted != null &&
+                                            !microphoneStatusState.microphonePermissionGranted!,
+                                        child: Positioned(
+                                          right: -8,
+                                          top: -2,
+                                          child: Container(
+                                            padding: EdgeInsets.all(3),
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context).colorScheme.error,
+                                              shape: BoxShape.circle,
+                                            ),
+                                            child: Icon(
+                                              Icons.mic_off,
+                                              color: Theme.of(context).colorScheme.onError,
+                                              size: 14,
+                                            ),
+                                          ),
                                         ),
-                                        child: Icon(
-                                          Icons.mic_off,
-                                          color: Theme.of(context).colorScheme.onError,
-                                          size: 14,
-                                        ),
-                                      ),
-                                    ),
-                                  );
-                                },
+                                      );
+                                    },
+                                  ),
+                                  BlocBuilder<SessionStatusCubit, SessionStatusState>(
+                                    buildWhen: (previous, current) => previous.topIssue != current.topIssue,
+                                    builder: (context, sessionState) {
+                                      final topIssue = sessionState.topIssue;
+                                      if (topIssue == null) return const SizedBox.shrink();
+                                      return Positioned(
+                                        right: -2,
+                                        bottom: -2,
+                                        child: SessionIssueBadge(color: topIssue.color(context), size: 12),
+                                      );
+                                    },
+                                  ),
+                                ],
                               ),
-                              BlocBuilder<SessionStatusCubit, SessionStatusState>(
-                                buildWhen: (previous, current) => previous.topIssue != current.topIssue,
-                                builder: (context, sessionState) {
-                                  final topIssue = sessionState.topIssue;
-                                  if (topIssue == null) return const SizedBox.shrink();
-                                  return Positioned(
-                                    right: -2,
-                                    bottom: -2,
-                                    child: SessionIssueBadge(color: topIssue.color(context), size: 12),
-                                  );
-                                },
-                              ),
-                            ],
+                            ),
                           ),
                         ),
+                        onPressed: () {
+                          FocusScope.of(context).unfocus();
+                          context.router.navigate(const SettingsRouterPageRoute());
+                        },
                       ),
-                      onPressed: () {
-                        FocusScope.of(context).unfocus();
-                        context.router.navigate(const SettingsRouterPageRoute());
-                      },
                     );
                   },
                 ),

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -119,8 +119,10 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
                 child: BlocBuilder<UserInfoCubit, UserInfoState>(
                   builder: (context, userinfoState) {
                     final info = userinfoState.userInfo;
+                    final displayName = info?.name ?? info?.numbers.main;
+                    final myAccount = context.l10n.settings_AppBarTitle_myAccount;
                     return SemanticAction(
-                      label: context.l10n.settings_AppBarTitle_myAccount,
+                      label: displayName == null ? myAccount : '$myAccount, $displayName',
                       identifier: mainAppBarId,
                       child: IconButton(
                         key: mainAppBarKey,

--- a/test/features/keypad/actionpad_test.dart
+++ b/test/features/keypad/actionpad_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/app/keys.dart';
+import 'package:webtrit_phone/features/keypad/widgets/actionpad.dart';
+import 'package:webtrit_phone/l10n/app_localizations.g.dart';
+
+import '../../helpers/helpers.dart';
+
+void main() {
+  Widget buildTestable({
+    List<String> callNumbers = const ['1001'],
+    VoidCallback? onAudioCallPressed,
+    VoidCallback? onVideoCallPressed,
+    VoidCallback? onTransferPressed,
+    VoidCallback? onInitiatedTransferPressed,
+    VoidCallback? onBackspacePressed,
+  }) {
+    return MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Actionpad(
+          callNumbers: callNumbers,
+          actionsEnabled: true,
+          onAudioCallPressed: onAudioCallPressed,
+          onVideoCallPressed: onVideoCallPressed,
+          onTransferPressed: onTransferPressed,
+          onInitiatedTransferPressed: onInitiatedTransferPressed,
+          onBackspacePressed: onBackspacePressed,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('call button is announced as "Audio call" and is targetable by id', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(buildTestable(onAudioCallPressed: () {}, onBackspacePressed: () {}));
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier(actionPadVoiceCallId),
+      label: 'Audio call',
+      identifier: actionPadVoiceCallId,
+      isButton: true,
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('video call button is announced as "Video call"', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(buildTestable(onAudioCallPressed: () {}, onVideoCallPressed: () {}));
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier(actionPadVideoCallId),
+      label: 'Video call',
+      identifier: actionPadVideoCallId,
+      isButton: true,
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('backspace is announced as "Backspace"', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(buildTestable(onAudioCallPressed: () {}, onBackspacePressed: () {}));
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier(actionPadBackspaceId),
+      label: 'Backspace',
+      identifier: actionPadBackspaceId,
+      isButton: true,
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('transfer button is announced and targetable during a transfer flow', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(buildTestable(onInitiatedTransferPressed: () {}));
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier(actionPadTransferId),
+      label: 'Transfer current call',
+      identifier: actionPadTransferId,
+      isButton: true,
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('overflow menu trigger keeps its localized name and gains an id, and still opens the menu', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      buildTestable(onAudioCallPressed: () {}, onVideoCallPressed: () {}, onTransferPressed: () {}),
+    );
+
+    final overflow = find.bySemanticsIdentifier(actionPadOverflowId);
+    expectTapTargetSemantics(tester, overflow, identifier: actionPadOverflowId, isButton: true);
+
+    await tester.tap(overflow);
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Video call'), findsOneWidget);
+    expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Transfer current call'), findsOneWidget);
+
+    handle.dispose();
+  });
+}

--- a/test/features/keypad/actionpad_test.dart
+++ b/test/features/keypad/actionpad_test.dart
@@ -110,11 +110,25 @@ void main() {
     final overflow = find.bySemanticsIdentifier(actionPadOverflowId);
     expectTapTargetSemantics(tester, overflow, identifier: actionPadOverflowId, isButton: true);
 
-    await tester.tap(overflow);
+    // Activate through the semantics node - the path assistive technology
+    // takes; a pointer tap can pass while this path hits a no-op.
+    await tapViaSemantics(tester, overflow);
     await tester.pumpAndSettle();
 
     expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Video call'), findsOneWidget);
     expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Transfer current call'), findsOneWidget);
+
+    handle.dispose();
+  });
+
+  testWidgets('call button fires its callback when activated through semantics', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    var called = false;
+    await tester.pumpWidget(buildTestable(onAudioCallPressed: () => called = true, onBackspacePressed: () {}));
+
+    await tapViaSemantics(tester, find.bySemanticsIdentifier(actionPadVoiceCallId));
+    expect(called, isTrue);
 
     handle.dispose();
   });

--- a/test/features/system_notifications/system_notification_badge_test.dart
+++ b/test/features/system_notifications/system_notification_badge_test.dart
@@ -1,0 +1,51 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/app/keys.dart';
+import 'package:webtrit_phone/features/system_notifications/system_notifications.dart';
+import 'package:webtrit_phone/l10n/app_localizations.g.dart';
+
+import '../../helpers/helpers.dart';
+
+class _MockCounterCubit extends MockCubit<int> implements SystemNotificationsCounterCubit {}
+
+void main() {
+  Widget buildTestable(SystemNotificationsCounterCubit cubit) {
+    return MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: BlocProvider<SystemNotificationsCounterCubit>.value(
+          value: cubit,
+          child: const SystemNotificationsBadge(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('bell is announced as "Notifications" and is targetable by id', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    final cubit = _MockCounterCubit();
+    whenListen(cubit, const Stream<int>.empty(), initialState: 0);
+    await tester.pumpWidget(buildTestable(cubit));
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier(systemNotificationsBadgeId),
+      label: 'Notifications',
+      identifier: systemNotificationsBadgeId,
+      isButton: true,
+    );
+
+    handle.dispose();
+
+    // Let the widget's unseen-count polling loop notice the disposal and stop,
+    // so no timer outlives the test.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(seconds: 2));
+  });
+}

--- a/test/features/system_notifications/system_notification_badge_test.dart
+++ b/test/features/system_notifications/system_notification_badge_test.dart
@@ -26,6 +26,27 @@ void main() {
     );
   }
 
+  testWidgets('with unseen items the bell announces the count as part of its name', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    final cubit = _MockCounterCubit();
+    whenListen(cubit, const Stream<int>.empty(), initialState: 3);
+    await tester.pumpWidget(buildTestable(cubit));
+
+    expectTapTargetSemantics(
+      tester,
+      find.bySemanticsIdentifier(systemNotificationsBadgeId),
+      label: 'Notifications, 3',
+      identifier: systemNotificationsBadgeId,
+      isButton: true,
+    );
+
+    handle.dispose();
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(seconds: 20));
+  });
+
   testWidgets('bell is announced as "Notifications" and is targetable by id', (tester) async {
     final handle = tester.ensureSemantics();
 

--- a/test/helpers/semantics.dart
+++ b/test/helpers/semantics.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Asserts that the control found by [finder] is exposed to assistive
@@ -15,4 +16,17 @@ void expectTapTargetSemantics(WidgetTester tester, Finder finder, {String? label
     tester.getSemantics(finder),
     isSemantics(label: label, identifier: identifier, hasTapAction: true, isButton: isButton),
   );
+}
+
+/// Activates the control found by [finder] the way assistive technology does:
+/// through the tap action of its semantics node, not through a pointer event.
+///
+/// A pointer tap can succeed while the semantics path is broken (the node's
+/// merged tap action pointing at a no-op), so activation tests must use this
+/// instead of `tester.tap`.
+Future<void> tapViaSemantics(WidgetTester tester, Finder finder) async {
+  final node = tester.getSemantics(finder);
+  expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue, reason: 'node has no tap action: $node');
+  node.owner!.performAction(node.id, SemanticsAction.tap);
+  await tester.pump();
 }

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -24,6 +24,7 @@ void main() {
     bool gesturesEnabled = true,
     VoidCallback? onDialPressed,
     IconData? dialIcon,
+    bool dialIsVideo = false,
     VoidCallback? onAudioCallPressed,
     VoidCallback? onVideoCallPressed,
     VoidCallback? onChatPressed,
@@ -42,6 +43,7 @@ void main() {
       gesturesEnabled: gesturesEnabled,
       onDialPressed: onDialPressed,
       dialIcon: dialIcon,
+      dialIsVideo: dialIsVideo,
       onAudioCallPressed: onAudioCallPressed,
       onVideoCallPressed: onVideoCallPressed,
       onChatPressed: onChatPressed,
@@ -187,6 +189,7 @@ void main() {
             expanded: true,
             onDialPressed: () {},
             dialIcon: Icons.videocam,
+            dialIsVideo: true,
             onAudioCallPressed: () {},
             onVideoCallPressed: () {},
           ),
@@ -276,7 +279,9 @@ void main() {
     testWidgets('video dial button is announced as "Video call <name>"', (tester) async {
       final handle = tester.ensureSemantics();
 
-      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () {}, dialIcon: Icons.videocam)));
+      await tester.pumpWidget(
+        buildTestable(buildTile(onDialPressed: () {}, dialIcon: Icons.videocam, dialIsVideo: true)),
+      );
       await tester.pumpAndSettle();
 
       expectTapTargetSemantics(
@@ -303,6 +308,19 @@ void main() {
         identifier: callTileMenuId,
         isButton: true,
       );
+
+      handle.dispose();
+    });
+
+    testWidgets('dial button fires its callback when activated through semantics', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      var called = false;
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () => called = true)));
+      await tester.pumpAndSettle();
+
+      await tapViaSemantics(tester, find.bySemanticsIdentifier(callTileDialId));
+      expect(called, isTrue);
 
       handle.dispose();
     });

--- a/test/widgets/call/call_tile_test.dart
+++ b/test/widgets/call/call_tile_test.dart
@@ -2,8 +2,11 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:webtrit_phone/app/keys.dart';
 import 'package:webtrit_phone/l10n/app_localizations.g.dart';
 import 'package:webtrit_phone/widgets/call/call_tile.dart';
+
+import '../../helpers/helpers.dart';
 
 void main() {
   Widget buildTestable(Widget child) {
@@ -249,6 +252,75 @@ void main() {
 
       expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Audio call'), findsOneWidget);
       expect(find.widgetWithText(PopupMenuItem<dynamic>, 'Copy number'), findsOneWidget);
+    });
+  });
+
+  group('CallTile accessibility', () {
+    testWidgets('dial button is announced as "Call <name>" and is targetable by id', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.bySemanticsIdentifier(callTileDialId),
+        label: 'Call John Doe',
+        identifier: callTileDialId,
+        isButton: true,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('video dial button is announced as "Video call <name>"', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(onDialPressed: () {}, dialIcon: Icons.videocam)));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.bySemanticsIdentifier(callTileDialId),
+        label: 'Video call John Doe',
+        identifier: callTileDialId,
+        isButton: true,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('trailing menu button is announced as "More"', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(onAudioCallPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.bySemanticsIdentifier(callTileMenuId),
+        label: 'More',
+        identifier: callTileMenuId,
+        isButton: true,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('inline actions expose their visible label on the tappable node', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestable(buildTile(expanded: true, onVideoCallPressed: () {})));
+      await tester.pumpAndSettle();
+
+      expectTapTargetSemantics(
+        tester,
+        find.descendant(of: find.byType(CallTileActionsBar), matching: find.text('Video call')),
+        label: 'Video call',
+        isButton: true,
+      );
+
+      handle.dispose();
     });
   });
 }


### PR DESCRIPTION
## Overview

Screen readers and UI test automation saw the app's main screens as fields of nameless tappable areas: on the call history screen every call button, the row menu and the two app bar buttons had no name and no automation id; on the keypad screen the action buttons did not exist in the accessibility tree at all; the account button announced itself as a bare initial digit, clashing with the keypad keys.

This names all of them. Call buttons in history, contacts and favorites rows announce "Call <name>" / "Video call <name>" with the row's contact name; the account button announces "My account" together with who is signed in, and the notifications bell speaks its unread count as part of its name; the keypad's call, video call, transfer, backspace and overflow buttons announce their purpose, and disabled ones now show up as present-but-disabled instead of missing. The dial, row menu, app bar and keypad buttons also expose stable automation ids; the inline row actions are named through their visible captions. Wording is localized in all four app languages, mostly by reusing existing labels; the three new Italian and Thai strings are drafts to be refined by translators.

Stacked on #1562, which provides the shared wrapper and test harness this change uses.

## Verification

Widget tests cover every renamed control's announced name and id, and activation is tested through the accessibility nodes themselves - the same path assistive technology takes - including one proving the keypad overflow menu opens that way (a pointer tap can pass while that path is broken; an earlier revision of this change had exactly that defect and it is now guarded against). Verified on a real device: the call history screen now has zero nameless tappable controls, and the keypad action row is present and targetable; end-to-end Maestro flows pass using only labels and ids - dial/call/hang up, a full sweep of every renamed control, and the transfer keypad exercised through a real attended-transfer call against a local backend. Full analyze and test suite pass.