### PR TITLE
feat: fastline cd scripts (WT-1813)

### DIFF
--- a/android/Gemfile
+++ b/android/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/android/fastlane/.gitignore
+++ b/android/fastlane/.gitignore
@@ -1,0 +1,2 @@
+README.md
+report.xml

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,0 +1,46 @@
+default_platform(:android)
+
+platform :android do
+  desc "Build the Android app bundle"
+  lane :build do
+    args = [
+      "build",
+      ENV['ANDROID_BUILD_TARGET'] || "appbundle",
+      "--dart-define-from-file=#{File.join(project_root, 'dart_define.json')}",
+      "--no-tree-shake-icons",
+    ]
+
+    args.push("--flavor", ENV['ANDROID_FLAVOR'].to_s.empty? ? "deeplinkssmsReceiver" : ENV['ANDROID_FLAVOR'])
+    args.push("--build-name=#{ENV['ANDROID_BUILD_NAME']}")
+    args.push("--build-number=#{ENV['ANDROID_BUILD_NUMBER']}")
+
+
+    # flutter must run from the project root, while fastlane actions run in android/.
+    Dir.chdir(project_root) do
+      sh("flutter", "pub", "get")
+      sh("flutter", *args)
+    end
+  end
+
+  desc "Upload the Android app to Play Store"
+  lane :upload do
+
+    upload_to_play_store(
+      track: ENV['ANDROID_PLAY_STORE_TRACK'].to_s.empty? ? "internal" : ENV['ANDROID_PLAY_STORE_TRACK'],
+      release_status: ENV['ANDROID_PLAY_STORE_RELEASE_STATUS'].to_s.empty? ? "draft" : ENV['ANDROID_PLAY_STORE_RELEASE_STATUS'],
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      skip_upload_changelogs: true,
+      skip_upload_apk: true,
+      aab: ENV['ANDROID_AAB_PATH'],
+      json_key: ENV['ANDROID_PLAY_STORE_JSON_KEY_PATH'],
+      package_name: ENV['ANDROID_PLAY_STORE_PACKAGE_NAME'],
+    )
+
+  end
+end
+
+def project_root
+  File.expand_path('../..', __dir__)
+end

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,8 +1,11 @@
 # Build & Development Process Overview
 
-This documentation describes how to build and run the WebTrit Phone project.
-It includes melos script usage, flavor configuration, Flutter SDK version management, and tips
-for local development.
+How to build, run, sign, and ship the WebTrit Phone project.
+
+Last reviewed: 2026-08-11
+
+It includes melos script usage, flavor configuration, signed release builds and store uploads via
+fastlane, Flutter SDK version management, and tips for local development.
 
 For all available melos scripts, see [Melos Commands](make_file.md).
 For how a release pins its `webtrit_callkeep` version, see [Release Versioning](release_versioning.md).
