### PR TITLE
fix: give the in-call keypad its full size back

### DIFF
--- a/lib/features/call/view/call_active_scaffold.dart
+++ b/lib/features/call/view/call_active_scaffold.dart
@@ -70,6 +70,11 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
   /// Consider moving this to a global state (e.g., BLoC or Some config provider).
   VideoBackgroundMode _backgroundMode = VideoBackgroundMode.blur;
 
+  /// Whether the in-call keypad is open. Owned here rather than inside the
+  /// actions grid: the layout around the open keypad changes too (the avatar
+  /// hides), so a single owner keeps both in sync.
+  bool _inCallKeypadShown = false;
+
   Timer? _remoteFrameWatcher;
   bool _hasRenderableRemoteFrame = false;
   late final FrameAnalysisWorker _frameAnalysisWorker;
@@ -106,6 +111,16 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     super.didUpdateWidget(oldWidget);
     // Synchronize the auto-hide logic with the latest call list configuration.
     _compactController.setActive(widget.activeCalls.shouldAutoCompact, reason: 'didUpdateWidget');
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // The in-call keypad exists only in portrait; rotating away closes it
+    // (a rebuild follows this callback, so no setState is needed).
+    if (MediaQuery.of(context).orientation != Orientation.portrait) {
+      _inCallKeypadShown = false;
+    }
   }
 
   @override
