### PR TITLE
refactor: extract the shared in-call action button

### DIFF
--- a/lib/features/call/widgets/active_call_actions.dart
+++ b/lib/features/call/widgets/active_call_actions.dart
@@ -158,6 +158,47 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     if (mounted) setState(() {});
   }
 
+  // --- Intent helpers -------------------------------------------------------
+  // Callbacks in the widget tree are single-expression; multi-step logic
+  // lives here.
+
+  /// Appends the pressed key to the DTMF display and forwards it upstream.
+  void _enterKeypadKey(String key) {
+    final newText = _keypadTextEditingController.text + key;
+    final newSelection = TextSelection.collapsed(offset: newText.length);
+    final value = _keypadTextEditingController.value.copyWith(text: newText, selection: newSelection);
+    _keypadTextFieldEditableTextState?.userUpdateTextEditingValue(value, SelectionChangedCause.keyboard);
+
+    final onKeyPressed = widget.enableInteractions ? widget.onKeyPressed : null;
+    onKeyPressed!(key);
+  }
+
+  /// Closes the in-call keypad, dropping the collected DTMF input.
+  void _hideKeypad() {
+    _keypadTextEditingController.clear();
+    widget.onKeypadToggle?.call(false);
+  }
+
+  /// Switches between the built-in speakerphone and the earpiece.
+  void _toggleSpeakerphone() {
+    final speakerOn = widget.audioDevice?.type == CallAudioDeviceType.speaker;
+    if (speakerOn) {
+      final earpieceDevice = widget.availableAudioDevices.getEarpiece;
+      if (earpieceDevice != null) {
+        widget.onAudioDeviceChanged(earpieceDevice);
+      } else {
+        _logger.warning('Earpiece device not found while trying to disable speakerphone');
+      }
+    } else {
+      final speakerDevice = widget.availableAudioDevices.getSpeaker;
+      if (speakerDevice != null) {
+        widget.onAudioDeviceChanged(speakerDevice);
+      } else {
+        _logger.warning('Speaker device not found while trying to enable speakerphone');
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
@@ -175,7 +216,6 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     // Transfer button itself is local (opens a popup), only the actions inside are signaling-dependent.
     final onBlindTransferInitiated = widget.onBlindTransferInitiated;
     final onAttendedTransferInitiated = widget.onAttendedTransferInitiated;
-    final onAttendedTransferSubmitted = widget.onAttendedTransferSubmitted;
     // Hold/resume sends signaling requests and triggers renegotiation.
     final onHeldChanged = widget.enableInteractions ? widget.onHeldChanged : null;
     final onKeyPressed = widget.enableInteractions ? widget.onKeyPressed : null;
@@ -183,9 +223,19 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
     // Always allow the user to hang up or answer the call
     final onHangupPressed = widget.onHangupPressed;
 
+    // The camera button flips between three intents (see cameraPermissionDenied).
+    final onCameraPressed = widget.cameraPermissionDenied
+        ? onCameraPermissionDeniedPressed
+        : (onCameraChanged != null ? () => onCameraChanged(!widget.cameraValue) : null);
+
+    // The keypad opens only in portrait and only when DTMF input is wired.
+    final canShowKeypad = onKeyPressed != null && _isOrientationPortrait;
+
+    // With no transfer intent wired the trigger renders disabled.
+    final transferInitAvailable = onBlindTransferInitiated != null || onAttendedTransferInitiated != null;
+
     // Icons
     final actionPadIconSize = themeData.textTheme.headlineMedium!.fontSize;
-    final popupMenuIconSize = themeData.textTheme.bodyLarge!.fontSize;
 
     // States
     final isAudioSelected = audioDevice?.type != CallAudioDeviceType.earpiece;
@@ -210,265 +260,99 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
 
     late List<Widget> actions;
     if (widget.keypadShown) {
-      actions = KeypadKey.numbers.indexed
-          .map((e) {
-            final (i, k) = e;
-            return [
-              KeypadKeyButton(
-                text: k.text,
-                subtext: k.subtext,
-                onKeyPressed: (key) {
-                  final newText = _keypadTextEditingController.text + key;
-                  final newSelection = TextSelection.collapsed(offset: newText.length);
-                  final value = _keypadTextEditingController.value.copyWith(text: newText, selection: newSelection);
-                  _keypadTextFieldEditableTextState?.userUpdateTextEditingValue(value, SelectionChangedCause.keyboard);
-
-                  onKeyPressed!(key);
-                },
-                style: KeypadKeyStyle(
-                  buttonStyle: widget.style?.key,
-                  textStyle: keypadTextStyle,
-                  subtextStyle: subKeypadTextStyle,
-                ),
-              ),
-              if ((i + 1) % 3 == 0) ...[
-                const SizedBox(),
-                SizedBox.square(dimension: _actionsDelimiterDimension),
-                const SizedBox(),
-              ],
-            ];
-          })
-          .expand((e) => e)
-          .toList(growable: false);
+      actions = _buildKeypadActions(keypadTextStyle, subKeypadTextStyle);
     } else {
       actions = [
         // row
-        Tooltip(
-          message: widget.mutedValue
+        CallActionButton(
+          key: callActionsMuteKey,
+          label: widget.mutedValue
               ? context.l10n.call_CallActionsTooltip_unmute
               : context.l10n.call_CallActionsTooltip_mute,
-          child: TextButton(
-            key: callActionsMuteKey,
-            onPressed: onMutedChanged != null ? () => onMutedChanged(!widget.mutedValue) : null,
-            statesController: _mutedStatesController..update(WidgetState.selected, widget.mutedValue),
-            style: widget.style?.muted,
-            child: Icon(widget.mutedValue ? Icons.mic_off : Icons.mic, size: actionPadIconSize),
-          ),
+          onPressed: onMutedChanged != null ? () => onMutedChanged(!widget.mutedValue) : null,
+          statesController: _mutedStatesController..update(WidgetState.selected, widget.mutedValue),
+          style: widget.style?.muted,
+          child: Icon(widget.mutedValue ? Icons.mic_off : Icons.mic, size: actionPadIconSize),
         ),
-        Tooltip(
+        CallActionButton(
           key: callActionsVideoCallKey,
-          message: widget.cameraPermissionDenied
+          label: widget.cameraPermissionDenied
               ? context.l10n.call_CallActionsTooltip_cameraPermissionDenied
               : widget.cameraValue
               ? context.l10n.call_CallActionsTooltip_disableCamera
               : context.l10n.call_CallActionsTooltip_enableCamera,
-          child: TextButton(
-            onPressed: widget.cameraPermissionDenied
-                ? (onCameraPermissionDeniedPressed != null ? () => onCameraPermissionDeniedPressed() : null)
-                : (onCameraChanged != null ? () => onCameraChanged(!widget.cameraValue) : null),
-            statesController: _cameraStatesController..update(WidgetState.selected, widget.cameraValue),
-            style: widget.style?.camera,
-            child: Icon(widget.cameraValue ? Icons.videocam : Icons.videocam_off, size: actionPadIconSize),
-          ),
+          onPressed: onCameraPressed,
+          statesController: _cameraStatesController..update(WidgetState.selected, widget.cameraValue),
+          style: widget.style?.camera,
+          child: Icon(widget.cameraValue ? Icons.videocam : Icons.videocam_off, size: actionPadIconSize),
         ),
         if (widget.availableAudioDevices.onlyBuiltIn)
-          Tooltip(
+          CallActionButton(
             key: callActionsSpeakerKey,
-            message: speakerOn
+            label: speakerOn
                 ? context.l10n.call_CallActionsTooltip_disableSpeaker
                 : context.l10n.call_CallActionsTooltip_enableSpeaker,
-            child: TextButton(
-              onPressed: () {
-                final speakerDevice = widget.availableAudioDevices.getSpeaker;
-                final earpieceDevice = widget.availableAudioDevices.getEarpiece;
-                if (speakerOn) {
-                  if (earpieceDevice != null) {
-                    onAudioDeviceChanged.call(earpieceDevice);
-                  } else {
-                    _logger.warning('Earpiece device not found while trying to disable speakerphone');
-                  }
-                } else {
-                  if (speakerDevice != null) {
-                    onAudioDeviceChanged.call(speakerDevice);
-                  } else {
-                    _logger.warning('Speaker device not found while trying to enable speakerphone');
-                  }
-                }
-              },
-              statesController: _speakerStatesController..update(WidgetState.selected, speakerOn),
-              style: widget.style?.speaker,
-              child: Icon(speakerOn ? Icons.volume_up : Icons.phone_in_talk, size: actionPadIconSize),
-            ),
+            onPressed: _toggleSpeakerphone,
+            statesController: _speakerStatesController..update(WidgetState.selected, speakerOn),
+            style: widget.style?.speaker,
+            child: Icon(speakerOn ? Icons.volume_up : Icons.phone_in_talk, size: actionPadIconSize),
           ),
         if (!widget.availableAudioDevices.onlyBuiltIn)
-          Tooltip(
-            message: context.l10n.call_CallActionsTooltip_changeAudioDevice,
-            child: CallPopupMenuButton<CallAudioDevice>(
-              offset: Offset(_dimension + 8, 0),
-              items: widget.availableAudioDevices
-                  .map((device) {
-                    final CallAudioDevice(:name, :type, :id) = device;
-                    return CallPopupMenuItem<CallAudioDevice>(
-                      value: device,
-                      text: switch (type) {
-                        CallAudioDeviceType.speaker => context.l10n.call_CallActionsTooltip_device_speaker,
-                        CallAudioDeviceType.earpiece => context.l10n.call_CallActionsTooltip_device_earpiece,
-                        CallAudioDeviceType.wiredHeadset => context.l10n.call_CallActionsTooltip_device_wiredHeadset,
-                        CallAudioDeviceType.bluetooth => name ?? context.l10n.call_CallActionsTooltip_device_bluetooth,
-                        CallAudioDeviceType.streaming => name ?? context.l10n.call_CallActionsTooltip_device_streaming,
-                        _ => name ?? context.l10n.call_CallActionsTooltip_device_unknown,
-                      },
-                      icon: Icon(
-                        switch (type) {
-                          CallAudioDeviceType.speaker => Icons.volume_up,
-                          CallAudioDeviceType.bluetooth => Icons.bluetooth_audio,
-                          CallAudioDeviceType.wiredHeadset => Icons.headset,
-                          CallAudioDeviceType.earpiece => Icons.phone_in_talk,
-                          CallAudioDeviceType.streaming => Icons.usb,
-                          _ => Icons.device_unknown,
-                        },
-                        size: 20,
-                        color: themeData.textTheme.bodyMedium!.color,
-                      ),
-                      textStyle: themeData.textTheme.bodyMedium,
-                    );
-                  })
-                  .toList(growable: false),
-              onSelected: onAudioDeviceChanged,
-              child: IgnorePointer(
-                child: TextButton(
-                  /// Use an empty callback instead of null to prevent the button from
-                  /// entering the 'disabled' state, which would override the custom
-                  /// style with default disabled theme colors.
-                  onPressed: () {},
-                  statesController: _speakerStatesController..update(WidgetState.selected, isAudioSelected),
-                  style: widget.style?.speaker,
-                  child: Icon(switch (audioDevice?.type) {
-                    CallAudioDeviceType.speaker => Icons.volume_up,
-                    CallAudioDeviceType.bluetooth => Icons.bluetooth_audio,
-                    CallAudioDeviceType.wiredHeadset => Icons.headset,
-                    CallAudioDeviceType.earpiece => Icons.phone_in_talk,
-                    CallAudioDeviceType.streaming => Icons.usb,
-                    _ => Icons.volume_off,
-                  }, size: actionPadIconSize),
-                ),
-              ),
-            ),
+          CallActionMenuButton<CallAudioDevice>(
+            label: context.l10n.call_CallActionsTooltip_changeAudioDevice,
+            offset: Offset(_dimension + 8, 0),
+            statesController: _speakerStatesController..update(WidgetState.selected, isAudioSelected),
+            style: widget.style?.speaker,
+            onSelected: onAudioDeviceChanged,
+            items: _buildAudioDeviceItems(themeData),
+            child: Icon(switch (audioDevice?.type) {
+              CallAudioDeviceType.speaker => Icons.volume_up,
+              CallAudioDeviceType.bluetooth => Icons.bluetooth_audio,
+              CallAudioDeviceType.wiredHeadset => Icons.headset,
+              CallAudioDeviceType.earpiece => Icons.phone_in_talk,
+              CallAudioDeviceType.streaming => Icons.usb,
+              _ => Icons.volume_off,
+            }, size: actionPadIconSize),
           ),
         // delimiter
         const SizedBox(),
         SizedBox.square(dimension: _actionsDelimiterDimension),
         const SizedBox(),
         if (widget.transferableCalls.isNotEmpty)
-          Tooltip(
-            message: context.l10n.call_CallActionsTooltip_transfer,
-            child: CallPopupMenuButton(
-              key: callActionsTransferMenuKey,
-              offset: Offset(_dimension + 8, 0),
-              items: [
-                for (final call in widget.transferableCalls)
-                  if (onAttendedTransferSubmitted != null)
-                    CallPopupMenuItem(
-                      key: callActionsTransferMenuNumberKey,
-                      // Transfer is signaling-dependent, disable during renegotiation.
-                      enabled: widget.enableInteractions,
-                      onTap: () => onAttendedTransferSubmitted.call(call),
-                      text: call.displayName ?? call.handle.value,
-                      icon: Icon(
-                        Icons.phone_paused_outlined,
-                        size: popupMenuIconSize,
-                        color: themeData.textTheme.bodyMedium!.color,
-                      ),
-                      textStyle: themeData.textTheme.bodyMedium,
-                    ),
-                if (onBlindTransferInitiated != null)
-                  CallPopupMenuItem(
-                    // Transfer is signaling-dependent, disable during renegotiation.
-                    enabled: widget.enableInteractions,
-                    onTap: onBlindTransferInitiated,
-                    text: context.l10n.call_CallActionsTooltip_transfer_choose,
-                    icon: Icon(
-                      Icons.phone_forwarded_outlined,
-                      size: popupMenuIconSize,
-                      color: themeData.textTheme.bodyMedium!.color,
-                    ),
-                    textStyle: themeData.textTheme.bodyMedium,
-                  ),
-              ],
-              child: IgnorePointer(
-                child: TextButton(
-                  onPressed: () {},
-                  style: widget.style?.transfer,
-                  child: Icon(Icons.phone_forwarded, size: actionPadIconSize),
-                ),
-              ),
-            ),
+          CallActionMenuButton(
+            key: callActionsTransferMenuKey,
+            label: context.l10n.call_CallActionsTooltip_transfer,
+            offset: Offset(_dimension + 8, 0),
+            style: widget.style?.transfer,
+            items: _buildTransferToCallItems(themeData),
+            child: Icon(Icons.phone_forwarded, size: actionPadIconSize),
           ),
         if (widget.transferableCalls.isEmpty)
-          Tooltip(
-            message: context.l10n.call_CallActionsTooltip_transfer,
-            child: CallPopupMenuButton(
-              key: callActionsTransferMenuKey,
-              offset: Offset(_dimension + 8, 0),
-              items: [
-                if (onBlindTransferInitiated != null)
-                  CallPopupMenuItem(
-                    key: callActionsTransferMenuBlindInitKey,
-                    // Transfer is signaling-dependent, disable during renegotiation.
-                    enabled: widget.enableInteractions,
-                    onTap: onBlindTransferInitiated,
-                    text: context.l10n.call_CallActionsTooltip_unattended_transfer,
-                    icon: Icon(
-                      Icons.phone_forwarded_outlined,
-                      size: popupMenuIconSize,
-                      color: themeData.textTheme.bodyMedium!.color,
-                    ),
-                    textStyle: themeData.textTheme.bodyMedium,
-                  ),
-                if (onAttendedTransferInitiated != null)
-                  CallPopupMenuItem(
-                    key: callActionsTransferMenuAttendedInitKey,
-                    // Transfer is signaling-dependent, disable during renegotiation.
-                    enabled: widget.enableInteractions,
-                    onTap: onAttendedTransferInitiated,
-                    text: context.l10n.call_CallActionsTooltip_attended_transfer,
-                    icon: Icon(
-                      Icons.phone_forwarded_outlined,
-                      size: popupMenuIconSize,
-                      color: themeData.textTheme.bodyMedium!.color,
-                    ),
-                    textStyle: themeData.textTheme.bodyMedium,
-                  ),
-              ],
-              child: IgnorePointer(
-                child: TextButton(
-                  onPressed: onBlindTransferInitiated == null && onAttendedTransferInitiated == null ? null : () {},
-                  style: widget.style?.transfer,
-                  child: Icon(Icons.phone_forwarded, size: actionPadIconSize),
-                ),
-              ),
-            ),
+          CallActionMenuButton(
+            key: callActionsTransferMenuKey,
+            label: context.l10n.call_CallActionsTooltip_transfer,
+            enabled: transferInitAvailable,
+            offset: Offset(_dimension + 8, 0),
+            style: widget.style?.transfer,
+            items: _buildTransferInitItems(themeData),
+            child: Icon(Icons.phone_forwarded, size: actionPadIconSize),
           ),
-        Tooltip(
+        CallActionButton(
           key: callActionsHoldKey,
-          message: widget.heldValue
+          label: widget.heldValue
               ? context.l10n.call_CallActionsTooltip_unhold
               : context.l10n.call_CallActionsTooltip_hold,
-          child: TextButton(
-            onPressed: onHeldChanged == null ? null : () => onHeldChanged(!widget.heldValue),
-            statesController: _heldStatesController..update(WidgetState.selected, widget.heldValue),
-            style: widget.style?.held,
-            child: Icon(widget.heldValue ? Icons.play_arrow : Icons.pause, size: actionPadIconSize),
-          ),
+          onPressed: onHeldChanged == null ? null : () => onHeldChanged(!widget.heldValue),
+          statesController: _heldStatesController..update(WidgetState.selected, widget.heldValue),
+          style: widget.style?.held,
+          child: Icon(widget.heldValue ? Icons.play_arrow : Icons.pause, size: actionPadIconSize),
         ),
-        Tooltip(
+        CallActionButton(
           key: callActionsKeypadKey,
-          message: context.l10n.call_CallActionsTooltip_showKeypad,
-          child: TextButton(
-            onPressed: onKeyPressed == null || !_isOrientationPortrait ? null : () => widget.onKeypadToggle?.call(true),
-            style: widget.style?.key,
-            child: Icon(Icons.dialpad, size: actionPadIconSize),
-          ),
+          label: context.l10n.call_CallActionsTooltip_showKeypad,
+          onPressed: canShowKeypad ? () => widget.onKeypadToggle?.call(true) : null,
+          style: widget.style?.key,
+          child: Icon(Icons.dialpad, size: actionPadIconSize),
         ),
         // hangup delimiter
         const SizedBox(),
@@ -485,26 +369,19 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
         ...actions,
         // hangup row
         const SizedBox(),
-        Tooltip(
-          message: context.l10n.call_CallActionsTooltip_hangup,
-          child: TextButton(
-            key: callActionsHangupKey,
-            onPressed: onHangupPressed,
-            style: widget.style?.hangup,
-            child: Icon(Icons.call_end, size: actionPadIconSize),
-          ),
+        CallActionButton(
+          key: callActionsHangupKey,
+          label: context.l10n.call_CallActionsTooltip_hangup,
+          onPressed: onHangupPressed,
+          style: widget.style?.hangup,
+          child: Icon(Icons.call_end, size: actionPadIconSize),
         ),
         widget.keypadShown
-            ? Tooltip(
-                message: context.l10n.call_CallActionsTooltip_hideKeypad,
-                child: TextButton(
-                  onPressed: () {
-                    _keypadTextEditingController.clear();
-                    widget.onKeypadToggle?.call(false);
-                  },
-                  style: widget.style?.key,
-                  child: Icon(Icons.dialpad, size: actionPadIconSize),
-                ),
+            ? CallActionButton(
+                label: context.l10n.call_CallActionsTooltip_hideKeypad,
+                onPressed: _hideKeypad,
+                style: widget.style?.key,
+                child: Icon(Icons.dialpad, size: actionPadIconSize),
               )
             : const SizedBox(),
       ],
@@ -533,5 +410,138 @@ class _ActiveCallActionsState extends State<ActiveCallActions> {
         ),
       ),
     );
+  }
+
+  /// The 12 DTMF keys, three per row with the row delimiters in between.
+  List<Widget> _buildKeypadActions(TextStyle keypadTextStyle, TextStyle subKeypadTextStyle) {
+    return KeypadKey.numbers.indexed
+        .map((e) {
+          final (i, k) = e;
+          return [
+            KeypadKeyButton(
+              text: k.text,
+              subtext: k.subtext,
+              onKeyPressed: _enterKeypadKey,
+              style: KeypadKeyStyle(
+                buttonStyle: widget.style?.key,
+                textStyle: keypadTextStyle,
+                subtextStyle: subKeypadTextStyle,
+              ),
+            ),
+            if ((i + 1) % 3 == 0) ...[
+              const SizedBox(),
+              SizedBox.square(dimension: _actionsDelimiterDimension),
+              const SizedBox(),
+            ],
+          ];
+        })
+        .expand((e) => e)
+        .toList(growable: false);
+  }
+
+  /// Menu items of the audio-device picker, one per available device.
+  List<PopupMenuItem<CallAudioDevice>> _buildAudioDeviceItems(ThemeData themeData) {
+    return widget.availableAudioDevices
+        .map((device) {
+          final CallAudioDevice(:name, :type, :id) = device;
+          return CallPopupMenuItem<CallAudioDevice>(
+            value: device,
+            text: switch (type) {
+              CallAudioDeviceType.speaker => context.l10n.call_CallActionsTooltip_device_speaker,
+              CallAudioDeviceType.earpiece => context.l10n.call_CallActionsTooltip_device_earpiece,
+              CallAudioDeviceType.wiredHeadset => context.l10n.call_CallActionsTooltip_device_wiredHeadset,
+              CallAudioDeviceType.bluetooth => name ?? context.l10n.call_CallActionsTooltip_device_bluetooth,
+              CallAudioDeviceType.streaming => name ?? context.l10n.call_CallActionsTooltip_device_streaming,
+              _ => name ?? context.l10n.call_CallActionsTooltip_device_unknown,
+            },
+            icon: Icon(
+              switch (type) {
+                CallAudioDeviceType.speaker => Icons.volume_up,
+                CallAudioDeviceType.bluetooth => Icons.bluetooth_audio,
+                CallAudioDeviceType.wiredHeadset => Icons.headset,
+                CallAudioDeviceType.earpiece => Icons.phone_in_talk,
+                CallAudioDeviceType.streaming => Icons.usb,
+                _ => Icons.device_unknown,
+              },
+              size: 20,
+              color: themeData.textTheme.bodyMedium!.color,
+            ),
+            textStyle: themeData.textTheme.bodyMedium,
+          );
+        })
+        .toList(growable: false);
+  }
+
+  /// Menu items of the transfer popup while other calls can be transfer
+  /// targets: one per transferable call, plus the free-number option.
+  List<PopupMenuItem<dynamic>> _buildTransferToCallItems(ThemeData themeData) {
+    final popupMenuIconSize = themeData.textTheme.bodyLarge!.fontSize;
+    final onAttendedTransferSubmitted = widget.onAttendedTransferSubmitted;
+    return [
+      for (final call in widget.transferableCalls)
+        if (onAttendedTransferSubmitted != null)
+          CallPopupMenuItem(
+            key: callActionsTransferMenuNumberKey,
+            // Transfer is signaling-dependent, disable during renegotiation.
+            enabled: widget.enableInteractions,
+            onTap: () => onAttendedTransferSubmitted.call(call),
+            text: call.displayName ?? call.handle.value,
+            icon: Icon(
+              Icons.phone_paused_outlined,
+              size: popupMenuIconSize,
+              color: themeData.textTheme.bodyMedium!.color,
+            ),
+            textStyle: themeData.textTheme.bodyMedium,
+          ),
+      if (widget.onBlindTransferInitiated != null)
+        CallPopupMenuItem(
+          // Transfer is signaling-dependent, disable during renegotiation.
+          enabled: widget.enableInteractions,
+          onTap: widget.onBlindTransferInitiated,
+          text: context.l10n.call_CallActionsTooltip_transfer_choose,
+          icon: Icon(
+            Icons.phone_forwarded_outlined,
+            size: popupMenuIconSize,
+            color: themeData.textTheme.bodyMedium!.color,
+          ),
+          textStyle: themeData.textTheme.bodyMedium,
+        ),
+    ];
+  }
+
+  /// Menu items of the transfer popup with no other calls around: start an
+  /// unattended or an attended transfer.
+  List<PopupMenuItem<dynamic>> _buildTransferInitItems(ThemeData themeData) {
+    final popupMenuIconSize = themeData.textTheme.bodyLarge!.fontSize;
+    return [
+      if (widget.onBlindTransferInitiated != null)
+        CallPopupMenuItem(
+          key: callActionsTransferMenuBlindInitKey,
+          // Transfer is signaling-dependent, disable during renegotiation.
+          enabled: widget.enableInteractions,
+          onTap: widget.onBlindTransferInitiated,
+          text: context.l10n.call_CallActionsTooltip_unattended_transfer,
+          icon: Icon(
+            Icons.phone_forwarded_outlined,
+            size: popupMenuIconSize,
+            color: themeData.textTheme.bodyMedium!.color,
+          ),
+          textStyle: themeData.textTheme.bodyMedium,
+        ),
+      if (widget.onAttendedTransferInitiated != null)
+        CallPopupMenuItem(
+          key: callActionsTransferMenuAttendedInitKey,
+          // Transfer is signaling-dependent, disable during renegotiation.
+          enabled: widget.enableInteractions,
+          onTap: widget.onAttendedTransferInitiated,
+          text: context.l10n.call_CallActionsTooltip_attended_transfer,
+          icon: Icon(
+            Icons.phone_forwarded_outlined,
+            size: popupMenuIconSize,
+            color: themeData.textTheme.bodyMedium!.color,
+          ),
+          textStyle: themeData.textTheme.bodyMedium,
+        ),
+    ];
   }
 }

--- a/lib/features/call/widgets/call_action_button.dart
+++ b/lib/features/call/widgets/call_action_button.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import 'popup_menu.dart';
+
+/// One in-call action button (mute, hold, hangup, ...).
+///
+/// All the action-grid buttons share the same tooltip-labeled icon button
+/// shape; this widget is that shape, so the buttons cannot drift apart and a
+/// future change touches one place instead of ten call sites.
+class CallActionButton extends StatelessWidget {
+  const CallActionButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.statesController,
+    this.style,
+    required this.child,
+  });
+
+  /// Shown as the long-press tooltip.
+  final String label;
+
+  final VoidCallback? onPressed;
+  final WidgetStatesController? statesController;
+  final ButtonStyle? style;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: label,
+      child: TextButton(onPressed: onPressed, statesController: statesController, style: style, child: child),
+    );
+  }
+}
+
+/// The popup-menu flavor of [CallActionButton] (transfer, audio device).
+///
+/// The [TextButton] is decoration only: [IgnorePointer] keeps taps on the
+/// popup trigger, and an empty callback (instead of null) keeps the button
+/// out of the 'disabled' state, which would override the custom style with
+/// default disabled theme colors.
+class CallActionMenuButton<T> extends StatelessWidget {
+  const CallActionMenuButton({
+    super.key,
+    required this.label,
+    this.enabled = true,
+    required this.items,
+    this.onSelected,
+    this.offset = Offset.zero,
+    this.statesController,
+    this.style,
+    required this.child,
+  });
+
+  /// Shown as the long-press tooltip.
+  final String label;
+
+  final bool enabled;
+  final List<PopupMenuItem<T>> items;
+  final PopupMenuItemSelected<T>? onSelected;
+  final Offset offset;
+  final WidgetStatesController? statesController;
+  final ButtonStyle? style;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: label,
+      child: CallPopupMenuButton<T>(
+        items: items,
+        onSelected: onSelected,
+        offset: offset,
+        child: IgnorePointer(
+          child: TextButton(
+            onPressed: enabled ? () {} : null,
+            statesController: statesController,
+            style: style,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/call/widgets/incoming_call_actions.dart
+++ b/lib/features/call/widgets/incoming_call_actions.dart
@@ -86,27 +86,23 @@ class _IncomingCallActionsState extends State<IncomingCallActions> {
     final TextButtonsTable buttonsTable;
 
     final buttons = [
-      Tooltip(
-        message: widget.inviteToAttendedTransfer
+      CallActionButton(
+        key: callActionsHangupKey,
+        label: widget.inviteToAttendedTransfer
             ? context.l10n.call_CallActionsTooltip_decline_inviteToAttendedTransfer
             : context.l10n.call_CallActionsTooltip_hangup,
-        child: TextButton(
-          key: callActionsHangupKey,
-          onPressed: onHangupPressed,
-          style: widget.style?.hangup,
-          child: Icon(Icons.call_end, size: actionPadIconSize),
-        ),
+        onPressed: onHangupPressed,
+        style: widget.style?.hangup,
+        child: Icon(Icons.call_end, size: actionPadIconSize),
       ),
       if (widget.onAcceptPressed != null)
-        Tooltip(
-          message: widget.inviteToAttendedTransfer
+        CallActionButton(
+          label: widget.inviteToAttendedTransfer
               ? context.l10n.call_CallActionsTooltip_accept_inviteToAttendedTransfer
               : context.l10n.call_CallActionsTooltip_accept,
-          child: TextButton(
-            onPressed: onAcceptPressed,
-            style: widget.style?.callStart,
-            child: Icon(widget.remoteVideo ? Icons.videocam : Icons.call, size: actionPadIconSize),
-          ),
+          onPressed: onAcceptPressed,
+          style: widget.style?.callStart,
+          child: Icon(widget.remoteVideo ? Icons.videocam : Icons.call, size: actionPadIconSize),
         ),
     ];
 

--- a/lib/features/call/widgets/widgets.dart
+++ b/lib/features/call/widgets/widgets.dart
@@ -1,5 +1,6 @@
 export 'incoming_call_actions.dart';
 export 'active_call_actions.dart';
+export 'call_action_button.dart';
 export 'call_active_thumbnail.dart';
 export 'call_info.dart';
 export 'call_remote_avatar.dart';

--- a/test/features/call/widgets/call_action_button_test.dart
+++ b/test/features/call/widgets/call_action_button_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webtrit_phone/features/call/widgets/call_action_button.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  group('CallActionButton', () {
+    testWidgets('renders the child, carries the tooltip and fires on tap', (tester) async {
+      var pressed = false;
+      await tester.pumpWidget(
+        wrap(CallActionButton(label: 'Mute microphone', onPressed: () => pressed = true, child: const Icon(Icons.mic))),
+      );
+
+      expect(find.byTooltip('Mute microphone'), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.mic));
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('null onPressed renders the disabled state', (tester) async {
+      await tester.pumpWidget(
+        wrap(const CallActionButton(label: 'Hold call', onPressed: null, child: Icon(Icons.pause))),
+      );
+
+      final button = tester.widget<TextButton>(find.byType(TextButton));
+      expect(button.onPressed, isNull);
+    });
+  });
+
+  group('CallActionMenuButton', () {
+    testWidgets('tap opens the menu with its items', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          CallActionMenuButton<int>(
+            label: 'Transfer',
+            items: const [
+              PopupMenuItem(value: 1, child: Text('Unattended transfer')),
+              PopupMenuItem(value: 2, child: Text('Attended transfer')),
+            ],
+            child: const Icon(Icons.phone_forwarded),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.phone_forwarded));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unattended transfer'), findsOneWidget);
+      expect(find.text('Attended transfer'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

All ten in-call and incoming-call buttons repeat the same tooltip-labeled icon button shape, and the two popup triggers (transfer, audio device) repeat their own variation of it. This extracts both shapes into one shared widget and migrates every call site to it.

Along the way the action grid itself became readable: multi-step tap handlers moved into named intent methods (toggle speakerphone, enter a DTMF key, hide the keypad), the popup menu item lists into their own builders, and compound conditions into named locals - the widget tree now reads as a plain list of buttons.

Pure refactoring: no visible or behavioral changes. It prepares the ground for the accessibility work stacked on top, and any future change to the in-call buttons now touches one place instead of ten call sites.

## Verification

New widget tests cover the shared button (renders, tooltip, tap, disabled state) and the menu trigger (opens its menu); the existing call screen suite passes unchanged; full analyze and test suite pass.