@@ -76,6 +79,104 @@ FLUTTER_FLAGS="--build-name=1.2.3 --build-number=42 --release" melos run build:a
 ```
 
 All build commands read configuration from `dart_define.json` automatically.
+
+The `build:*` scripts produce **unsigned / debug-signed** artifacts for local use. For signed
+release artifacts and store uploads, use the fastlane scripts below.
+
+---
+
+## Signed Builds & Store Uploads (fastlane)
+
+Signing and store submission live in two Fastfiles - `ios/fastlane/Fastfile` and
+`android/fastlane/Fastfile` - wrapped by melos scripts so they are invoked the same way from a
+laptop and from CI.
+
+| Command                             | Description                                          |
+|-------------------------------------|------------------------------------------------------|
+| `melos run fastlane:install`        | Install fastlane if missing (brew on macOS, gem else) |
+| `melos run fastlane:ios:build`      | Build and sign the iOS ipa                           |
+| `melos run fastlane:ios:upload`     | Upload the ipa to TestFlight                         |
+| `melos run fastlane:android:build`  | Build the signed Android app bundle                  |
+| `melos run fastlane:android:upload` | Upload the aab to Google Play                        |
+
+Every build/upload script runs `fastlane:install` first, so a fresh machine provisions itself.
+All inputs come from the environment, prefixed per platform (`IOS_` / `ANDROID_`) so the two
+platforms can define same-named values side by side without collisions.
+
+### iOS
+
+`melos run fastlane:ios:build` creates a throwaway keychain, imports the certificate and
+provisioning profile, stamps the version into `Runner.xcodeproj`, disables automatic signing,
+builds via `build_app`, then deletes the keychain.
+
+| Variable                                    | Purpose                                            |
+|---------------------------------------------|----------------------------------------------------|
+| `IOS_CERTIFICATE_PATH`                      | Signing certificate to import                      |
+| `IOS_PROVISIONING_PROFILE_PATH`             | Provisioning profile to install and apply          |
+| `IOS_CODE_SIGNING_IDENTITY`                 | Identity for signing and `signingCertificate`      |
+| `IOS_TEAM_ID`                               | Development team / export team                     |
+| `IOS_BUILD_NAME`                             | Marketing version (`CFBundleShortVersionString`)   |
+| `IOS_BUILD_NUMBER`                          | Build number (`CFBundleVersion`)                   |
+| `IOS_BUILD_FILE_NAME`                       | Output ipa name, also the upload input             |
+| `IOS_BUILD_SDK`                             | Optional `sdk` override for `build_app`            |
+| `IOS_APP_STORE_CONNECT_API_KEY_ID`          | App Store Connect API key id (upload)              |
+| `IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID`   | App Store Connect issuer id (upload)               |
+| `IOS_APP_STORE_CONNECT_API_KEY_P8_PATH`     | Path to the `.p8` private key (upload)             |
+
+The upload lane authenticates with an App Store Connect API key - no Apple ID password or 2FA
+session - and skips waiting for build processing.
+
+> The `.p8` path variable is deliberately prefixed. Unprefixed, pilot would pick
+> `APP_STORE_CONNECT_API_KEY_PATH` up as its own `api_key_path` option, which expects a **JSON**
+> key file, and fail while parsing the PEM.
+
+### Android
+
+`melos run fastlane:android:build` drives the flutter tool
+(`flutter build appbundle --dart-define-from-file=dart_define.json --no-tree-shake-icons`) so
+dart-defines, flavor selection, and version stamping behave exactly as in the `build:*` scripts.
+
+| Variable                              | Default                | Purpose                                |
+|---------------------------------------|------------------------|----------------------------------------|
+| `ANDROID_BUILD_TARGET`                | `appbundle`            | `appbundle` or `apk`                   |
+| `ANDROID_FLAVOR`                      | `deeplinkssmsReceiver` | Flavor combinator (see [Flavors](flavors.md)) |
+| `ANDROID_BUILD_NAME`                  | -                      | Marketing version                      |
+| `ANDROID_BUILD_NUMBER`                | -                      | Version code                           |
+| `ANDROID_AAB_PATH`                    | -                      | Bundle to upload                       |
+| `ANDROID_PLAY_STORE_JSON_KEY_PATH`    | -                      | Play service account JSON              |
+| `ANDROID_PLAY_STORE_PACKAGE_NAME`     | -                      | Application id to publish under        |
+| `ANDROID_PLAY_STORE_TRACK`            | `internal`             | Play track                             |
+| `ANDROID_PLAY_STORE_RELEASE_STATUS`   | `draft`                | Play release status                    |
+
+Release signing needs no fastlane input: `android/app/build.gradle` builds the release
+`signingConfig` from `upload-keystore-metadata.json` in the keystore directory pointed at by the
+`WEBTRIT_ANDROID_RELEASE_UPLOAD_KEYSTORE_PATH` dart-define. Watch the build log for
+`Release signing NOT configured` if that path is wrong.
+
+The upload lane pushes the bundle only - metadata, images, screenshots, and changelogs are skipped.
+
+### Examples
+
+```bash
+# Keep the values in the gitignored .env and export them all at once
+source .env
+melos run fastlane:ios:build
+
+# Or pass them inline
+IOS_TEAM_ID=ABCDE12345 \
+IOS_CERTIFICATE_PATH=certs/dist.p12 \
+IOS_PROVISIONING_PROFILE_PATH=certs/app.mobileprovision \
+IOS_CODE_SIGNING_IDENTITY="Apple Distribution" \
+IOS_BUILD_NAME=1.2.3 IOS_BUILD_NUMBER=42 IOS_BUILD_FILE_NAME=build.ipa \
+  melos run fastlane:ios:build
+
+ANDROID_BUILD_NAME=1.2.3 ANDROID_BUILD_NUMBER=42 \
+  melos run fastlane:android:build
+```
+
+The lanes can also be invoked directly from the platform directory - `cd ios && fastlane ios build`
+- which is what the melos scripts do. Both platform directories carry a `Gemfile`, so prefer
+`bundle exec fastlane ...` when running by hand to pin the fastlane version.
 
 ---
 

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/ios/fastlane/.gitignore
+++ b/ios/fastlane/.gitignore
@@ -1,0 +1,2 @@
+README.md
+report.xml

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,84 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Build the iOS app"
+  lane :build do
+    keychain_name = 'ios-build.keychain'
+    keychain_password = SecureRandom.uuid
+
+    create_keychain(
+      name: keychain_name,
+      password: keychain_password,
+      default_keychain: true,
+      unlock: true,
+      timeout: 3600
+    )
+
+    import_certificate(
+      certificate_path: ENV['IOS_CERTIFICATE_PATH'], 
+      keychain_name: keychain_name,
+      keychain_password: keychain_password,
+    )
+
+    install_provisioning_profile(path: ENV['IOS_PROVISIONING_PROFILE_PATH'])
+
+    increment_build_number(
+      build_number: ENV['IOS_BUILD_NUMBER'],
+      xcodeproj: "Runner.xcodeproj"
+    )
+
+    increment_version_number(
+      version_number: ENV['IOS_BUILD_NAME'],
+      xcodeproj: "Runner.xcodeproj"
+    )
+
+    update_code_signing_settings(
+      # Replaces code_sign_style_script.rb from build_tools
+      use_automatic_signing: false,
+      code_sign_identity: ENV['IOS_CODE_SIGNING_IDENTITY']
+    )
+
+    update_project_team(
+      teamid: ENV['IOS_TEAM_ID'],
+    )
+
+    update_project_provisioning(
+      xcodeproj: "Runner.xcodeproj",
+      profile: ENV['IOS_PROVISIONING_PROFILE_PATH'],
+      target_filter: nil
+    )
+
+    build_app(
+      scheme: "Runner",
+      workspace: "Runner.xcworkspace",
+      # archive_path: "build.xcarchive", # Uncomment if you want to keep the archive, for manual upload
+      output_name: ENV['IOS_BUILD_FILE_NAME'],
+      export_team_id: ENV['IOS_TEAM_ID'],
+      export_options: {
+        signingCertificate: ENV['IOS_CODE_SIGNING_IDENTITY'],
+      },
+      sdk: ENV['IOS_BUILD_SDK'].nil? ? nil : ENV['IOS_BUILD_SDK'],
+    )
+
+    delete_keychain(name: keychain_name)
+  end
+
+  desc "Upload the iOS app to TestFlight"
+  lane :upload do
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV['IOS_APP_STORE_CONNECT_API_KEY_ID'],
+      issuer_id: ENV['IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
+      key_filepath: ENV['IOS_APP_STORE_CONNECT_API_KEY_P8_PATH'],
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: ENV['IOS_BUILD_FILE_NAME'],
+      skip_waiting_for_build_processing: true, # Remove if need to specify test groups
+
+      # TODO: automate testgroups
+      # testers_file_path: "testers.csv",
+    )
+  end
+end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -397,6 +397,57 @@ melos:
       run: flutter build ios --dart-define-from-file=dart_define.json --no-tree-shake-icons --config-only
 
     # ===========================
+    # Fastlane - melos run fastlane:ios:build | fastlane:android:upload
+    # ===========================
+
+    fastlane:install:
+      description: Install fastlane if it is missing (brew on macOS, gem elsewhere).
+      run: |
+        set -eo pipefail
+        if command -v fastlane >/dev/null 2>&1; then
+          echo "fastlane already installed: $(fastlane --version | tail -n 1)"
+        elif [ "$(uname -s)" = "Darwin" ]; then
+          brew install fastlane
+        else
+          gem install fastlane
+        fi
+
+    fastlane:ios:build:
+      description: >
+        Build and sign the iOS ipa via ios/fastlane. Reads IOS_CERTIFICATE_PATH,
+        IOS_PROVISIONING_PROFILE_PATH, IOS_CODE_SIGNING_IDENTITY, IOS_TEAM_ID, IOS_BUILD_NAME,
+        IOS_BUILD_NUMBER, IOS_BUILD_FILE_NAME from the environment.
+      steps:
+        - fastlane:install
+        - cd ios && fastlane ios build
+
+    fastlane:ios:upload:
+      description: >
+        Upload the built ipa to TestFlight. Reads IOS_APP_STORE_CONNECT_API_KEY_ID,
+        IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID, IOS_APP_STORE_CONNECT_API_KEY_P8_PATH,
+        IOS_BUILD_FILE_NAME from the environment.
+      steps:
+        - fastlane:install
+        - cd ios && fastlane ios upload
+
+    fastlane:android:build:
+      description: >
+        Build the Android app bundle via android/fastlane. Reads ANDROID_BUILD_TARGET,
+        ANDROID_FLAVOR, ANDROID_BUILD_NAME, ANDROID_BUILD_NUMBER from the environment.
+      steps:
+        - fastlane:install
+        - cd android && fastlane android build
+
+    fastlane:android:upload:
+      description: >
+        Upload the built aab to Google Play. Reads ANDROID_PLAY_STORE_TRACK,
+        ANDROID_PLAY_STORE_RELEASE_STATUS, ANDROID_PLAY_STORE_JSON_KEY_PATH,
+        ANDROID_PLAY_STORE_PACKAGE_NAME, ANDROID_AAB_PATH from the environment.
+      steps:
+        - fastlane:install
+        - cd android && fastlane android upload
+
+    # ===========================
     # Clean - melos run clean | clean:git
     # ===========================
 


### PR DESCRIPTION
This pull request introduces a comprehensive Fastlane-based workflow for building, signing, and distributing both Android and iOS apps. It adds Fastlane configuration and scripts for both platforms, integrates these with Melos scripts for consistent local and CI usage, and updates documentation to clearly describe the new process and required environment variables.

**Fastlane Integration for Build, Signing, and Distribution**

* Added Fastlane configuration and Gemfiles for both `android` and `ios` directories to manage dependencies and enable automated build and deployment.
* Created `Fastfile` scripts for Android and iOS to handle building, signing, and uploading apps to Google Play and TestFlight, including support for environment-based configuration of all required secrets and build parameters. [[1]](diffhunk://#diff-d0c99c3583617d28a3669e90c98158993dfbd7a57c6e010b1a70e2a8acaed5a6R1-R46) [[2]](diffhunk://#diff-96a113f9048a44bf631e40227acc27a302b3daa91b60217ad3a7ff91fa6973deR1-R84)
* Updated `.gitignore` files in both `android/fastlane` and `ios/fastlane` to exclude generated files and documentation.

**Melos Script Integration**

* Added new Melos scripts in `pubspec.yaml` to wrap Fastlane commands for both platforms, ensuring consistent invocation and environment variable management for local and CI builds.

**Documentation Updates**

* Expanded and clarified `docs/build.md` to describe the new Fastlane-based workflow, including detailed tables of environment variables, example usage, and integration with Melos scripts. [[1]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77L3-R8) [[2]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77R83-R180)

These changes provide a standardized, automated, and documented process for building, signing, and distributing mobile app releases for both Android and iOS.