@@ -266,202 +281,233 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
                               Expanded(
                                 child: LayoutBuilder(
                                   builder: (context, constraints) {
+                                    final isPortrait = mediaQueryData.orientation == Orientation.portrait;
+                                    final content = Column(
+                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                      children: [
+                                        // List-based call screen: with more than one call every
+                                        // call is a tappable row, and the info block + action
+                                        // area below act on the focused call.
+                                        if (activeCalls.length > 1)
+                                          CallList(
+                                            calls: activeCalls,
+                                            focusedCallId: focusedCall.callId,
+                                            style: style?.callInfo,
+                                            listStyle: style?.list,
+                                            onCallTap: (callId) {
+                                              _callBloc.add(CallControlEvent.callSelected(callId));
+                                            },
+                                          ),
+                                        // With multiple calls the list rows carry the per-call
+                                        // info, so the central info block is single-call only.
+                                        if (activeCalls.length == 1)
+                                          CallInfo(
+                                            transfering: focusedTransfer is Transfering,
+                                            requestToAttendedTransfer: false,
+                                            inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
+                                            isIncoming: focusedCall.isIncoming,
+                                            held: focusedCall.held,
+                                            number: focusedCall.handle.value,
+                                            username: focusedCall.displayName,
+                                            acceptedTime: focusedCall.acceptedTime,
+                                            style: style?.callInfo,
+                                            processingStatus: focusedCall.processingStatus,
+                                          ),
+                                        // Nothing to render in the video area (audio-only call,
+                                        // remote camera off, or a held call): the remote party's
+                                        // avatar takes its place, between the info block and the
+                                        // action area. The avatar takes only the height LEFT OVER
+                                        // by the info block and the action area and scales itself
+                                        // down into it - so growing content (e.g. the open in-call
+                                        // keypad) shrinks the avatar, never the controls.
+                                        if (!_hasRenderableRemoteFrame && !_inCallKeypadShown)
+                                          if (isPortrait)
+                                            Flexible(
+                                              child: Center(
+                                                child: FittedBox(
+                                                  fit: BoxFit.scaleDown,
+                                                  child: CallRemoteAvatar(
+                                                    activeCall: activeCall,
+                                                    radius: _avatarRadius(mediaQueryData),
+                                                    contactResolver: widget.contactResolver,
+                                                  ),
+                                                ),
+                                              ),
+                                            )
+                                          else
+                                            CallRemoteAvatar(
+                                              activeCall: activeCall,
+                                              radius: _avatarRadius(mediaQueryData),
+                                              contactResolver: widget.contactResolver,
+                                            ),
+                                        if (!focusedIsRinging)
+                                          ActiveCallActions(
+                                            style: style?.actions,
+                                            keypadShown: _inCallKeypadShown,
+                                            onKeypadToggle: (shown) => setState(() => _inCallKeypadShown = shown),
+                                            // Blocks signaling-dependent actions (hold, transfer, camera).
+                                            // False during: interaction debounce, signaling not ready, SDP renegotiation.
+                                            enableInteractions:
+                                                interactionsDebounceActive == false &&
+                                                widget.callStatus == CallStatus.ready &&
+                                                activeCalls.any((call) => call.updating) == false,
+                                            isIncoming: focusedCall.isIncoming,
+                                            wasAccepted: focusedCall.wasAccepted,
+                                            wasHungUp: focusedCall.wasHungUp,
+                                            cameraValue: focusedCall.isCameraActive,
+                                            cameraPermissionDenied:
+                                                widget.callConfig.isVideoCallEnabled &&
+                                                focusedCall.videoPermissionDenied,
+                                            onCameraPermissionDeniedPressed: _onCameraPermissionDeniedPressed,
+                                            inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
+                                            onCameraChanged: widget.callConfig.isVideoCallEnabled
+                                                ? _toggleFocusedCamera
+                                                : null,
+                                            mutedValue: focusedCall.muted,
+                                            onMutedChanged: (bool value) {
+                                              _callBloc.add(CallControlEvent.setMuted(focusedCall.callId, value));
+                                            },
+                                            audioDevice: widget.audioDevice,
+                                            availableAudioDevices: widget.availableAudioDevices,
+                                            onAudioDeviceChanged: (CallAudioDevice device) {
+                                              _callBloc.add(
+                                                CallControlEvent.audioDeviceSet(focusedCall.callId, device),
+                                              );
+                                            },
+                                            transferableCalls: heldCalls,
+                                            onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
+                                                ? (!focusedCall.wasAccepted || focusedTransfer != null
+                                                      ? null
+                                                      : () {
+                                                          _callBloc.add(
+                                                            CallControlEvent.blindTransferInitiated(focusedCall.callId),
+                                                          );
+                                                        })
+                                                : null,
+                                            // TODO (Serdun): Simplify complex condition in the widget tree.
+                                            onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
+                                                ? (!focusedCall.wasAccepted || focusedTransfer != null
+                                                      ? null
+                                                      : () {
+                                                          _callBloc.add(
+                                                            CallControlEvent.attendedTransferInitiated(
+                                                              focusedCall.callId,
+                                                            ),
+                                                          );
+                                                        })
+                                                : null,
+                                            // TODO (Serdun): Simplify complex condition in the widget tree.
+                                            // The submit acts on the consultation call (the derived
+                                            // `current`), not the focused one: focus may sit on the
+                                            // held original call being transferred (an incoming call
+                                            // grabs the selection at ring time), and using it as the
+                                            // replace target would produce a self-referential REFER.
+                                            //
+                                            // KNOWN LIMITATION: `current` is still a positional guess
+                                            // ("the live non-held call"), which breaks once a third,
+                                            // unrelated call is concurrently active - it can point at
+                                            // that call instead of the real consultation call. Left out
+                                            // of scope here: server config typically caps concurrent
+                                            // lines at 3 (not hardcoded in the app - see linesCount),
+                                            // and this heuristic is unchanged from pre-1.16.0 behavior (not
+                                            // a new regression). A proper fix needs an explicit
+                                            // referor<->consultation link, not a positional guess -
+                                            // see git history for a prior (closed) attempt.
+                                            onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
+                                                ? (!activeCall.wasAccepted || focusedTransfer != null
+                                                      ? null
+                                                      : (ActiveCall referorCall) {
+                                                          _callBloc.add(
+                                                            CallControlEvent.attendedTransferSubmitted(
+                                                              referorCall: referorCall,
+                                                              replaceCall: activeCall,
+                                                            ),
+                                                          );
+                                                        })
+                                                : null,
+                                            heldValue: focusedCall.held,
+                                            // Hold pauses just the focused call; Resume brings it
+                                            // back as the only live one (the other live calls are
+                                            // put on hold first). Switching lines = focus the other
+                                            // row and press Resume - there is no separate swap.
+                                            onHeldChanged: _toggleFocusedHeld,
+                                            onHangupPressed: _hangupFocused,
+
+                                            onKeyPressed: (value) {
+                                              _callBloc.add(CallControlEvent.sentDTMF(focusedCall.callId, value));
+                                            },
+                                          )
+                                        else
+                                          // Decline / Answer for the focused ringing call -
+                                          // always two buttons. Answering holds the answered
+                                          // calls (or ends the non-holdable ones); the hint
+                                          // names the focused call and spells the side effect.
+                                          // The hint and the buttons are one column child so
+                                          // the spaceBetween layout keeps them glued together
+                                          // at the bottom.
+                                          // Edge-cases (covered by the call list above):
+                                          // - two incoming ringing calls
+                                          // - one outgoing ringing + one incoming ringing
+                                          Column(
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              if (activeCalls.length > 1)
+                                                FocusedActionHint(
+                                                  focusedName: focusedCall.displayName ?? focusedCall.handle.value,
+                                                  willBeHeldNames: nonIncomingRingingCanBeHolded.isEmpty
+                                                      ? const []
+                                                      : [
+                                                          for (final call in nonIncomingRingingCanBeHolded)
+                                                            if (!call.held) call.displayName ?? call.handle.value,
+                                                        ],
+                                                  willBeEndedNames: nonIncomingRingingCanBeHolded.isNotEmpty
+                                                      ? const []
+                                                      : [
+                                                          for (final call in nonIncomingRingingCalls)
+                                                            call.displayName ?? call.handle.value,
+                                                        ],
+                                                  style: style?.callInfo,
+                                                  hintStyle: style?.hint,
+                                                ),
+                                              IncomingCallActions(
+                                                style: style?.actions,
+                                                inviteToAttendedTransfer: false,
+                                                remoteVideo: focusedCall.remoteVideo && focusedCall.held == false,
+                                                onHangupPressed: _hangupFocused,
+                                                // Answering with other calls present mutates them
+                                                // (hold/end), so it is gated by the interactions
+                                                // debounce like any signaling-dependent action.
+                                                onAcceptPressed:
+                                                    nonIncomingRingingCalls.isNotEmpty &&
+                                                        (interactionsDebounceActive ||
+                                                            widget.callStatus != CallStatus.ready ||
+                                                            activeCalls.any((call) => call.updating))
+                                                    ? null
+                                                    : _answerFocused,
+                                              ),
+                                            ],
+                                          ),
+                                      ],
+                                    );
+
+                                    // Portrait has the room: controls render at natural size and
+                                    // the avatar flexes into what is left. Landscape keeps the
+                                    // legacy scale-to-fit of the whole block - heights there are
+                                    // too small for the natural layout.
+                                    if (isPortrait) {
+                                      return SizedBox(
+                                        width: constraints.maxWidth,
+                                        height: constraints.maxHeight,
+                                        child: content,
+                                      );
+                                    }
                                     return FittedBox(
                                       child: ConstrainedBox(
                                         constraints: BoxConstraints(
                                           maxWidth: constraints.maxWidth,
                                           minHeight: constraints.minHeight,
                                         ),
-                                        child: Column(
-                                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                          children: [
-                                            // List-based call screen: with more than one call every
-                                            // call is a tappable row, and the info block + action
-                                            // area below act on the focused call.
-                                            if (activeCalls.length > 1)
-                                              CallList(
-                                                calls: activeCalls,
-                                                focusedCallId: focusedCall.callId,
-                                                style: style?.callInfo,
-                                                listStyle: style?.list,
-                                                onCallTap: (callId) {
-                                                  _callBloc.add(CallControlEvent.callSelected(callId));
-                                                },
-                                              ),
-                                            // With multiple calls the list rows carry the per-call
-                                            // info, so the central info block is single-call only.
-                                            if (activeCalls.length == 1)
-                                              CallInfo(
-                                                transfering: focusedTransfer is Transfering,
-                                                requestToAttendedTransfer: false,
-                                                inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
-                                                isIncoming: focusedCall.isIncoming,
-                                                held: focusedCall.held,
-                                                number: focusedCall.handle.value,
-                                                username: focusedCall.displayName,
-                                                acceptedTime: focusedCall.acceptedTime,
-                                                style: style?.callInfo,
-                                                processingStatus: focusedCall.processingStatus,
-                                              ),
-                                            // Nothing to render in the video area (audio-only call,
-                                            // remote camera off, or a held call): the remote party's
-                                            // avatar takes its place, between the info block and the
-                                            // action area.
-                                            if (!_hasRenderableRemoteFrame)
-                                              CallRemoteAvatar(
-                                                activeCall: activeCall,
-                                                radius: _avatarRadius(mediaQueryData),
-                                                contactResolver: widget.contactResolver,
-                                              ),
-                                            if (!focusedIsRinging)
-                                              ActiveCallActions(
-                                                style: style?.actions,
-                                                // Blocks signaling-dependent actions (hold, transfer, camera).
-                                                // False during: interaction debounce, signaling not ready, SDP renegotiation.
-                                                enableInteractions:
-                                                    interactionsDebounceActive == false &&
-                                                    widget.callStatus == CallStatus.ready &&
-                                                    activeCalls.any((call) => call.updating) == false,
-                                                isIncoming: focusedCall.isIncoming,
-                                                wasAccepted: focusedCall.wasAccepted,
-                                                wasHungUp: focusedCall.wasHungUp,
-                                                cameraValue: focusedCall.isCameraActive,
-                                                cameraPermissionDenied:
-                                                    widget.callConfig.isVideoCallEnabled &&
-                                                    focusedCall.videoPermissionDenied,
-                                                onCameraPermissionDeniedPressed: _onCameraPermissionDeniedPressed,
-                                                inviteToAttendedTransfer: focusedTransfer is InviteToAttendedTransfer,
-                                                onCameraChanged: widget.callConfig.isVideoCallEnabled
-                                                    ? _toggleFocusedCamera
-                                                    : null,
-                                                mutedValue: focusedCall.muted,
-                                                onMutedChanged: (bool value) {
-                                                  _callBloc.add(CallControlEvent.setMuted(focusedCall.callId, value));
-                                                },
-                                                audioDevice: widget.audioDevice,
-                                                availableAudioDevices: widget.availableAudioDevices,
-                                                onAudioDeviceChanged: (CallAudioDevice device) {
-                                                  _callBloc.add(
-                                                    CallControlEvent.audioDeviceSet(focusedCall.callId, device),
-                                                  );
-                                                },
-                                                transferableCalls: heldCalls,
-                                                onBlindTransferInitiated: widget.callConfig.isBlindTransferEnabled
-                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
-                                                          ? null
-                                                          : () {
-                                                              _callBloc.add(
-                                                                CallControlEvent.blindTransferInitiated(
-                                                                  focusedCall.callId,
-                                                                ),
-                                                              );
-                                                            })
-                                                    : null,
-                                                // TODO (Serdun): Simplify complex condition in the widget tree.
-                                                onAttendedTransferInitiated: widget.callConfig.isAttendedTransferEnabled
-                                                    ? (!focusedCall.wasAccepted || focusedTransfer != null
-                                                          ? null
-                                                          : () {
-                                                              _callBloc.add(
-                                                                CallControlEvent.attendedTransferInitiated(
-                                                                  focusedCall.callId,
-                                                                ),
-                                                              );
-                                                            })
-                                                    : null,
-                                                // TODO (Serdun): Simplify complex condition in the widget tree.
-                                                // The submit acts on the consultation call (the derived
-                                                // `current`), not the focused one: focus may sit on the
-                                                // held original call being transferred (an incoming call
-                                                // grabs the selection at ring time), and using it as the
-                                                // replace target would produce a self-referential REFER.
-                                                //
-                                                // KNOWN LIMITATION: `current` is still a positional guess
-                                                // ("the live non-held call"), which breaks once a third,
-                                                // unrelated call is concurrently active - it can point at
-                                                // that call instead of the real consultation call. Left out
-                                                // of scope here: server config typically caps concurrent
-                                                // lines at 3 (not hardcoded in the app - see linesCount),
-                                                // and this heuristic is unchanged from pre-1.16.0 behavior (not
-                                                // a new regression). A proper fix needs an explicit
-                                                // referor<->consultation link, not a positional guess -
-                                                // see git history for a prior (closed) attempt.
-                                                onAttendedTransferSubmitted: widget.callConfig.isAttendedTransferEnabled
-                                                    ? (!activeCall.wasAccepted || focusedTransfer != null
-                                                          ? null
-                                                          : (ActiveCall referorCall) {
-                                                              _callBloc.add(
-                                                                CallControlEvent.attendedTransferSubmitted(
-                                                                  referorCall: referorCall,
-                                                                  replaceCall: activeCall,
-                                                                ),
-                                                              );
-                                                            })
-                                                    : null,
-                                                heldValue: focusedCall.held,
-                                                // Hold pauses just the focused call; Resume brings it
-                                                // back as the only live one (the other live calls are
-                                                // put on hold first). Switching lines = focus the other
-                                                // row and press Resume - there is no separate swap.
-                                                onHeldChanged: _toggleFocusedHeld,
-                                                onHangupPressed: _hangupFocused,
-
-                                                onKeyPressed: (value) {
-                                                  _callBloc.add(CallControlEvent.sentDTMF(focusedCall.callId, value));
-                                                },
-                                              )
-                                            else
-                                              // Decline / Answer for the focused ringing call -
-                                              // always two buttons. Answering holds the answered
-                                              // calls (or ends the non-holdable ones); the hint
-                                              // names the focused call and spells the side effect.
-                                              // The hint and the buttons are one column child so
-                                              // the spaceBetween layout keeps them glued together
-                                              // at the bottom.
-                                              // Edge-cases (covered by the call list above):
-                                              // - two incoming ringing calls
-                                              // - one outgoing ringing + one incoming ringing
-                                              Column(
-                                                mainAxisSize: MainAxisSize.min,
-                                                children: [
-                                                  if (activeCalls.length > 1)
-                                                    FocusedActionHint(
-                                                      focusedName: focusedCall.displayName ?? focusedCall.handle.value,
-                                                      willBeHeldNames: nonIncomingRingingCanBeHolded.isEmpty
-                                                          ? const []
-                                                          : [
-                                                              for (final call in nonIncomingRingingCanBeHolded)
-                                                                if (!call.held) call.displayName ?? call.handle.value,
-                                                            ],
-                                                      willBeEndedNames: nonIncomingRingingCanBeHolded.isNotEmpty
-                                                          ? const []
-                                                          : [
-                                                              for (final call in nonIncomingRingingCalls)
-                                                                call.displayName ?? call.handle.value,
-                                                            ],
-                                                      style: style?.callInfo,
-                                                      hintStyle: style?.hint,
-                                                    ),
-                                                  IncomingCallActions(
-                                                    style: style?.actions,
-                                                    inviteToAttendedTransfer: false,
-                                                    remoteVideo: focusedCall.remoteVideo && focusedCall.held == false,
-                                                    onHangupPressed: _hangupFocused,
-                                                    // Answering with other calls present mutates them
-                                                    // (hold/end), so it is gated by the interactions
-                                                    // debounce like any signaling-dependent action.
-                                                    onAcceptPressed:
-                                                        nonIncomingRingingCalls.isNotEmpty &&
-                                                            (interactionsDebounceActive ||
-                                                                widget.callStatus != CallStatus.ready ||
-                                                                activeCalls.any((call) => call.updating))
-                                                        ? null
-                                                        : _answerFocused,
-                                                  ),
-                                                ],
-                                              ),
-                                          ],
-                                        ),
+                                        child: content,
                                       ),
                                     );
                                   },
@@ -483,8 +529,9 @@ class CallActiveScaffoldState extends State<CallActiveScaffold> {
     );
   }
 
-  /// Radius of the avatar shown in place of the remote video, derived from the screen:
-  /// the call layout sits inside a `FittedBox`, so local constraints are unbounded there.
+  /// Preferred radius of the avatar shown in place of the remote video; the
+  /// avatar scales itself down when the space left over by the info block and
+  /// the action area is smaller than this.
   double _avatarRadius(MediaQueryData mediaQueryData) {
     return (mediaQueryData.size.shortestSide * 0.30).clamp(24.0, 150.0);
   }

--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -40,6 +40,8 @@ class ActiveCallActions extends StatefulWidget {
     this.onHeldChanged,
     this.onHangupPressed,
     this.onKeyPressed,
+    this.keypadShown = false,
+    this.onKeypadToggle,
     this.style,
   });
 
@@ -73,6 +75,14 @@ class ActiveCallActions extends StatefulWidget {
   final void Function()? onHangupPressed;
   final void Function(String value)? onKeyPressed;
 
+  /// Whether the in-call keypad is shown. The state is owned by the parent:
+  /// the surrounding layout renders differently around the open keypad (the
+  /// avatar hides), so a single owner keeps the two in sync.
+  final bool keypadShown;
+
+  /// Requests the in-call keypad to be shown or hidden.
+  final ValueChanged<bool>? onKeypadToggle;
+
   final CallScreenActionsStyle? style;
 
   @override
@@ -80,8 +90,6 @@ class ActiveCallActions extends StatefulWidget {
 }
 
 class _ActiveCallActionsState extends State<ActiveCallActions> {
-  bool _keypadShow = false;
-
   final _keypadTextFieldKey = GlobalKey();
 
   EditableTextState? get _keypadTextFieldEditableTextState =>
@@ -146,7 +154,6 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
       _actionsDelimiterDimension = _dimension / 9;
       _hangupDelimiterDimension = _actionsDelimiterDimension;
       _horizontalPadding = _dimension * 3;
-      if (_keypadShow) _keypadShow = false;
     }
     if (mounted) setState(() {});
   }
@@ -202,7 +209,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     final TextButtonsTable buttonsTable;
 
     late List<Widget> actions;
-    if (_keypadShow) {
+    if (widget.keypadShown) {
       actions = KeypadKey.numbers.indexed
           .map((e) {
             final (i, k) = e;
@@ -458,13 +465,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
           key: callActionsKeypadKey,
           message: context.l10n.call_CallActionsTooltip_showKeypad,
           child: TextButton(
-            onPressed: onKeyPressed == null || !_isOrientationPortrait
-                ? null
-                : () {
-                    setState(() {
-                      _keypadShow = true;
-                    });
-                  },
+            onPressed: onKeyPressed == null || !_isOrientationPortrait ? null : () => widget.onKeypadToggle?.call(true),
             style: widget.style?.key,
             child: Icon(Icons.dialpad, size: actionPadIconSize),
           ),
@@ -493,16 +494,13 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
             child: Icon(Icons.call_end, size: actionPadIconSize),
           ),
         ),
-        _keypadShow
+        widget.keypadShown
             ? Tooltip(
                 message: context.l10n.call_CallActionsTooltip_hideKeypad,
                 child: TextButton(
                   onPressed: () {
                     _keypadTextEditingController.clear();
-
-                    setState(() {
-                      _keypadShow = false;
-                    });
+                    widget.onKeypadToggle?.call(false);
                   },
                   style: widget.style?.key,
                   child: Icon(Icons.dialpad, size: actionPadIconSize),
@@ -518,7 +516,7 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
         data: IconThemeData(size: _iconSize),
         child: Column(
           children: [
-            if (_keypadShow) ...[
+            if (widget.keypadShown) ...[
               TextField(
                 key: _keypadTextFieldKey,
                 controller: _keypadTextEditingController,

--- a/test/features/call/view/call_active_scaffold_test.dart
+++ b/test/features/call/view/call_active_scaffold_test.dart
@@ -13,6 +13,7 @@ import 'package:webtrit_phone/features/call/view/call_active_scaffold.dart';
 import 'package:webtrit_phone/l10n/l10n.dart';
 import 'package:webtrit_phone/models/models.dart';
 import 'package:webtrit_phone/theme/theme.dart';
+import 'package:webtrit_phone/widgets/keypad_key_button.dart';
 
 // ---------------------------------------------------------------------------
 // Mocks / helpers
@@ -323,6 +324,32 @@ void main() {
       await tester.pump();
 
       expect(find.descendant(of: find.byType(CallRemoteAvatar), matching: find.text('BK')), findsOneWidget);
+      await _teardown(tester);
+    });
+
+    testWidgets('the open in-call keypad hides the avatar and keeps the keys full size', (tester) async {
+      // The in-call keypad opens only in portrait orientation.
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_buildSubject(callBloc, activeCalls: [active], focusedCall: active));
+      expect(find.byType(CallRemoteAvatar), findsOneWidget);
+
+      await tester.tap(find.byKey(callActionsKeypadKey));
+      await tester.pumpAndSettle();
+
+      // The avatar makes way for the keypad, and the keys render at their
+      // natural size (screen shortest side / 5) - never scaled down.
+      expect(find.byType(CallRemoteAvatar), findsNothing);
+      final keySize = tester.getSize(find.byType(KeypadKeyButton).first);
+      expect(keySize.width, greaterThanOrEqualTo(360 / 5));
+
+      await tester.tap(find.byTooltip('Hide keypad'));
+      await tester.pumpAndSettle();
+      expect(find.byType(KeypadKeyButton), findsNothing);
+      expect(find.byType(CallRemoteAvatar), findsOneWidget);
+
       await _teardown(tester);
     });
   });


### PR DESCRIPTION
## Overview

On develop, opening the keypad during a call shows it noticeably smaller than in release 1.16.2 - narrower keys and bigger side margins.

## Cause

The regression came with the call screen avatar (#1538). The call content column renders everything at natural size and then scales the whole block down if it does not fit the screen. Before the avatar this never triggered. The avatar added a large fixed-size element that stayed on screen with the keypad open; info plus avatar plus twelve keys no longer fit, so the layout shrank the entire content - keys included.

## Solution

Two things, so the regression cannot come back:

* The layout root: in portrait the controls always render at their natural size, and the avatar takes only the space left over, scaling itself into it - growing content can never shrink the controls again. Landscape keeps the previous compact scale-to-fit behavior, where heights are too small for the natural layout.
* The behavior: the open keypad hides the avatar entirely, as the screen worked in 1.16.2. The keypad visibility is owned by the call screen, which renders one or the other, so the two can never show together; the avatar returns the moment the keypad closes, and rotating to landscape still closes the keypad.

## Verification

A widget test walks the open-close cycle: avatar shown, keypad opens - avatar gone and the keys assert their natural size, keypad closes - avatar back. Checked on a real device in a live call: with the keypad open the key geometry matches release 1.16.2 exactly (compared via the accessibility tree of both builds on the same phone) and the avatar is hidden. Full analyze and test suite pass.